### PR TITLE
Http ssl options

### DIFF
--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -208,7 +208,7 @@ describe('HTTP', () => {
           validStatusCodes: [100],
           validHTTPVersions: [HttpVersion.HTTP1_0],
           failIfNotSSL: true,
-          failIfSSL: true,
+          failIfSSL: false,
           bearerToken: 'a bear',
           basicAuth: { username: 'steve', password: 'stevessecurepassword' },
           cacheBustingQueryParamName: 'busted',
@@ -251,8 +251,7 @@ describe('HTTP', () => {
 
     expect(await within(validation).findByText('100')).toBeInTheDocument();
     expect(await within(validation).findByText('HTTP/1.0')).toBeInTheDocument();
-    expect(await screen.findByLabelText('Fail if SSL', { exact: false })).toBeChecked();
-    expect(await screen.findByLabelText('Fail if not SSL', { exact: false })).toBeChecked();
+    expect(await within(validation).findByText('Probe fails if SSL is not present.')).toBeInTheDocument();
 
     const advancedOptions = await toggleSection('Advanced Options');
     expect(await within(advancedOptions).findByPlaceholderText('name')).toHaveValue('a great label');

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -1,5 +1,5 @@
 import { enumToStringArray } from '../utils';
-import { DnsResponseCodes, DnsRecordType, DnsProtocol, IpVersion, CheckType } from 'types';
+import { DnsResponseCodes, DnsRecordType, DnsProtocol, IpVersion, CheckType, HttpSslOption } from 'types';
 
 export const DNS_RESPONSE_CODES = enumToStringArray(DnsResponseCodes).map(responseCode => ({
   label: responseCode,
@@ -112,5 +112,20 @@ export const CHECK_TYPE_OPTIONS = [
   {
     label: 'TCP',
     value: CheckType.TCP,
+  },
+];
+
+export const HTTP_SSL_OPTIONS = [
+  {
+    label: 'Ignore SSL',
+    value: HttpSslOption.Ignore,
+  },
+  {
+    label: 'Probe fails if SSL is present.',
+    value: HttpSslOption.FailIfPresent,
+  },
+  {
+    label: 'Probe fails if SSL is not present.',
+    value: HttpSslOption.FailIfNotPresent,
   },
 ];

--- a/src/components/http/HttpSettings.tsx
+++ b/src/components/http/HttpSettings.tsx
@@ -9,6 +9,7 @@ import {
   TextArea,
   Input,
   VerticalGroup,
+  useStyles,
 } from '@grafana/ui';
 import { css } from 'emotion';
 import { useFormContext, Controller } from 'react-hook-form';
@@ -21,6 +22,7 @@ import { LabelField } from 'components/LabelField';
 import { TLSConfig } from 'components/TLSConfig';
 import { NameValueInput } from 'components/NameValueInput';
 import { validateBearerToken, validateHTTPBody, validateHTTPHeaderName, validateHTTPHeaderValue } from 'validation';
+import { GrafanaTheme } from '@grafana/data';
 
 const httpVersionOptions = [
   {
@@ -129,6 +131,12 @@ const generateValidStatusCodes = () => {
 
 const validStatusCodes = generateValidStatusCodes();
 
+const getStyles = (theme?: GrafanaTheme) => ({
+  validationGroup: css`
+    max-width: 400px;
+  `,
+});
+
 interface Props {
   isEditor: boolean;
 }
@@ -144,6 +152,7 @@ export const HttpSettingsForm: FC<Props> = ({ isEditor }) => {
   const basicAuth = watch('settings.http.basicAuth');
   const [includeBearerToken, setIncludeBearerToken] = useState(Boolean(bearerToken));
   const [includeBasicAuth, setIncludeBasicAuth] = useState(Boolean(basicAuth));
+  const styles = useStyles(getStyles);
 
   return (
     <Container>
@@ -291,7 +300,7 @@ export const HttpSettingsForm: FC<Props> = ({ isEditor }) => {
         isOpen={showValidation}
         collapsible
       >
-        <HorizontalGroup>
+        <div className={styles.validationGroup}>
           <Field
             label="Valid Status Codes"
             description="Accepted status codes for this probe. Defaults to 2xx."
@@ -328,19 +337,7 @@ export const HttpSettingsForm: FC<Props> = ({ isEditor }) => {
               disabled={!isEditor}
             />
           </Field>
-
-          {/* <Field label="Fail if SSL" description="Probe fails if SSL is present" disabled={!isEditor}>
-            <Switch id="http-settings-fail-ssl" ref={register} name="settings.http.failIfSSL" disabled={!isEditor} />
-          </Field>
-          <Field label="Fail if not SSL" description="Probe fails if SSL is not present" disabled={!isEditor}>
-            <Switch
-              id="http-settings-fail-not-ssl"
-              ref={register}
-              name="settings.http.failIfNotSSL"
-              disabled={!isEditor}
-            />
-          </Field> */}
-        </HorizontalGroup>
+        </div>
         <BodyRegexMatcherInput
           label="Fail if body matches regexp"
           description="Probe fails if response body matches regex"

--- a/src/components/http/HttpSettings.tsx
+++ b/src/components/http/HttpSettings.tsx
@@ -16,7 +16,7 @@ import { HttpMethod, HttpVersion, CheckType } from 'types';
 import { Collapse } from 'components/Collapse';
 import { BodyRegexMatcherInput } from 'components/BodyRegexMatcherInput';
 import { HeaderRegexMatcherInput } from 'components/HeaderRegexMatcherInput';
-import { IP_OPTIONS } from '../constants';
+import { HTTP_SSL_OPTIONS, IP_OPTIONS } from '../constants';
 import { LabelField } from 'components/LabelField';
 import { TLSConfig } from 'components/TLSConfig';
 import { NameValueInput } from 'components/NameValueInput';
@@ -315,7 +315,21 @@ export const HttpSettingsForm: FC<Props> = ({ isEditor }) => {
             />
           </Field>
 
-          <Field label="Fail if SSL" description="Probe fails if SSL is present" disabled={!isEditor}>
+          <Field
+            label="SSL Options"
+            description="Choose whether probe fails if SSL is present or not present"
+            disabled={!isEditor}
+          >
+            <Controller
+              as={Select}
+              name="settings.http.sslOptions"
+              control={control}
+              options={HTTP_SSL_OPTIONS}
+              disabled={!isEditor}
+            />
+          </Field>
+
+          {/* <Field label="Fail if SSL" description="Probe fails if SSL is present" disabled={!isEditor}>
             <Switch id="http-settings-fail-ssl" ref={register} name="settings.http.failIfSSL" disabled={!isEditor} />
           </Field>
           <Field label="Fail if not SSL" description="Probe fails if SSL is not present" disabled={!isEditor}>
@@ -325,7 +339,7 @@ export const HttpSettingsForm: FC<Props> = ({ isEditor }) => {
               name="settings.http.failIfNotSSL"
               disabled={!isEditor}
             />
-          </Field>
+          </Field> */}
         </HorizontalGroup>
         <BodyRegexMatcherInput
           label="Fail if body matches regexp"

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,7 +183,11 @@ interface HttpHeaderFormValue {
 }
 
 export interface HttpSettingsFormValues
-  extends Omit<HttpSettings, 'validStatusCodes' | 'validHTTPVersions' | 'method' | 'ipVersion' | 'headers'> {
+  extends Omit<
+    HttpSettings,
+    'validStatusCodes' | 'validHTTPVersions' | 'method' | 'ipVersion' | 'headers' | 'failIfSSL' | 'failIfNotSSL'
+  > {
+  sslOptions: SelectableValue<HttpSslOption>;
   validStatusCodes: Array<SelectableValue<number>>;
   validHTTPVersions: Array<SelectableValue<HttpVersion>>;
   method: SelectableValue<HttpMethod>;
@@ -322,4 +326,10 @@ export interface APIError {
 export interface OnUpdateSettingsArgs {
   settings: Settings;
   labels?: Label[];
+}
+
+export enum HttpSslOption {
+  Ignore,
+  FailIfPresent,
+  FailIfNotPresent,
 }


### PR DESCRIPTION
- Moves HTTP SSL options from two switchers to one dropdown
- Changes HTTP validation fields to lay out vertically instead of horizontally

Before:
![Screen Shot 2020-09-17 at 3 45 26 PM](https://user-images.githubusercontent.com/8377044/93535940-d65baa00-f8fc-11ea-988d-21facee35a17.png)

After:

![Screen Shot 2020-09-17 at 3 41 56 PM](https://user-images.githubusercontent.com/8377044/93535875-bcba6280-f8fc-11ea-9c95-92a580867c3d.png)
