### PR TITLE
Fix linting error

### DIFF
--- a/src/components/TenantSetup.tsx
+++ b/src/components/TenantSetup.tsx
@@ -107,7 +107,7 @@ export class TenantSetup extends PureComponent<Props, State> {
       },
       dashboards: [],
     };
-    
+
     // Save the dashboard names
     for (const json of dashboardPaths) {
       const d = await importDashboard(json, options);


### PR DESCRIPTION
yarn build was failing with:

```
/home/joe/dev/grafana/worldping-app/src/components/TenantSetup.tsx
    110:1  error  Delete `····`  prettier/prettier
```

The submitted PR allows worldping-app to build cleanly.