### PR TITLE
fix: handle editing check with no probes

### DIFF
--- a/src/components/CheckEditor.tsx
+++ b/src/components/CheckEditor.tsx
@@ -36,6 +36,7 @@ interface State {
   probes: Probe[];
   showDeleteModal: boolean;
   showOptions: boolean;
+  probesLoading: boolean;
 }
 
 export class CheckEditor extends PureComponent<Props, State> {
@@ -43,6 +44,7 @@ export class CheckEditor extends PureComponent<Props, State> {
     showDeleteModal: false,
     check: { ...this.props.check },
     showOptions: false,
+    probesLoading: true,
     probes: [],
   };
 
@@ -53,6 +55,7 @@ export class CheckEditor extends PureComponent<Props, State> {
     const typeOfCheck = checkType(check.settings);
     this.setState({
       typeOfCheck,
+      probesLoading: false,
       probes,
     });
   }
@@ -161,8 +164,8 @@ export class CheckEditor extends PureComponent<Props, State> {
   };
 
   render() {
-    const { check, showDeleteModal, probes, typeOfCheck, showOptions } = this.state;
-    if (!check || probes.length === 0) {
+    const { check, showDeleteModal, probes, probesLoading, typeOfCheck, showOptions } = this.state;
+    if (!check || probesLoading) {
       return <div>Loading...</div>;
     }
 


### PR DESCRIPTION
fixes https://github.com/grafana/synthetic-monitoring-app/issues/35

Check will now load without probe values:

<img width="1017" alt="Screen Shot 2020-08-11 at 3 45 56 PM" src="https://user-images.githubusercontent.com/8377044/89941992-ccea6e00-dbe9-11ea-8ef2-024affc24af7.png">
