### PR TITLE
chore: alphabetize probe list, change uptime label

### DIFF
--- a/src/components/UptimeGauge.tsx
+++ b/src/components/UptimeGauge.tsx
@@ -78,7 +78,7 @@ export class UptimeGauge extends PureComponent<Props, State> {
     }
     let value: DisplayValue = {
       numeric: 0,
-      title: 'Uptime',
+      title: 'Success rate',
       text: 'loading...',
     };
     if (resp.data.data.result.length < 1) {

--- a/src/page/ProbesPage.tsx
+++ b/src/page/ProbesPage.tsx
@@ -130,42 +130,44 @@ export class ProbesPage extends PureComponent<Props, State> {
             <Button onClick={this.onAddNew}>New</Button>
           </HorizontalGroup>
         )}
-        {probes.map(probe => {
-          const probeId: number = probe.id || 0;
-          if (!probe.id) {
-            return;
-          }
-          let onlineTxt = 'Offline';
-          let onlineIcon = 'heart-break' as IconName;
-          let color = 'red' as BadgeColor;
-          if (probe.online) {
-            onlineTxt = 'Online';
-            onlineIcon = 'heart';
-            color = 'green';
-          }
-          return (
-            <div key={probeId} className="add-data-source-item" onClick={() => this.onSelectProbe(probeId)}>
-              <div className="add-data-source-item-text-wrapper">
-                <span className="add-data-source-item-text">{probe.name}</span>
-                <span className="add-data-source-item-desc">
-                  <Badge color={color} icon={onlineIcon} text={onlineTxt} />
-                  <div>{this.labelsToString(probe.labels)}</div>
-                </span>
+        {probes
+          .sort((probeA, probeB) => probeA.name.localeCompare(probeB.name))
+          .map(probe => {
+            const probeId: number = probe.id || 0;
+            if (!probe.id) {
+              return;
+            }
+            let onlineTxt = 'Offline';
+            let onlineIcon = 'heart-break' as IconName;
+            let color = 'red' as BadgeColor;
+            if (probe.online) {
+              onlineTxt = 'Online';
+              onlineIcon = 'heart';
+              color = 'green';
+            }
+            return (
+              <div key={probeId} className="add-data-source-item" onClick={() => this.onSelectProbe(probeId)}>
+                <div className="add-data-source-item-text-wrapper">
+                  <span className="add-data-source-item-text">{probe.name}</span>
+                  <span className="add-data-source-item-desc">
+                    <Badge color={color} icon={onlineIcon} text={onlineTxt} />
+                    <div>{this.labelsToString(probe.labels)}</div>
+                  </span>
+                </div>
+                <UptimeGauge
+                  labelNames={['probe']}
+                  labelValues={[probe.name]}
+                  ds={instance.api.getMetricsDS()}
+                  height={60}
+                  width={150}
+                  sparkline={false}
+                />
+                <div className="add-data-source-item-actions">
+                  <Button>Select</Button>
+                </div>
               </div>
-              <UptimeGauge
-                labelNames={['probe']}
-                labelValues={[probe.name]}
-                ds={instance.api.getMetricsDS()}
-                height={60}
-                width={150}
-                sparkline={false}
-              />
-              <div className="add-data-source-item-actions">
-                <Button>Select</Button>
-              </div>
-            </div>
-          );
-        })}
+            );
+          })}
         <br />
       </div>
     );


### PR DESCRIPTION
This PR:

 - Alphabetizes the list of probes by name (fixes https://github.com/grafana/synthetic-monitoring-app/issues/57)
 - Changes the "Uptime" label to "Success rate" (fixes https://github.com/grafana/synthetic-monitoring-app/issues/58)