### PR TITLE
fix: annotation and labels in alerts not getting sent to ruler

### DIFF
--- a/src/components/AlertAnnotations.tsx
+++ b/src/components/AlertAnnotations.tsx
@@ -5,8 +5,6 @@ import { SubCollapse } from 'components/SubCollapse';
 import { GrafanaTheme } from '@grafana/data';
 import { css } from 'emotion';
 
-const NAME = 'alert.annotations';
-
 const getStyles = (theme: GrafanaTheme) => ({
   grid: css`
     display: grid;
@@ -22,7 +20,12 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
 });
 
-export const AlertAnnotations: FC = () => {
+type Props = {
+  index: number;
+};
+
+export const AlertAnnotations: FC<Props> = ({ index }) => {
+  const NAME = `alerts[${index}].annotations`;
   const styles = useStyles(getStyles);
   const { control, register } = useFormContext();
   const { fields, append, remove } = useFieldArray({
@@ -43,10 +46,20 @@ export const AlertAnnotations: FC = () => {
             <div />
           </>
         ) : null}
-        {fields.map((field, index) => (
+        {fields.map((field, annotationIndex) => (
           <Fragment key={field.id}>
-            <Input ref={register()} name={`${NAME}[${index}].name`} placeholder="Name" />
-            <TextArea ref={register()} name={`${NAME}[${index}].value`} placeholder="Value" />
+            <Input
+              ref={register()}
+              name={`${NAME}[${annotationIndex}].name`}
+              placeholder="Name"
+              data-testid={`alert-${index}-annotationName-${annotationIndex}`}
+            />
+            <TextArea
+              ref={register()}
+              name={`${NAME}[${annotationIndex}].value`}
+              placeholder="Value"
+              data-testid={`alert-${index}-annotationValue-${annotationIndex}`}
+            />
             <Button type="button" onClick={() => remove(index)} variant="link">
               Delete
             </Button>

--- a/src/components/AlertLabels.tsx
+++ b/src/components/AlertLabels.tsx
@@ -5,8 +5,6 @@ import { SubCollapse } from './SubCollapse';
 import { css } from 'emotion';
 import { GrafanaTheme } from '@grafana/data';
 
-const NAME = 'alert.labels';
-
 const getStyles = (theme: GrafanaTheme) => ({
   grid: css`
     display: grid;
@@ -22,7 +20,12 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
 });
 
-export const AlertLabels: FC = () => {
+type Props = {
+  index: number;
+};
+
+export const AlertLabels: FC<Props> = ({ index }) => {
+  const NAME = `alerts[${index}].labels`;
   const styles = useStyles(getStyles);
   const { control, register } = useFormContext();
   const { fields, append, remove } = useFieldArray({
@@ -44,10 +47,20 @@ export const AlertLabels: FC = () => {
             <div />
           </>
         ) : null}
-        {fields.map((field, index) => (
+        {fields.map((field, labelIndex) => (
           <Fragment key={field.id}>
-            <Input ref={register()} name={`${NAME}[${index}].name`} placeholder="Name" />
-            <Input ref={register()} name={`${NAME}[${index}].value`} placeholder="Value" />
+            <Input
+              ref={register()}
+              name={`${NAME}[${labelIndex}].name`}
+              placeholder="Name"
+              data-testid={`alert-${index}-labelName-${labelIndex}`}
+            />
+            <Input
+              ref={register()}
+              name={`${NAME}[${labelIndex}].value`}
+              placeholder="Value"
+              data-testid={`alert-${index}-labelValue-${labelIndex}`}
+            />
             <Button type="button" onClick={() => remove(index)} variant="link">
               Delete
             </Button>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -248,8 +248,8 @@ export const Alerting: FC<Props> = ({ alertRules, editing, checkId }) => {
               </Label>
               <code className={styles.promql}>{promqlAlertingExp}</code>
             </div>
-            <AlertLabels />
-            <AlertAnnotations />
+            <AlertLabels index={index} />
+            <AlertAnnotations index={index} />
             <div className={styles.deleteButton}>
               <Button onClick={() => remove(index)} size="sm" variant="destructive" type="button">
                 <Icon name="trash-alt" />

--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -632,9 +632,27 @@ describe('Alerting', () => {
     userEvent.clear(nameInput);
     await act(async () => await userEvent.type(nameInput, 'Horchata'));
     userEvent.clear(probeCountInput);
-    await act(async () => await userEvent.paste(probeCountInput, '1'));
+    await act(async () => await userEvent.type(probeCountInput, '1'));
     userEvent.clear(timeCountInput);
-    await act(async () => await userEvent.paste(timeCountInput, '10'));
+    await act(async () => await userEvent.type(timeCountInput, '10'));
+
+    const labelsExpand = await within(alertingSection).findByText('Labels');
+    userEvent.click(labelsExpand);
+    const addLabel = await within(alertingSection).findByRole('button', { name: 'Add label' });
+    userEvent.click(addLabel);
+    const labelNameInput = await within(alertingSection).findByTestId('alert-0-labelName-0');
+    await act(async () => await userEvent.type(labelNameInput, 'steve'));
+    const labelValueInput = await within(alertingSection).findByTestId('alert-0-labelValue-0');
+    await act(async () => await userEvent.type(labelValueInput, 'mcsteveson'));
+
+    const annotationsExpand = await within(alertingSection).findByText('Annotations');
+    userEvent.click(annotationsExpand);
+    const addAnnotation = await within(alertingSection).findByRole('button', { name: 'Add annotation' });
+    userEvent.click(addAnnotation);
+    const annotationNameInput = await within(alertingSection).findByTestId('alert-0-annotationName-0');
+    await act(async () => await userEvent.type(annotationNameInput, 'bob'));
+    const annotationValueInput = await within(alertingSection).findByTestId('alert-0-annotationValue-0');
+    await act(async () => await userEvent.paste(annotationValueInput, 'mcbobson'));
 
     await submitForm();
     const expectedValues = [
@@ -647,6 +665,18 @@ describe('Alerting', () => {
         },
         timeCount: '10',
         timeUnit: { label: 'minutes', value: 'm' },
+        labels: [
+          {
+            name: 'steve',
+            value: 'mcsteveson',
+          },
+        ],
+        annotations: [
+          {
+            name: 'bob',
+            value: 'mcbobson',
+          },
+        ],
       },
     ];
     expect(setRulesForCheck).toHaveBeenCalledWith(3, expectedValues, 'tacos', 'grafana.com');


### PR DESCRIPTION
We have a bug with creating alerts. We didn't quite map the labels and annotations correctly when we moved to adding multiple alert rules.