### PR TITLE
chore: production-release.sh script needs bash

### DIFF
--- a/scripts/production-release.sh
+++ b/scripts/production-release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 fail() {
 	echo error: "$@" 1>&2
@@ -25,9 +25,9 @@ gcom() {
 
 GIT_TAG=$(git tag --points-at HEAD)
 URL='https://github.com/grafana/synthetic-monitoring-app/releases/download/'"$GIT_TAG"'/grafana-synthetic-monitoring-app-'"${GIT_TAG//v}"'.zip'
-PKG_SUM=$(curl -sL $URL | md5sum)
+PKG_SUM=$(curl -sL $URL | md5sum | cut -d' ' -f1)
 gcom /plugins \
-  -d download[any][url]=$URL \
-  -d download[any][md5]=$PKG_SUM \
-	-d url=https://github.com/grafana/synthetic-monitoring-app
+  -d "download[any][url]=$URL" \
+  -d "download[any][md5]=$PKG_SUM" \
+  -d url=https://github.com/grafana/synthetic-monitoring-app
 


### PR DESCRIPTION
`${GIT_TAG//v}` is bash, not POSIX, so change /bin/sh to /bin/bash

md5sum outputs a '-' for the filename when working against stdin, so
make sure we don't pass that to curl (gcom).

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>