### PR TITLE
fix: auto update dashboards on UI load

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -364,3 +364,11 @@ export interface SubmissionError {
   status?: string;
   message?: string;
 }
+
+export interface DashboardMeta {
+  json: string;
+  latestVersion: number;
+  title: string;
+  uid: string;
+  version: number;
+}


### PR DESCRIPTION
When the metrics underpinning dashboard queries in the SM dashboard templates change, it breaks the dashboards unless users navigate to `Plugin config` => click on `Update` => click `Update` for each dashboard that has changes. This pr would check for dashboard template changes and present a modal that prompts the user to update them when they visit the SM plugin UI.

![Screen Shot 2020-10-19 at 10 44 26 AM](https://user-images.githubusercontent.com/8377044/96492611-c800f680-11f8-11eb-8a69-424437b33518.png)
