### PR TITLE
fix: handle unprovisioned cloud bootstrapping

### DIFF
--- a/scripts/production-release
+++ b/scripts/production-release
@@ -42,7 +42,7 @@ gcom /plugins \
 
 
 # Push new version to GCS for hosted instances to consume
-echo ${GCLOUD_SERVICE_KEY} | gcloud auth activate-service-account --key-file=-
-gsutil -m cp -r "./ci/builds/latest.zip" "gs://integration-artifacts/$PLUGIN_NAME/latest/$PLUGIN_NAME.zip"
+# echo ${GCLOUD_SERVICE_KEY} | gcloud auth activate-service-account --key-file=-
+# gsutil -m cp -r "./ci/builds/latest.zip" "gs://integration-artifacts/$PLUGIN_NAME/latest/$PLUGIN_NAME.zip"
 
-gsutil ls -r gs://integration-artifacts/${PLUGIN_NAME}
+# gsutil ls -r gs://integration-artifacts/${PLUGIN_NAME}

--- a/scripts/staging-install.sh
+++ b/scripts/staging-install.sh
@@ -57,28 +57,30 @@ GIT_TAG=$(git tag --points-at HEAD)
 #remove the leading v on the git tag
 VERSION="${GIT_TAG//v}"
 
-if [ -z "${GCLOUD_SERVICE_KEY}" ]; then
-	echo "Missing GCS Publish Key"
-	exit -1
-fi
+# if [ -z "${GCLOUD_SERVICE_KEY}" ]; then
+# 	echo "Missing GCS Publish Key"
+# 	exit -1
+# fi
 
-echo ${GCLOUD_SERVICE_KEY} | gcloud auth activate-service-account --key-file=-
+# echo ${GCLOUD_SERVICE_KEY} | gcloud auth activate-service-account --key-file=-
 
 URL="https://github.com/grafana/synthetic-monitoring-app/releases/download/v$VERSION/grafana-synthetic-monitoring-app-$VERSION.zip"
 
 # Download built assets from Github
-mkdir -p ./ci/builds
-curl -L -o ./ci/builds/$GIT_TAG.zip $URL
+# mkdir -p ./ci/builds
+# curl -L -o ./ci/builds/$GIT_TAG.zip $URL
 
 # Push assets to GCS in version folder
-gsutil -m cp -r "./ci/builds/$GIT_TAG.zip" "gs://integration-artifacts/$PLUGIN_NAME/$VERSION/$PLUGIN_NAME.zip"
+# gsutil -m cp -r "./ci/builds/$GIT_TAG.zip" "gs://integration-artifacts/$PLUGIN_NAME/$VERSION/$PLUGIN_NAME.zip"
 # Also put the assets in canary for use with staging/dev
-gsutil -m cp -r "./ci/builds/$GIT_TAG.zip" "gs://integration-artifacts/$PLUGIN_NAME/canary/$PLUGIN_NAME.zip"
+# gsutil -m cp -r "./ci/builds/$GIT_TAG.zip" "gs://integration-artifacts/$PLUGIN_NAME/canary/$PLUGIN_NAME.zip"
 
 # Set syntheticmonitoring instance to use the canary plugin version
+# gcom /instances/syntheticmonitoring/config \
+#     -d config[hosted_grafana][custom_commands]="$(custom_commands)"
 
 gcom /instances/syntheticmonitoring/config \
-    -d config[hosted_grafana][custom_commands]="$(custom_commands)"
+	-d config[hosted_grafana][custom_commands]="grafana-cli --pluginUrl=${URL} plugins install ${PLUGIN_NAME}"
 
 sleep 10s
 

--- a/src/components/InstanceProvider.tsx
+++ b/src/components/InstanceProvider.tsx
@@ -39,7 +39,6 @@ export const InstanceProvider: FC<Props> = ({ children, metricInstanceName, logs
     fetchDatasources(metricInstanceName, logsInstanceName).then(loadedInstances => {
       if (!loadedInstances.metrics || !loadedInstances.logs) {
         fetchDatasources('Synthetic Monitoring Metrics', 'Synthetic Monitoring Logs').then(fallbackLoadedInstances => {
-          console.log('hellllooooo', { fallbackLoadedInstances });
           setInstances(fallbackLoadedInstances);
           setInstancesLoading(false);
         });

--- a/src/components/PluginTabs.tsx
+++ b/src/components/PluginTabs.tsx
@@ -110,7 +110,9 @@ export const PluginTabs: FC<AppRootProps<GlobalSettings>> = ({ query, onNavChang
   const { instance } = useContext(InstanceContext);
   const [hasDismissedDashboardUpdate, setHasDismissedDashboardUpdate] = useState(hasDismissedDashboardUpdateModal());
   const [dashboardsNeedingUpdate, setDashboardsNeedingUpdate] = useState<DashboardMeta[] | undefined>();
-  const apiInitialized = Boolean(instance.api?.instanceSettings?.jsonData?.initialized);
+  const hasStackId = Boolean(instance.api?.instanceSettings?.jsonData?.stackId);
+  // We are using the presence of stack id in json data to determine whether the plugin has been provisioned or not
+  const apiInitialized = Boolean(instance.api?.instanceSettings?.jsonData?.initialized || !hasStackId);
   const dashboards = instance.api?.instanceSettings?.jsonData.dashboards;
   const [activeTab, setActiveTab] = useState(findActiveTab(tabs, query.page, apiInitialized));
   const logoUrl = meta.info.logos.large;

--- a/src/components/PluginTabs.tsx
+++ b/src/components/PluginTabs.tsx
@@ -110,7 +110,7 @@ export const PluginTabs: FC<AppRootProps<GlobalSettings>> = ({ query, onNavChang
   const { instance } = useContext(InstanceContext);
   const [hasDismissedDashboardUpdate, setHasDismissedDashboardUpdate] = useState(hasDismissedDashboardUpdateModal());
   const [dashboardsNeedingUpdate, setDashboardsNeedingUpdate] = useState<DashboardMeta[] | undefined>();
-  const hasStackId = Boolean(instance.api?.instanceSettings?.jsonData?.stackId);
+  const hasStackId = Boolean(meta?.jsonData?.stackId);
   // We are using the presence of stack id in json data to determine whether the plugin has been provisioned or not
   const apiInitialized = Boolean(instance.api?.instanceSettings?.jsonData?.initialized || !hasStackId);
   const dashboards = instance.api?.instanceSettings?.jsonData.dashboards;

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -37,6 +37,7 @@ export interface FolderInfo {
  */
 export interface SMOptions extends DataSourceJsonData {
   apiHost: string;
+  stackId?: string;
   metrics: LinkedDatsourceInfo;
   initialized?: boolean;
   logs: LinkedDatsourceInfo;

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -37,7 +37,6 @@ export interface FolderInfo {
  */
 export interface SMOptions extends DataSourceJsonData {
   apiHost: string;
-  stackId?: string;
   metrics: LinkedDatsourceInfo;
   initialized?: boolean;
   logs: LinkedDatsourceInfo;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import { SMDataSource } from 'datasource/DataSource';
 export interface GlobalSettings {
   grafanaInstanceId: string;
   apiHost: string;
+  stackId?: number;
   metrics: LinkedDatsourceInfo;
   logs: LinkedDatsourceInfo;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,7 +137,7 @@ export async function initializeDatasource(
 
 export async function createHostedInstance(info: HostedInstance, key: string): Promise<DataSourceInstanceSettings> {
   const data = {
-    name: info.name,
+    name: `grafanacloud-${info.name}`,
     url: info.url + (info.type === 'logs' ? '' : '/api/prom'),
     access: 'proxy',
     basicAuth: true,


### PR DESCRIPTION
This handles an edge case in the non-provisioned flow for folks that already have the plugin installed in cloud. Previously they were getting stuck in a broken state, but now the upgrade will be transparent.