### PR TITLE
allow apiHost to be configurable

### DIFF
--- a/src/datasource/ConfigEditor.tsx
+++ b/src/datasource/ConfigEditor.tsx
@@ -69,8 +69,8 @@ export function isValid(settings: WorldpingOptions): boolean {
     return false;
   }
 
-  const { metrics, logs } = settings;
-  if (!metrics || !metrics.grafanaName || !metrics.hostedId) {
+  const { apiHost, metrics, logs } = settings;
+  if (!apiHost || !metrics || !metrics.grafanaName || !metrics.hostedId) {
     return false;
   }
 

--- a/src/datasource/plugin.json
+++ b/src/datasource/plugin.json
@@ -8,7 +8,7 @@
     {
       "path": "dev",
       "method": "GET",
-      "url": "https://worldping-api-dev.grafana.net/api/v1/",
+      "url": "https://{{.JsonData.apiHost}}/api/v1/",
       "reqRole": "Viewer",
       "headers": [
         {
@@ -20,7 +20,7 @@
     {
       "path": "dev",
       "method": "POST",
-      "url": "https://worldping-api-dev.grafana.net/api/v1/",
+      "url": "https://{{.JsonData.apiHost}}/api/v1/",
       "reqRole": "Editor",
       "headers": [
         {
@@ -32,7 +32,7 @@
     {
       "path": "dev",
       "method": "DELETE",
-      "url": "https://worldping-api-dev.grafana.net/api/v1/",
+      "url": "https://{{.JsonData.apiHost}}/api/v1/",
       "reqRole": "Editor",
       "headers": [
         {

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -36,6 +36,7 @@ export interface FolderInfo {
  * These are options configured for each DataSource instance
  */
 export interface WorldpingOptions extends DataSourceJsonData {
+  apiHost: string;
   metrics: LinkedDatsourceInfo;
   logs: LinkedDatsourceInfo;
   dashboards: DashboardInfo[];


### PR DESCRIPTION
This will allow using custom deployments of worldping-api, eg our
ops-tools deployment.