### PR TITLE
chore: use external library for url validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@testing-library/user-event": "^12.0.17",
     "@types/ip-address": "latest",
     "@types/lodash": "latest",
+    "@types/valid-url": "^1.0.3",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-react-hooks": "^4.1.0",
     "husky": "^4.2.5",
@@ -37,6 +38,7 @@
   },
   "dependencies": {
     "ip-address": "^6.3.0",
-    "punycode": "^2.1.1"
+    "punycode": "^2.1.1",
+    "valid-url": "^1.0.9"
   }
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -2,6 +2,7 @@ import { Check, CheckType, Settings, HttpSettings, PingSettings, DnsSettings, Tc
 import { checkType } from 'utils';
 import * as punycode from 'punycode';
 import { Address4, Address6 } from 'ip-address';
+import validUrl from 'valid-url';
 
 export const CheckValidation = {
   job: validateJob,
@@ -138,12 +139,7 @@ export function validateSettingsTCP(settings: TcpSettings): boolean {
 }
 
 function validateHttpTarget(target: string): boolean {
-  try {
-    const url = new URL(target);
-    return url.protocol === 'https:' || url.protocol === 'http:';
-  } catch (_) {
-    return false;
-  }
+  return Boolean(validUrl.isWebUri(target));
 }
 
 function validateHostname(target: string): boolean {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,6 +2150,11 @@
   dependencies:
     source-map "^0.6.1"
 
+"@types/valid-url@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/valid-url/-/valid-url-1.0.3.tgz#a124389fb953559c7f889795a98620e91adb3687"
+  integrity sha512-+33x29mg+ecU88ODdWpqaie2upIuRkhujVLA7TuJjM823cNMbeggfI6NhxewaRaRF8dy+g33e4uIg/m5Mb3xDQ==
+
 "@types/webpack-dev-server@*":
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz#bcc3b85e7dc6ac2db25330610513f2228c2fcfb2"
@@ -12661,6 +12666,11 @@ v8-compile-cache@^2.0.3:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
   integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
+
+valid-url@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+  integrity sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
Fixes https://github.com/grafana/synthetic-monitoring-app/issues/77 (sort of)
Pulls in an external [url validation library](https://github.com/ogt/valid-url) to handle more URL validation cases