### PR TITLE
fix: add severity as an alert rule label

### DIFF
--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -59,12 +59,14 @@ export function useAlerts(checkId?: number) {
     const rules = alerts.map(alert => {
       const annotations = tranformFormValues(alert.annotations ?? []);
       const labels = tranformFormValues(alert.labels ?? []);
+      if (alert.severity.value) {
+        labels.severity = alert.severity.value;
+      }
 
       return {
         alert: alert.name,
         expr: `sum(1-probe_success{job="${job}", instance="${target}"}) by (job, instance) >= ${alert.probeCount}`,
         for: `${alert.timeCount}${alert.timeUnit.value}`,
-        severity: alert.severity.value,
         annotations,
         labels,
       };


### PR DESCRIPTION
We are currently trying to send `severity` as it's own key in an alert rule, which doesn't exist. It seems like the convention is to send `severity` as a label instead. https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/