### PR TITLE
Navigation: Make Home the default page

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -32,7 +32,8 @@
       "type": "page",
       "name": "Home",
       "path": "/a/grafana-synthetic-monitoring-app/?page=redirect&dashboard=summary",
-      "addToNav": true
+      "addToNav": true,
+      "defaultNav": true
     },
     {
       "type": "page",


### PR DESCRIPTION
By adding defaultNav it makes clicking on the sidenav app icon go this page.  Noticed that nothing happened when I clicked the synthetic monitoring icon.