### PR TITLE
Probe options

### DIFF
--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -10,17 +10,15 @@ import {
   Switch,
   Select,
   Legend,
-  Collapse,
   Alert,
 } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
-import { Check, Label as SMLabel, Settings, CheckType, Probe, OrgRole, APIError } from 'types';
+import { Check, Label as SMLabel, CheckType, Probe, OrgRole, APIError } from 'types';
 import { SMDataSource } from 'datasource/DataSource';
 import { hasRole, checkType, defaultSettings } from 'utils';
-import SMLabelsForm from 'components/SMLabelsForm';
 import * as Validation from 'validation';
 import CheckTarget from 'components/CheckTarget';
-import CheckSettings from './CheckSettings';
+import CheckSettings, { OnUpdateArgs } from './CheckSettings';
 import { ProbeOptions, OnChangeArgs } from './ProbeOptions';
 
 interface Props {
@@ -86,9 +84,11 @@ export default class CheckEditor extends PureComponent<Props, State> {
     this.setState({ check });
   };
 
-  onSettingsUpdate = (settings: Settings) => {
+  onSettingsUpdate = ({ settings, labels }: OnUpdateArgs) => {
     let check = { ...this.state.check } as Check;
+
     check.settings = settings;
+    check.labels = labels ?? [];
     this.setState({ check });
   };
 
@@ -245,30 +245,13 @@ export default class CheckEditor extends PureComponent<Props, State> {
             probes={check.probes}
             onChange={this.onProbeOptionsChange}
           />
-          <Collapse label="Options" collapsible={true} onToggle={this.onToggleOptions} isOpen={showOptions}>
-            <Field
-              label="Labels"
-              description="Custom labels to be included with collected metrics and logs."
-              disabled={!isEditor}
-              invalid={!Validation.validateLabels(check.labels)}
-            >
-              <SMLabelsForm
-                labels={check.labels}
-                onUpdate={this.onLabelsUpdate}
-                isEditor={isEditor}
-                type="Label"
-                limit={5}
-              />
-            </Field>
-            <br />
-            <h3 className="page-heading">{typeOfCheck!.toLocaleUpperCase()} Settings</h3>
-            <CheckSettings
-              settings={check.settings}
-              typeOfCheck={typeOfCheck || CheckType.HTTP}
-              onUpdate={this.onSettingsUpdate}
-              isEditor={isEditor}
-            />
-          </Collapse>
+          <CheckSettings
+            labels={check.labels}
+            settings={check.settings}
+            typeOfCheck={typeOfCheck || CheckType.HTTP}
+            onUpdate={this.onSettingsUpdate}
+            isEditor={isEditor}
+          />
         </div>
         <HorizontalGroup>
           <Button onClick={this.onSave} disabled={!isEditor || !Validation.validateCheck(check)}>

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -18,6 +18,7 @@ import { SMDataSource } from 'datasource/DataSource';
 import { hasRole, checkType, defaultSettings } from 'utils';
 import * as Validation from 'validation';
 import CheckTarget from 'components/CheckTarget';
+import { Subheader } from 'components/Subheader';
 import CheckSettings, { OnUpdateArgs } from './CheckSettings';
 import { ProbeOptions, OnChangeArgs } from './ProbeOptions';
 
@@ -213,6 +214,7 @@ export default class CheckEditor extends PureComponent<Props, State> {
       <div>
         <Legend>{legend}</Legend>
         <div>
+          <Subheader>Check Details</Subheader>
           <HorizontalGroup justify="flex-start" spacing="md">
             <Field label="Check Type" disabled={check.id ? true : false}>
               <Select value={typeOfCheck} options={checkTypes} onChange={this.onSetType} width={30} />
@@ -237,6 +239,11 @@ export default class CheckEditor extends PureComponent<Props, State> {
             checkSettings={check.settings}
             disabled={!isEditor}
             onChange={this.onTargetUpdate}
+          />
+          <hr
+            className={css`
+              margin-top: 24px;
+            `}
           />
           <ProbeOptions
             isEditor={isEditor}

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -178,7 +178,7 @@ export default class CheckEditor extends PureComponent<Props, State> {
   };
 
   render() {
-    const { check, showDeleteModal, probes, probesLoading, typeOfCheck, showOptions, error } = this.state;
+    const { check, showDeleteModal, probesLoading, typeOfCheck, error } = this.state;
     if (!check || probesLoading) {
       return <div>Loading...</div>;
     }

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -13,13 +13,13 @@ import {
   Alert,
 } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
-import { Check, Label as SMLabel, CheckType, Probe, OrgRole, APIError } from 'types';
+import { Check, Label as SMLabel, CheckType, Probe, OrgRole, APIError, OnUpdateSettingsArgs } from 'types';
 import { SMDataSource } from 'datasource/DataSource';
 import { hasRole, checkType, defaultSettings } from 'utils';
 import * as Validation from 'validation';
 import CheckTarget from 'components/CheckTarget';
 import { Subheader } from 'components/Subheader';
-import CheckSettings, { OnUpdateArgs } from './CheckSettings';
+import { CheckSettings } from './CheckSettings';
 import { ProbeOptions, OnChangeArgs } from './ProbeOptions';
 
 interface Props {
@@ -85,7 +85,7 @@ export default class CheckEditor extends PureComponent<Props, State> {
     this.setState({ check });
   };
 
-  onSettingsUpdate = ({ settings, labels }: OnUpdateArgs) => {
+  onSettingsUpdate = ({ settings, labels }: OnUpdateSettingsArgs) => {
     this.setState(state => {
       const check = state.check as Check;
       check.settings = settings;

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -86,11 +86,12 @@ export default class CheckEditor extends PureComponent<Props, State> {
   };
 
   onSettingsUpdate = ({ settings, labels }: OnUpdateArgs) => {
-    let check = { ...this.state.check } as Check;
-
-    check.settings = settings;
-    check.labels = labels ?? [];
-    this.setState({ check });
+    this.setState(state => {
+      const check = state.check as Check;
+      check.settings = settings;
+      check.labels = labels ?? [];
+      return { check };
+    });
   };
 
   onSetType = (type: SelectableValue<CheckType>) => {
@@ -213,7 +214,11 @@ export default class CheckEditor extends PureComponent<Props, State> {
     return (
       <div>
         <Legend>{legend}</Legend>
-        <div>
+        <div
+          className={css`
+            margin-bottom: 8px;
+          `}
+        >
           <Subheader>Check Details</Subheader>
           <HorizontalGroup justify="flex-start" spacing="md">
             <Field label="Check Type" disabled={check.id ? true : false}>

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -122,15 +122,14 @@ export default class CheckEditor extends PureComponent<Props, State> {
   };
 
   onProbeOptionsChange = ({ timeout, frequency, probes }: OnChangeArgs) => {
-    const { check } = this.state;
-    this.setState({
+    this.setState(state => ({
       check: {
-        ...check,
+        ...state.check,
         timeout,
         frequency,
         probes,
       },
-    });
+    }));
   };
 
   onFrequencyUpdate = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -21,7 +21,7 @@ import SMLabelsForm from 'components/SMLabelsForm';
 import * as Validation from 'validation';
 import CheckTarget from 'components/CheckTarget';
 import CheckSettings from './CheckSettings';
-import CheckProbes from './CheckProbes';
+import { ProbeOptions, OnChangeArgs } from './ProbeOptions';
 
 interface Props {
   check: Check;
@@ -117,6 +117,18 @@ export default class CheckEditor extends PureComponent<Props, State> {
     let check = { ...this.state.check } as Check;
     check.target = target;
     this.setState({ check });
+  };
+
+  onProbeOptionsChange = ({ timeout, frequency, probes }: OnChangeArgs) => {
+    const { check } = this.state;
+    this.setState({
+      check: {
+        ...check,
+        timeout,
+        frequency,
+        probes,
+      },
+    });
   };
 
   onFrequencyUpdate = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -226,59 +238,14 @@ export default class CheckEditor extends PureComponent<Props, State> {
             disabled={!isEditor}
             onChange={this.onTargetUpdate}
           />
-          <div>
-            <Field
-              label="Probe Locations"
-              description="Select the locations where this target should be monitored from"
-              disabled={!isEditor}
-              invalid={!Validation.validateProbes(check.probes)}
-            >
-              <CheckProbes
-                probes={check.probes}
-                availableProbes={probes}
-                onUpdate={this.onProbesUpdate}
-                isEditor={isEditor}
-              />
-            </Field>
-          </div>
+          <ProbeOptions
+            isEditor={isEditor}
+            timeout={check.timeout}
+            frequency={check.frequency}
+            probes={check.probes}
+            onChange={this.onProbeOptionsChange}
+          />
           <Collapse label="Options" collapsible={true} onToggle={this.onToggleOptions} isOpen={showOptions}>
-            <Field
-              label="Frequency"
-              description="How frequently the check should run."
-              disabled={!isEditor}
-              invalid={!Validation.validateFrequency(check.frequency)}
-            >
-              <Input
-                label="Frequency"
-                type="number"
-                step={10}
-                value={check!.frequency / 1000 || 60}
-                onChange={this.onFrequencyUpdate}
-                suffix="seconds"
-                max={120}
-                min={10}
-                width={30}
-              />
-            </Field>
-            <Field
-              label="Timeout"
-              description="Maximum execution time for a check"
-              disabled={!isEditor}
-              invalid={!Validation.validateTimeout(check.timeout)}
-            >
-              <Input
-                label="Timeout"
-                type="number"
-                step={0.1}
-                value={check!.timeout / 1000 || 5}
-                onChange={this.onTimeoutUpdate}
-                suffix="seconds"
-                max={10}
-                min={1}
-                width={30}
-              />
-            </Field>
-
             <Field
               label="Labels"
               description="Custom labels to be included with collected metrics and logs."

--- a/src/components/CheckEditor/CheckProbes.tsx
+++ b/src/components/CheckEditor/CheckProbes.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { css } from 'emotion';
-import { Button, HorizontalGroup, MultiSelect } from '@grafana/ui';
+import { Button, HorizontalGroup, MultiSelect, ThemeContext } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { Probe } from 'types';
 import * as Validation from 'validation';
@@ -56,7 +56,7 @@ export default class CheckProbes extends PureComponent<CheckProbesProps, CheckPr
   render() {
     const { probes } = this.state;
     const { availableProbes, isEditor } = this.props;
-    let options = [];
+    let options: SelectableValue[] = [];
     for (const p of availableProbes) {
       options.push({
         label: p.name,
@@ -64,7 +64,7 @@ export default class CheckProbes extends PureComponent<CheckProbesProps, CheckPr
         description: p.online ? 'Online' : 'Offline',
       });
     }
-    let selectedProbes = [];
+    let selectedProbes: SelectableValue[] = [];
     for (const p of probes) {
       let existing = options.find(item => item.value === p);
       if (existing) {
@@ -73,30 +73,34 @@ export default class CheckProbes extends PureComponent<CheckProbesProps, CheckPr
     }
 
     return (
-      <div>
-        <MultiSelect
-          options={options}
-          value={selectedProbes}
-          onChange={this.onChange}
-          disabled={!isEditor}
-          invalid={!Validation.validateProbes(probes)}
-          closeMenuOnSelect={false}
-        />
-        <div
-          className={css`
-            margin-top: 0.5rem;
-          `}
-        >
-          <HorizontalGroup spacing="sm">
-            <Button onClick={this.onAllLocations} disabled={!isEditor} variant="secondary" size="sm">
-              All&nbsp;&nbsp;
-            </Button>
-            <Button onClick={this.onClearLocations} disabled={!isEditor} variant="secondary" size="sm" type="reset">
-              Clear
-            </Button>
-          </HorizontalGroup>
-        </div>
-      </div>
+      <ThemeContext.Consumer>
+        {theme => (
+          <div>
+            <MultiSelect
+              options={options}
+              value={selectedProbes}
+              onChange={this.onChange}
+              disabled={!isEditor}
+              invalid={!Validation.validateProbes(probes)}
+              closeMenuOnSelect={false}
+            />
+            <div
+              className={css`
+                margin-top: ${theme.spacing.sm};
+              `}
+            >
+              <HorizontalGroup spacing="sm">
+                <Button onClick={this.onAllLocations} disabled={!isEditor} variant="secondary" size="sm">
+                  All&nbsp;&nbsp;
+                </Button>
+                <Button onClick={this.onClearLocations} disabled={!isEditor} variant="secondary" size="sm" type="reset">
+                  Clear
+                </Button>
+              </HorizontalGroup>
+            </div>
+          </div>
+        )}
+      </ThemeContext.Consumer>
     );
   }
 }

--- a/src/components/CheckEditor/CheckProbes.tsx
+++ b/src/components/CheckEditor/CheckProbes.tsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Button, Container, HorizontalGroup, MultiSelect } from '@grafana/ui';
+import { css } from 'emotion';
+import { Button, HorizontalGroup, MultiSelect } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { Probe } from 'types';
 import * as Validation from 'validation';
@@ -81,8 +82,12 @@ export default class CheckProbes extends PureComponent<CheckProbesProps, CheckPr
           invalid={!Validation.validateProbes(probes)}
           closeMenuOnSelect={false}
         />
-        <Container margin="xs">
-          <HorizontalGroup spacing="md">
+        <div
+          className={css`
+            margin-top: 0.5rem;
+          `}
+        >
+          <HorizontalGroup spacing="sm">
             <Button onClick={this.onAllLocations} disabled={!isEditor} variant="secondary" size="sm">
               All&nbsp;&nbsp;
             </Button>
@@ -90,7 +95,7 @@ export default class CheckProbes extends PureComponent<CheckProbesProps, CheckPr
               Clear
             </Button>
           </HorizontalGroup>
-        </Container>
+        </div>
       </div>
     );
   }

--- a/src/components/CheckEditor/CheckSettings.tsx
+++ b/src/components/CheckEditor/CheckSettings.tsx
@@ -1,38 +1,45 @@
 import React, { PureComponent } from 'react';
-import { Settings, CheckType } from 'types';
+import { Settings, CheckType, Label } from 'types';
 import { PingSettingsForm } from 'components/PingSettings';
 import { HttpSettingsForm } from 'components/http/HttpSettings';
 import DnsSettingsForm from 'components/DnsSettings';
 import TcpSettingsForm from 'components/TcpSettings';
 
+export interface OnUpdateArgs {
+  settings: Settings;
+  labels?: Label[];
+}
+
 interface Props {
   isEditor: boolean;
+  labels: Label[];
   settings: Settings;
   typeOfCheck: CheckType;
-  onUpdate: (settings: Settings) => void;
+  onUpdate: (values: OnUpdateArgs) => void;
 }
 
 interface State {
   settings?: Settings;
+  labels?: Label[];
 }
 
 export default class CheckSettings extends PureComponent<Props, State> {
   state: State = {};
 
   componentDidMount() {
-    const { settings } = this.props;
-    this.setState({ settings });
+    const { settings, labels = [] } = this.props;
+    this.setState({ settings, labels });
   }
 
   componentDidUpdate(oldProps: Props) {
-    const { settings, typeOfCheck } = this.props;
+    const { settings, typeOfCheck, labels } = this.props;
     if (typeOfCheck !== oldProps.typeOfCheck) {
-      this.setState({ settings });
+      this.setState({ settings, labels });
     }
   }
 
   onUpdate = () => {
-    this.props.onUpdate(this.state.settings!);
+    this.props.onUpdate({ settings: this.state.settings!, labels: this.state.labels });
   };
 
   onJsonChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -41,12 +48,12 @@ export default class CheckSettings extends PureComponent<Props, State> {
     this.setState({ settings: settings }, this.onUpdate);
   };
 
-  onSettingsChange = (settings: Settings) => {
-    this.setState({ settings: settings }, this.onUpdate);
+  onSettingsChange = (settings: Settings, labels: Label[]) => {
+    this.setState({ settings, labels }, this.onUpdate);
   };
 
   render() {
-    const { settings } = this.state;
+    const { settings, labels } = this.state;
     if (!settings) {
       return <div>Loading....</div>;
     }
@@ -54,7 +61,9 @@ export default class CheckSettings extends PureComponent<Props, State> {
 
     switch (this.props.typeOfCheck) {
       case CheckType.PING: {
-        return <PingSettingsForm settings={settings} onUpdate={this.onSettingsChange} isEditor={isEditor} />;
+        return (
+          <PingSettingsForm labels={labels} settings={settings} onUpdate={this.onSettingsChange} isEditor={isEditor} />
+        );
       }
       case CheckType.HTTP: {
         return <HttpSettingsForm settings={settings} onUpdate={this.onSettingsChange} isEditor={isEditor} />;

--- a/src/components/CheckEditor/CheckSettings.tsx
+++ b/src/components/CheckEditor/CheckSettings.tsx
@@ -86,7 +86,14 @@ export default class CheckSettings extends PureComponent<Props, State> {
         );
       }
       case CheckType.TCP: {
-        return <TcpSettingsForm settings={settings} onUpdate={this.onSettingsChange} isEditor={isEditor} />;
+        return (
+          <TcpSettingsForm
+            settings={settings}
+            labels={labels ?? []}
+            onUpdate={this.onSettingsChange}
+            isEditor={isEditor}
+          />
+        );
       }
     }
   }

--- a/src/components/CheckEditor/CheckSettings.tsx
+++ b/src/components/CheckEditor/CheckSettings.tsx
@@ -66,10 +66,24 @@ export default class CheckSettings extends PureComponent<Props, State> {
         );
       }
       case CheckType.HTTP: {
-        return <HttpSettingsForm settings={settings} onUpdate={this.onSettingsChange} isEditor={isEditor} />;
+        return (
+          <HttpSettingsForm
+            labels={labels ?? []}
+            settings={settings}
+            onUpdate={this.onSettingsChange}
+            isEditor={isEditor}
+          />
+        );
       }
       case CheckType.DNS: {
-        return <DnsSettingsForm settings={settings} onUpdate={this.onSettingsChange} isEditor={isEditor} />;
+        return (
+          <DnsSettingsForm
+            labels={labels ?? []}
+            settings={settings}
+            onUpdate={this.onSettingsChange}
+            isEditor={isEditor}
+          />
+        );
       }
       case CheckType.TCP: {
         return <TcpSettingsForm settings={settings} onUpdate={this.onSettingsChange} isEditor={isEditor} />;

--- a/src/components/CheckEditor/CheckSettings.tsx
+++ b/src/components/CheckEditor/CheckSettings.tsx
@@ -1,100 +1,35 @@
-import React, { PureComponent } from 'react';
-import { Settings, CheckType, Label } from 'types';
+import React, { FC } from 'react';
+import { Settings, CheckType, Label, OnUpdateSettingsArgs } from 'types';
 import { PingSettingsForm } from 'components/PingSettings';
 import { HttpSettingsForm } from 'components/http/HttpSettings';
 import DnsSettingsForm from 'components/DnsSettings';
 import TcpSettingsForm from 'components/TcpSettings';
-
-export interface OnUpdateArgs {
-  settings: Settings;
-  labels?: Label[];
-}
 
 interface Props {
   isEditor: boolean;
   labels: Label[];
   settings: Settings;
   typeOfCheck: CheckType;
-  onUpdate: (values: OnUpdateArgs) => void;
+  onUpdate: (values: OnUpdateSettingsArgs) => void;
 }
 
-interface State {
-  settings?: Settings;
-  labels?: Label[];
-}
-
-export default class CheckSettings extends PureComponent<Props, State> {
-  state: State = {};
-
-  componentDidMount() {
-    const { settings, labels = [] } = this.props;
-    this.setState({ settings, labels });
+export const CheckSettings: FC<Props> = ({ onUpdate, settings, labels = [], isEditor, typeOfCheck }) => {
+  if (!settings) {
+    return <div>Loading....</div>;
   }
 
-  componentDidUpdate(oldProps: Props) {
-    const { settings, typeOfCheck, labels } = this.props;
-    if (typeOfCheck !== oldProps.typeOfCheck) {
-      this.setState({ settings, labels });
+  switch (typeOfCheck) {
+    case CheckType.PING: {
+      return <PingSettingsForm labels={labels} settings={settings} onUpdate={onUpdate} isEditor={isEditor} />;
+    }
+    case CheckType.HTTP: {
+      return <HttpSettingsForm labels={labels} settings={settings} onUpdate={onUpdate} isEditor={isEditor} />;
+    }
+    case CheckType.DNS: {
+      return <DnsSettingsForm labels={labels} settings={settings} onUpdate={onUpdate} isEditor={isEditor} />;
+    }
+    case CheckType.TCP: {
+      return <TcpSettingsForm settings={settings} labels={labels} onUpdate={onUpdate} isEditor={isEditor} />;
     }
   }
-
-  onUpdate = () => {
-    this.props.onUpdate({ settings: this.state.settings!, labels: this.state.labels });
-  };
-
-  onJsonChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    let settings: Settings = {};
-    settings[this.props.typeOfCheck] = JSON.parse(event.target.value);
-    this.setState({ settings: settings }, this.onUpdate);
-  };
-
-  onSettingsChange = (settings: Settings, labels: Label[]) => {
-    this.setState({ settings, labels }, this.onUpdate);
-  };
-
-  render() {
-    const { settings, labels } = this.state;
-    if (!settings) {
-      return <div>Loading....</div>;
-    }
-    const { isEditor } = this.props;
-
-    switch (this.props.typeOfCheck) {
-      case CheckType.PING: {
-        return (
-          <PingSettingsForm labels={labels} settings={settings} onUpdate={this.onSettingsChange} isEditor={isEditor} />
-        );
-      }
-      case CheckType.HTTP: {
-        return (
-          <HttpSettingsForm
-            labels={labels ?? []}
-            settings={settings}
-            onUpdate={this.onSettingsChange}
-            isEditor={isEditor}
-          />
-        );
-      }
-      case CheckType.DNS: {
-        return (
-          <DnsSettingsForm
-            labels={labels ?? []}
-            settings={settings}
-            onUpdate={this.onSettingsChange}
-            isEditor={isEditor}
-          />
-        );
-      }
-      case CheckType.TCP: {
-        return (
-          <TcpSettingsForm
-            settings={settings}
-            labels={labels ?? []}
-            onUpdate={this.onSettingsChange}
-            isEditor={isEditor}
-          />
-        );
-      }
-    }
-  }
-}
+};

--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -1,23 +1,17 @@
 import React, { FC, useState, useEffect, useContext } from 'react';
-import { css } from 'emotion';
 import { Field } from '@grafana/ui';
 import { validateFrequency, validateProbes, validateTimeout } from 'validation';
 import CheckProbes from './CheckProbes';
 import { InstanceContext } from 'components/InstanceContext';
 import { Probe } from 'types';
 import { SliderInput } from 'components/SliderInput';
+import { Subheader } from 'components/Subheader';
 
 export interface OnChangeArgs {
   timeout: number;
   frequency: number;
   probes: number[];
 }
-
-const styles = {
-  header: css`
-    margin-bottom: 1rem;
-  `,
-};
 
 interface Props {
   isEditor: boolean;
@@ -54,7 +48,7 @@ export const ProbeOptions: FC<Props> = ({ frequency, timeout, isEditor, onChange
 
   return (
     <div>
-      <h3 className={styles.header}>Probe Options</h3>
+      <Subheader>Probe Options</Subheader>
       <Field
         label="Probe Locations"
         description="Select up to 20 locations where this target will be checked from."

--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -5,6 +5,7 @@ import { validateFrequency, validateProbes, validateTimeout } from 'validation';
 import CheckProbes from './CheckProbes';
 import { InstanceContext } from 'components/InstanceContext';
 import { Probe } from 'types';
+import { SliderInput } from 'components/SliderInput';
 
 export interface OnChangeArgs {
   timeout: number;
@@ -73,34 +74,30 @@ export const ProbeOptions: FC<Props> = ({ frequency, timeout, isEditor, onChange
         disabled={!isEditor}
         invalid={!validateFrequency(frequencyValue)}
       >
-        <Input
-          label="Frequency"
-          type="number"
-          step={10}
-          value={frequency / 1000}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setFrequencyValue(e.target.valueAsNumber * 1000)}
-          suffix="seconds"
-          max={120}
+        <SliderInput
+          id="probe-options-frequency"
+          value={frequencyValue / 1000}
+          onChange={value => setFrequencyValue(value * 1000)}
           min={10}
-          width={30}
+          max={120}
+          separationLabel="every"
+          suffixLabel="seconds"
         />
       </Field>
       <Field
         label="Timeout"
         description="Maximum execution time for a check"
         disabled={!isEditor}
-        invalid={!validateTimeout(timeout)}
+        invalid={!validateTimeout(timeoutValue)}
       >
-        <Input
-          label="Timeout"
-          type="number"
-          step={0.1}
+        <SliderInput
+          id="probe-options-timeout"
           value={timeout / 1000}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setTimeoutValue(e.target.valueAsNumber * 1000)}
-          suffix="seconds"
           max={10}
           min={1}
-          width={30}
+          suffixLabel="seconds"
+          separationLabel="every"
+          onChange={value => setTimeoutValue(value * 1000)}
         />
       </Field>
     </div>

--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -1,0 +1,108 @@
+import React, { FC, useState, useEffect, useContext, ChangeEvent } from 'react';
+import { css } from 'emotion';
+import { Field, Input } from '@grafana/ui';
+import { validateFrequency, validateProbes, validateTimeout } from 'validation';
+import CheckProbes from './CheckProbes';
+import { InstanceContext } from 'components/InstanceContext';
+import { Probe } from 'types';
+
+export interface OnChangeArgs {
+  timeout: number;
+  frequency: number;
+  probes: number[];
+}
+
+const styles = {
+  header: css`
+    margin-bottom: 1rem;
+  `,
+};
+
+interface Props {
+  isEditor: boolean;
+  timeout: number;
+  frequency: number;
+  probes: number[];
+  onChange: (values: OnChangeArgs) => void;
+}
+
+export const ProbeOptions: FC<Props> = ({ frequency, timeout, isEditor, onChange, probes }) => {
+  const [timeoutValue, setTimeoutValue] = useState(timeout);
+  const [frequencyValue, setFrequencyValue] = useState(frequency);
+  const [selectedProbes, setSelectedProbes] = useState(probes);
+  const [availableProbes, setAvailableProbes] = useState<Probe[]>([]);
+  const { instance } = useContext(InstanceContext);
+
+  useEffect(() => {
+    const fetchProbes = async () => {
+      const probes = await instance?.api.listProbes();
+
+      setAvailableProbes(probes ?? []);
+    };
+
+    fetchProbes();
+  }, [instance]);
+
+  useEffect(() => {
+    onChange({
+      timeout: timeoutValue,
+      frequency: frequencyValue,
+      probes: selectedProbes,
+    });
+  }, [timeoutValue, frequencyValue, selectedProbes, onChange]);
+
+  return (
+    <div>
+      <h3 className={styles.header}>Probe Options</h3>
+      <Field
+        label="Probe Locations"
+        description="Select up to 20 locations where this target will be checked from."
+        disabled={!isEditor}
+        invalid={!validateProbes(selectedProbes)}
+      >
+        <CheckProbes
+          probes={selectedProbes}
+          availableProbes={availableProbes}
+          onUpdate={setSelectedProbes}
+          isEditor={isEditor}
+        />
+      </Field>
+      <Field
+        label="Frequency"
+        description="How frequently the check should run."
+        disabled={!isEditor}
+        invalid={!validateFrequency(frequencyValue)}
+      >
+        <Input
+          label="Frequency"
+          type="number"
+          step={10}
+          value={frequency / 1000}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setFrequencyValue(e.target.valueAsNumber * 1000)}
+          suffix="seconds"
+          max={120}
+          min={10}
+          width={30}
+        />
+      </Field>
+      <Field
+        label="Timeout"
+        description="Maximum execution time for a check"
+        disabled={!isEditor}
+        invalid={!validateTimeout(timeout)}
+      >
+        <Input
+          label="Timeout"
+          type="number"
+          step={0.1}
+          value={timeout / 1000}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setTimeoutValue(e.target.valueAsNumber * 1000)}
+          suffix="seconds"
+          max={10}
+          min={1}
+          width={30}
+        />
+      </Field>
+    </div>
+  );
+};

--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -90,7 +90,7 @@ export const ProbeOptions: FC<Props> = ({ frequency, timeout, isEditor, onChange
           max={10}
           min={1}
           suffixLabel="seconds"
-          separationLabel="every"
+          separationLabel="after"
           onChange={value => setTimeoutValue(value * 1000)}
         />
       </Field>

--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -1,6 +1,6 @@
-import React, { FC, useState, useEffect, useContext, ChangeEvent } from 'react';
+import React, { FC, useState, useEffect, useContext } from 'react';
 import { css } from 'emotion';
-import { Field, Input } from '@grafana/ui';
+import { Field } from '@grafana/ui';
 import { validateFrequency, validateProbes, validateTimeout } from 'validation';
 import CheckProbes from './CheckProbes';
 import { InstanceContext } from 'components/InstanceContext';

--- a/src/components/Collapse.tsx
+++ b/src/components/Collapse.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from 'react';
+import { Collapse as GrafanaCollapse } from '@grafana/ui';
+import { css } from 'emotion';
+
+interface Props {
+  isOpen?: boolean;
+  label: string;
+  loading?: boolean;
+  collapsible?: boolean;
+  onToggle?: (isOpen: boolean) => void;
+}
+
+export const Collapse: FC<Props> = props => (
+  <div
+    className={css`
+      .panel-container {
+        border-right: none;
+        border-left: none;
+        border-bottom: none;
+      }
+      .panel-container :first-child {
+        padding-left: 0px;
+      }
+    `}
+  >
+    <GrafanaCollapse {...props} />
+  </div>
+);

--- a/src/components/Collapse.tsx
+++ b/src/components/Collapse.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Collapse as GrafanaCollapse } from '@grafana/ui';
+import { Collapse as GrafanaCollapse, useTheme } from '@grafana/ui';
 import { css } from 'emotion';
 
 interface Props {
@@ -10,23 +10,27 @@ interface Props {
   onToggle?: (isOpen: boolean) => void;
 }
 
-const containerStyles = css`
-  .panel-container {
-    border-right: none;
-    border-left: none;
-    border-bottom: none;
-    margin-bottom: 0;
-  }
-  .panel-container > div:first-of-type {
-    padding: 16px 0px;
-  }
-  .panel-container > div:nth-child(2) {
-    padding: 0 8px;
-  }
-`;
+export const Collapse: FC<Props> = ({ isOpen, ...props }) => {
+  const theme = useTheme();
 
-export const Collapse: FC<Props> = ({ isOpen, ...props }) => (
-  <div className={containerStyles}>
-    <GrafanaCollapse isOpen={isOpen} {...props} />
-  </div>
-);
+  const containerStyles = css`
+    .panel-container {
+      border-right: none;
+      border-left: none;
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+    .panel-container > div:first-of-type {
+      padding: ${theme.spacing.md} 0px;
+    }
+    .panel-container > div:nth-child(2) {
+      padding: 0 ${theme.spacing.sm};
+    }
+  `;
+
+  return (
+    <div className={containerStyles}>
+      <GrafanaCollapse isOpen={isOpen} {...props} />
+    </div>
+  );
+};

--- a/src/components/Collapse.tsx
+++ b/src/components/Collapse.tsx
@@ -10,19 +10,23 @@ interface Props {
   onToggle?: (isOpen: boolean) => void;
 }
 
-export const Collapse: FC<Props> = props => (
-  <div
-    className={css`
-      .panel-container {
-        border-right: none;
-        border-left: none;
-        border-bottom: none;
-      }
-      .panel-container :first-child {
-        padding-left: 0px;
-      }
-    `}
-  >
-    <GrafanaCollapse {...props} />
+const containerStyles = css`
+  .panel-container {
+    border-right: none;
+    border-left: none;
+    border-bottom: none;
+    margin-bottom: 0;
+  }
+  .panel-container > div:first-of-type {
+    padding: 16px 0px;
+  }
+  .panel-container > div:nth-child(2) {
+    padding: 0 8px;
+  }
+`;
+
+export const Collapse: FC<Props> = ({ isOpen, ...props }) => (
+  <div className={containerStyles}>
+    <GrafanaCollapse isOpen={isOpen} {...props} />
   </div>
 );

--- a/src/components/DnsSettings.test.tsx
+++ b/src/components/DnsSettings.test.tsx
@@ -4,6 +4,7 @@ import { screen, render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DnsResponseCodes, Label } from 'types';
 jest.unmock('utils');
+jest.setTimeout(10000);
 
 const onUpdateMock = jest.fn();
 const defaultSettings = {};

--- a/src/components/DnsSettings.test.tsx
+++ b/src/components/DnsSettings.test.tsx
@@ -33,8 +33,8 @@ describe('Validations', () => {
     userEvent.click(addButton);
     const addInput = await within(answerValidations).findByRole('textbox');
     await userEvent.type(addInput, 'a validation');
-    expect(onUpdateMock).toHaveBeenLastCalledWith(
-      {
+    expect(onUpdateMock).toHaveBeenLastCalledWith({
+      settings: {
         dns: {
           ipVersion: 'V4',
           port: 53,
@@ -56,8 +56,8 @@ describe('Validations', () => {
           },
         },
       },
-      []
-    );
+      labels: [],
+    });
   });
 
   it('adds answer does not match validations', async () => {
@@ -69,8 +69,8 @@ describe('Validations', () => {
     userEvent.click(addButton);
     const addInput = await within(answerValidations).findByRole('textbox');
     await userEvent.type(addInput, 'a validation');
-    expect(onUpdateMock).toHaveBeenLastCalledWith(
-      {
+    expect(onUpdateMock).toHaveBeenLastCalledWith({
+      settings: {
         dns: {
           ipVersion: 'V4',
           port: 53,
@@ -92,8 +92,8 @@ describe('Validations', () => {
           },
         },
       },
-      []
-    );
+      labels: [],
+    });
   });
 
   it('adds authority does match validations', async () => {
@@ -105,8 +105,8 @@ describe('Validations', () => {
     userEvent.click(addButton);
     const addInput = await within(answerValidations).findByRole('textbox');
     await userEvent.type(addInput, 'a validation');
-    expect(onUpdateMock).toHaveBeenLastCalledWith(
-      {
+    expect(onUpdateMock).toHaveBeenLastCalledWith({
+      settings: {
         dns: {
           ipVersion: 'V4',
           port: 53,
@@ -128,8 +128,8 @@ describe('Validations', () => {
           },
         },
       },
-      []
-    );
+      labels: [],
+    });
   });
 
   it('adds authority does not match validations', async () => {
@@ -141,8 +141,8 @@ describe('Validations', () => {
     userEvent.click(addButton);
     const addInput = await within(answerValidations).findByRole('textbox');
     await userEvent.type(addInput, 'a validation');
-    expect(onUpdateMock).toHaveBeenLastCalledWith(
-      {
+    expect(onUpdateMock).toHaveBeenLastCalledWith({
+      settings: {
         dns: {
           ipVersion: 'V4',
           port: 53,
@@ -164,8 +164,8 @@ describe('Validations', () => {
           },
         },
       },
-      []
-    );
+      labels: [],
+    });
   });
 });
 

--- a/src/components/DnsSettings.test.tsx
+++ b/src/components/DnsSettings.test.tsx
@@ -2,14 +2,20 @@ import React from 'react';
 import DnsSettingsForm from './DnsSettings';
 import { screen, render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { DnsResponseCodes } from 'types';
+import { DnsResponseCodes, Label } from 'types';
 jest.unmock('utils');
 
 const onUpdateMock = jest.fn();
 const defaultSettings = {};
+const defaultLabels: Label[] = [];
 
-const renderDnsSettings = ({ isEditor = true, onUpdate = onUpdateMock, settings = defaultSettings } = {}) => {
-  return render(<DnsSettingsForm settings={settings} onUpdate={onUpdate} isEditor={isEditor} />);
+const renderDnsSettings = ({
+  isEditor = true,
+  onUpdate = onUpdateMock,
+  settings = defaultSettings,
+  labels = defaultLabels,
+} = {}) => {
+  return render(<DnsSettingsForm labels={labels} settings={settings} onUpdate={onUpdate} isEditor={isEditor} />);
 };
 
 beforeEach(() => {
@@ -26,28 +32,31 @@ describe('Validations', () => {
     userEvent.click(addButton);
     const addInput = await within(answerValidations).findByRole('textbox');
     await userEvent.type(addInput, 'a validation');
-    expect(onUpdateMock).toHaveBeenLastCalledWith({
-      dns: {
-        ipVersion: 'V4',
-        port: 53,
-        protocol: 'UDP',
-        recordType: 'A',
-        server: '8.8.8.8',
-        validRCodes: [DnsResponseCodes.NOERROR],
-        validateAdditionalRRS: {
-          failIfMatchesRegexp: [],
-          failIfNotMatchesRegexp: [],
-        },
-        validateAnswerRRS: {
-          failIfMatchesRegexp: ['a validation'],
-          failIfNotMatchesRegexp: [],
-        },
-        validateAuthorityRRS: {
-          failIfMatchesRegexp: [],
-          failIfNotMatchesRegexp: [],
+    expect(onUpdateMock).toHaveBeenLastCalledWith(
+      {
+        dns: {
+          ipVersion: 'V4',
+          port: 53,
+          protocol: 'UDP',
+          recordType: 'A',
+          server: '8.8.8.8',
+          validRCodes: [DnsResponseCodes.NOERROR],
+          validateAdditionalRRS: {
+            failIfMatchesRegexp: [],
+            failIfNotMatchesRegexp: [],
+          },
+          validateAnswerRRS: {
+            failIfMatchesRegexp: ['a validation'],
+            failIfNotMatchesRegexp: [],
+          },
+          validateAuthorityRRS: {
+            failIfMatchesRegexp: [],
+            failIfNotMatchesRegexp: [],
+          },
         },
       },
-    });
+      []
+    );
   });
 
   it('adds answer does not match validations', async () => {
@@ -59,28 +68,31 @@ describe('Validations', () => {
     userEvent.click(addButton);
     const addInput = await within(answerValidations).findByRole('textbox');
     await userEvent.type(addInput, 'a validation');
-    expect(onUpdateMock).toHaveBeenLastCalledWith({
-      dns: {
-        ipVersion: 'V4',
-        port: 53,
-        protocol: 'UDP',
-        recordType: 'A',
-        server: '8.8.8.8',
-        validRCodes: [DnsResponseCodes.NOERROR],
-        validateAdditionalRRS: {
-          failIfMatchesRegexp: [],
-          failIfNotMatchesRegexp: [],
-        },
-        validateAnswerRRS: {
-          failIfMatchesRegexp: [],
-          failIfNotMatchesRegexp: ['a validation'],
-        },
-        validateAuthorityRRS: {
-          failIfMatchesRegexp: [],
-          failIfNotMatchesRegexp: [],
+    expect(onUpdateMock).toHaveBeenLastCalledWith(
+      {
+        dns: {
+          ipVersion: 'V4',
+          port: 53,
+          protocol: 'UDP',
+          recordType: 'A',
+          server: '8.8.8.8',
+          validRCodes: [DnsResponseCodes.NOERROR],
+          validateAdditionalRRS: {
+            failIfMatchesRegexp: [],
+            failIfNotMatchesRegexp: [],
+          },
+          validateAnswerRRS: {
+            failIfMatchesRegexp: [],
+            failIfNotMatchesRegexp: ['a validation'],
+          },
+          validateAuthorityRRS: {
+            failIfMatchesRegexp: [],
+            failIfNotMatchesRegexp: [],
+          },
         },
       },
-    });
+      []
+    );
   });
 
   it('adds authority does match validations', async () => {
@@ -92,28 +104,31 @@ describe('Validations', () => {
     userEvent.click(addButton);
     const addInput = await within(answerValidations).findByRole('textbox');
     await userEvent.type(addInput, 'a validation');
-    expect(onUpdateMock).toHaveBeenLastCalledWith({
-      dns: {
-        ipVersion: 'V4',
-        port: 53,
-        protocol: 'UDP',
-        recordType: 'A',
-        server: '8.8.8.8',
-        validRCodes: [DnsResponseCodes.NOERROR],
-        validateAdditionalRRS: {
-          failIfMatchesRegexp: [],
-          failIfNotMatchesRegexp: [],
-        },
-        validateAnswerRRS: {
-          failIfMatchesRegexp: [],
-          failIfNotMatchesRegexp: [],
-        },
-        validateAuthorityRRS: {
-          failIfMatchesRegexp: ['a validation'],
-          failIfNotMatchesRegexp: [],
+    expect(onUpdateMock).toHaveBeenLastCalledWith(
+      {
+        dns: {
+          ipVersion: 'V4',
+          port: 53,
+          protocol: 'UDP',
+          recordType: 'A',
+          server: '8.8.8.8',
+          validRCodes: [DnsResponseCodes.NOERROR],
+          validateAdditionalRRS: {
+            failIfMatchesRegexp: [],
+            failIfNotMatchesRegexp: [],
+          },
+          validateAnswerRRS: {
+            failIfMatchesRegexp: [],
+            failIfNotMatchesRegexp: [],
+          },
+          validateAuthorityRRS: {
+            failIfMatchesRegexp: ['a validation'],
+            failIfNotMatchesRegexp: [],
+          },
         },
       },
-    });
+      []
+    );
   });
 
   it('adds authority does not match validations', async () => {
@@ -125,28 +140,31 @@ describe('Validations', () => {
     userEvent.click(addButton);
     const addInput = await within(answerValidations).findByRole('textbox');
     await userEvent.type(addInput, 'a validation');
-    expect(onUpdateMock).toHaveBeenLastCalledWith({
-      dns: {
-        ipVersion: 'V4',
-        port: 53,
-        protocol: 'UDP',
-        recordType: 'A',
-        server: '8.8.8.8',
-        validRCodes: [DnsResponseCodes.NOERROR],
-        validateAdditionalRRS: {
-          failIfMatchesRegexp: [],
-          failIfNotMatchesRegexp: [],
-        },
-        validateAnswerRRS: {
-          failIfMatchesRegexp: [],
-          failIfNotMatchesRegexp: [],
-        },
-        validateAuthorityRRS: {
-          failIfMatchesRegexp: [],
-          failIfNotMatchesRegexp: ['a validation'],
+    expect(onUpdateMock).toHaveBeenLastCalledWith(
+      {
+        dns: {
+          ipVersion: 'V4',
+          port: 53,
+          protocol: 'UDP',
+          recordType: 'A',
+          server: '8.8.8.8',
+          validRCodes: [DnsResponseCodes.NOERROR],
+          validateAdditionalRRS: {
+            failIfMatchesRegexp: [],
+            failIfNotMatchesRegexp: [],
+          },
+          validateAnswerRRS: {
+            failIfMatchesRegexp: [],
+            failIfNotMatchesRegexp: [],
+          },
+          validateAuthorityRRS: {
+            failIfMatchesRegexp: [],
+            failIfNotMatchesRegexp: ['a validation'],
+          },
         },
       },
-    });
+      []
+    );
   });
 });
 

--- a/src/components/DnsSettings.tsx
+++ b/src/components/DnsSettings.tsx
@@ -69,6 +69,24 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
     []
   );
 
+  const onValidateAuthorityChange = useCallback(
+    (validations: DNSRRValidator | undefined) => {
+      const dns = getUpdatedSettings(values, { name: 'validateAuthorityRRS', value: validations });
+      onUpdate({ dns }, labels);
+    },
+    // eslint-disable-next-line
+    []
+  );
+
+  const onValidateAdditionalChange = useCallback(
+    (validations: DNSRRValidator | undefined) => {
+      const dns = getUpdatedSettings(values, { name: 'validateAdditionalRRS', value: validations });
+      onUpdate({ dns }, labels);
+    },
+    // eslint-disable-next-line
+    []
+  );
+
   return (
     <Container>
       <Collapse
@@ -176,26 +194,20 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
             onChange={onValidateAnswerChange}
             isEditor={isEditor}
           />
-          {/* <DnsValidatorForm
+          <DnsValidatorForm
             name="Validate Authority"
             description="Validate entries in the Authority section of the DNS response"
             validations={values.validateAuthorityRRS}
-            onChange={(validations: DNSRRValidator | undefined) => {
-              const dns = getUpdatedSettings(values, { name: 'validateAuthorityRRS', value: validations });
-              onUpdate({ dns }, labels);
-            }}
+            onChange={onValidateAuthorityChange}
             isEditor={isEditor}
           />
           <DnsValidatorForm
             name="Validate Additional"
             description="Validate entries in the Additional section of the DNS response"
             validations={values.validateAdditionalRRS}
-            onChange={(validations: DNSRRValidator | undefined) => {
-              const dns = getUpdatedSettings(values, { name: 'validateAdditionalRRS', value: validations });
-              onUpdate({ dns }, labels);
-            }}
+            onChange={onValidateAdditionalChange}
             isEditor={isEditor}
-          /> */}
+          />
         </div>
       </Collapse>
       <Collapse

--- a/src/components/DnsSettings.tsx
+++ b/src/components/DnsSettings.tsx
@@ -1,15 +1,26 @@
-import React, { FC, ChangeEvent, useState } from 'react';
+import React, { FC, ChangeEvent, useState, useCallback, useMemo } from 'react';
 import { css } from 'emotion';
 import { Collapse, Container, HorizontalGroup, Field, Select, MultiSelect, Input } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
-import { IpVersion, Settings, DnsSettings, DnsProtocol, DnsRecordType, DNSRRValidator, DnsResponseCodes } from 'types';
+import {
+  IpVersion,
+  Label,
+  Settings,
+  DnsSettings,
+  DnsProtocol,
+  DnsRecordType,
+  DNSRRValidator,
+  DnsResponseCodes,
+} from 'types';
 import DnsValidatorForm from './DnsValidatorForm';
+import { LabelField } from './LabelField';
 import { DNS_RESPONSE_CODES, DNS_RECORD_TYPES, DNS_PROTOCOLS, IP_OPTIONS } from './constants';
 
 interface Props {
   settings: Settings;
   isEditor: boolean;
-  onUpdate: (settings: Settings) => void;
+  labels: Label[];
+  onUpdate: (settings: Settings, labels: Label[]) => void;
 }
 
 const defaultValues = {
@@ -37,80 +48,103 @@ function getUpdatedSettings(settings: DnsSettings, action: Action): DnsSettings 
   };
 }
 
-const DnsSettingsForm: FC<Props> = ({ settings, isEditor, onUpdate }) => {
-  const values = {
-    ...defaultValues,
-    ...settings.dns,
-  };
+const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) => {
+  const values = useMemo(
+    () => ({
+      ...defaultValues,
+      ...settings.dns,
+    }),
+    [settings.dns]
+  );
 
   const [showValidation, setShowValidation] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [showDNSSettings, setShowDNSSettings] = useState(false);
+  const onValidateAnswerChange = useCallback(
+    (validations: DNSRRValidator | undefined) => {
+      const dns = getUpdatedSettings(values, { name: 'validateAnswerRRS', value: validations });
+      onUpdate({ dns }, labels);
+    },
+    // eslint-disable-next-line
+    []
+  );
 
   return (
     <Container>
-      <HorizontalGroup>
-        <Field label="Record Type" description="DNS record type to query for" disabled={!isEditor}>
-          <Select
-            value={values.recordType}
-            options={DNS_RECORD_TYPES}
-            onChange={(selected: SelectableValue<DnsRecordType>) => {
-              const dns = getUpdatedSettings(values, {
-                name: 'recordType',
-                value: selected.value,
-                fallbackValue: DnsRecordType.A,
-              });
-              onUpdate({ dns });
-            }}
-          />
-        </Field>
-        <Field label="Server" description="Address of server to query" disabled={!isEditor}>
-          <Input
-            id="dns-settings-server-address"
-            value={values.server}
-            type="text"
-            placeholder="server"
-            onChange={(e: ChangeEvent<HTMLInputElement>) => {
-              const dns = getUpdatedSettings(values, {
-                name: 'server',
-                value: e.target.value,
-                fallbackValue: '8.8.8.8',
-              });
-              onUpdate({ dns });
-            }}
-          />
-        </Field>
-        <Field label="Protocol" description="Transport protocol to use" disabled={!isEditor}>
-          <Select
-            value={values.protocol}
-            options={DNS_PROTOCOLS}
-            onChange={selected => {
-              const dns = getUpdatedSettings(values, {
-                name: 'protocol',
-                value: selected.value,
-                fallbackValue: DnsProtocol.UDP,
-              });
-              onUpdate({ dns });
-            }}
-          />
-        </Field>
-        <Field label="Port" description="port on server to query" disabled={!isEditor}>
-          <Input
-            id="dns-settings-port"
-            value={values.port}
-            type="number"
-            placeholder="port"
-            onChange={(e: ChangeEvent<HTMLInputElement>) => {
-              const dns = getUpdatedSettings(values, { name: 'port', value: e.target.value, fallbackValue: 53 });
-              onUpdate({ dns });
-            }}
-          />
-        </Field>
-      </HorizontalGroup>
+      <Collapse
+        label="DNS Settings"
+        onToggle={() => setShowDNSSettings(!showDNSSettings)}
+        isOpen={showDNSSettings}
+        collapsible
+      >
+        <div
+          className={css`
+            max-width: 240px;
+          `}
+        >
+          <Field label="Record Type" disabled={!isEditor}>
+            <Select
+              value={values.recordType}
+              options={DNS_RECORD_TYPES}
+              onChange={(selected: SelectableValue<DnsRecordType>) => {
+                const dns = getUpdatedSettings(values, {
+                  name: 'recordType',
+                  value: selected.value,
+                  fallbackValue: DnsRecordType.A,
+                });
+                onUpdate({ dns }, labels);
+              }}
+            />
+          </Field>
+          <Field label="Server" disabled={!isEditor}>
+            <Input
+              id="dns-settings-server-address"
+              value={values.server}
+              type="text"
+              placeholder="server"
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                const dns = getUpdatedSettings(values, {
+                  name: 'server',
+                  value: e.target.value,
+                  fallbackValue: '8.8.8.8',
+                });
+                onUpdate({ dns }, labels);
+              }}
+            />
+          </Field>
+          <Field label="Protocol" disabled={!isEditor}>
+            <Select
+              value={values.protocol}
+              options={DNS_PROTOCOLS}
+              onChange={selected => {
+                const dns = getUpdatedSettings(values, {
+                  name: 'protocol',
+                  value: selected.value,
+                  fallbackValue: DnsProtocol.UDP,
+                });
+                onUpdate({ dns }, labels);
+              }}
+            />
+          </Field>
+          <Field label="Port" disabled={!isEditor}>
+            <Input
+              id="dns-settings-port"
+              value={values.port}
+              type="number"
+              placeholder="port"
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                const dns = getUpdatedSettings(values, { name: 'port', value: e.target.value, fallbackValue: 53 });
+                onUpdate({ dns }, labels);
+              }}
+            />
+          </Field>
+        </div>
+      </Collapse>
       <Collapse
         label="Validation"
-        collapsible={true}
         onToggle={() => setShowValidation(!showValidation)}
         isOpen={showValidation}
+        collapsible
       >
         <HorizontalGroup>
           <Field label="Valid Response Codes" description="List of valid response codes" disabled={!isEditor}>
@@ -123,7 +157,7 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, onUpdate }) => {
                   value: responseCodes.map(code => code.value),
                   fallbackValue: [DnsResponseCodes.NOERROR],
                 });
-                onUpdate({ dns });
+                onUpdate({ dns }, labels);
               }}
             />
           </Field>
@@ -139,19 +173,16 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, onUpdate }) => {
             name="Validate Answer"
             description="Validate entries in the Answer section of the DNS response"
             validations={values.validateAnswerRRS}
-            onChange={(validations: DNSRRValidator | undefined) => {
-              const dns = getUpdatedSettings(values, { name: 'validateAnswerRRS', value: validations });
-              onUpdate({ dns });
-            }}
+            onChange={onValidateAnswerChange}
             isEditor={isEditor}
           />
-          <DnsValidatorForm
+          {/* <DnsValidatorForm
             name="Validate Authority"
             description="Validate entries in the Authority section of the DNS response"
             validations={values.validateAuthorityRRS}
             onChange={(validations: DNSRRValidator | undefined) => {
               const dns = getUpdatedSettings(values, { name: 'validateAuthorityRRS', value: validations });
-              onUpdate({ dns });
+              onUpdate({ dns }, labels);
             }}
             isEditor={isEditor}
           />
@@ -161,10 +192,10 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, onUpdate }) => {
             validations={values.validateAdditionalRRS}
             onChange={(validations: DNSRRValidator | undefined) => {
               const dns = getUpdatedSettings(values, { name: 'validateAdditionalRRS', value: validations });
-              onUpdate({ dns });
+              onUpdate({ dns }, labels);
             }}
             isEditor={isEditor}
-          />
+          /> */}
         </div>
       </Collapse>
       <Collapse
@@ -173,23 +204,28 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, onUpdate }) => {
         onToggle={() => setShowAdvanced(!showAdvanced)}
         isOpen={showAdvanced}
       >
+        <LabelField
+          isEditor={isEditor}
+          labels={labels}
+          onLabelsUpdate={labelsValue => {
+            onUpdate({ dns: values }, labelsValue);
+          }}
+        />
         <HorizontalGroup>
-          <div>
-            <Field label="IP Version" description="The IP protocol of the ICMP request" disabled={!isEditor}>
-              <Select
-                value={values.ipVersion}
-                options={IP_OPTIONS}
-                onChange={selected => {
-                  const dns = getUpdatedSettings(values, {
-                    name: 'ipVersion',
-                    value: selected.value,
-                    fallbackValue: IpVersion.Any,
-                  });
-                  onUpdate({ dns });
-                }}
-              />
-            </Field>
-          </div>
+          <Field label="IP Version" description="The IP protocol of the ICMP request" disabled={!isEditor}>
+            <Select
+              value={values.ipVersion}
+              options={IP_OPTIONS}
+              onChange={selected => {
+                const dns = getUpdatedSettings(values, {
+                  name: 'ipVersion',
+                  value: selected.value,
+                  fallbackValue: IpVersion.Any,
+                });
+                onUpdate({ dns }, labels);
+              }}
+            />
+          </Field>
         </HorizontalGroup>
       </Collapse>
     </Container>

--- a/src/components/DnsSettings.tsx
+++ b/src/components/DnsSettings.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ChangeEvent, useState, useCallback, useMemo } from 'react';
 import { css } from 'emotion';
-import { Collapse, Container, HorizontalGroup, Field, Select, MultiSelect, Input } from '@grafana/ui';
+import { Container, HorizontalGroup, Field, Select, MultiSelect, Input } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import {
   IpVersion,
@@ -13,6 +13,7 @@ import {
   DnsResponseCodes,
 } from 'types';
 import DnsValidatorForm from './DnsValidatorForm';
+import { Collapse } from 'components/Collapse';
 import { LabelField } from './LabelField';
 import { DNS_RESPONSE_CODES, DNS_RECORD_TYPES, DNS_PROTOCOLS, IP_OPTIONS } from './constants';
 
@@ -163,6 +164,9 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
         onToggle={() => setShowValidation(!showValidation)}
         isOpen={showValidation}
         collapsible
+        css={css`
+          border: none;
+        `}
       >
         <HorizontalGroup>
           <Field label="Valid Response Codes" description="List of valid response codes" disabled={!isEditor}>

--- a/src/components/DnsSettings.tsx
+++ b/src/components/DnsSettings.tsx
@@ -11,6 +11,7 @@ import {
   DnsRecordType,
   DNSRRValidator,
   DnsResponseCodes,
+  OnUpdateSettingsArgs,
 } from 'types';
 import DnsValidatorForm from './DnsValidatorForm';
 import { Collapse } from 'components/Collapse';
@@ -21,7 +22,7 @@ interface Props {
   settings: Settings;
   isEditor: boolean;
   labels: Label[];
-  onUpdate: (settings: Settings, labels: Label[]) => void;
+  onUpdate: (args: OnUpdateSettingsArgs) => void;
 }
 
 const defaultValues = {
@@ -55,7 +56,7 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
       ...defaultValues,
       ...settings.dns,
     }),
-    [settings.dns]
+    [settings]
   );
 
   const [showValidation, setShowValidation] = useState(false);
@@ -64,28 +65,25 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
   const onValidateAnswerChange = useCallback(
     (validations: DNSRRValidator | undefined) => {
       const dns = getUpdatedSettings(values, { name: 'validateAnswerRRS', value: validations });
-      onUpdate({ dns }, labels);
+      onUpdate({ settings: { dns }, labels });
     },
-    // eslint-disable-next-line
-    []
+    [onUpdate, labels, values]
   );
 
   const onValidateAuthorityChange = useCallback(
     (validations: DNSRRValidator | undefined) => {
       const dns = getUpdatedSettings(values, { name: 'validateAuthorityRRS', value: validations });
-      onUpdate({ dns }, labels);
+      onUpdate({ settings: { dns }, labels });
     },
-    // eslint-disable-next-line
-    []
+    [onUpdate, labels, values]
   );
 
   const onValidateAdditionalChange = useCallback(
     (validations: DNSRRValidator | undefined) => {
       const dns = getUpdatedSettings(values, { name: 'validateAdditionalRRS', value: validations });
-      onUpdate({ dns }, labels);
+      onUpdate({ settings: { dns }, labels });
     },
-    // eslint-disable-next-line
-    []
+    [onUpdate, labels, values]
   );
 
   return (
@@ -111,7 +109,7 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
                   value: selected.value,
                   fallbackValue: DnsRecordType.A,
                 });
-                onUpdate({ dns }, labels);
+                onUpdate({ settings: { dns }, labels });
               }}
             />
           </Field>
@@ -127,7 +125,7 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
                   value: e.target.value,
                   fallbackValue: '8.8.8.8',
                 });
-                onUpdate({ dns }, labels);
+                onUpdate({ settings: { dns }, labels });
               }}
             />
           </Field>
@@ -141,7 +139,7 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
                   value: selected.value,
                   fallbackValue: DnsProtocol.UDP,
                 });
-                onUpdate({ dns }, labels);
+                onUpdate({ settings: { dns }, labels });
               }}
             />
           </Field>
@@ -153,7 +151,7 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
               placeholder="port"
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const dns = getUpdatedSettings(values, { name: 'port', value: e.target.value, fallbackValue: 53 });
-                onUpdate({ dns }, labels);
+                onUpdate({ settings: { dns }, labels });
               }}
             />
           </Field>
@@ -164,9 +162,6 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
         onToggle={() => setShowValidation(!showValidation)}
         isOpen={showValidation}
         collapsible
-        css={css`
-          border: none;
-        `}
       >
         <HorizontalGroup>
           <Field label="Valid Response Codes" description="List of valid response codes" disabled={!isEditor}>
@@ -179,7 +174,7 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
                   value: responseCodes.map(code => code.value),
                   fallbackValue: [DnsResponseCodes.NOERROR],
                 });
-                onUpdate({ dns }, labels);
+                onUpdate({ settings: { dns }, labels });
               }}
             />
           </Field>
@@ -224,7 +219,7 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
           isEditor={isEditor}
           labels={labels}
           onLabelsUpdate={labelsValue => {
-            onUpdate({ dns: values }, labelsValue);
+            onUpdate({ settings: { dns: values }, labels: labelsValue });
           }}
         />
         <HorizontalGroup>
@@ -238,7 +233,7 @@ const DnsSettingsForm: FC<Props> = ({ settings, isEditor, labels, onUpdate }) =>
                   value: selected.value,
                   fallbackValue: IpVersion.Any,
                 });
-                onUpdate({ dns }, labels);
+                onUpdate({ settings: { dns }, labels });
               }}
             />
           </Field>

--- a/src/components/DnsValidatorForm.tsx
+++ b/src/components/DnsValidatorForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useCallback, useMemo } from 'react';
 import { DNSRRValidator } from 'types';
 import ListInput from './ListInput';
 
@@ -11,8 +11,28 @@ interface Props {
 }
 
 const DnsValidatorForm: FC<Props> = ({ onChange, validations, isEditor, name, description }) => {
-  const failIfMatchesRegexp = validations?.failIfMatchesRegexp ?? [];
-  const failIfNotMatchesRegexp = validations?.failIfNotMatchesRegexp ?? [];
+  const failIfMatchesRegexp = useMemo(() => validations?.failIfMatchesRegexp ?? [], [validations]);
+  const failIfNotMatchesRegexp = useMemo(() => validations?.failIfNotMatchesRegexp ?? [], [validations]);
+
+  const onFailIfMatchesUpdate = useCallback(
+    (failIfMatches: string[]) => {
+      onChange({
+        failIfMatchesRegexp: failIfMatches,
+        failIfNotMatchesRegexp,
+      });
+    },
+    [onChange, failIfNotMatchesRegexp]
+  );
+
+  const onFailIfNotMatchesUpdate = useCallback(
+    (failIfNotMatches: string[]) => {
+      onChange({
+        failIfNotMatchesRegexp: failIfNotMatches,
+        failIfMatchesRegexp,
+      });
+    },
+    [onChange, failIfMatchesRegexp]
+  );
 
   const dataTestId = name.replace(' ', '-').toLowerCase();
   return (
@@ -23,12 +43,7 @@ const DnsValidatorForm: FC<Props> = ({ onChange, validations, isEditor, name, de
         description={`${description} match`}
         placeholder="Enter regexp"
         items={failIfMatchesRegexp}
-        onUpdate={(failIfMatches: string[]) => {
-          onChange({
-            failIfMatchesRegexp: failIfMatches,
-            failIfNotMatchesRegexp,
-          });
-        }}
+        onUpdate={onFailIfMatchesUpdate}
         disabled={!isEditor}
       />
       <ListInput
@@ -37,12 +52,7 @@ const DnsValidatorForm: FC<Props> = ({ onChange, validations, isEditor, name, de
         description={`${description} don't match`}
         placeholder="Enter regexp"
         items={failIfNotMatchesRegexp}
-        onUpdate={(failIfNotMatches: string[]) => {
-          onChange({
-            failIfNotMatchesRegexp: failIfNotMatches,
-            failIfMatchesRegexp,
-          });
-        }}
+        onUpdate={onFailIfNotMatchesUpdate}
         disabled={!isEditor}
       />
     </>

--- a/src/components/LabelField.tsx
+++ b/src/components/LabelField.tsx
@@ -1,0 +1,22 @@
+import React, { FC } from 'react';
+import { Field } from '@grafana/ui';
+import SMLabelsForm from 'components/SMLabelsForm';
+import { validateLabels } from 'validation';
+import { Label } from 'types';
+
+interface Props {
+  labels: Label[];
+  onLabelsUpdate: (labels: Label[]) => void;
+  isEditor: boolean;
+}
+
+export const LabelField: FC<Props> = ({ labels, onLabelsUpdate, isEditor }) => (
+  <Field
+    label="Labels"
+    description="Custom labels to be included with collected metrics and logs."
+    disabled={!isEditor}
+    invalid={!validateLabels(labels)}
+  >
+    <SMLabelsForm labels={labels} onUpdate={onLabelsUpdate} isEditor={isEditor} type="Label" limit={5} />
+  </Field>
+);

--- a/src/components/ListInput.tsx
+++ b/src/components/ListInput.tsx
@@ -56,6 +56,7 @@ const ListInput: FC<Props> = ({
   className,
 }) => {
   const [state, dispatch] = useReducer(listInputReducer, items);
+
   useEffect(() => {
     onUpdate(state);
   }, [state, onUpdate]);

--- a/src/components/PingSettings.tsx
+++ b/src/components/PingSettings.tsx
@@ -1,31 +1,35 @@
 import React, { PureComponent } from 'react';
 import { Collapse, Container, HorizontalGroup, Field, Select, Switch } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
-import { IpVersion, Settings, PingSettings } from 'types';
+import { IpVersion, Settings, PingSettings, Label } from 'types';
 import { IP_OPTIONS } from './constants';
+import { LabelField } from 'components/LabelField';
 
 interface Props {
   settings: Settings;
+  labels?: Label[];
   isEditor: boolean;
-  onUpdate: (settings: Settings) => void;
+  onUpdate: (settings: Settings, labels: Label[]) => void;
 }
 
 interface State extends PingSettings {
   showAdvanced: boolean;
+  settings?: Settings;
+  labels: Label[];
 }
 
 export class PingSettingsForm extends PureComponent<Props, State> {
   state: State = {
     ipVersion: this.props.settings!.ping?.ipVersion || IpVersion.V4,
     dontFragment: this.props.settings!.ping?.dontFragment || false,
+    labels: this.props.labels ?? [],
     showAdvanced: false,
   };
 
   onUpdate = () => {
-    const settings = this.state as PingSettings;
-    this.props.onUpdate({
-      ping: settings,
-    });
+    const { settings, labels } = this.state;
+    const pingSettings = { settings: { ping: settings } } as Settings;
+    this.props.onUpdate(pingSettings, labels);
   };
 
   onIpVersionChange = (value: SelectableValue<IpVersion>) => {
@@ -40,33 +44,36 @@ export class PingSettingsForm extends PureComponent<Props, State> {
     this.setState({ showAdvanced: !this.state.showAdvanced });
   };
 
+  onLabelsUpdate = (labels: Label[]) => {
+    this.setState({ labels }, this.onUpdate);
+  };
+
   render() {
-    const { ipVersion, dontFragment, showAdvanced } = this.state;
+    const { ipVersion, dontFragment, showAdvanced, labels } = this.state;
     const { isEditor } = this.props;
 
     return (
-      <Container>
-        <Collapse label="Advanced Options" collapsible={true} onToggle={this.onToggleOptions} isOpen={showAdvanced}>
-          <HorizontalGroup>
-            <div>
-              <Field label="IP Version" description="The IP protocol of the ICMP request" disabled={!isEditor}>
-                <Select value={ipVersion} options={IP_OPTIONS} onChange={this.onIpVersionChange} />
-              </Field>
-            </div>
-            <div>
-              <Field
-                label="Don't Fragment"
-                description="Set the DF-bit in the IP-header. Only works with ipV4"
-                disabled={!isEditor}
-              >
-                <Container padding="sm">
-                  <Switch value={dontFragment} onChange={this.onDontFragmentChange} disabled={!isEditor} />
-                </Container>
-              </Field>
-            </div>
-          </HorizontalGroup>
-        </Collapse>
-      </Container>
+      <Collapse label="Advanced Options" collapsible={true} onToggle={this.onToggleOptions} isOpen={showAdvanced}>
+        <LabelField labels={labels} isEditor={isEditor} onLabelsUpdate={this.onLabelsUpdate} />
+        <HorizontalGroup>
+          <div>
+            <Field label="IP Version" description="The IP protocol of the ICMP request" disabled={!isEditor}>
+              <Select value={ipVersion} options={IP_OPTIONS} onChange={this.onIpVersionChange} />
+            </Field>
+          </div>
+          <div>
+            <Field
+              label="Don't Fragment"
+              description="Set the DF-bit in the IP-header. Only works with ipV4"
+              disabled={!isEditor}
+            >
+              <Container padding="sm">
+                <Switch value={dontFragment} onChange={this.onDontFragmentChange} disabled={!isEditor} />
+              </Container>
+            </Field>
+          </div>
+        </HorizontalGroup>
+      </Collapse>
     );
   }
 }

--- a/src/components/PingSettings.tsx
+++ b/src/components/PingSettings.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import { Container, HorizontalGroup, Field, Select, Switch } from '@grafana/ui';
 import { Collapse } from 'components/Collapse';
 import { SelectableValue } from '@grafana/data';
-import { IpVersion, Settings, PingSettings, Label } from 'types';
+import { IpVersion, Settings, PingSettings, Label, OnUpdateSettingsArgs } from 'types';
 import { IP_OPTIONS } from './constants';
 import { LabelField } from 'components/LabelField';
 
@@ -10,7 +10,7 @@ interface Props {
   settings: Settings;
   labels?: Label[];
   isEditor: boolean;
-  onUpdate: (settings: Settings, labels: Label[]) => void;
+  onUpdate: (args: OnUpdateSettingsArgs) => void;
 }
 
 interface State extends PingSettings {
@@ -30,7 +30,7 @@ export class PingSettingsForm extends PureComponent<Props, State> {
   onUpdate = () => {
     const { settings, labels } = this.state;
     const pingSettings = { settings: { ping: settings } } as Settings;
-    this.props.onUpdate(pingSettings, labels);
+    this.props.onUpdate({ settings: pingSettings, labels });
   };
 
   onIpVersionChange = (value: SelectableValue<IpVersion>) => {

--- a/src/components/PingSettings.tsx
+++ b/src/components/PingSettings.tsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
-import { Collapse, Container, HorizontalGroup, Field, Select, Switch } from '@grafana/ui';
+import { Container, HorizontalGroup, Field, Select, Switch } from '@grafana/ui';
+import { Collapse } from 'components/Collapse';
 import { SelectableValue } from '@grafana/data';
 import { IpVersion, Settings, PingSettings, Label } from 'types';
 import { IP_OPTIONS } from './constants';

--- a/src/components/SliderInput.tsx
+++ b/src/components/SliderInput.tsx
@@ -20,7 +20,7 @@ const styles = {
   `,
   slider: css`
     width: 14rem;
-    margin-right: 1rem;
+    margin-right: 1.5rem;
     margin-left: 0;
   `,
   inputGroupWrapper: css`
@@ -29,6 +29,10 @@ const styles = {
     align-items: center;
   `,
   rightMargin: css`
+    margin-right: 0.5rem;
+  `,
+  sliderInput: css`
+    width: 40px;
     margin-right: 0.5rem;
   `,
 };
@@ -51,7 +55,7 @@ export const SliderInput: FC<Props> = ({ value, min, max, id, onChange, separati
         <Input
           id={id}
           invalid={invalid}
-          className={styles.rightMargin}
+          className={styles.sliderInput}
           type="number"
           value={value}
           max={max}

--- a/src/components/SliderInput.tsx
+++ b/src/components/SliderInput.tsx
@@ -1,0 +1,65 @@
+import React, { FC, ChangeEvent } from 'react';
+import { Slider, Input } from '@grafana/ui';
+import { css } from 'emotion';
+
+interface Props {
+  value: number;
+  min: number;
+  max: number;
+  id?: string;
+  separationLabel?: string;
+  suffixLabel?: string;
+  invalid?: boolean;
+  onChange: (value: number) => void;
+}
+
+const styles = {
+  container: css`
+    display: flex;
+    align-items: center;
+  `,
+  slider: css`
+    width: 14rem;
+    margin-right: 1rem;
+    margin-left: 0;
+  `,
+  inputGroupWrapper: css`
+    margin-top: 1rem;
+    display: flex;
+    align-items: center;
+  `,
+  rightMargin: css`
+    margin-right: 0.5rem;
+  `,
+};
+
+export const SliderInput: FC<Props> = ({ value, min, max, id, onChange, separationLabel, suffixLabel, invalid }) => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.slider}>
+        <Slider
+          tooltipAlwaysVisible={false}
+          css={styles.slider}
+          min={min}
+          max={max}
+          value={[value]}
+          onAfterChange={([value]) => onChange(value)}
+        />
+      </div>
+      <div className={styles.inputGroupWrapper}>
+        <span className={styles.rightMargin}>{separationLabel}</span>
+        <Input
+          id={id}
+          invalid={invalid}
+          className={styles.rightMargin}
+          type="number"
+          value={value}
+          max={max}
+          min={min}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.valueAsNumber)}
+        />
+        {suffixLabel}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Subheader.tsx
+++ b/src/components/Subheader.tsx
@@ -1,0 +1,20 @@
+import React, { FC } from 'react';
+import { css } from 'emotion';
+
+interface Props {
+  children: string;
+  className?: string;
+}
+
+export const Subheader: FC<Props> = ({ children, className }) => (
+  <h3
+    className={css`
+      font-size: 19px;
+      font-weight: 100;
+      line-height: 24px;
+      margin-bottom: 16px;
+    `}
+  >
+    {children}
+  </h3>
+);

--- a/src/components/TcpSettings/TcpSettings.tsx
+++ b/src/components/TcpSettings/TcpSettings.tsx
@@ -19,6 +19,7 @@ interface State extends TcpSettings {
   showQueryResponse: boolean;
   showAdvanced: boolean;
   showTLS: boolean;
+  showTCPSettings: boolean;
   labels: Label[];
 }
 /*
@@ -37,6 +38,7 @@ export default class TcpSettingsForm extends PureComponent<Props, State> {
     showQueryResponse: false,
     showAdvanced: false,
     showTLS: false,
+    showTCPSettings: false,
   };
 
   onUpdate = () => {
@@ -61,6 +63,10 @@ export default class TcpSettingsForm extends PureComponent<Props, State> {
 
   onToggleTLS = (isOpen: boolean) => {
     this.setState({ showTLS: !this.state.showTLS }, this.onUpdate);
+  };
+
+  onToggleTCPSettings = () => {
+    this.setState({ showTCPSettings: !this.state.showTCPSettings });
   };
 
   onTLSChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -97,26 +103,22 @@ export default class TcpSettingsForm extends PureComponent<Props, State> {
   };
 
   render() {
-    const { ipVersion, tls, showTLS, showQueryResponse, showAdvanced, tlsConfig, queryResponse, labels } = this.state;
+    const {
+      ipVersion,
+      tls,
+      showTCPSettings,
+      showTLS,
+      showQueryResponse,
+      showAdvanced,
+      tlsConfig,
+      queryResponse,
+      labels,
+    } = this.state;
     const { isEditor } = this.props;
 
     return (
       <Container>
-        <Collapse
-          label="Query/Response"
-          collapsible={true}
-          onToggle={this.onShowQueryResponse}
-          isOpen={showQueryResponse}
-        >
-          <Container>
-            <QueryResponseForm
-              queryResponses={queryResponse}
-              isEditor={isEditor}
-              onChange={this.onQueryResponsesUpdate}
-            />
-          </Container>
-        </Collapse>
-        <Collapse label="TLS Config" collapsible={true} onToggle={this.onToggleTLS} isOpen={showTLS}>
+        <Collapse label="TCP Settings" onToggle={this.onToggleTCPSettings} isOpen={showTCPSettings} collapsible>
           <Field
             label="Use TLS"
             description="Whether or not TLS is used when the connection is initiated."
@@ -126,9 +128,20 @@ export default class TcpSettingsForm extends PureComponent<Props, State> {
               <Switch title="Use TLS" value={tls} onChange={this.onTLSChange} disabled={!isEditor} />
             </Container>
           </Field>
+        </Collapse>
+        <Collapse label="Query/Response" onToggle={this.onShowQueryResponse} isOpen={showQueryResponse} collapsible>
+          <Container>
+            <QueryResponseForm
+              queryResponses={queryResponse}
+              isEditor={isEditor}
+              onChange={this.onQueryResponsesUpdate}
+            />
+          </Container>
+        </Collapse>
+        <Collapse label="TLS Config" onToggle={this.onToggleTLS} isOpen={showTLS} collapsible>
           <TLSForm onChange={this.onTLSCOnfigChange} isEditor={isEditor} tlsConfig={tlsConfig} />
         </Collapse>
-        <Collapse label="Advanced Options" collapsible={true} onToggle={this.onShowAdvanced} isOpen={showAdvanced}>
+        <Collapse label="Advanced Options" onToggle={this.onShowAdvanced} isOpen={showAdvanced} collapsible>
           <LabelField isEditor={isEditor} labels={labels} onLabelsUpdate={this.onLabelsChange} />
           <HorizontalGroup>
             <div>

--- a/src/components/TcpSettings/TcpSettings.tsx
+++ b/src/components/TcpSettings/TcpSettings.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { Container, HorizontalGroup, Field, Select, Switch } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
-import { IpVersion, Settings, TcpSettings, TLSConfig, TCPQueryResponse, Label } from 'types';
+import { IpVersion, Settings, TcpSettings, TLSConfig, TCPQueryResponse, Label, OnUpdateSettingsArgs } from 'types';
 import { TLSForm } from 'components/http/HttpSettings';
 import QueryResponseForm from './TcpQueryResponseForm';
 import { IP_OPTIONS } from '../constants';
@@ -12,7 +12,7 @@ interface Props {
   settings: Settings;
   isEditor: boolean;
   labels: Label[];
-  onUpdate: (settings: Settings, labels: Label[]) => void;
+  onUpdate: (args: OnUpdateSettingsArgs) => void;
 }
 
 interface State extends TcpSettings {
@@ -49,12 +49,12 @@ export default class TcpSettingsForm extends PureComponent<Props, State> {
       tlsConfig,
       queryResponse,
     };
-    this.props.onUpdate(
-      {
+    this.props.onUpdate({
+      settings: {
         tcp: settings,
       },
-      labels
-    );
+      labels,
+    });
   };
 
   onIpVersionChange = (value: SelectableValue<IpVersion>) => {

--- a/src/components/TcpSettings/TcpSettings.tsx
+++ b/src/components/TcpSettings/TcpSettings.tsx
@@ -1,11 +1,12 @@
 import React, { PureComponent } from 'react';
-import { Collapse, Container, HorizontalGroup, Field, Select, Switch } from '@grafana/ui';
+import { Container, HorizontalGroup, Field, Select, Switch } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { IpVersion, Settings, TcpSettings, TLSConfig, TCPQueryResponse, Label } from 'types';
 import { TLSForm } from 'components/http/HttpSettings';
 import QueryResponseForm from './TcpQueryResponseForm';
 import { IP_OPTIONS } from '../constants';
 import { LabelField } from 'components/LabelField';
+import { Collapse } from 'components/Collapse';
 
 interface Props {
   settings: Settings;

--- a/src/components/TenantAPISetupForm.tsx
+++ b/src/components/TenantAPISetupForm.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState } from 'react';
-import { Alert, Button, Collapse, Container, Field, Form, HorizontalGroup, InfoBox, Input } from '@grafana/ui';
+import { Alert, Button, Container, Field, Form, HorizontalGroup, InfoBox, Input } from '@grafana/ui';
+import { Collapse } from 'components/Collapse';
 import { DEFAULT_API_HOST } from './constants';
 
 interface FormValues {

--- a/src/components/http/AuthSettings.tsx
+++ b/src/components/http/AuthSettings.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { css } from 'emotion';
-import { Collapse, Container, HorizontalGroup, Field, Switch, Input, VerticalGroup } from '@grafana/ui';
+import { Container, HorizontalGroup, Field, Switch, Input, VerticalGroup } from '@grafana/ui';
+import { Collapse } from 'components/Collapse';
 import { BasicAuth } from 'types';
 
 interface Props {

--- a/src/components/http/HttpSettings.tsx
+++ b/src/components/http/HttpSettings.tsx
@@ -25,6 +25,7 @@ import {
   BasicAuth,
   TLSConfig,
   HeaderMatch,
+  OnUpdateSettingsArgs,
 } from 'types';
 import { Collapse } from 'components/Collapse';
 import SMLabelsForm from 'components/SMLabelsForm';
@@ -36,7 +37,7 @@ interface Props {
   settings: Settings;
   isEditor: boolean;
   labels: SMLabel[];
-  onUpdate: (settings: Settings, labels: SMLabel[]) => void;
+  onUpdate: (args: OnUpdateSettingsArgs) => void;
 }
 
 interface State extends HttpSettings {
@@ -83,12 +84,12 @@ export class HttpSettingsForm extends PureComponent<Props, State> {
   onUpdate = () => {
     const settings = this.state as HttpSettings;
     const { labels } = this.state;
-    this.props.onUpdate(
-      {
+    this.props.onUpdate({
+      settings: {
         http: settings,
       },
-      labels
-    );
+      labels,
+    });
   };
 
   onLabelsChange = (labels: SMLabel[]) => {

--- a/src/components/http/HttpSettings.tsx
+++ b/src/components/http/HttpSettings.tsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import {
-  Collapse,
   Container,
   HorizontalGroup,
   Field,
@@ -27,6 +26,7 @@ import {
   TLSConfig,
   HeaderMatch,
 } from 'types';
+import { Collapse } from 'components/Collapse';
 import SMLabelsForm from 'components/SMLabelsForm';
 import { IP_OPTIONS } from '../constants';
 import { AuthSettings } from './AuthSettings';

--- a/src/page/ProbesPage.test.tsx
+++ b/src/page/ProbesPage.test.tsx
@@ -5,6 +5,7 @@ import { ProbesPage } from './ProbesPage';
 import { InstanceContext } from 'components/InstanceContext';
 import { getInstanceMock, instanceSettings } from '../datasource/__mocks__/DataSource';
 import * as runtime from '@grafana/runtime';
+jest.setTimeout(10000);
 
 interface RenderArgs {
   id?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,3 +254,8 @@ export interface APIError {
   status: number;
   message: string;
 }
+
+export interface OnUpdateSettingsArgs {
+  settings: Settings;
+  labels?: Label[];
+}


### PR DESCRIPTION
This PR rearranges the check editing experience:
 - Collapses are restyled to meet design spec
 - Nested collapses are removed and flattened out
 - Label inputs are moved to advanced options in every check type
 - Common fields for all check types are broken up into sections
 - Frequency and timeout fields are converted to a combination slider/input component

Before: 
![Screen Shot 2020-09-08 at 10 42 54 AM](https://user-images.githubusercontent.com/8377044/92510060-1d8cc100-f1c0-11ea-855c-8b75643532ec.png)

After:
![Screen Shot 2020-09-08 at 10 16 52 AM](https://user-images.githubusercontent.com/8377044/92510303-7bb9a400-f1c0-11ea-924d-fd8decd7cee8.png)

