### PR TITLE
fix: legend displays "Value" instead of probe name

### DIFF
--- a/src/dashboards/sm-dns.json
+++ b/src/dashboards/sm-dns.json
@@ -606,11 +606,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(probe_dns_duration_seconds{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}) by (phase)",
+          "expr": "avg(probe_dns_duration_seconds{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}) by (probe)",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{phase}}",
+          "legendFormat": "{{probe}}",
           "refId": "A"
         }
       ],
@@ -916,5 +916,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring - DNS",
   "uid": "lgL6odgGz",
-  "version": 14
+  "version": 15
 }

--- a/src/dashboards/sm-http.json
+++ b/src/dashboards/sm-http.json
@@ -646,7 +646,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Response Latency: $probe ⮕ $job / $instance",
+      "title": "Response latency by phase: $probe ⮕ $job / $instance",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -763,7 +763,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{phase}}",
+          "legendFormat": "{{probe}}",
           "refId": "A"
         }
       ],
@@ -771,7 +771,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Response Latency by Probe",
+      "title": "Response latency by probe",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -940,5 +940,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring HTTP",
   "uid": "rq0JrllZz",
-  "version": 26
+  "version": 27
 }

--- a/src/dashboards/sm-ping.json
+++ b/src/dashboards/sm-ping.json
@@ -566,7 +566,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Response Latency: $probe ⮕ $job / $instance",
+      "title": "Response latency by phase: $probe ⮕ $job / $instance",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -683,7 +683,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{phase}}",
+          "legendFormat": "{{probe}}",
           "refId": "A"
         }
       ],
@@ -691,7 +691,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Response Latency by Probe",
+      "title": "Response latency by probe",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -860,5 +860,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring Ping",
   "uid": "EHyn7ueZk",
-  "version": 25
+  "version": 26
 }

--- a/src/dashboards/sm-tcp.json
+++ b/src/dashboards/sm-tcp.json
@@ -639,7 +639,7 @@
             "instant": false,
             "interval": "",
             "intervalFactor": 1,
-            "legendFormat": "{{phase}}",
+            "legendFormat": "{{probe}}",
             "refId": "A"
           }
         ],
@@ -816,5 +816,5 @@
     "timezone": "",
     "title": "Synthetic Monitoring TCP",
     "uid": "mh84e5mMk",
-    "version": 9
+    "version": 10
   }


### PR DESCRIPTION
In the DNS dashboard, the query is wrong, as it should be summing by
probe and not phase to coincide with the panel's description. In the
same panel, the legend should use the probe label, not the phase.

The the HTTP dashboard, the query is correct but the legend has the same
issue. Same goes for ping and TCP dashboards.

Also fix some casing issues in the panel titles.

Fixes #146.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>