### PR TITLE
fix: update TCP queries to use old and new metric names

### DIFF
--- a/src/components/UptimeGauge.tsx
+++ b/src/components/UptimeGauge.tsx
@@ -63,8 +63,8 @@ export const UptimeGauge: FC<Props> = ({ labelNames, labelValues, height, width,
     }, [])
     .join(',');
 
-  const uptimeQuery = `sum(rate(probe_all_success_sum{${filter}}[3h])) / sum(rate(probe_all_success_count{${filter}}[3h]))`;
-  const sparklineQuery = `100 * sum(rate(probe_all_success_sum{${filter}}[10m])) / sum(rate(probe_all_success_count{${filter}}[10m]))`;
+  const uptimeQuery = `sum((rate(probe_all_success_sum{${filter}}[3h]) OR rate(probe_success_sum{${filter}}[3h]))) / sum((rate(probe_all_success_count{${filter}}[3h]) OR rate(probe_success_count{${filter}}[3h])))`;
+  const sparklineQuery = `100 * sum((rate(probe_all_success_sum{${filter}}[10m]) OR rate(probe_success_sum{${filter}}[10m]))) / sum((rate(probe_all_success_count{${filter}}[10m]) OR rate(probe_success_count{${filter}}[10m])))`;
 
   const lastUpdate = Math.floor(Date.now() / 1000);
 

--- a/src/dashboards/sm-tcp.json
+++ b/src/dashboards/sm-tcp.json
@@ -128,7 +128,7 @@
         },
         "targets": [
           {
-            "expr": "100*(1 - (sum(rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"tcp\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum(rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"tcp\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
+            "expr": "100*(1 - (sum((rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])) * on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"tcp\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])) * on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"tcp\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
             "format": "table",
             "instant": true,
             "interval": "",
@@ -213,7 +213,7 @@
         "pluginVersion": "7.0.3",
         "targets": [
           {
-            "expr": "sum(rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])) / sum(rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))",
+            "expr": "sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
             "hide": false,
             "instant": false,
             "interval": "",
@@ -285,7 +285,7 @@
         "pluginVersion": "7.0.3",
         "targets": [
           {
-            "expr": "sum(rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])) / sum(rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))",
+            "expr": "sum((rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
             "hide": false,
             "instant": true,
             "interval": "",
@@ -513,7 +513,7 @@
         "steppedLine": true,
         "targets": [
           {
-            "expr": "100*(1-(sum(rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])) / sum(rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))))",
+            "expr": "100*(1-(sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])))))",
             "hide": false,
             "interval": "",
             "legendFormat": "errors",
@@ -816,5 +816,5 @@
     "timezone": "",
     "title": "Synthetic Monitoring TCP",
     "uid": "mh84e5mMk",
-    "version": 8
+    "version": 9
   }


### PR DESCRIPTION
TCP was missing from the previous change.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>