### PR TITLE
chore: reduce maximum Jest workers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,4 +9,5 @@ const config = standard.jestConfig();
 // Adding jest-environment-jsdom-fifteen because the jsdom included with @grafana/toolkit doesn't play nice with the current version of @testing-library
 config.testEnvironment = 'jest-environment-jsdom-fifteen';
 config.setupFilesAfterEnv = ['@testing-library/jest-dom/extend-expect', ...(config.setupFilesAfterEnv || [])];
+config.maxWorkers = '25%';
 module.exports = config;


### PR DESCRIPTION
Jest is too aggressive about running tests in parallel. It seems there's
something about the CheckEditor test suite that causes it to use more
memory than the other tests, so when running on all CPUs, it chews up
memory like nothing.

Reduce maxWorkers to 25% of the available CPUs as a guess... on my
machine, going above 25% does not reduce the test time (and in fact
going above 50% starts to increase it). I would happily keep it at 1 or
2, as that doesn't increase the total run time by any significant
amount.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>