### PR TITLE
fix: update queries that use the renamed metrics

### DIFF
--- a/src/dashboards/sm-dns.json
+++ b/src/dashboards/sm-dns.json
@@ -128,7 +128,7 @@
         },
         "targets": [
           {
-            "expr": "100*(1 - (sum(rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"dns\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum(rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"dns\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
+            "expr": "100*(1 - (sum((rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])) * on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"dns\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"dns\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
             "format": "table",
             "instant": true,
             "interval": "",
@@ -213,7 +213,7 @@
         "pluginVersion": "7.0.3",
         "targets": [
           {
-            "expr": "sum(rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])) / sum(rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))",
+            "expr": "sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
             "hide": false,
             "instant": false,
             "interval": "",
@@ -285,7 +285,7 @@
         "pluginVersion": "7.0.3",
         "targets": [
           {
-            "expr": "sum(rate(probe_dns_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])) / sum(rate(probe_dns_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))",
+            "expr": "sum((rate(probe_dns_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_dns_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_dns_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_dns_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
             "hide": false,
             "instant": true,
             "interval": "",
@@ -504,7 +504,7 @@
         "steppedLine": true,
         "targets": [
           {
-            "expr": "100*(1-(sum(rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])) / sum(rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))))",
+            "expr": "100*(1-(sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])))))",
             "hide": false,
             "interval": "",
             "legendFormat": "errors",
@@ -948,5 +948,5 @@
     "timezone": "",
     "title": "Synthetic Monitoring - DNS",
     "uid": "lgL6odgGz",
-    "version": 11
+    "version": 12
   }

--- a/src/dashboards/sm-http.json
+++ b/src/dashboards/sm-http.json
@@ -128,7 +128,7 @@
       },
       "targets": [
         {
-          "expr": "100*(1 - (sum(rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"http\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum(rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"http\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
+          "expr": "100*(1 - (sum((rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"http\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"http\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -213,7 +213,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "sum(rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])) / sum(rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))",
+          "expr": "sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
           "hide": false,
           "instant": false,
           "interval": "",
@@ -285,7 +285,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "sum(rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])) / sum(rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))",
+          "expr": "sum((rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -513,7 +513,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "100*(1-(sum(rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])) / sum(rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))))",
+          "expr": "100*(1-(sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])))))",
           "hide": false,
           "interval": "",
           "legendFormat": "errors",
@@ -940,5 +940,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring HTTP",
   "uid": "rq0JrllZz",
-  "version": 25
+  "version": 26
 }

--- a/src/dashboards/sm-ping.json
+++ b/src/dashboards/sm-ping.json
@@ -128,7 +128,7 @@
       },
       "targets": [
         {
-          "expr": "100*(1 - (sum(rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"ping\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum(rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"ping\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
+          "expr": "100*(1 - (sum((rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"ping\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"ping\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -213,7 +213,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "sum(rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])) / sum(rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))",
+          "expr": "sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
           "hide": false,
           "instant": false,
           "interval": "",
@@ -285,7 +285,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "sum(rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])) / sum(rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))",
+          "expr": "sum((rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -433,7 +433,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "100*(1-(sum(rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])) / sum(rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))))",
+          "expr": "100*(1-(sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])))))",
           "hide": false,
           "interval": "",
           "legendFormat": "errors",
@@ -860,5 +860,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring Ping",
   "uid": "EHyn7ueZk",
-  "version": 24
+  "version": 25
 }

--- a/src/dashboards/sm-summary.json
+++ b/src/dashboards/sm-summary.json
@@ -133,7 +133,7 @@
       },
       "targets": [
         {
-          "expr": "100*(1 - (sum(rate(probe_all_success_sum[${__range_s}s]) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum(rate(probe_all_success_count[${__range_s}s]) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
+          "expr": "100*(1 - (sum((rate(probe_all_success_sum[${__range_s}s]) OR rate(probe_success_sum[${__range_s}s])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count[${__range_s}s]) OR rate(probe_success_count[${__range_s}s])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -213,7 +213,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - (sum(rate(probe_all_success_sum[$__interval]) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)) / sum(rate(probe_all_success_count[$__interval]) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)))",
+          "expr": "1 - (sum((rate(probe_all_success_sum[$__interval]) OR rate(probe_success_sum[$__interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)) / sum((rate(probe_all_success_count[$__interval]) OR rate(probe_success_count[$__interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)))",
           "hide": false,
           "interval": "",
           "legendFormat": "% Errors",
@@ -388,7 +388,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(rate(probe_all_success_sum[$__range]) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, job, check_name) / sum(rate(probe_all_success_count[$__range]) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, check_name, job)",
+          "expr": "sum((rate(probe_all_success_sum[$__range]) OR rate(probe_success_sum[$__range])) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, job, check_name) / sum((rate(probe_all_success_count[$__range]) OR rate(probe_success_count[$__range])) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, check_name, job)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -396,7 +396,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(rate(probe_all_duration_seconds_sum[$__range]) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, job, check_name) / sum(rate(probe_all_duration_seconds_count[$__range]) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, job, check_name)",
+          "expr": "sum((rate(probe_all_duration_seconds_sum[$__range]) OR rate(probe_duration_seconds_sum[$__range])) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, job, check_name) / sum((rate(probe_all_duration_seconds_count[$__range]) OR rate(probe_duration_seconds_count[$__range])) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, job, check_name)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -466,7 +466,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(probe_all_duration_seconds_sum[5m]) * on (instance, job, probe, config_version) group_left max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version))  by (job, instance) / sum(rate(probe_all_duration_seconds_count[5m]) * on (instance, job, probe, config_version) group_left max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)) by (job, instance)",
+          "expr": "sum((rate(probe_all_duration_seconds_sum[5m]) OR rate(probe_duration_seconds_sum[5m])) * on (instance, job, probe, config_version) group_left max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version))  by (job, instance) / sum((rate(probe_all_duration_seconds_count[5m]) OR rate(probe_duration_seconds_count[5m])) * on (instance, job, probe, config_version) group_left max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)) by (job, instance)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{job}}/{{ instance }}",
@@ -608,5 +608,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring Summary",
   "uid": "fU-WBSqWz",
-  "version": 37
+  "version": 38
 }


### PR DESCRIPTION
We did the following renames in the probes to prevents problems down the
road:

 * probe_success_sum to probe_all_success_sum
 * probe_success_count to probe_all_success_count
 * probe_dns_duration_seconds_count to probe_dns_all_duration_seconds_count
 * probe_dns_duration_seconds_sum to probe_dns_all_duration_seconds_sum
 * probe_http_duration_seconds_count to probe_http_all_duration_seconds_count
 * probe_http_duration_seconds_sum to probe_http_all_duration_seconds_sum
 * probe_icmp_duration_seconds_count to probe_icmp_all_duration_seconds_count
 * probe_icmp_duration_seconds_sum to probe_icmp_all_duration_seconds_sum
 * probe_tcp_duration_seconds_count to probe_tcp_all_duration_seconds_count
 * probe_tcp_duration_seconds_sum to probe_tcp_all_duration_seconds_sum

This renames causes the panels not to display anything for time periods
before the rename. To avoid that, change the queries to use either
metric, e.g. `probe_all_success_sum` changes to `probe_all_success_sum
OR probe_success_sum`.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>