### PR TITLE
Refactor check health

### DIFF
--- a/src/RootPage.tsx
+++ b/src/RootPage.tsx
@@ -9,6 +9,7 @@ import { findSMDataSources, createNewApiInstance, dashboardUID } from 'utils';
 import { SMOptions } from 'datasource/types';
 import { getDataSourceSrv, getLocationSrv } from '@grafana/runtime';
 import { TenantSetup } from './components/TenantSetup';
+import { InstanceContext } from './components/InstanceContext';
 import { ChecksPage } from 'page/ChecksPage';
 import { ProbesPage } from 'page/ProbesPage';
 
@@ -16,6 +17,7 @@ interface Props extends AppRootProps<GlobalSettings> {}
 interface State {
   settings: Array<DataSourceInstanceSettings<SMOptions>>;
   instance?: GrafanaInstances;
+  loadingInstance: boolean;
   info?: RegistrationInfo;
   valid?: boolean;
 }
@@ -26,6 +28,7 @@ export class RootPage extends PureComponent<Props, State> {
 
     this.state = {
       settings: findSMDataSources(),
+      loadingInstance: true,
     };
   }
 
@@ -43,6 +46,7 @@ export class RootPage extends PureComponent<Props, State> {
 
         this.setState({
           instance,
+          loadingInstance: false,
           valid: isValid(instance),
         });
         this.updateNav();
@@ -183,7 +187,7 @@ export class RootPage extends PureComponent<Props, State> {
     return <TenantSetup instance={instance.api} />;
   }
 
-  render() {
+  renderPage() {
     const { settings, valid, instance } = this.state;
     if (settings.length > 1) {
       return this.renderMultipleConfigs();
@@ -205,6 +209,16 @@ export class RootPage extends PureComponent<Props, State> {
     }
 
     return <div>Page not found.</div>;
+  }
+
+  render() {
+    const { instance, loadingInstance } = this.state;
+
+    return (
+      <InstanceContext.Provider value={{ instance, loading: loadingInstance }}>
+        {this.renderPage()}
+      </InstanceContext.Provider>
+    );
   }
 }
 

--- a/src/__mocks__/utils.ts
+++ b/src/__mocks__/utils.ts
@@ -5,7 +5,19 @@ function hasRole(requiredRole: OrgRole): boolean {
   return true;
 }
 
+const queryMetric = jest.fn().mockImplementation(() => {
+  return Promise.resolve({
+    data: [
+      {
+        metric: {},
+        value: [1598535155, '1'],
+      },
+    ],
+  });
+});
+
 module.exports = {
   ...utils,
   hasRole,
+  queryMetric,
 };

--- a/src/components/CheckHealth.test.tsx
+++ b/src/components/CheckHealth.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { CheckHealth } from './CheckHealth';
+import { InstanceContext } from './InstanceContext';
+import { Check } from 'types';
+import { getInstanceMock, instanceSettings } from '../datasource/__mocks__/DataSource';
+
+const defaultCheck = {
+  id: 2,
+  tenantId: 1,
+  frequency: 60000,
+  offset: 0,
+  timeout: 2500,
+  enabled: true,
+  labels: [],
+  settings: {
+    ping: {
+      ipVersion: 'V4',
+      dontFragment: false,
+    },
+  },
+  probes: [1],
+  target: 'grafana.com',
+  job: 'tacos',
+  created: 1597928927.7490728,
+  modified: 1597928927.7490728,
+} as Check;
+
+const renderCheckHealth = (check: Check = defaultCheck) => {
+  const instance = {
+    api: getInstanceMock(instanceSettings),
+  };
+  return render(
+    <InstanceContext.Provider value={{ instance, loading: false }}>
+      <CheckHealth check={check} />
+    </InstanceContext.Provider>
+  );
+};
+
+test('renders without crashing', async () => {
+  const { container } = renderCheckHealth();
+  const icon = container.querySelector('svg');
+  // should have a paused icon while loading
+  expect(icon).toHaveClass('alert-state-paused');
+  await waitFor(() => {
+    // should turn to a green heart when data has loaded
+    const heartIcon = container.querySelector('svg');
+    expect(heartIcon).toHaveClass('alert-state-ok');
+  });
+});

--- a/src/components/CheckList.tsx
+++ b/src/components/CheckList.tsx
@@ -173,7 +173,7 @@ export const CheckList: FC<Props> = ({ instance, onAddNewClick, checks }) => {
                   <HorizontalGroup justify="space-between">
                     <div className="card-item-body">
                       <figure className="card-item-figure">
-                        <CheckHealth check={check} ds={datasource} />
+                        <CheckHealth check={check} />
                       </figure>
                       <VerticalGroup>
                         <div className="card-item-name">{check.target}</div>

--- a/src/components/InstanceContext.ts
+++ b/src/components/InstanceContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+import { GrafanaInstances } from 'types';
+
+interface InstanceContextValue {
+  loading: boolean;
+  instance: GrafanaInstances | undefined;
+}
+
+export const InstanceContext = createContext<InstanceContextValue>({ instance: undefined, loading: true });

--- a/src/hooks/useMetricData.ts
+++ b/src/hooks/useMetricData.ts
@@ -1,0 +1,27 @@
+import { useContext, useState, useEffect } from 'react';
+import { InstanceContext } from 'components/InstanceContext';
+import { queryMetric } from 'utils';
+
+export function useMetricData(query: string) {
+  const { instance } = useContext(InstanceContext);
+  const [isFetchingData, setIsFetchingData] = useState(true);
+  const [data, setData] = useState<any[]>([]);
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    const getData = async () => {
+      setIsFetchingData(true);
+      const url = instance?.api?.getMetricsDS()?.url;
+      if (!url) {
+        return;
+      }
+      const { error: queryError, data: queryData } = await queryMetric(url, query);
+      setData(queryData);
+      setError(queryError);
+      setIsFetchingData(false);
+    };
+    getData();
+  }, [query, instance?.api]);
+
+  return { loading: isFetchingData, data, error };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -189,3 +189,32 @@ export const matchStrings = (string: string, comparisons: string[]): boolean => 
   const lowerCased = string.toLowerCase();
   return comparisons.some(comparison => comparison.toLowerCase().match(lowerCased));
 };
+
+interface MetricQueryResponse {
+  error?: string;
+  data: any[];
+}
+
+export const queryMetric = async (url: string, query: string): Promise<MetricQueryResponse> => {
+  const backendSrv = getBackendSrv();
+  const lastUpdate = Math.floor(Date.now() / 1000);
+
+  try {
+    const response = await backendSrv.datasourceRequest({
+      method: 'GET',
+      url: `${url}/api/v1/query`,
+      params: {
+        query,
+        time: lastUpdate,
+      },
+    });
+    if (!response.ok) {
+      return { error: 'Error fetching data', data: [] };
+    }
+    return {
+      data: response.data?.data?.result ?? [],
+    };
+  } catch (e) {
+    return { error: (e.message || e.data?.message) ?? 'Error fetching data', data: [] };
+  }
+};


### PR DESCRIPTION
Currently we have a bit of prop drilling with the `instance` class which is muddying component APIs, increasing testing complexity, and requiring duplicative code when doing things like fetching metric data. This is the first step in extracting that out by putting the `instance` in a context in the `RootPage`. This allows for creating custom hooks that handle the currently duplicative logic and will allow us to get rid of the prop drilling in future PRs. 

This PR:
- Puts `instance` in a context
- Creates a custom hook that accesses the instance context and fetches metric data
- Refactors the CheckHealth component to use the new custom hook
