### PR TITLE
Add alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@testing-library/user-event": "^12.0.17",
     "@types/eslint": "^7.2.4",
     "@types/ip-address": "latest",
+    "@types/js-yaml": "^3.12.5",
     "@types/lodash": "latest",
     "@types/valid-url": "^1.0.3",
     "eslint-plugin-import": "^2.22.0",
@@ -47,6 +48,7 @@
     "punycode": "^2.1.1",
     "react-async-hook": "^3.6.1",
     "react-hook-form": "5.1.3",
-    "valid-url": "^1.0.9"
+    "valid-url": "^1.0.9",
+    "yaml": "^1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@testing-library/user-event": "^12.0.17",
     "@types/eslint": "^7.2.4",
     "@types/ip-address": "latest",
-    "@types/js-yaml": "^3.12.5",
     "@types/lodash": "latest",
     "@types/valid-url": "^1.0.3",
     "eslint-plugin-import": "^2.22.0",

--- a/src/components/AlertAnnotations.tsx
+++ b/src/components/AlertAnnotations.tsx
@@ -1,0 +1,53 @@
+import React, { FC, Fragment } from 'react';
+import { TextArea, Input, Button, useStyles } from '@grafana/ui';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { SubCollapse } from 'components/SubCollapse';
+import { GrafanaTheme } from '@grafana/data';
+import { css } from 'emotion';
+
+interface Props {}
+
+const NAME = 'alert.annotations';
+
+const getStyles = (theme: GrafanaTheme) => ({
+  grid: css`
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    grid-column-gap: ${theme.spacing.lg};
+    grid-row-gap: ${theme.spacing.sm};
+  `,
+});
+
+export const AlertAnnotations: FC<Props> = () => {
+  const styles = useStyles(getStyles);
+  const { control, register } = useFormContext();
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: NAME,
+  });
+  return (
+    <SubCollapse title="Annotations">
+      <div className={styles.grid}>
+        {fields.length ? (
+          <>
+            <span>Name</span>
+            <span>Annotation</span>
+            <div />
+          </>
+        ) : null}
+        {fields.map((field, index) => (
+          <Fragment key={field.id}>
+            <Input ref={register()} name={`${NAME}[${index}].key`} placeholder="Name" />
+            <TextArea ref={register()} name={`${NAME}[${index}].value`} placeholder="Value" />
+            <Button type="button" onClick={() => remove(index)} variant="link">
+              Delete
+            </Button>
+          </Fragment>
+        ))}
+      </div>
+      <Button type="button" variant="link" icon="plus" onClick={() => append({})}>
+        Add annotation
+      </Button>
+    </SubCollapse>
+  );
+};

--- a/src/components/AlertAnnotations.tsx
+++ b/src/components/AlertAnnotations.tsx
@@ -5,8 +5,6 @@ import { SubCollapse } from 'components/SubCollapse';
 import { GrafanaTheme } from '@grafana/data';
 import { css } from 'emotion';
 
-interface Props {}
-
 const NAME = 'alert.annotations';
 
 const getStyles = (theme: GrafanaTheme) => ({
@@ -19,9 +17,12 @@ const getStyles = (theme: GrafanaTheme) => ({
   addButton: css`
     margin: ${theme.spacing.md} 0;
   `,
+  helpText: css`
+    font-size: ${theme.typography.size.sm};
+  `,
 });
 
-export const AlertAnnotations: FC<Props> = () => {
+export const AlertAnnotations: FC = () => {
   const styles = useStyles(getStyles);
   const { control, register } = useFormContext();
   const { fields, append, remove } = useFieldArray({
@@ -30,6 +31,10 @@ export const AlertAnnotations: FC<Props> = () => {
   });
   return (
     <SubCollapse title="Annotations">
+      <p className={styles.helpText}>
+        Annotations specify a set of informational labels that can be used to store longer additional information such
+        as alert descriptions or runbook links. The annotation values can be templated.
+      </p>
       <div className={styles.grid}>
         {fields.length ? (
           <>

--- a/src/components/AlertAnnotations.tsx
+++ b/src/components/AlertAnnotations.tsx
@@ -1,5 +1,5 @@
 import React, { FC, Fragment } from 'react';
-import { TextArea, Input, Button, useStyles } from '@grafana/ui';
+import { TextArea, Input, Button, useStyles, Label } from '@grafana/ui';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { SubCollapse } from 'components/SubCollapse';
 import { GrafanaTheme } from '@grafana/data';
@@ -16,6 +16,9 @@ const getStyles = (theme: GrafanaTheme) => ({
     grid-column-gap: ${theme.spacing.lg};
     grid-row-gap: ${theme.spacing.sm};
   `,
+  addButton: css`
+    margin: ${theme.spacing.md} 0;
+  `,
 });
 
 export const AlertAnnotations: FC<Props> = () => {
@@ -30,14 +33,14 @@ export const AlertAnnotations: FC<Props> = () => {
       <div className={styles.grid}>
         {fields.length ? (
           <>
-            <span>Name</span>
-            <span>Annotation</span>
+            <Label>Name</Label>
+            <Label>Annotation</Label>
             <div />
           </>
         ) : null}
         {fields.map((field, index) => (
           <Fragment key={field.id}>
-            <Input ref={register()} name={`${NAME}[${index}].key`} placeholder="Name" />
+            <Input ref={register()} name={`${NAME}[${index}].name`} placeholder="Name" />
             <TextArea ref={register()} name={`${NAME}[${index}].value`} placeholder="Value" />
             <Button type="button" onClick={() => remove(index)} variant="link">
               Delete
@@ -45,7 +48,14 @@ export const AlertAnnotations: FC<Props> = () => {
           </Fragment>
         ))}
       </div>
-      <Button type="button" variant="link" icon="plus" onClick={() => append({})}>
+      <Button
+        type="button"
+        variant="link"
+        size="sm"
+        icon="plus"
+        onClick={() => append({})}
+        className={styles.addButton}
+      >
         Add annotation
       </Button>
     </SubCollapse>

--- a/src/components/AlertLabels.tsx
+++ b/src/components/AlertLabels.tsx
@@ -1,0 +1,54 @@
+import { useStyles, Input, TextArea, Button } from '@grafana/ui';
+import React, { FC, Fragment } from 'react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { SubCollapse } from './SubCollapse';
+import { css } from 'emotion';
+import { GrafanaTheme } from '@grafana/data';
+
+interface Props {}
+
+const NAME = 'alert.labels';
+
+const getStyles = (theme: GrafanaTheme) => ({
+  grid: css`
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    grid-column-gap: ${theme.spacing.lg};
+    grid-row-gap: ${theme.spacing.sm};
+  `,
+});
+
+export const AlertLabels: FC<Props> = () => {
+  const styles = useStyles(getStyles);
+  const { control, register } = useFormContext();
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: NAME,
+  });
+
+  return (
+    <SubCollapse title="Labels">
+      <div className={styles.grid}>
+        {fields.length ? (
+          <>
+            <span>Name</span>
+            <span>Value</span>
+            <div />
+          </>
+        ) : null}
+        {fields.map((field, index) => (
+          <Fragment key={field.id}>
+            <Input ref={register()} name={`${NAME}[${index}].key`} placeholder="Name" />
+            <Input ref={register()} name={`${NAME}[${index}].value`} placeholder="Value" />
+            <Button type="button" onClick={() => remove(index)} variant="link">
+              Delete
+            </Button>
+          </Fragment>
+        ))}
+      </div>
+      <Button type="button" variant="link" icon="plus" onClick={() => append({})}>
+        Add label
+      </Button>
+    </SubCollapse>
+  );
+};

--- a/src/components/AlertLabels.tsx
+++ b/src/components/AlertLabels.tsx
@@ -1,4 +1,4 @@
-import { useStyles, Input, TextArea, Button } from '@grafana/ui';
+import { useStyles, Input, Button, Label } from '@grafana/ui';
 import React, { FC, Fragment } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { SubCollapse } from './SubCollapse';
@@ -16,6 +16,9 @@ const getStyles = (theme: GrafanaTheme) => ({
     grid-column-gap: ${theme.spacing.lg};
     grid-row-gap: ${theme.spacing.sm};
   `,
+  addButton: css`
+    margin: ${theme.spacing.md} 0;
+  `,
 });
 
 export const AlertLabels: FC<Props> = () => {
@@ -31,14 +34,14 @@ export const AlertLabels: FC<Props> = () => {
       <div className={styles.grid}>
         {fields.length ? (
           <>
-            <span>Name</span>
-            <span>Value</span>
+            <Label>Name</Label>
+            <Label>Value</Label>
             <div />
           </>
         ) : null}
         {fields.map((field, index) => (
           <Fragment key={field.id}>
-            <Input ref={register()} name={`${NAME}[${index}].key`} placeholder="Name" />
+            <Input ref={register()} name={`${NAME}[${index}].name`} placeholder="Name" />
             <Input ref={register()} name={`${NAME}[${index}].value`} placeholder="Value" />
             <Button type="button" onClick={() => remove(index)} variant="link">
               Delete
@@ -46,7 +49,14 @@ export const AlertLabels: FC<Props> = () => {
           </Fragment>
         ))}
       </div>
-      <Button type="button" variant="link" icon="plus" onClick={() => append({})}>
+      <Button
+        type="button"
+        variant="link"
+        size="sm"
+        icon="plus"
+        onClick={() => append({})}
+        className={styles.addButton}
+      >
         Add label
       </Button>
     </SubCollapse>

--- a/src/components/AlertLabels.tsx
+++ b/src/components/AlertLabels.tsx
@@ -5,8 +5,6 @@ import { SubCollapse } from './SubCollapse';
 import { css } from 'emotion';
 import { GrafanaTheme } from '@grafana/data';
 
-interface Props {}
-
 const NAME = 'alert.labels';
 
 const getStyles = (theme: GrafanaTheme) => ({
@@ -19,9 +17,12 @@ const getStyles = (theme: GrafanaTheme) => ({
   addButton: css`
     margin: ${theme.spacing.md} 0;
   `,
+  helpText: css`
+    font-size: ${theme.typography.size.sm};
+  `,
 });
 
-export const AlertLabels: FC<Props> = () => {
+export const AlertLabels: FC = () => {
   const styles = useStyles(getStyles);
   const { control, register } = useFormContext();
   const { fields, append, remove } = useFieldArray({
@@ -31,6 +32,10 @@ export const AlertLabels: FC<Props> = () => {
 
   return (
     <SubCollapse title="Labels">
+      <p className={styles.helpText}>
+        Labels allow you to specify a set of additional labels to be attached to the alert. Any existing conflicting
+        labels will be overwritten. The label values can be templated.
+      </p>
       <div className={styles.grid}>
         {fields.length ? (
           <>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -63,10 +63,15 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
       <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
         <div className={styles.container}>
           <p>
-            Alerts can only be created for Synthetic Monitoring checks from{' '}
-            <a href="https://grafana.com" className={styles.link}>
+            Synthetic Monitoring uses &nbsp;
+            <a href="https://grafana.com/docs/grafana-cloud/alerts/grafana-cloud-alerting/" className={styles.link}>
               Grafana Cloud Alerting
             </a>
+            &nbsp; for creating alert rules. You can edit this check in &nbsp;
+            <a href="https://grafana.com" className={styles.link}>
+              Grafana Cloud
+            </a>
+            &nbsp; to add alerts.
           </p>
         </div>
       </Collapse>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -1,19 +1,25 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useState, useContext } from 'react';
 import { css } from 'emotion';
 import { GrafanaTheme } from '@grafana/data';
 import { Input, Label, Select, useStyles } from '@grafana/ui';
 import { Collapse } from './Collapse';
-import { Controller } from 'react-hook-form';
-import { TIME_UNIT_OPTIONS } from './constants';
+import { Controller, useFormContext } from 'react-hook-form';
+import { ALERTING_SEVERITY_OPTIONS, TIME_UNIT_OPTIONS } from './constants';
+import { AlertRule } from 'types';
+import { InstanceContext } from './InstanceContext';
 
-interface Props {}
+interface Props {
+  alertRules: AlertRule[];
+  editing: boolean;
+  checkId?: number;
+}
 
 const getStyles = (theme: GrafanaTheme) => ({
   subheader: css`
     margin-top: ${theme.spacing.md};
-    & a {
-      text-decoration: underline;
-    }
+  `,
+  link: css`
+    text-decoration: underline;
   `,
   container: css`
     background: #202226;
@@ -41,26 +47,62 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
 });
 
-export const Alerting: FC<Props> = () => {
+export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
   const [showAlerting, setShowAlerting] = useState(false);
+  const { instance } = useContext(InstanceContext);
+  const { register } = useFormContext();
   const styles = useStyles(getStyles);
+  if (alertRules.length && editing) {
+    return (
+      <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
+        <div className={styles.container}>
+          <p>
+            {alertRules.length} alert{alertRules.length > 1 ? 's are' : ' is'} tied to this check. Edit this check's
+            alerts in the <code>syntheticmonitoring &gt; {checkId}</code> section of{' '}
+            <a
+              href={`a/grafana-alerting-ui-app/?tab=rules&rulessource=${instance.metrics?.name}`}
+              className={styles.link}
+            >
+              Cloud Alerting
+            </a>
+          </p>
+        </div>
+      </Collapse>
+    );
+  }
   return (
     <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
       <p className={styles.subheader}>
-        Set up alerts based on criteria that you define. These alerts can be accessed and edited here or in the{' '}
-        <a href="FIXME">Grafana Cloud Alerting UI</a>.
+        Set up alerts based on criteria that you define. These alerts can be created here and edited in the{' '}
+        <a href={`a/grafana-alerting-ui-app/?tab=rules&rulessource=${instance.metrics?.name}`} className={styles.link}>
+          Grafana Cloud Alerting UI
+        </a>
+        .
       </p>
       <div className={styles.container}>
         <div className={styles.inputWrapper}>
           <Label htmlFor="alert-name">Alert name</Label>
-          <Input id="alert-name" type="text" />
+          <Input
+            ref={register()}
+            name="alert.name"
+            id="alert-name"
+            type="text"
+            placeholder="Name to identify alert rule"
+          />
         </div>
         <div className={styles.inputWrapper}>
           <Label htmlFor="probe-count" description="If">
             Expression
           </Label>
           <div className={styles.horizontallyAligned}>
-            <Input id="probe-count" type="number" className={styles.numberInput} />
+            <Input
+              ref={register()}
+              name="alert.probeCount"
+              id="probe-count"
+              type="number"
+              placeholder="#"
+              className={styles.numberInput}
+            />
             <span className={styles.text}>or more probes report connection errors</span>
           </div>
         </div>
@@ -72,13 +114,25 @@ export const Alerting: FC<Props> = () => {
             For
           </Label>
           <div className={styles.horizontallyAligned}>
-            <Input id="alert-time-quantity" className={styles.numberInput} />
-            <Controller as={Select} name="alert.timeUnit" options={TIME_UNIT_OPTIONS} className={styles.select} />
+            <Input
+              ref={register()}
+              name="alert.timeCount"
+              id="alert-time-quantity"
+              placeholder="#"
+              className={styles.numberInput}
+            />
+            <Controller
+              as={Select}
+              name="alert.timeUnit"
+              options={TIME_UNIT_OPTIONS}
+              className={styles.select}
+              defaultValue={TIME_UNIT_OPTIONS[1]}
+            />
           </div>
         </div>
         <div>
           <Label>Severity</Label>
-          <Controller as={Select} name="alert.severity" options={[]} className={styles.select} />
+          <Controller as={Select} name="alert.severity" options={ALERTING_SEVERITY_OPTIONS} className={styles.select} />
         </div>
       </div>
     </Collapse>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -47,6 +47,9 @@ const getStyles = (theme: GrafanaTheme) => ({
   select: css`
     max-width: 200px;
   `,
+  severityContainer: css`
+    margin-bottom: ${theme.spacing.md};
+  `,
 });
 
 export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
@@ -132,7 +135,7 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
             />
           </div>
         </div>
-        <div>
+        <div className={styles.severityContainer}>
           <Label>Severity</Label>
           <Controller as={Select} name="alert.severity" options={ALERTING_SEVERITY_OPTIONS} className={styles.select} />
         </div>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -67,11 +67,11 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
             <a href="https://grafana.com/docs/grafana-cloud/alerts/grafana-cloud-alerting/" className={styles.link}>
               Grafana Cloud Alerting
             </a>
-            &nbsp; for creating alert rules. You can edit this check in &nbsp;
+            , which is not accessible for Grafana instances running on-prem. Alert rules can be added to new or existing
+            checks in &nbsp;
             <a href="https://grafana.com" className={styles.link}>
-              Grafana Cloud
+              Grafana Cloud.
             </a>
-            &nbsp; to add alerts.
           </p>
         </div>
       </Collapse>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState, useContext } from 'react';
 import { css } from 'emotion';
 import { GrafanaTheme } from '@grafana/data';
-import { Field, Input, Label, Select, useStyles } from '@grafana/ui';
+import { Field, Icon, Input, Label, Select, useStyles } from '@grafana/ui';
 import { Collapse } from './Collapse';
 import { Controller, useFormContext } from 'react-hook-form';
 import { ALERTING_SEVERITY_OPTIONS, TIME_UNIT_OPTIONS } from './constants';
@@ -28,6 +28,9 @@ const getStyles = (theme: GrafanaTheme) => ({
     padding: ${theme.spacing.md};
     display: flex;
     flex-direction: column;
+  `,
+  icon: css`
+    margin-right: ${theme.spacing.xs};
   `,
   inputWrapper: css`
     margin-bottom: ${theme.spacing.md};
@@ -64,6 +67,7 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
       <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
         <div className={styles.container}>
           <p>
+            <Icon className={styles.icon} name="exclamation-triangle" />
             Synthetic Monitoring uses &nbsp;
             <a href="https://grafana.com/docs/grafana-cloud/alerts/grafana-cloud-alerting/" className={styles.link}>
               Grafana Cloud Alerting
@@ -102,7 +106,7 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
       <p className={styles.subheader}>
         Set up alerts based on criteria that you define. These alerts can be created here and edited in the{' '}
         <a href={`a/grafana-alerting-ui-app/?tab=rules&rulessource=${instance.metrics?.name}`} className={styles.link}>
-          Grafana Cloud Alerting UI
+          Alerting UI
         </a>
         .
       </p>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -124,13 +124,15 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
       <div className={styles.container}>
         <div className={styles.inputWrapper}>
           <Label htmlFor="alert-name">Alert name</Label>
-          <Input
-            ref={register()}
-            name="alert.name"
-            id="alert-name"
-            type="text"
-            placeholder="Name to identify alert rule"
-          />
+          <Field invalid={errors?.alert?.name}>
+            <Input
+              ref={register()}
+              name="alert.name"
+              id="alert-name"
+              type="text"
+              placeholder="Name to identify alert rule"
+            />
+          </Field>
         </div>
         <div className={styles.inputWrapper}>
           <Label htmlFor="probe-count" description="Fire alert if">
@@ -161,13 +163,15 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
             For
           </Label>
           <div className={styles.horizontallyAligned}>
-            <Input
-              ref={register()}
-              name="alert.timeCount"
-              id="alert-time-quantity"
-              placeholder="number"
-              className={styles.numberInput}
-            />
+            <Field invalid={errors?.alert?.timeCount}>
+              <Input
+                ref={register()}
+                name="alert.timeCount"
+                id="alert-time-quantity"
+                placeholder="number"
+                className={styles.numberInput}
+              />
+            </Field>
             <Controller
               as={Select}
               name="alert.timeUnit"

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState, useContext } from 'react';
 import { css } from 'emotion';
 import { GrafanaTheme } from '@grafana/data';
-import { Input, Label, Select, useStyles } from '@grafana/ui';
+import { Field, Input, Label, Select, useStyles } from '@grafana/ui';
 import { Collapse } from './Collapse';
 import { Controller, useFormContext } from 'react-hook-form';
 import { ALERTING_SEVERITY_OPTIONS, TIME_UNIT_OPTIONS } from './constants';
@@ -55,8 +55,11 @@ const getStyles = (theme: GrafanaTheme) => ({
 export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
   const [showAlerting, setShowAlerting] = useState(false);
   const { instance } = useContext(InstanceContext);
-  const { register } = useFormContext();
+  const { register, watch, errors } = useFormContext();
   const styles = useStyles(getStyles);
+  const probeCount = watch('probes').length;
+
+  console.log({ errors });
 
   if (!instance.alertRuler) {
     return (
@@ -121,14 +124,19 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
             Expression
           </Label>
           <div className={styles.horizontallyAligned}>
-            <Input
-              ref={register()}
-              name="alert.probeCount"
-              id="probe-count"
-              type="number"
-              placeholder="number"
-              className={styles.numberInput}
-            />
+            <Field invalid={errors?.alert?.probeCount} error={errors?.alert?.probeCount?.message}>
+              <Input
+                ref={register({
+                  max: { value: probeCount, message: `There are ${probeCount} probes attached to this check` },
+                })}
+                name="alert.probeCount"
+                id="probe-count"
+                type="number"
+                placeholder="number"
+                className={styles.numberInput}
+              />
+            </Field>
+
             <span className={styles.text}>or more probes report connection errors</span>
           </div>
         </div>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -1,0 +1,86 @@
+import React, { FC, useState } from 'react';
+import { css } from 'emotion';
+import { GrafanaTheme } from '@grafana/data';
+import { Input, Label, Select, useStyles } from '@grafana/ui';
+import { Collapse } from './Collapse';
+import { Controller } from 'react-hook-form';
+import { TIME_UNIT_OPTIONS } from './constants';
+
+interface Props {}
+
+const getStyles = (theme: GrafanaTheme) => ({
+  subheader: css`
+    margin-top: ${theme.spacing.md};
+    & a {
+      text-decoration: underline;
+    }
+  `,
+  container: css`
+    background: #202226;
+    padding: ${theme.spacing.md};
+    display: flex;
+    flex-direction: column;
+  `,
+  inputWrapper: css`
+    margin-bottom: ${theme.spacing.md};
+  `,
+  numberInput: css`
+    max-width: 72px;
+    margin-right: ${theme.spacing.sm};
+  `,
+  horizontallyAligned: css`
+    display: flex;
+    align-items: center;
+  `,
+  text: css`
+    font-size: ${theme.typography.size.sm};
+    color: ${theme.colors.formLabel};
+  `,
+  select: css`
+    max-width: 200px;
+  `,
+});
+
+export const Alerting: FC<Props> = () => {
+  const [showAlerting, setShowAlerting] = useState(false);
+  const styles = useStyles(getStyles);
+  return (
+    <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
+      <p className={styles.subheader}>
+        Set up alerts based on criteria that you define. These alerts can be accessed and edited here or in the{' '}
+        <a href="FIXME">Grafana Cloud Alerting UI</a>.
+      </p>
+      <div className={styles.container}>
+        <div className={styles.inputWrapper}>
+          <Label htmlFor="alert-name">Alert name</Label>
+          <Input id="alert-name" type="text" />
+        </div>
+        <div className={styles.inputWrapper}>
+          <Label htmlFor="probe-count" description="If">
+            Expression
+          </Label>
+          <div className={styles.horizontallyAligned}>
+            <Input id="probe-count" type="number" className={styles.numberInput} />
+            <span className={styles.text}>or more probes report connection errors</span>
+          </div>
+        </div>
+        <div className={styles.inputWrapper}>
+          <Label
+            description="Expression has to be true for this long for alert to be fired."
+            htmlFor="alert-time-quantity"
+          >
+            For
+          </Label>
+          <div className={styles.horizontallyAligned}>
+            <Input id="alert-time-quantity" className={styles.numberInput} />
+            <Controller as={Select} name="alert.timeUnit" options={TIME_UNIT_OPTIONS} className={styles.select} />
+          </div>
+        </div>
+        <div>
+          <Label>Severity</Label>
+          <Controller as={Select} name="alert.severity" options={[]} className={styles.select} />
+        </div>
+      </div>
+    </Collapse>
+  );
+};

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -59,8 +59,6 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
   const styles = useStyles(getStyles);
   const probeCount = watch('probes').length;
 
-  console.log({ errors });
-
   if (!instance.alertRuler) {
     return (
       <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
@@ -127,7 +125,7 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
             <Field invalid={errors?.alert?.probeCount} error={errors?.alert?.probeCount?.message}>
               <Input
                 ref={register({
-                  max: { value: probeCount, message: `There are ${probeCount} probes attached to this check` },
+                  max: { value: probeCount, message: `There are ${probeCount} probes configured for this check` },
                 })}
                 name="alert.probeCount"
                 id="probe-count"

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -57,6 +57,22 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
   const { instance } = useContext(InstanceContext);
   const { register } = useFormContext();
   const styles = useStyles(getStyles);
+
+  if (!instance.alertRuler) {
+    return (
+      <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
+        <div className={styles.container}>
+          <p>
+            Alerts can only be created for Synthetic Monitoring checks from{' '}
+            <a href="https://grafana.com" className={styles.link}>
+              Grafana Cloud Alerting
+            </a>
+          </p>
+        </div>
+      </Collapse>
+    );
+  }
+
   if (alertRules.length && editing) {
     return (
       <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -34,7 +34,7 @@ const getStyles = (theme: GrafanaTheme) => ({
     margin-right: ${theme.spacing.xs};
   `,
   inputWrapper: css`
-    margin-bottom: ${theme.spacing.md};
+    margin-bottom: ${theme.spacing.sm};
   `,
   numberInput: css`
     max-width: 72px;
@@ -74,6 +74,12 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
   clearMarginBottom: css`
     margin-bottom: 0;
+  `,
+  halfWidth: css`
+    width: 50%;
+  `,
+  unsetMaxWidth: css`
+    max-width: unset;
   `,
 });
 
@@ -118,7 +124,7 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
             {alertRules.length} alert{alertRules.length > 1 ? 's are' : ' is'} tied to this check. Edit this check's
             alerts in the <code>syntheticmonitoring &gt; {checkId}</code> section of{' '}
             <a href={alertingUiUrl} className={styles.link}>
-              Cloud Alerting
+              Grafana Cloud Alerting
             </a>
           </p>
         </div>
@@ -128,9 +134,13 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
   return (
     <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
       <p className={styles.subheader}>
-        Set up alerts based on criteria that you define. These alerts can be created here and edited in the{' '}
+        Set up alerts for this check here. You must visit{' '}
         <a href={alertingUiUrl} className={styles.link}>
-          Alerting UI
+          Grafana Cloud Alerting
+        </a>
+        &nbsp; to edit this alert and add receivers. Learn more about alert conditions and receivers in{' '}
+        <a href={'https://grafana.com/docs/grafana-cloud/alerts/grafana-cloud-alerting/'}>
+          Grafana Cloud documentation
         </a>
         .
       </p>
@@ -140,69 +150,73 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
         ].probeCount || `<value not selected>`}`;
         return (
           <div key={field.id} className={styles.container}>
+            <Label htmlFor={`alert-name-${index}`}>Alert name</Label>
+            <Field className={styles.halfWidth} invalid={errors?.alerts?.[index]?.name}>
+              <Input
+                ref={register({ required: true })}
+                name={`alerts[${index}].name`}
+                id={`alert-name-${index}`}
+                type="text"
+                placeholder="Name to identify alert rule"
+                defaultValue={field.name}
+              />
+            </Field>
+
             <div className={styles.inputWrapper}>
-              <Label htmlFor={`alert-name-${index}`}>Alert name</Label>
-              <Field invalid={errors?.alerts?.[index]?.name}>
-                <Input
-                  ref={register({ required: true })}
-                  name={`alerts[${index}].name`}
-                  id={`alert-name-${index}`}
-                  type="text"
-                  placeholder="Name to identify alert rule"
-                  defaultValue={field.name}
-                />
-              </Field>
-            </div>
-            <Label>Expression</Label>
-            <div className={styles.horizontalFlexRow}>
-              <div className={styles.horizontallyAligned}>
-                <span className={styles.text}>An alert will fire if</span>
+              <Label>Expression</Label>
+              <div className={styles.horizontalFlexRow}>
+                <div className={styles.horizontallyAligned}>
+                  <span className={styles.text}>An alert will fire if</span>
+                  <Field
+                    className={styles.clearMarginBottom}
+                    invalid={errors?.alerts?.[index]?.probeCount}
+                    error={errors?.alerts?.[index]?.probeCount?.message}
+                    horizontal
+                  >
+                    <Input
+                      ref={register({
+                        required: true,
+                        max: { value: probeCount, message: `There are ${probeCount} probes configured for this check` },
+                      })}
+                      name={`alerts[${index}].probeCount`}
+                      id={`probe-count-${index}`}
+                      type="number"
+                      placeholder="number"
+                      className={styles.numberInput}
+                      defaultValue={field.probeCount}
+                      data-testid={`alert-probeCount-${index}`}
+                    />
+                  </Field>
+
+                  <span className={styles.text}>or more probes report connection errors for</span>
+                </div>
+
                 <Field
                   className={styles.clearMarginBottom}
-                  invalid={errors?.alerts?.[index]?.probeCount}
-                  error={errors?.alerts?.[index]?.probeCount?.message}
+                  invalid={errors?.alerts?.[index]?.timeCount}
+                  error={errors?.alerts?.[index]?.timeCount?.message}
                   horizontal
                 >
                   <Input
-                    ref={register({
-                      required: true,
-                      max: { value: probeCount, message: `There are ${probeCount} probes configured for this check` },
-                    })}
-                    name={`alerts[${index}].probeCount`}
-                    id={`probe-count-${index}`}
-                    type="number"
+                    type={'number'}
+                    ref={register({ required: true })}
+                    name={`alerts[${index}].timeCount`}
+                    id={`alert-time-quantity-${index}`}
                     placeholder="number"
                     className={styles.numberInput}
-                    defaultValue={field.probeCount}
+                    defaultValue={field.timeCount}
+                    data-testid={`alert-timeCount-${index}`}
                   />
                 </Field>
-
-                <span className={styles.text}>or more probes report connection errors for</span>
-              </div>
-
-              <Field
-                className={styles.clearMarginBottom}
-                invalid={errors?.alerts?.[index]?.timeCount}
-                error={errors?.alerts?.[index]?.timeCount}
-                horizontal
-              >
-                <Input
-                  type={'number'}
-                  ref={register({ required: true })}
-                  name={`alerts[${index}].timeCount`}
-                  id={`alert-time-quantity-${index}`}
-                  placeholder="number"
-                  className={styles.numberInput}
-                  defaultValue={field.timeCount}
+                <Controller
+                  as={Select}
+                  name={`alerts[${index}].timeUnit`}
+                  options={TIME_UNIT_OPTIONS}
+                  className={styles.select}
+                  defaultValue={TIME_UNIT_OPTIONS[1]}
+                  data-testid={`alert-timeUnit-${index}`}
                 />
-              </Field>
-              <Controller
-                as={Select}
-                name={`alerts[${index}].timeUnit`}
-                options={TIME_UNIT_OPTIONS}
-                className={styles.select}
-                defaultValue={TIME_UNIT_OPTIONS[1]}
-              />
+              </div>
             </div>
             <div className={styles.severityContainer}>
               <Label>Severity</Label>
@@ -216,11 +230,12 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
             </div>
             <div className={styles.promqlSection}>
               <Label
+                className={styles.unsetMaxWidth}
                 description={
                   <p>
                     This alert will appear as promQL in the{' '}
                     <a className={styles.link} href={alertingUiUrl}>
-                      Alerting UI.
+                      Grafana Cloud Alerting.
                     </a>{' '}
                     If you prefer to write alerts in promQL, you can do so from the Alerting UI.{' '}
                     <a href={'https://prometheus.io/docs/prometheus/latest/querying/basics/'} className={styles.link}>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -7,6 +7,8 @@ import { Controller, useFormContext } from 'react-hook-form';
 import { ALERTING_SEVERITY_OPTIONS, TIME_UNIT_OPTIONS } from './constants';
 import { AlertRule } from 'types';
 import { InstanceContext } from './InstanceContext';
+import { AlertAnnotations } from './AlertAnnotations';
+import { AlertLabels } from './AlertLabels';
 
 interface Props {
   alertRules: AlertRule[];
@@ -134,6 +136,8 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
           <Label>Severity</Label>
           <Controller as={Select} name="alert.severity" options={ALERTING_SEVERITY_OPTIONS} className={styles.select} />
         </div>
+        <AlertLabels />
+        <AlertAnnotations />
       </div>
     </Collapse>
   );

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -1,9 +1,9 @@
 import React, { FC, useState, useContext } from 'react';
 import { css } from 'emotion';
 import { GrafanaTheme } from '@grafana/data';
-import { Field, Icon, Input, Label, Select, useStyles } from '@grafana/ui';
+import { Button, Field, Icon, Input, Label, Select, useStyles } from '@grafana/ui';
 import { Collapse } from './Collapse';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 import { ALERTING_SEVERITY_OPTIONS, TIME_UNIT_OPTIONS } from './constants';
 import { AlertRule } from 'types';
 import { InstanceContext } from './InstanceContext';
@@ -28,6 +28,7 @@ const getStyles = (theme: GrafanaTheme) => ({
     padding: ${theme.spacing.md};
     display: flex;
     flex-direction: column;
+    margin-bottom: ${theme.spacing.md};
   `,
   icon: css`
     margin-right: ${theme.spacing.xs};
@@ -37,9 +38,13 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
   numberInput: css`
     max-width: 72px;
-    margin-right: ${theme.spacing.sm};
+    margin: 0 ${theme.spacing.sm};
   `,
   horizontallyAligned: css`
+    display: flex;
+    align-items: center;
+  `,
+  horizontalFlexRow: css`
     display: flex;
     align-items: center;
   `,
@@ -54,27 +59,35 @@ const getStyles = (theme: GrafanaTheme) => ({
     margin-bottom: ${theme.spacing.md};
   `,
   promql: css`
-    padding: ${theme.spacing.sm};
+    padding: ${theme.spacing.sm} ${theme.spacing.md};
     color: ${theme.colors.textWeak};
+    font-size: ${theme.typography.size.md};
+    display: block;
+    width: 100%;
   `,
   promqlSection: css`
     margin-bottom: ${theme.spacing.md};
+  `,
+  deleteButton: css`
+    display: flex;
+    justify-content: flex-end;
+  `,
+  clearMarginBottom: css`
+    margin-bottom: 0;
   `,
 });
 
 export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
   const [showAlerting, setShowAlerting] = useState(false);
   const { instance } = useContext(InstanceContext);
-  const { register, watch, errors } = useFormContext();
+  const { register, watch, errors, control } = useFormContext();
+  const { fields, append, remove } = useFieldArray({ control, name: 'alerts' });
   const styles = useStyles(getStyles);
   const alertingUiUrl = `a/grafana-alerting-ui-app/?tab=rules&rulessource=${instance.metrics?.name}`;
   const probeCount = watch('probes').length;
-  const alertingProbeCount = watch('alert.probeCount');
+  const alerts = watch('alerts');
   const job = watch('job');
   const target = watch('target');
-
-  const promqlAlertingExp = `sum(1 - probe_success{job="${job}", instance="${target}"}) by (job, instance) >= ${alertingProbeCount ||
-    `<value not selected>`}`;
 
   if (!instance.alertRuler) {
     return (
@@ -121,92 +134,117 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
         </a>
         .
       </p>
-      <div className={styles.container}>
-        <div className={styles.inputWrapper}>
-          <Label htmlFor="alert-name">Alert name</Label>
-          <Field invalid={errors?.alert?.name}>
-            <Input
-              ref={register()}
-              name="alert.name"
-              id="alert-name"
-              type="text"
-              placeholder="Name to identify alert rule"
-            />
-          </Field>
-        </div>
-        <div className={styles.inputWrapper}>
-          <Label htmlFor="probe-count" description="Fire alert if">
-            Expression
-          </Label>
-          <div className={styles.horizontallyAligned}>
-            <Field invalid={errors?.alert?.probeCount} error={errors?.alert?.probeCount?.message}>
-              <Input
-                ref={register({
-                  max: { value: probeCount, message: `There are ${probeCount} probes configured for this check` },
-                })}
-                name="alert.probeCount"
-                id="probe-count"
-                type="number"
-                placeholder="number"
-                className={styles.numberInput}
-              />
-            </Field>
+      {fields.map((field, index) => {
+        const promqlAlertingExp = `sum(1 - probe_success{job="${job}", instance="${target}"}) by (job, instance) >= ${alerts[
+          index
+        ].probeCount || `<value not selected>`}`;
+        return (
+          <div key={field.id} className={styles.container}>
+            <div className={styles.inputWrapper}>
+              <Label htmlFor={`alert-name-${index}`}>Alert name</Label>
+              <Field invalid={errors?.alert?.name}>
+                <Input
+                  ref={register()}
+                  name={`alerts[${index}].name`}
+                  id={`alert-name-${index}`}
+                  type="text"
+                  placeholder="Name to identify alert rule"
+                  defaultValue={field.name}
+                />
+              </Field>
+            </div>
+            <Label>Expression</Label>
+            <div className={styles.horizontalFlexRow}>
+              <div className={styles.horizontallyAligned}>
+                <span className={styles.text}>An alert will fire if</span>
+                <Field
+                  className={styles.clearMarginBottom}
+                  invalid={errors?.alert?.probeCount}
+                  error={errors?.alert?.probeCount?.message}
+                  horizontal
+                >
+                  <Input
+                    ref={register({
+                      max: { value: probeCount, message: `There are ${probeCount} probes configured for this check` },
+                    })}
+                    name={`alerts[${index}].probeCount`}
+                    id={`probe-count-${index}`}
+                    type="number"
+                    placeholder="number"
+                    className={styles.numberInput}
+                    defaultValue={field.probeCount}
+                  />
+                </Field>
 
-            <span className={styles.text}>or more probes report connection errors</span>
-          </div>
-        </div>
-        <div className={styles.inputWrapper}>
-          <Label
-            description="Expression has to be true for this long for alert to be fired."
-            htmlFor="alert-time-quantity"
-          >
-            For
-          </Label>
-          <div className={styles.horizontallyAligned}>
-            <Field invalid={errors?.alert?.timeCount}>
-              <Input
-                ref={register()}
-                name="alert.timeCount"
-                id="alert-time-quantity"
-                placeholder="number"
-                className={styles.numberInput}
+                <span className={styles.text}>or more probes report connection errors for</span>
+              </div>
+
+              <Field className={styles.clearMarginBottom} invalid={errors?.alert?.timeCount} horizontal>
+                <Input
+                  ref={register()}
+                  name={`alerts[${index}].timeCount`}
+                  id={`alert-time-quantity-${index}`}
+                  placeholder="number"
+                  className={styles.numberInput}
+                  defaultValue={field.timeCount}
+                />
+              </Field>
+              <Controller
+                as={Select}
+                name={`alerts[${index}].timeUnit`}
+                options={TIME_UNIT_OPTIONS}
+                className={styles.select}
+                defaultValue={TIME_UNIT_OPTIONS[1]}
               />
-            </Field>
-            <Controller
-              as={Select}
-              name="alert.timeUnit"
-              options={TIME_UNIT_OPTIONS}
-              className={styles.select}
-              defaultValue={TIME_UNIT_OPTIONS[1]}
-            />
+            </div>
+            <div className={styles.severityContainer}>
+              <Label>Severity</Label>
+              <Controller
+                as={Select}
+                name={`alerts[${index}].severity`}
+                options={ALERTING_SEVERITY_OPTIONS}
+                className={styles.select}
+              />
+            </div>
+            <div className={styles.promqlSection}>
+              <Label
+                description={
+                  <p>
+                    This alert will appear as promQL in the{' '}
+                    <a className={styles.link} href={alertingUiUrl}>
+                      Alerting UI.
+                    </a>{' '}
+                    If you prefer to write alerts in promQL, you can do so from the Alerting UI.{' '}
+                    <a href={'https://prometheus.io/docs/prometheus/latest/querying/basics/'} className={styles.link}>
+                      Learn more about PromQL.
+                    </a>
+                  </p>
+                }
+              >
+                PromQL preview
+              </Label>
+              <code className={styles.promql}>{promqlAlertingExp}</code>
+            </div>
+            <AlertLabels />
+            <AlertAnnotations />
+            <div className={styles.deleteButton}>
+              <Button onClick={() => remove(index)} size="sm" variant="destructive" type="button">
+                <Icon name="trash-alt" />
+                &nbsp; Remove alert rule
+              </Button>
+            </div>
           </div>
-        </div>
-        <div className={styles.severityContainer}>
-          <Label>Severity</Label>
-          <Controller as={Select} name="alert.severity" options={ALERTING_SEVERITY_OPTIONS} className={styles.select} />
-        </div>
-        <div className={styles.promqlSection}>
-          <Label
-            description={
-              <p>
-                This alert will appear as promQL in the{' '}
-                <a className={styles.link} href={alertingUiUrl}>
-                  Alerting UI.
-                </a>{' '}
-                If you prefer to write alerts in promQL, you can do so from the Alerting UI.{' '}
-                <a href={'https://prometheus.io/docs/prometheus/latest/querying/basics/'} className={styles.link}>
-                  Learn more about PromQL.
-                </a>
-              </p>
-            }
-          >
-            PromQL preview
-          </Label>
-          <code className={styles.promql}>{promqlAlertingExp}</code>
-        </div>
-        <AlertLabels />
-        <AlertAnnotations />
-      </div>
+        );
+      })}
+      <Button
+        onClick={() => append({ name: '', timeCount: 5, probeCount: 1 })}
+        variant="secondary"
+        size="sm"
+        type="button"
+      >
+        <Icon name="plus" />
+        &nbsp; Add alert rule
+      </Button>
     </Collapse>
   );
 };

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -117,7 +117,7 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
           />
         </div>
         <div className={styles.inputWrapper}>
-          <Label htmlFor="probe-count" description="If">
+          <Label htmlFor="probe-count" description="Fire alert if">
             Expression
           </Label>
           <div className={styles.horizontallyAligned}>
@@ -126,7 +126,7 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
               name="alert.probeCount"
               id="probe-count"
               type="number"
-              placeholder="#"
+              placeholder="number"
               className={styles.numberInput}
             />
             <span className={styles.text}>or more probes report connection errors</span>
@@ -144,7 +144,7 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
               ref={register()}
               name="alert.timeCount"
               id="alert-time-quantity"
-              placeholder="#"
+              placeholder="number"
               className={styles.numberInput}
             />
             <Controller

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -142,9 +142,9 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
           <div key={field.id} className={styles.container}>
             <div className={styles.inputWrapper}>
               <Label htmlFor={`alert-name-${index}`}>Alert name</Label>
-              <Field invalid={errors?.alert?.name}>
+              <Field invalid={errors?.alerts?.[index]?.name}>
                 <Input
-                  ref={register()}
+                  ref={register({ required: true })}
                   name={`alerts[${index}].name`}
                   id={`alert-name-${index}`}
                   type="text"
@@ -159,12 +159,13 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
                 <span className={styles.text}>An alert will fire if</span>
                 <Field
                   className={styles.clearMarginBottom}
-                  invalid={errors?.alert?.probeCount}
-                  error={errors?.alert?.probeCount?.message}
+                  invalid={errors?.alerts?.[index]?.probeCount}
+                  error={errors?.alerts?.[index]?.probeCount?.message}
                   horizontal
                 >
                   <Input
                     ref={register({
+                      required: true,
                       max: { value: probeCount, message: `There are ${probeCount} probes configured for this check` },
                     })}
                     name={`alerts[${index}].probeCount`}
@@ -179,9 +180,15 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
                 <span className={styles.text}>or more probes report connection errors for</span>
               </div>
 
-              <Field className={styles.clearMarginBottom} invalid={errors?.alert?.timeCount} horizontal>
+              <Field
+                className={styles.clearMarginBottom}
+                invalid={errors?.alerts?.[index]?.timeCount}
+                error={errors?.alerts?.[index]?.timeCount}
+                horizontal
+              >
                 <Input
-                  ref={register()}
+                  type={'number'}
+                  ref={register({ required: true })}
                   name={`alerts[${index}].timeCount`}
                   id={`alert-time-quantity-${index}`}
                   placeholder="number"
@@ -204,6 +211,7 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
                 name={`alerts[${index}].severity`}
                 options={ALERTING_SEVERITY_OPTIONS}
                 className={styles.select}
+                defaultValue={ALERTING_SEVERITY_OPTIONS[1]}
               />
             </div>
             <div className={styles.promqlSection}>
@@ -237,7 +245,7 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
         );
       })}
       <Button
-        onClick={() => append({ name: '', timeCount: 5, probeCount: 1 })}
+        onClick={() => append({ name: job, timeCount: 5, probeCount: 1 })}
         variant="secondary"
         size="sm"
         type="button"

--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -625,23 +625,30 @@ describe('Alerting', () => {
   it('adds an alert if specified', async () => {
     await renderCheckEditor({ check: getMinimumCheck({ target: 'grafana.com' }) });
     const alertingSection = await toggleSection('Alerting');
-    await act(
-      async () => await userEvent.type(await within(alertingSection).findByLabelText('Alert name'), 'Horchata')
-    );
-    await act(
-      async () => await userEvent.type(await within(alertingSection).findByLabelText('If', { exact: false }), '1')
-    );
-    await act(
-      async () => await userEvent.type(await within(alertingSection).findByLabelText('For', { exact: false }), '5')
-    );
+    await userEvent.click(await within(alertingSection).findByRole('button', { name: 'Add alert rule', exact: false }));
+    const nameInput = await within(alertingSection).findByLabelText('Alert name');
+    const probeCountInput = await within(alertingSection).findByTestId('alert-probeCount-0');
+    const timeCountInput = await within(alertingSection).findByTestId('alert-timeCount-0');
+    userEvent.clear(nameInput);
+    await act(async () => await userEvent.type(nameInput, 'Horchata'));
+    userEvent.clear(probeCountInput);
+    await act(async () => await userEvent.paste(probeCountInput, '1'));
+    userEvent.clear(timeCountInput);
+    await act(async () => await userEvent.paste(timeCountInput, '10'));
+
     await submitForm();
-    const expectedValues = {
-      name: 'Horchata',
-      probeCount: '1',
-      severity: undefined,
-      timeCount: '5',
-      timeUnit: { label: 'minutes', value: 'm' },
-    };
+    const expectedValues = [
+      {
+        name: 'Horchata',
+        probeCount: '1',
+        severity: {
+          label: 'Warning',
+          value: 'warn',
+        },
+        timeCount: '10',
+        timeUnit: { label: 'minutes', value: 'm' },
+      },
+    ];
     expect(setRulesForCheck).toHaveBeenCalledWith(3, expectedValues, 'tacos', 'grafana.com');
   });
 

--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -380,8 +380,9 @@ describe('HTTP', () => {
 
     userEvent.click(await screen.findByRole('button', { name: 'Add Regex Validation' }));
     userEvent.click(await within(validationSection).findByText('Field name'));
-    userEvent.click(await within(validationSection).findByText('Check fails if response body matches'));
-
+    userEvent.click(
+      await within(validationSection).findByText('Check fails if response body matches', { exact: false })
+    );
     const regexFields = await within(validationSection).findAllByPlaceholderText('Regex');
     await act(async () => await userEvent.type(regexFields[1], 'a body regex'));
 
@@ -648,10 +649,7 @@ describe('Alerting', () => {
     await renderCheckEditor({ check: getMinimumCheck({ target: 'grafana.com' }), withAlerting: false });
     await toggleSection('Alerting');
     // Using a partial string here since the message is broken up across html elements
-    const disabledMessage = screen.getByText(
-      'Synthetic Monitoring uses for creating alert rules. You can edit this check in to add alerts',
-      { exact: false }
-    );
+    const disabledMessage = screen.getByText('Grafana instances running on-prem', { exact: false });
     const cloudAlertingLink = screen.getByRole('link', { name: 'Grafana Cloud Alerting' });
     expect(disabledMessage).toBeInTheDocument();
     expect(cloudAlertingLink).toBeInTheDocument();

--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -647,7 +647,11 @@ describe('Alerting', () => {
   it('shows disabled message if no datasource', async () => {
     await renderCheckEditor({ check: getMinimumCheck({ target: 'grafana.com' }), withAlerting: false });
     await toggleSection('Alerting');
-    const disabledMessage = screen.getByText('Alerts can only be created for Synthetic Monitoring checks from');
+    // Using a partial string here since the message is broken up across html elements
+    const disabledMessage = screen.getByText(
+      'Synthetic Monitoring uses for creating alert rules. You can edit this check in to add alerts',
+      { exact: false }
+    );
     const cloudAlertingLink = screen.getByRole('link', { name: 'Grafana Cloud Alerting' });
     expect(disabledMessage).toBeInTheDocument();
     expect(cloudAlertingLink).toBeInTheDocument();

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -17,6 +17,9 @@ import { useForm, FormContext, Controller } from 'react-hook-form';
 import { GrafanaTheme } from '@grafana/data';
 import { CheckUsage } from '../CheckUsage';
 import { Alerting } from 'components/Alerting';
+import { config, getBackendSrv } from '@grafana/runtime';
+import { parse, stringify } from 'yaml';
+import { useAlerts } from 'hooks/useAlerts';
 
 interface Props {
   check?: Check;
@@ -45,10 +48,45 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
 });
 
+const createAlert = async (checkId: number) => {
+  const ruler = config.datasources['grafanacloud-rdubrock-ruler'];
+  const rulesConfig = await getBackendSrv()
+    .fetch({
+      method: 'GET',
+      url: `${ruler.url}/rules`,
+      headers: {
+        'Content-Type': 'application/yaml',
+      },
+    })
+    .toPromise()
+    .then(response => {
+      return parse(response.data);
+    });
+
+  const rule = {
+    name: checkId,
+    rules: [{ alert: 'hi there', expr: 1 }],
+  };
+
+  getBackendSrv()
+    .fetch({
+      url: `${ruler.url}/rules/syntheticmonitoring`,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/yaml',
+      },
+      data: stringify(rule),
+    })
+    .toPromise()
+    .then(response => {
+      console.log({ postResponse: response });
+    });
+};
+
 export const CheckEditor: FC<Props> = ({ check, instance, onReturn }) => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const { alertRules, setRulesForCheck, deleteRulesForCheck } = useAlerts(check?.id);
   const styles = useStyles(getStyles);
-
   const defaultValues = useMemo(() => getDefaultValuesFromCheck(check), [check]);
 
   const formMethods = useForm<CheckFormValues>({ defaultValues, mode: 'onChange' });
@@ -56,19 +94,27 @@ export const CheckEditor: FC<Props> = ({ check, instance, onReturn }) => {
 
   const isEditor = hasRole(OrgRole.EDITOR);
 
-  const { execute: onSubmit, error, loading: submitting } = useAsyncCallback(async (values: CheckFormValues) => {
-    const updatedCheck = getCheckFromFormValues(values, defaultValues);
-    if (check?.id) {
-      await instance.updateCheck({
-        id: check.id,
-        tenantId: check.tenantId,
-        ...updatedCheck,
-      });
-    } else {
-      await instance.addCheck(updatedCheck);
+  const { execute: onSubmit, error, loading: submitting } = useAsyncCallback(
+    async ({ alert, ...checkValues }: CheckFormValues) => {
+      const updatedCheck = getCheckFromFormValues(checkValues, defaultValues);
+      if (check?.id) {
+        await instance.updateCheck({
+          id: check.id,
+          tenantId: check.tenantId,
+          ...updatedCheck,
+        });
+        if (alert) {
+          await setRulesForCheck(check.id, alert, checkValues.job, checkValues.target);
+        }
+      } else {
+        const { id } = await instance.addCheck(updatedCheck);
+        if (alert) {
+          await setRulesForCheck(id, alert, checkValues.job, checkValues.target);
+        }
+      }
+      onReturn(true);
     }
-    onReturn(true);
-  });
+  );
 
   const submissionError = error as SubmissionError;
 
@@ -78,6 +124,7 @@ export const CheckEditor: FC<Props> = ({ check, instance, onReturn }) => {
       return;
     }
     await instance.deleteCheck(id);
+    await deleteRulesForCheck(id);
     onReturn(true);
   };
 
@@ -148,7 +195,7 @@ export const CheckEditor: FC<Props> = ({ check, instance, onReturn }) => {
           />
           <CheckUsage />
           <CheckSettings typeOfCheck={selectedCheckType} isEditor={isEditor} />
-          <Alerting />
+          <Alerting alertRules={alertRules} editing={Boolean(check?.id)} checkId={check?.id} />
         </div>
         <HorizontalGroup>
           <Button

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -16,6 +16,7 @@ import { CHECK_TYPE_OPTIONS, fallbackCheck } from 'components/constants';
 import { useForm, FormContext, Controller } from 'react-hook-form';
 import { GrafanaTheme } from '@grafana/data';
 import { CheckUsage } from '../CheckUsage';
+import { Alerting } from 'components/Alerting';
 
 interface Props {
   check?: Check;
@@ -147,6 +148,7 @@ export const CheckEditor: FC<Props> = ({ check, instance, onReturn }) => {
           />
           <CheckUsage />
           <CheckSettings typeOfCheck={selectedCheckType} isEditor={isEditor} />
+          <Alerting />
         </div>
         <HorizontalGroup>
           <Button

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -71,7 +71,7 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
             formMethods.setError(`alert.${name}`, { type: 'manual', message: 'required' });
           }
         });
-        return null;
+        return;
       }
       const updatedCheck = getCheckFromFormValues(checkValues, defaultValues);
       if (check?.id) {

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -1,9 +1,8 @@
-import React, { FC, useState, useMemo } from 'react';
+import React, { FC, useState, useMemo, useContext } from 'react';
 import { css } from 'emotion';
 import { Button, ConfirmModal, Field, Input, HorizontalGroup, Select, Legend, Alert, useStyles } from '@grafana/ui';
 import { useAsyncCallback } from 'react-async-hook';
 import { Check, CheckType, OrgRole, CheckFormValues, SubmissionError } from 'types';
-import { SMDataSource } from 'datasource/DataSource';
 import { hasRole } from 'utils';
 import { getDefaultValuesFromCheck, getCheckFromFormValues } from './checkFormTransformations';
 import { validateJob, validateTarget } from 'validation';
@@ -17,13 +16,11 @@ import { useForm, FormContext, Controller } from 'react-hook-form';
 import { GrafanaTheme } from '@grafana/data';
 import { CheckUsage } from '../CheckUsage';
 import { Alerting } from 'components/Alerting';
-import { config, getBackendSrv } from '@grafana/runtime';
-import { parse, stringify } from 'yaml';
 import { useAlerts } from 'hooks/useAlerts';
+import { InstanceContext } from 'components/InstanceContext';
 
 interface Props {
   check?: Check;
-  instance: SMDataSource;
   onReturn: (reload: boolean) => void;
 }
 
@@ -48,7 +45,10 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
 });
 
-export const CheckEditor: FC<Props> = ({ check, instance, onReturn }) => {
+export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
+  const {
+    instance: { api },
+  } = useContext(InstanceContext);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { alertRules, setRulesForCheck, deleteRulesForCheck } = useAlerts(check?.id);
   const styles = useStyles(getStyles);
@@ -63,7 +63,7 @@ export const CheckEditor: FC<Props> = ({ check, instance, onReturn }) => {
     async ({ alert, ...checkValues }: CheckFormValues) => {
       const updatedCheck = getCheckFromFormValues(checkValues, defaultValues);
       if (check?.id) {
-        await instance.updateCheck({
+        await api?.updateCheck({
           id: check.id,
           tenantId: check.tenantId,
           ...updatedCheck,
@@ -72,7 +72,7 @@ export const CheckEditor: FC<Props> = ({ check, instance, onReturn }) => {
           await setRulesForCheck(check.id, alert, checkValues.job, checkValues.target);
         }
       } else {
-        const { id } = await instance.addCheck(updatedCheck);
+        const { id } = await api?.addCheck(updatedCheck);
         if (alert) {
           await setRulesForCheck(id, alert, checkValues.job, checkValues.target);
         }
@@ -88,7 +88,7 @@ export const CheckEditor: FC<Props> = ({ check, instance, onReturn }) => {
     if (!id) {
       return;
     }
-    await instance.deleteCheck(id);
+    await api?.deleteCheck(id);
     await deleteRulesForCheck(id);
     onReturn(true);
   };

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -48,41 +48,6 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
 });
 
-const createAlert = async (checkId: number) => {
-  const ruler = config.datasources['grafanacloud-rdubrock-ruler'];
-  const rulesConfig = await getBackendSrv()
-    .fetch({
-      method: 'GET',
-      url: `${ruler.url}/rules`,
-      headers: {
-        'Content-Type': 'application/yaml',
-      },
-    })
-    .toPromise()
-    .then(response => {
-      return parse(response.data);
-    });
-
-  const rule = {
-    name: checkId,
-    rules: [{ alert: 'hi there', expr: 1 }],
-  };
-
-  getBackendSrv()
-    .fetch({
-      url: `${ruler.url}/rules/syntheticmonitoring`,
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/yaml',
-      },
-      data: stringify(rule),
-    })
-    .toPromise()
-    .then(response => {
-      console.log({ postResponse: response });
-    });
-};
-
 export const CheckEditor: FC<Props> = ({ check, instance, onReturn }) => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { alertRules, setRulesForCheck, deleteRulesForCheck } = useAlerts(check?.id);

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState, useMemo, useContext } from 'react';
 import { css } from 'emotion';
 import { Button, ConfirmModal, Field, Input, HorizontalGroup, Select, Legend, Alert, useStyles } from '@grafana/ui';
 import { useAsyncCallback } from 'react-async-hook';
-import { Check, CheckType, OrgRole, CheckFormValues, SubmissionError, AlertFormValues } from 'types';
+import { Check, CheckType, OrgRole, CheckFormValues, SubmissionError } from 'types';
 import { hasRole } from 'utils';
 import { getDefaultValuesFromCheck, getCheckFromFormValues } from './checkFormTransformations';
 import { validateJob, validateTarget } from 'validation';
@@ -60,7 +60,7 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
   const isEditor = hasRole(OrgRole.EDITOR);
 
   const { execute: onSubmit, error, loading: submitting } = useAsyncCallback(
-    async ({ alert, ...checkValues }: CheckFormValues) => {
+    async ({ alerts, ...checkValues }: CheckFormValues) => {
       const updatedCheck = getCheckFromFormValues(checkValues, defaultValues);
       if (check?.id) {
         await api?.updateCheck({
@@ -68,13 +68,13 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
           tenantId: check.tenantId,
           ...updatedCheck,
         });
-        if (alert) {
-          await setRulesForCheck(check.id, alert, checkValues.job, checkValues.target);
+        if (alerts?.length) {
+          await setRulesForCheck(check.id, alerts, checkValues.job, checkValues.target);
         }
       } else {
         const { id } = await api?.addCheck(updatedCheck);
-        if (alert) {
-          await setRulesForCheck(id, alert, checkValues.job, checkValues.target);
+        if (alerts) {
+          await setRulesForCheck(id, alerts, checkValues.job, checkValues.target);
         }
       }
       onReturn(true);

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -54,7 +54,7 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
   const styles = useStyles(getStyles);
   const defaultValues = useMemo(() => getDefaultValuesFromCheck(check), [check]);
 
-  const formMethods = useForm<CheckFormValues>({ defaultValues, mode: 'onBlur' });
+  const formMethods = useForm<CheckFormValues>({ defaultValues, mode: 'onChange' });
   const selectedCheckType = formMethods.watch('checkType').value as CheckType;
 
   const isEditor = hasRole(OrgRole.EDITOR);

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -54,7 +54,7 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
   const styles = useStyles(getStyles);
   const defaultValues = useMemo(() => getDefaultValuesFromCheck(check), [check]);
 
-  const formMethods = useForm<CheckFormValues>({ defaultValues, mode: 'onChange' });
+  const formMethods = useForm<CheckFormValues>({ defaultValues, mode: 'onBlur' });
   const selectedCheckType = formMethods.watch('checkType').value as CheckType;
 
   const isEditor = hasRole(OrgRole.EDITOR);

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -61,18 +61,6 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
 
   const { execute: onSubmit, error, loading: submitting } = useAsyncCallback(
     async ({ alert, ...checkValues }: CheckFormValues) => {
-      const alertFieldNames: Array<keyof AlertFormValues> = ['name', 'probeCount', 'severity', 'timeCount'];
-      const isAddingAlert = alert?.name || alert?.probeCount || alert?.severity || alert?.timeCount;
-      const isValid = alert?.name && alert?.probeCount && alert?.severity && alert?.timeCount;
-      if (isAddingAlert && !isValid) {
-        console.log({ alert });
-        alertFieldNames.forEach(name => {
-          if (!alert?.[name]) {
-            formMethods.setError(`alert.${name}`, { type: 'manual', message: 'required' });
-          }
-        });
-        return;
-      }
       const updatedCheck = getCheckFromFormValues(checkValues, defaultValues);
       if (check?.id) {
         await api?.updateCheck({

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -494,7 +494,10 @@ const getSettingsFromFormValues = (formValues: Partial<CheckFormValues>, default
   }
 };
 
-export const getCheckFromFormValues = (formValues: CheckFormValues, defaultValues: CheckFormValues): Check => {
+export const getCheckFromFormValues = (
+  formValues: Omit<CheckFormValues, 'alert'>,
+  defaultValues: CheckFormValues
+): Check => {
   return {
     job: formValues.job,
     target: formValues.target,

--- a/src/components/Collapse.tsx
+++ b/src/components/Collapse.tsx
@@ -50,8 +50,8 @@ export const Collapse: FC<Props> = ({ isOpen, label, children, onToggle, ...prop
   return (
     <div className={cx(['panel-container', styles.container])}>
       <div className={styles.header} onClick={() => onToggle && onToggle(Boolean(isOpen))}>
-        <Icon name={isOpen ? 'angle-up' : 'angle-down'} className={styles.headerIcon} />
         <div className={styles.label}>{label}</div>
+        <Icon name={isOpen ? 'angle-down' : 'angle-right'} className={styles.headerIcon} />
       </div>
       <div className={cx(styles.body, { [styles.hidden]: !isOpen })}>{children}</div>
     </div>

--- a/src/components/InstanceProvider.tsx
+++ b/src/components/InstanceProvider.tsx
@@ -1,11 +1,15 @@
 import React, { useState, FC, useEffect } from 'react';
 import { InstanceContext } from 'components/InstanceContext';
 import { GlobalSettings, GrafanaInstances } from 'types';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { SMDataSource } from 'datasource/DataSource';
 import { Spinner } from '@grafana/ui';
 import { AppPluginMeta } from '@grafana/data';
 import { UnprovisionedSetup } from 'components/UnprovisionedSetup';
+
+function getRulerDatasource() {
+  return Object.values(config.datasources).find(ds => ds.type === 'grafana-ruler-datasource');
+}
 
 async function fetchDatasources(
   metricInstanceName: string | undefined,
@@ -18,10 +22,14 @@ async function fetchDatasources(
 
   const logsName = logsInstanceName ?? smApi?.instanceSettings?.jsonData?.logs?.grafanaName;
   const logs = logsName ? await dataSourceSrv.get(logsName).catch(e => undefined) : undefined;
+
+  const alertRuler = getRulerDatasource();
+
   return {
     api: smApi,
     metrics,
     logs,
+    alertRuler,
   };
 }
 

--- a/src/components/InstanceProvider.tsx
+++ b/src/components/InstanceProvider.tsx
@@ -73,6 +73,7 @@ export const InstanceProvider: FC<Props> = ({ children, metricInstanceName, logs
   if (!instances.metrics || !instances.logs) {
     return <UnprovisionedSetup pluginId={meta.id} pluginName={meta.name} />;
   }
+
   return (
     <InstanceContext.Provider value={{ meta, instance: instances, loading: instancesLoading }}>
       {children}

--- a/src/components/InstanceProvider.tsx
+++ b/src/components/InstanceProvider.tsx
@@ -1,14 +1,27 @@
 import React, { useState, FC, useEffect } from 'react';
 import { InstanceContext } from 'components/InstanceContext';
 import { GlobalSettings, GrafanaInstances } from 'types';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv, getBackendSrv } from '@grafana/runtime';
 import { SMDataSource } from 'datasource/DataSource';
 import { Spinner } from '@grafana/ui';
 import { AppPluginMeta } from '@grafana/data';
 import { UnprovisionedSetup } from 'components/UnprovisionedSetup';
 
-function getRulerDatasource() {
-  return Object.values(config.datasources).find(ds => ds.type === 'grafana-ruler-datasource');
+async function getRulerDatasource(metricDatasourceId?: number) {
+  if (!metricDatasourceId) {
+    return undefined;
+  }
+  const basicAuthUserId = await getBackendSrv()
+    .get(`api/datasources/${metricDatasourceId}`)
+    .then(settings => settings.basicAuthUser);
+  const rulers = Object.values(config.datasources).filter(ds => ds.type === 'grafana-ruler-datasource');
+  const rulerSettings = await Promise.all(
+    rulers.map(ruler => {
+      return getBackendSrv().get(`api/datasources/${ruler.id}`);
+    })
+  );
+  const matchedRuler = rulerSettings.find(ruler => ruler.basicAuthUser === basicAuthUserId);
+  return rulers.find(ruler => ruler.id === matchedRuler.id);
 }
 
 async function fetchDatasources(
@@ -23,7 +36,7 @@ async function fetchDatasources(
   const logsName = logsInstanceName ?? smApi?.instanceSettings?.jsonData?.logs?.grafanaName;
   const logs = logsName ? await dataSourceSrv.get(logsName).catch(e => undefined) : undefined;
 
-  const alertRuler = getRulerDatasource();
+  const alertRuler = await getRulerDatasource(metrics?.id);
 
   return {
     api: smApi,

--- a/src/components/SubCollapse.tsx
+++ b/src/components/SubCollapse.tsx
@@ -1,15 +1,42 @@
-import { Label } from '@grafana/ui';
+import { GrafanaTheme } from '@grafana/data';
+import { Icon, useStyles } from '@grafana/ui';
 import React, { FC, useState } from 'react';
+import { css } from 'emotion';
 
 interface Props {
   title: string;
 }
 
+const getStyles = (theme: GrafanaTheme) => ({
+  header: css`
+    border-top: 1px solid #343b40;
+    display: flex;
+    align-items: center;
+    padding: ${theme.spacing.sm} 0;
+    cursor: pointer;
+  `,
+  headerIcon: css`
+    margin-right: ${theme.spacing.sm};
+  `,
+  title: css`
+    font-size: ${theme.typography.size.sm};
+    font-weight: ${theme.typography.weight.bold};
+  `,
+  hidden: css`
+    display: none;
+  `,
+});
+
 export const SubCollapse: FC<Props> = ({ children, title }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const styles = useStyles(getStyles);
   return (
-    <div>
-      <Label>{title}</Label>
-      {children}
-    </div>
+    <>
+      <div className={styles.header} onClick={() => setIsOpen(!isOpen)}>
+        <Icon name={isOpen ? 'angle-up' : 'angle-down'} className={styles.headerIcon} />
+        <span className={styles.title}>{title}</span>
+      </div>
+      <div className={!isOpen ? styles.hidden : ''}>{children}</div>
+    </>
   );
 };

--- a/src/components/SubCollapse.tsx
+++ b/src/components/SubCollapse.tsx
@@ -1,7 +1,7 @@
 import { GrafanaTheme } from '@grafana/data';
 import { Icon, useStyles } from '@grafana/ui';
 import React, { FC, useState } from 'react';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 interface Props {
   title: string;
@@ -14,6 +14,9 @@ const getStyles = (theme: GrafanaTheme) => ({
     align-items: center;
     padding: ${theme.spacing.sm} 0;
     cursor: pointer;
+  `,
+  headerOpen: css`
+    padding-bottom: 0;
   `,
   headerIcon: css`
     margin-right: ${theme.spacing.sm};
@@ -35,8 +38,8 @@ export const SubCollapse: FC<Props> = ({ children, title }) => {
   const styles = useStyles(getStyles);
   return (
     <>
-      <div className={styles.header} onClick={() => setIsOpen(!isOpen)}>
-        <Icon name={isOpen ? 'angle-up' : 'angle-down'} className={styles.headerIcon} />
+      <div className={cx(styles.header, { [styles.headerOpen]: isOpen })} onClick={() => setIsOpen(!isOpen)}>
+        <Icon name={isOpen ? 'angle-down' : 'angle-right'} className={styles.headerIcon} />
         <span className={styles.title}>{title}</span>
       </div>
       <div className={!isOpen ? styles.hidden : styles.visible}>{children}</div>

--- a/src/components/SubCollapse.tsx
+++ b/src/components/SubCollapse.tsx
@@ -25,6 +25,9 @@ const getStyles = (theme: GrafanaTheme) => ({
   hidden: css`
     display: none;
   `,
+  visible: css`
+    padding-left: ${theme.spacing.lg};
+  `,
 });
 
 export const SubCollapse: FC<Props> = ({ children, title }) => {
@@ -36,7 +39,7 @@ export const SubCollapse: FC<Props> = ({ children, title }) => {
         <Icon name={isOpen ? 'angle-up' : 'angle-down'} className={styles.headerIcon} />
         <span className={styles.title}>{title}</span>
       </div>
-      <div className={!isOpen ? styles.hidden : ''}>{children}</div>
+      <div className={!isOpen ? styles.hidden : styles.visible}>{children}</div>
     </>
   );
 };

--- a/src/components/SubCollapse.tsx
+++ b/src/components/SubCollapse.tsx
@@ -1,0 +1,15 @@
+import { Label } from '@grafana/ui';
+import React, { FC, useState } from 'react';
+
+interface Props {
+  title: string;
+}
+
+export const SubCollapse: FC<Props> = ({ children, title }) => {
+  return (
+    <div>
+      <Label>{title}</Label>
+      {children}
+    </div>
+  );
+};

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -148,17 +148,17 @@ export const HTTP_REGEX_VALIDATION_OPTIONS = [
 
 export const TIME_UNIT_OPTIONS = [
   {
-    label: 'Seconds',
+    label: 'seconds',
     value: TimeUnits.seconds,
   },
 
   {
-    label: 'Minutes',
+    label: 'minutes',
     value: TimeUnits.minutes,
   },
 
   {
-    label: 'Hours',
+    label: 'hours',
     value: TimeUnits.hours,
   },
 ];

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -149,17 +149,17 @@ export const HTTP_REGEX_VALIDATION_OPTIONS = [
 export const TIME_UNIT_OPTIONS = [
   {
     label: 'seconds',
-    value: TimeUnits.seconds,
+    value: TimeUnits.Seconds,
   },
 
   {
     label: 'minutes',
-    value: TimeUnits.minutes,
+    value: TimeUnits.Minutes,
   },
 
   {
     label: 'hours',
-    value: TimeUnits.hours,
+    value: TimeUnits.Hours,
   },
 ];
 
@@ -196,18 +196,18 @@ export const SM_ALERTING_NAMESPACE = 'syntheticmonitoring';
 export const ALERTING_SEVERITY_OPTIONS = [
   {
     label: 'Critical',
-    value: AlertSeverity.critical,
+    value: AlertSeverity.Critical,
   },
   {
     label: 'Warning',
-    value: AlertSeverity.warn,
+    value: AlertSeverity.Warn,
   },
   {
     label: 'Error',
-    value: AlertSeverity.error,
+    value: AlertSeverity.Error,
   },
   {
     label: 'Info',
-    value: AlertSeverity.info,
+    value: AlertSeverity.Info,
   },
 ];

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -8,6 +8,7 @@ import {
   HttpSslOption,
   HttpRegexValidationType,
   Check,
+  TimeUnits,
 } from 'types';
 
 export const DNS_RESPONSE_CODES = enumToStringArray(DnsResponseCodes).map(responseCode => ({
@@ -142,6 +143,23 @@ export const HTTP_SSL_OPTIONS = [
 export const HTTP_REGEX_VALIDATION_OPTIONS = [
   { label: 'Check fails if response header matches', value: HttpRegexValidationType.Header },
   { label: 'Check fails if response body matches', value: HttpRegexValidationType.Body },
+];
+
+export const TIME_UNIT_OPTIONS = [
+  {
+    label: TimeUnits.seconds,
+    value: TimeUnits.seconds,
+  },
+
+  {
+    label: TimeUnits.minutes,
+    value: TimeUnits.minutes,
+  },
+
+  {
+    label: TimeUnits.hours,
+    value: TimeUnits.hours,
+  },
 ];
 
 export const fallbackCheck = {

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -9,6 +9,7 @@ import {
   HttpRegexValidationType,
   Check,
   TimeUnits,
+  AlertSeverity,
 } from 'types';
 
 export const DNS_RESPONSE_CODES = enumToStringArray(DnsResponseCodes).map(responseCode => ({
@@ -147,17 +148,17 @@ export const HTTP_REGEX_VALIDATION_OPTIONS = [
 
 export const TIME_UNIT_OPTIONS = [
   {
-    label: TimeUnits.seconds,
+    label: 'Seconds',
     value: TimeUnits.seconds,
   },
 
   {
-    label: TimeUnits.minutes,
+    label: 'Minutes',
     value: TimeUnits.minutes,
   },
 
   {
-    label: TimeUnits.hours,
+    label: 'Hours',
     value: TimeUnits.hours,
   },
 ];
@@ -191,3 +192,22 @@ export const colors = {
 
 export const LEGACY_METRICS_DS_NAME = 'Synthetic Monitoring Metrics';
 export const LEGACY_LOGS_DS_NAME = 'Synthetic Monitoring Logs';
+export const SM_ALERTING_NAMESPACE = 'syntheticmonitoring';
+export const ALERTING_SEVERITY_OPTIONS = [
+  {
+    label: 'Critical',
+    value: AlertSeverity.critical,
+  },
+  {
+    label: 'Warning',
+    value: AlertSeverity.warn,
+  },
+  {
+    label: 'Error',
+    value: AlertSeverity.error,
+  },
+  {
+    label: 'Info',
+    value: AlertSeverity.info,
+  },
+];

--- a/src/datasource/__mocks__/DataSource.ts
+++ b/src/datasource/__mocks__/DataSource.ts
@@ -96,7 +96,7 @@ export const instanceSettings: DataSourceInstanceSettings<SMOptions> = {
 export const getInstanceMock = (settings: DataSourceInstanceSettings<SMOptions> | undefined = instanceSettings) => {
   const instance = new SMDataSource(settings);
   instance.getMetricsDS = jest.fn().mockImplementation(() => ({ url: 'a url' }));
-  instance.addCheck = jest.fn().mockImplementation(() => Promise.resolve());
+  instance.addCheck = jest.fn().mockImplementation(() => Promise.resolve({ id: 3 }));
   instance.listProbes = jest.fn().mockImplementation(() =>
     Promise.resolve([
       {

--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -1,0 +1,84 @@
+import { useState, useEffect } from 'react';
+import { config, getBackendSrv } from '@grafana/runtime';
+import { parse, stringify } from 'yaml';
+import { SM_ALERTING_NAMESPACE } from 'components/constants';
+import { AlertFormValues, AlertRule } from 'types';
+
+const getRulerDatasource = () => config.datasources['grafanacloud-rdubrock-ruler'];
+
+const fetchRulesForCheck = async (checkId: number) => {
+  const ruler = getRulerDatasource();
+  try {
+    return await getBackendSrv()
+      .fetch<any>({
+        method: 'GET',
+        url: `${ruler.url}/rules/${SM_ALERTING_NAMESPACE}/${checkId}`,
+        headers: {
+          'Content-Type': 'application/yaml',
+        },
+      })
+      .toPromise()
+      .then(response => {
+        const alertGroup = parse(response.data);
+        return alertGroup.rules;
+      });
+  } catch (e) {
+    if (e.status === 404) {
+      return [];
+    }
+    throw new Error(`Could not fetch alerting rules for check ${checkId}`);
+  }
+};
+
+const deleteRulesForCheck = (checkId: number) => {
+  const ruler = getRulerDatasource();
+  return getBackendSrv()
+    .fetch<any>({
+      method: 'DELETE',
+      url: `${ruler.url}/rules/${SM_ALERTING_NAMESPACE}/${checkId}`,
+    })
+    .toPromise();
+};
+
+export function useAlerts(checkId?: number) {
+  const [alertRules, setAlertRules] = useState<AlertRule[]>([]);
+
+  const setRulesForCheck = async (checkId: number, alert: AlertFormValues, job: string, target: string) => {
+    const ruler = getRulerDatasource();
+
+    const ruleGroup = {
+      name: checkId,
+      rules: [
+        {
+          alert: alert.name,
+          expr: `sum(1-probe_success{job="${job}", instance="${target}"}) by (job, instance)`,
+          for: `${alert.timeCount}${alert.timeUnit.value}`,
+          severity: alert.severity.value,
+        },
+      ],
+    };
+
+    const updateResponse = getBackendSrv()
+      .fetch({
+        url: `${ruler.url}/rules/syntheticmonitoring`,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/yaml',
+        },
+        data: stringify(ruleGroup),
+      })
+      .toPromise();
+
+    return updateResponse;
+  };
+
+  useEffect(() => {
+    if (checkId) {
+      fetchRulesForCheck(checkId).then(rules => {
+        setAlertRules(rules);
+      });
+    }
+  }, [checkId]);
+
+  return { alertRules, setRulesForCheck, deleteRulesForCheck };
+}

--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -1,11 +1,9 @@
 import { useState, useEffect, useContext } from 'react';
-import { config, getBackendSrv } from '@grafana/runtime';
+import { getBackendSrv } from '@grafana/runtime';
 import { parse, stringify } from 'yaml';
 import { SM_ALERTING_NAMESPACE } from 'components/constants';
 import { AlertFormValues, AlertRule, Label } from 'types';
 import { InstanceContext } from 'components/InstanceContext';
-
-const getRulerDatasource = () => config.datasources['grafanacloud-rdubrock-ruler'];
 
 const fetchRulesForCheck = async (checkId: number, alertRulerUrl: string) => {
   try {
@@ -30,12 +28,11 @@ const fetchRulesForCheck = async (checkId: number, alertRulerUrl: string) => {
   }
 };
 
-const deleteRulesForCheck = (checkId: number) => {
-  const ruler = getRulerDatasource();
+const getDeleteRulesForCheck = (datasourceUrl: string) => (checkId: number) => {
   return getBackendSrv()
     .fetch<any>({
       method: 'DELETE',
-      url: `${ruler.url}/rules/${SM_ALERTING_NAMESPACE}/${checkId}`,
+      url: `${datasourceUrl}/rules/${SM_ALERTING_NAMESPACE}/${checkId}`,
     })
     .toPromise();
 };
@@ -99,5 +96,5 @@ export function useAlerts(checkId?: number) {
     }
   }, [checkId, alertRulerUrl]);
 
-  return { alertRules, setRulesForCheck, deleteRulesForCheck };
+  return { alertRules, setRulesForCheck, deleteRulesForCheck: getDeleteRulesForCheck(alertRulerUrl ?? '') };
 }

--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -68,7 +68,7 @@ export function useAlerts(checkId?: number) {
       rules: [
         {
           alert: alert.name,
-          expr: `sum(1-probe_success{job="${job}", instance="${target}"}) by (job, instance)`,
+          expr: `sum(1-probe_success{job="${job}", instance="${target}"}) by (job, instance) >= ${alert.probeCount}`,
           for: `${alert.timeCount}${alert.timeUnit.value}`,
           severity: alert.severity.value,
           annotations,

--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -4,7 +4,6 @@ import { parse, stringify } from 'yaml';
 import { SM_ALERTING_NAMESPACE } from 'components/constants';
 import { AlertFormValues, AlertRule, Label } from 'types';
 import { InstanceContext } from 'components/InstanceContext';
-import { DataSourceInstanceSettings } from '@grafana/data';
 
 const getRulerDatasource = () => config.datasources['grafanacloud-rdubrock-ruler'];
 
@@ -93,7 +92,6 @@ export function useAlerts(checkId?: number) {
   };
 
   useEffect(() => {
-    console.log('effect running');
     if (checkId && alertRulerUrl) {
       fetchRulesForCheck(checkId, alertRulerUrl).then(rules => {
         setAlertRules(rules);

--- a/src/page/ChecksPage.tsx
+++ b/src/page/ChecksPage.tsx
@@ -92,10 +92,10 @@ export class ChecksPage extends PureComponent<Props, State> {
       return <div>Loading...</div>;
     }
     if (check) {
-      return <CheckEditor check={check} instance={instance.api} onReturn={this.onGoBack} />;
+      return <CheckEditor check={check} onReturn={this.onGoBack} />;
     }
     if (addNew) {
-      return <CheckEditor instance={instance.api} onReturn={this.onGoBack} />;
+      return <CheckEditor onReturn={this.onGoBack} />;
     }
     return <CheckList instance={instance} onAddNewClick={this.onAddNew} checks={checks} />;
   }

--- a/src/page/WelcomePage.tsx
+++ b/src/page/WelcomePage.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState, useContext } from 'react';
 import { Button, Alert, useStyles, HorizontalGroup, useTheme } from '@grafana/ui';
 import { getBackendSrv, config } from '@grafana/runtime';
-import { initializeDatasource } from 'utils';
+import { hasRole, initializeDatasource } from 'utils';
 import { importAllDashboards } from 'dashboards/loader';
 import { InstanceContext } from 'components/InstanceContext';
 import { DataSourceInstanceSettings, GrafanaTheme } from '@grafana/data';
@@ -20,6 +20,7 @@ import lightCircledSM from 'img/light-circled-sm.svg';
 import circledLoki from 'img/circled-loki.svg';
 import { CloudDatasourceJsonData } from 'datasource/types';
 import { isNumber } from 'lodash';
+import { OrgRole } from 'types';
 
 const getStyles = (theme: GrafanaTheme) => {
   const textColor = theme.isDark ? colors.darkText : colors.lightText;
@@ -206,7 +207,10 @@ export const WelcomePage: FC<Props> = () => {
               </div>
             </div>
           </div>
-          <Button onClick={onClick} disabled={!Boolean(metricsDatasource) || !Boolean(logsDatasource)}>
+          <Button
+            onClick={onClick}
+            disabled={!Boolean(metricsDatasource) || !Boolean(logsDatasource) || !hasRole(OrgRole.EDITOR)}
+          >
             Monitor your systems
           </Button>
           {error && <Alert title="Something went wrong:">{error}</Alert>}

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,7 +248,7 @@ export interface CheckFormValues extends Omit<Check, 'settings' | 'labels'> {
   checkType: SelectableValue<CheckType>;
   settings: SettingsFormValues;
   labels?: Label[];
-  alert?: AlertFormValues;
+  alerts?: AlertFormValues[];
 }
 
 export interface Check extends BaseObject {

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,10 +234,19 @@ export interface SettingsFormValues {
   dns?: DnsSettingsFormValues;
   tcp?: TcpSettingsFormValues;
 }
+export interface AlertFormValues {
+  name: string;
+  probeCount: number;
+  timeCount: number;
+  timeUnit: SelectableValue<TimeUnits>;
+  severity: SelectableValue<AlertSeverity>;
+}
+
 export interface CheckFormValues extends Omit<Check, 'settings' | 'labels'> {
   checkType: SelectableValue<CheckType>;
   settings: SettingsFormValues;
   labels?: Label[];
+  alert?: AlertFormValues;
 }
 
 export interface Check extends BaseObject {
@@ -377,7 +386,26 @@ export interface DashboardMeta {
 }
 
 export enum TimeUnits {
-  seconds = 'seconds',
-  minutes = 'minutes',
-  hours = 'hours',
+  seconds = 's',
+  minutes = 'm',
+  hours = 'h',
 }
+
+export enum AlertSeverity {
+  critical = 'critical',
+  error = 'error',
+  warn = 'warn',
+  info = 'info',
+}
+
+export type AlertRule = {
+  alert: string;
+  expr: string;
+  for?: string;
+  labels?: {
+    [key: string]: string;
+  };
+  annotations?: {
+    [key: string]: string;
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { DataSourceApi, SelectableValue } from '@grafana/data';
+import { DataSourceApi, DataSourceInstanceSettings, SelectableValue } from '@grafana/data';
 import { LinkedDatsourceInfo } from './datasource/types';
 import { SMDataSource } from 'datasource/DataSource';
 
@@ -312,6 +312,7 @@ export interface GrafanaInstances {
   api?: SMDataSource;
   metrics?: DataSourceApi;
   logs?: DataSourceApi;
+  alertRuler?: DataSourceInstanceSettings;
 }
 
 export interface User {

--- a/src/types.ts
+++ b/src/types.ts
@@ -375,3 +375,9 @@ export interface DashboardMeta {
   uid: string;
   version: number;
 }
+
+export enum TimeUnits {
+  seconds = 'seconds',
+  minutes = 'minutes',
+  hours = 'hours',
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -240,6 +240,8 @@ export interface AlertFormValues {
   timeCount: number;
   timeUnit: SelectableValue<TimeUnits>;
   severity: SelectableValue<AlertSeverity>;
+  labels: Label[];
+  annotations: Label[];
 }
 
 export interface CheckFormValues extends Omit<Check, 'settings' | 'labels'> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -389,16 +389,16 @@ export interface DashboardMeta {
 }
 
 export enum TimeUnits {
-  seconds = 's',
-  minutes = 'm',
-  hours = 'h',
+  Seconds = 's',
+  Minutes = 'm',
+  Hours = 'h',
 }
 
 export enum AlertSeverity {
-  critical = 'critical',
-  error = 'error',
-  warn = 'warn',
-  info = 'info',
+  Critical = 'critical',
+  Error = 'error',
+  Warn = 'warn',
+  Info = 'info',
 }
 
 export type AlertRule = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,11 +2330,6 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/js-yaml@^3.12.5":
-  version "3.12.5"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.5.tgz#136d5e6a57a931e1cce6f9d8126aa98a9c92a6bb"
-  integrity sha512-JCcp6J0GV66Y4ZMDAQCXot4xprYB+Zfd3meK9+INSJeVZwJmHAW30BBEEkPzXswMXuiyReUGOP3GxrADc9wPww==
-
 "@types/jsbn@*":
   version "1.2.29"
   resolved "https://registry.yarnpkg.com/@types/jsbn/-/jsbn-1.2.29.tgz#28229bc0262c704a1506c3ed69a7d7e115bd7832"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,6 +2330,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/js-yaml@^3.12.5":
+  version "3.12.5"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.5.tgz#136d5e6a57a931e1cce6f9d8126aa98a9c92a6bb"
+  integrity sha512-JCcp6J0GV66Y4ZMDAQCXot4xprYB+Zfd3meK9+INSJeVZwJmHAW30BBEEkPzXswMXuiyReUGOP3GxrADc9wPww==
+
 "@types/jsbn@*":
   version "1.2.29"
   resolved "https://registry.yarnpkg.com/@types/jsbn/-/jsbn-1.2.29.tgz#28229bc0262c704a1506c3ed69a7d7e115bd7832"


### PR DESCRIPTION
What this PR does:
Adds the ability to create an alert rule from the synthetic monitoring UI. It's meant to be a one way operation, it allows users to create a rule, but pushes them to alerting-ui if a rule is already created. Closes #160 

Creation:
![Screen Shot 2020-12-02 at 8 34 53 AM](https://user-images.githubusercontent.com/8377044/100904230-ab084600-347b-11eb-8211-de001071e0e4.png)

Editing:
![Screen Shot 2020-12-02 at 8 35 12 AM](https://user-images.githubusercontent.com/8377044/100904272-b52a4480-347b-11eb-992d-5b5c3d67cd47.png)

Rule created in alerting-ui:
![Screen Shot 2020-12-02 at 8 35 32 AM](https://user-images.githubusercontent.com/8377044/100904323-c2473380-347b-11eb-8ccd-07030ae8d55b.png)

Running on prem:
![Screen Shot 2020-12-02 at 8 54 09 AM](https://user-images.githubusercontent.com/8377044/100904549-fc183a00-347b-11eb-8ac7-79ad793c7985.png)



