### PR TITLE
Edit alert rules in check edit

### DIFF
--- a/src/components/AlertAnnotations.tsx
+++ b/src/components/AlertAnnotations.tsx
@@ -53,12 +53,14 @@ export const AlertAnnotations: FC<Props> = ({ index }) => {
               name={`${NAME}[${annotationIndex}].name`}
               placeholder="Name"
               data-testid={`alert-${index}-annotationName-${annotationIndex}`}
+              defaultValue={field.name}
             />
             <TextArea
               ref={register()}
               name={`${NAME}[${annotationIndex}].value`}
               placeholder="Value"
               data-testid={`alert-${index}-annotationValue-${annotationIndex}`}
+              defaultValue={field.value}
             />
             <Button type="button" onClick={() => remove(index)} variant="link">
               Delete

--- a/src/components/AlertLabels.tsx
+++ b/src/components/AlertLabels.tsx
@@ -54,12 +54,14 @@ export const AlertLabels: FC<Props> = ({ index }) => {
               name={`${NAME}[${labelIndex}].name`}
               placeholder="Name"
               data-testid={`alert-${index}-labelName-${labelIndex}`}
+              defaultValue={field.name}
             />
             <Input
               ref={register()}
               name={`${NAME}[${labelIndex}].value`}
               placeholder="Value"
               data-testid={`alert-${index}-labelValue-${labelIndex}`}
+              defaultValue={field.value}
             />
             <Button type="button" onClick={() => remove(index)} variant="link">
               Delete

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -14,6 +14,7 @@ import { PromqlExpression } from './PromqlExpression';
 
 interface Props {
   alertRules: AlertRule[];
+  unparseable?: boolean;
   editing: boolean;
   checkId?: number;
 }
@@ -82,7 +83,7 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
 });
 
-export const Alerting: FC<Props> = ({ editing, alertRules }) => {
+export const Alerting: FC<Props> = ({ editing, alertRules, unparseable, checkId }) => {
   const [showAlerting, setShowAlerting] = useState(false);
   const { instance } = useContext(InstanceContext);
   const { register, watch, errors, control } = useFormContext();
@@ -112,21 +113,20 @@ export const Alerting: FC<Props> = ({ editing, alertRules }) => {
     );
   }
 
-  // if (alertRules.length && editing) {
-  //   return (
-  //     <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
-  //       <div className={styles.container}>
-  //         <p>
-  //           {alertRules.length} alert{alertRules.length > 1 ? 's are' : ' is'} tied to this check. Edit this check's
-  //           alerts in the <code>syntheticmonitoring &gt; {checkId}</code> section of{' '}
-  //           <a href={alertingUiUrl} className={styles.link}>
-  //             Grafana Cloud Alerting
-  //           </a>
-  //         </p>
-  //       </div>
-  //     </Collapse>
-  //   );
-  // }
+  if (unparseable) {
+    return (
+      <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
+        <div className={styles.container}>
+          The alerting rules for this check can't be edited here. Please to go the{' '}
+          <code>syntheticmonitoring &gt; {checkId}</code> section of &nbsp;
+          <a href={alertingUiUrl} className={styles.link}>
+            Grafana Cloud Alerting.
+          </a>{' '}
+          &nbsp; to edit.
+        </div>
+      </Collapse>
+    );
+  }
 
   return (
     <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -89,9 +89,7 @@ export const Alerting: FC<Props> = ({ editing, alertRules }) => {
   const { fields, append, remove } = useFieldArray({ control, name: 'alerts' });
   const styles = useStyles(getStyles);
   const alertingUiUrl = `a/grafana-alerting-ui-app/?tab=rules&rulessource=${instance.metrics?.name}`;
-  const alerts = watch('alerts');
   const job = watch('job');
-  const target = watch('target');
 
   if (!instance.alertRuler) {
     return (
@@ -129,7 +127,7 @@ export const Alerting: FC<Props> = ({ editing, alertRules }) => {
   //     </Collapse>
   //   );
   // }
-  console.log({ fields, editing });
+
   return (
     <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
       <p className={styles.subheader}>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -27,11 +27,15 @@ const getStyles = (theme: GrafanaTheme) => ({
     text-decoration: underline;
   `,
   container: css`
-    background: #202226;
+    background: ${theme.colors.bg2};
     padding: ${theme.spacing.md};
     display: flex;
     flex-direction: column;
     margin-bottom: ${theme.spacing.md};
+  `,
+  unparseableContainer: css`
+    background: ${theme.colors.bg2};
+    padding: ${theme.spacing.md};
   `,
   icon: css`
     margin-right: ${theme.spacing.xs};
@@ -116,13 +120,13 @@ export const Alerting: FC<Props> = ({ editing, alertRules, unparseable, checkId 
   if (unparseable) {
     return (
       <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
-        <div className={styles.container}>
+        <div className={styles.unparseableContainer}>
           The alerting rules for this check can't be edited here. Please to go the{' '}
           <code>syntheticmonitoring &gt; {checkId}</code> section of &nbsp;
           <a href={alertingUiUrl} className={styles.link}>
-            Grafana Cloud Alerting.
+            Grafana Cloud Alerting
           </a>{' '}
-          &nbsp; to edit.
+          to edit.
         </div>
       </Collapse>
     );

--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -742,6 +742,29 @@ describe('Alerting', () => {
     expect(annotationValueInput).toHaveValue('mcbobson');
   });
 
+  it('shows a disabled message on edit if a rule cant be parsed', async () => {
+    const alertRules = [
+      {
+        alert: 'tacos',
+        expr: 'sum(1-probe_success{job="tacos", instance="grafana.com"}) by (job, instance) >= 1',
+        for: 'one MILLION years',
+        labels: {
+          severity: 'something completely different',
+          steve: 'mcsteveson',
+        },
+        annotations: {
+          bob: 'mcbobson',
+        },
+      },
+    ];
+    await renderCheckEditor({ check: getMinimumCheck({ target: 'grafana.com', id: 32 }), alertRules });
+    const alertingSection = await toggleSection('Alerting');
+    const errorMessage = await within(
+      alertingSection
+    ).findByText("The alerting rules for this check can't be edited here.", { exact: false });
+    expect(errorMessage).toBeInTheDocument();
+  });
+
   it('shows disabled message if no datasource', async () => {
     await renderCheckEditor({ check: getMinimumCheck({ target: 'grafana.com' }), withAlerting: false });
     await toggleSection('Alerting');

--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -704,7 +704,7 @@ describe('Alerting', () => {
     const alertRules = [
       {
         alert: 'tacos',
-        expr: 'sum(1-probe_success{job="tacos", instance="grafana.com"}) by (job, instance) >= 1',
+        expr: 'sum(1-probe_success{job="tacos", instance="grafana.com"}) by (job, instance) >= 2',
         for: '2h',
         labels: {
           severity: 'critical',
@@ -721,7 +721,7 @@ describe('Alerting', () => {
     const nameInput = await within(alertingSection).findByLabelText('Alert name');
     expect(nameInput).toHaveValue('tacos');
     const probeCountInput = await within(alertingSection).queryByTestId('alert-probeCount-0');
-    expect(probeCountInput).not.toBeInTheDocument();
+    expect(probeCountInput).toHaveValue(2);
     const timeCountInput = await within(alertingSection).findByTestId('alert-timeCount-0');
     expect(timeCountInput).toHaveValue(2);
     const timeUnitInput = await within(alertingSection).findByText('hours');

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -17,13 +17,14 @@ import { GrafanaTheme } from '@grafana/data';
 import { CheckUsage } from '../CheckUsage';
 import { Alerting } from 'components/Alerting';
 import { InstanceContext } from 'components/InstanceContext';
+import { UseAlertsReturnType } from 'hooks/useAlerts';
 
 interface Props {
   check?: Check;
   onReturn: (reload: boolean) => void;
   alertRules: AlertRule[];
-  setRulesForCheck: () => void;
-  deleteRulesForCheck: () => void;
+  setRulesForCheck: UseAlertsReturnType['setRulesForCheck'];
+  deleteRulesForCheck: UseAlertsReturnType['deleteRulesForCheck'];
 }
 
 const getStyles = (theme: GrafanaTheme) => ({
@@ -60,9 +61,6 @@ export const CheckEditor: FC<Props> = ({ check, onReturn, alertRules, setRulesFo
   const formMethods = useForm<CheckFormValues>({ defaultValues, mode: 'onChange' });
 
   const selectedCheckType = formMethods.watch('checkType').value as CheckType;
-  const alerts = formMethods.watch('alerts');
-  console.log({ alerts });
-  console.log({ defaultValues });
 
   const isEditor = hasRole(OrgRole.EDITOR);
 

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -56,7 +56,10 @@ export const CheckEditor: FC<Props> = ({ check, onReturn, alertRules, setRulesFo
 
   const styles = useStyles(getStyles);
 
-  const defaultValues = useMemo(() => getDefaultValuesFromCheck(check, alertRules), [check, alertRules]);
+  const { defaultValues, alertsUnparseable } = useMemo(() => getDefaultValuesFromCheck(check, alertRules), [
+    check,
+    alertRules,
+  ]);
 
   const formMethods = useForm<CheckFormValues>({ defaultValues, mode: 'onChange' });
 
@@ -167,7 +170,12 @@ export const CheckEditor: FC<Props> = ({ check, onReturn, alertRules, setRulesFo
           />
           <CheckUsage />
           <CheckSettings typeOfCheck={selectedCheckType} isEditor={isEditor} />
-          <Alerting alertRules={alertRules} editing={Boolean(check?.id)} checkId={check?.id} />
+          <Alerting
+            alertRules={alertRules}
+            editing={Boolean(check?.id)}
+            checkId={check?.id}
+            unparseable={alertsUnparseable}
+          />
         </div>
         <HorizontalGroup>
           <Button

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useMemo, useContext } from 'react';
+import React, { FC, useState, useMemo, useContext, useEffect } from 'react';
 import { css } from 'emotion';
 import { Button, ConfirmModal, Field, Input, HorizontalGroup, Select, Legend, Alert, useStyles } from '@grafana/ui';
 import { useAsyncCallback } from 'react-async-hook';
@@ -52,10 +52,17 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { alertRules, setRulesForCheck, deleteRulesForCheck } = useAlerts(check?.id);
   const styles = useStyles(getStyles);
-  const defaultValues = useMemo(() => getDefaultValuesFromCheck(check), [check]);
+
+  const defaultValues = useMemo(() => getDefaultValuesFromCheck(check, alertRules), [check, alertRules]);
 
   const formMethods = useForm<CheckFormValues>({ defaultValues, mode: 'onChange' });
+
+  useEffect(() => {
+    formMethods.reset(defaultValues);
+  }, [defaultValues]);
+
   const selectedCheckType = formMethods.watch('checkType').value as CheckType;
+  console.log({ defaultValues });
 
   const isEditor = hasRole(OrgRole.EDITOR);
 

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -1,8 +1,8 @@
-import React, { FC, useState, useMemo, useContext, useEffect } from 'react';
+import React, { FC, useState, useMemo, useContext } from 'react';
 import { css } from 'emotion';
 import { Button, ConfirmModal, Field, Input, HorizontalGroup, Select, Legend, Alert, useStyles } from '@grafana/ui';
 import { useAsyncCallback } from 'react-async-hook';
-import { Check, CheckType, OrgRole, CheckFormValues, SubmissionError } from 'types';
+import { Check, CheckType, OrgRole, CheckFormValues, SubmissionError, AlertRule } from 'types';
 import { hasRole } from 'utils';
 import { getDefaultValuesFromCheck, getCheckFromFormValues } from './checkFormTransformations';
 import { validateJob, validateTarget } from 'validation';
@@ -16,12 +16,14 @@ import { useForm, FormContext, Controller } from 'react-hook-form';
 import { GrafanaTheme } from '@grafana/data';
 import { CheckUsage } from '../CheckUsage';
 import { Alerting } from 'components/Alerting';
-import { useAlerts } from 'hooks/useAlerts';
 import { InstanceContext } from 'components/InstanceContext';
 
 interface Props {
   check?: Check;
   onReturn: (reload: boolean) => void;
+  alertRules: AlertRule[];
+  setRulesForCheck: () => void;
+  deleteRulesForCheck: () => void;
 }
 
 const getStyles = (theme: GrafanaTheme) => ({
@@ -45,23 +47,21 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
 });
 
-export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
+export const CheckEditor: FC<Props> = ({ check, onReturn, alertRules, setRulesForCheck, deleteRulesForCheck }) => {
   const {
     instance: { api },
   } = useContext(InstanceContext);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const { alertRules, setRulesForCheck, deleteRulesForCheck } = useAlerts(check?.id);
+
   const styles = useStyles(getStyles);
 
   const defaultValues = useMemo(() => getDefaultValuesFromCheck(check, alertRules), [check, alertRules]);
 
   const formMethods = useForm<CheckFormValues>({ defaultValues, mode: 'onChange' });
 
-  useEffect(() => {
-    formMethods.reset(defaultValues);
-  }, [defaultValues]);
-
   const selectedCheckType = formMethods.watch('checkType').value as CheckType;
+  const alerts = formMethods.watch('alerts');
+  console.log({ alerts });
   console.log({ defaultValues });
 
   const isEditor = hasRole(OrgRole.EDITOR);

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -73,13 +73,15 @@ export const CheckEditor: FC<Props> = ({ check, onReturn, alertRules, setRulesFo
           tenantId: check.tenantId,
           ...updatedCheck,
         });
-        if (alerts?.length) {
-          await setRulesForCheck(check.id, alerts, checkValues.job, checkValues.target);
+        if (alerts) {
+          await setRulesForCheck({ checkId: check.id, alerts, job: checkValues.job, target: checkValues.target });
+        } else {
+          await deleteRulesForCheck(check.id);
         }
       } else {
         const { id } = await api?.addCheck(updatedCheck);
         if (alerts) {
-          await setRulesForCheck(id, alerts, checkValues.job, checkValues.target);
+          await setRulesForCheck({ checkId: id, alerts, job: checkValues.job, target: checkValues.target });
         }
       }
       onReturn(true);

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -26,6 +26,8 @@ import {
   HttpRegexValidationType,
   HeaderMatch,
   DnsResponseCodes,
+  AlertRule,
+  AlertFormValues,
 } from 'types';
 
 import {
@@ -257,9 +259,29 @@ const getAllFormSettingsForCheck = (): SettingsFormValues => {
   };
 };
 
-export const getDefaultValuesFromCheck = (check: Check = fallbackCheck): CheckFormValues => {
+const getAlertFormValues = (
+  alertRules: AlertRule[]
+): Array<Pick<AlertFormValues, 'name' | 'annotations' | 'labels' | 'annotations'>> =>
+  alertRules.map(rule => ({
+    name: rule.alert,
+    expression: rule.expr,
+    annotations: Object.keys(rule.annotations ?? {}).map(annotationName => ({
+      name: annotationName,
+      value: rule.annotations?.[annotationName] ?? '',
+    })),
+    labels: Object.keys(rule.labels ?? {}).map(labelName => ({
+      name: labelName,
+      value: rule.labels?.[labelName] ?? '',
+    })),
+  }));
+
+export const getDefaultValuesFromCheck = (
+  check: Check = fallbackCheck,
+  alertRules: AlertRule[] = []
+): CheckFormValues => {
   const defaultCheckType = checkType(check.settings);
   const settings = check.id ? getFormSettingsForCheck(check.settings) : getAllFormSettingsForCheck();
+  const alerts = getAlertFormValues(alertRules);
 
   return {
     ...check,
@@ -269,6 +291,7 @@ export const getDefaultValuesFromCheck = (check: Check = fallbackCheck): CheckFo
     checkType:
       CHECK_TYPE_OPTIONS.find(checkTypeOption => checkTypeOption.value === defaultCheckType) ?? CHECK_TYPE_OPTIONS[1],
     settings,
+    alerts,
   };
 };
 

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -274,10 +274,6 @@ const getAlertFormValues = (alertRules: AlertRule[]): GetAlertFormValuesReturn =
       const severityLabel = rule.labels?.severity;
       const severity = ALERTING_SEVERITY_OPTIONS.find(option => option.value === severityLabel);
 
-      if (!timeOption || !severity) {
-        acc.unparseable = true;
-      }
-
       const labels = Object.entries(rule.labels ?? {})
         .map(([name, value]) => ({
           name,
@@ -285,9 +281,14 @@ const getAlertFormValues = (alertRules: AlertRule[]): GetAlertFormValuesReturn =
         }))
         .filter(({ name }) => name !== 'severity'); // We give severity it's own location in the UI, so it needs to be removed from the labels section
 
+      const probeCount = parseInt(rule.expr.split(' >= ')?.[1], 10);
+
+      if (!timeOption || !severity || !probeCount) {
+        acc.unparseable = true;
+      }
       acc.alerts.push({
         name: rule.alert,
-        expression: rule.expr,
+        probeCount,
         timeCount: parseInt(timeCount, 10),
         timeUnit: timeOption ?? {},
         annotations: Object.keys(rule.annotations ?? {}).map(annotationName => ({

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -269,6 +269,13 @@ const getAlertFormValues = (alertRules: AlertRule[]): AlertFormValues[] =>
     const severity =
       ALERTING_SEVERITY_OPTIONS.find(option => option.value === severityLabel) ?? ALERTING_SEVERITY_OPTIONS[1];
 
+    const labels = Object.entries(rule.labels ?? {})
+      .map(([name, value]) => ({
+        name,
+        value,
+      }))
+      .filter(({ name }) => name !== 'severity'); // We give severity it's own location in the UI, so it needs to be removed from the labels section
+
     return {
       name: rule.alert,
       expression: rule.expr,
@@ -278,10 +285,7 @@ const getAlertFormValues = (alertRules: AlertRule[]): AlertFormValues[] =>
         name: annotationName,
         value: rule.annotations?.[annotationName] ?? '',
       })),
-      labels: Object.keys(rule.labels ?? {}).map(labelName => ({
-        name: labelName,
-        value: rule.labels?.[labelName] ?? '',
-      })),
+      labels,
       severity,
     };
   });

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -38,6 +38,7 @@ import {
   HTTP_REGEX_VALIDATION_OPTIONS,
   fallbackCheck,
   TIME_UNIT_OPTIONS,
+  ALERTING_SEVERITY_OPTIONS,
 } from 'components/constants';
 import { checkType, parseAlertTimeUnits } from 'utils';
 
@@ -260,16 +261,18 @@ const getAllFormSettingsForCheck = (): SettingsFormValues => {
   };
 };
 
-const getAlertFormValues = (
-  alertRules: AlertRule[]
-): Array<Pick<AlertFormValues, 'name' | 'annotations' | 'labels' | 'annotations'>> =>
+const getAlertFormValues = (alertRules: AlertRule[]): AlertFormValues[] =>
   alertRules.map(rule => {
     const { timeCount, timeUnit } = parseAlertTimeUnits(rule.for ?? '');
-    const timeOption = TIME_UNIT_OPTIONS.find(({ value }) => value === timeUnit);
+    const timeOption = TIME_UNIT_OPTIONS.find(({ value }) => value === timeUnit) ?? TIME_UNIT_OPTIONS[1];
+    const severityLabel = rule.labels?.severity;
+    const severity =
+      ALERTING_SEVERITY_OPTIONS.find(option => option.value === severityLabel) ?? ALERTING_SEVERITY_OPTIONS[1];
+
     return {
       name: rule.alert,
       expression: rule.expr,
-      timeCount,
+      timeCount: parseInt(timeCount, 10),
       timeUnit: timeOption,
       annotations: Object.keys(rule.annotations ?? {}).map(annotationName => ({
         name: annotationName,
@@ -279,6 +282,7 @@ const getAlertFormValues = (
         name: labelName,
         value: rule.labels?.[labelName] ?? '',
       })),
+      severity,
     };
   });
 
@@ -288,7 +292,6 @@ export const getDefaultValuesFromCheck = (
 ): CheckFormValues => {
   const defaultCheckType = checkType(check.settings);
   const settings = check.id ? getFormSettingsForCheck(check.settings) : getAllFormSettingsForCheck();
-  console.log({ alertRules });
   const alerts = getAlertFormValues(alertRules);
 
   return {

--- a/src/components/ExpressionField.tsx
+++ b/src/components/ExpressionField.tsx
@@ -1,8 +1,7 @@
 import React, { FC } from 'react';
 import { Field, Input, Label, Select, useStyles } from '@grafana/ui';
 import { GrafanaTheme } from '@grafana/data';
-import { Controller, useFormContext, Field as FormField } from 'react-hook-form';
-import { AlertFormValues } from 'types';
+import { Controller, useFormContext, ArrayField } from 'react-hook-form';
 import { TIME_UNIT_OPTIONS } from './constants';
 
 import { css } from 'emotion';
@@ -37,7 +36,7 @@ const getStyles = (theme: GrafanaTheme) => ({
 
 interface Props {
   editing: boolean;
-  field: Pick<AlertFormValues, 'probeCount' | 'timeCount' | 'timeUnit'>;
+  field: Partial<ArrayField<Record<string, any>>>;
   index: number;
 }
 

--- a/src/components/ExpressionField.tsx
+++ b/src/components/ExpressionField.tsx
@@ -1,0 +1,113 @@
+import React, { FC } from 'react';
+import { Field, Input, Label, Select, useStyles } from '@grafana/ui';
+import { GrafanaTheme } from '@grafana/data';
+import { Controller, useFormContext, Field as FormField } from 'react-hook-form';
+import { AlertFormValues } from 'types';
+import { TIME_UNIT_OPTIONS } from './constants';
+
+import { css } from 'emotion';
+
+const getStyles = (theme: GrafanaTheme) => ({
+  inputWrapper: css`
+    margin-bottom: ${theme.spacing.sm};
+  `,
+  numberInput: css`
+    max-width: 72px;
+    margin: 0 ${theme.spacing.sm};
+  `,
+  horizontallyAligned: css`
+    display: flex;
+    align-items: center;
+  `,
+  horizontalFlexRow: css`
+    display: flex;
+    align-items: center;
+  `,
+  text: css`
+    font-size: ${theme.typography.size.sm};
+    color: ${theme.colors.formLabel};
+  `,
+  select: css`
+    max-width: 200px;
+  `,
+  clearMarginBottom: css`
+    margin-bottom: 0;
+  `,
+});
+
+interface Props {
+  editing: boolean;
+  field: Pick<AlertFormValues, 'probeCount' | 'timeCount' | 'timeUnit'>;
+  index: number;
+}
+
+export const ExpressionField: FC<Props> = ({ editing, field, index }) => {
+  const { errors, register, watch } = useFormContext();
+  const probeCount = watch('probeCount');
+  const styles = useStyles(getStyles);
+  return (
+    <div className={styles.inputWrapper}>
+      <Label>Expression</Label>
+      <div className={styles.horizontalFlexRow}>
+        {editing ? (
+          <span className={styles.text}>If probes report connection errors for</span>
+        ) : (
+          <div className={styles.horizontallyAligned}>
+            <span className={styles.text}>An alert will fire if</span>
+            <Field
+              className={styles.clearMarginBottom}
+              invalid={errors?.alerts?.[index]?.probeCount}
+              error={errors?.alerts?.[index]?.probeCount?.message}
+              horizontal
+            >
+              <Input
+                ref={register({
+                  required: true,
+                  max: {
+                    value: probeCount,
+                    message: `There are ${probeCount} probes configured for this check`,
+                  },
+                })}
+                name={`alerts[${index}].probeCount`}
+                id={`probe-count-${index}`}
+                type="number"
+                placeholder="number"
+                className={styles.numberInput}
+                defaultValue={field.probeCount}
+                data-testid={`alert-probeCount-${index}`}
+              />
+            </Field>
+
+            <span className={styles.text}>or more probes report connection errors for</span>
+          </div>
+        )}
+
+        <Field
+          className={styles.clearMarginBottom}
+          invalid={errors?.alerts?.[index]?.timeCount}
+          error={errors?.alerts?.[index]?.timeCount?.message}
+          horizontal
+        >
+          <Input
+            type={'number'}
+            ref={register({ required: true })}
+            name={`alerts[${index}].timeCount`}
+            id={`alert-time-quantity-${index}`}
+            placeholder="number"
+            className={styles.numberInput}
+            defaultValue={field.timeCount}
+            data-testid={`alert-timeCount-${index}`}
+          />
+        </Field>
+        <Controller
+          as={Select}
+          name={`alerts[${index}].timeUnit`}
+          options={TIME_UNIT_OPTIONS}
+          className={styles.select}
+          defaultValue={field.timeUnit}
+          data-testid={`alert-timeUnit-${index}`}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/ExpressionField.tsx
+++ b/src/components/ExpressionField.tsx
@@ -48,38 +48,33 @@ export const ExpressionField: FC<Props> = ({ editing, field, index }) => {
     <div className={styles.inputWrapper}>
       <Label>Expression</Label>
       <div className={styles.horizontalFlexRow}>
-        {editing ? (
-          <span className={styles.text}>If probes report connection errors for</span>
-        ) : (
-          <div className={styles.horizontallyAligned}>
-            <span className={styles.text}>An alert will fire if</span>
-            <Field
-              className={styles.clearMarginBottom}
-              invalid={errors?.alerts?.[index]?.probeCount}
-              error={errors?.alerts?.[index]?.probeCount?.message}
-              horizontal
-            >
-              <Input
-                ref={register({
-                  required: true,
-                  max: {
-                    value: probeCount,
-                    message: `There are ${probeCount} probes configured for this check`,
-                  },
-                })}
-                name={`alerts[${index}].probeCount`}
-                id={`probe-count-${index}`}
-                type="number"
-                placeholder="number"
-                className={styles.numberInput}
-                defaultValue={field.probeCount}
-                data-testid={`alert-probeCount-${index}`}
-              />
-            </Field>
-
-            <span className={styles.text}>or more probes report connection errors for</span>
-          </div>
-        )}
+        <div className={styles.horizontallyAligned}>
+          <span className={styles.text}>An alert will fire if</span>
+          <Field
+            className={styles.clearMarginBottom}
+            invalid={errors?.alerts?.[index]?.probeCount}
+            error={errors?.alerts?.[index]?.probeCount?.message}
+            horizontal
+          >
+            <Input
+              ref={register({
+                required: true,
+                max: {
+                  value: probeCount,
+                  message: `There are ${probeCount} probes configured for this check`,
+                },
+              })}
+              name={`alerts[${index}].probeCount`}
+              id={`probe-count-${index}`}
+              type="number"
+              placeholder="number"
+              className={styles.numberInput}
+              defaultValue={field.probeCount}
+              data-testid={`alert-probeCount-${index}`}
+            />
+          </Field>
+          <span className={styles.text}>or more probes report connection errors for</span>
+        </div>
 
         <Field
           className={styles.clearMarginBottom}

--- a/src/components/PromqlExpression.tsx
+++ b/src/components/PromqlExpression.tsx
@@ -14,6 +14,7 @@ const getStyles = (theme: GrafanaTheme) => ({
     font-size: ${theme.typography.size.md};
     display: block;
     width: 100%;
+    white-space: pre-wrap;
   `,
   promqlSection: css`
     margin-bottom: ${theme.spacing.md};

--- a/src/components/PromqlExpression.tsx
+++ b/src/components/PromqlExpression.tsx
@@ -1,0 +1,72 @@
+import React, { FC } from 'react';
+import { css } from 'emotion';
+import { GrafanaTheme } from '@grafana/data';
+import { Input, Label, useStyles } from '@grafana/ui';
+import { useFormContext } from 'react-hook-form';
+
+const getStyles = (theme: GrafanaTheme) => ({
+  link: css`
+    text-decoration: underline;
+  `,
+  promql: css`
+    padding: ${theme.spacing.sm} ${theme.spacing.md};
+    color: ${theme.colors.textWeak};
+    font-size: ${theme.typography.size.md};
+    display: block;
+    width: 100%;
+  `,
+  promqlSection: css`
+    margin-bottom: ${theme.spacing.md};
+  `,
+  unsetMaxWidth: css`
+    max-width: unset;
+  `,
+  displayNone: css`
+    display: none;
+  `,
+});
+
+interface Props {
+  alertingUiUrl: string;
+  index: number;
+}
+
+export const PromqlExpression: FC<Props> = ({ alertingUiUrl, index }) => {
+  const styles = useStyles(getStyles);
+  const { watch, register } = useFormContext();
+  const job = watch('job');
+  const target = watch('target');
+  const probeCount = watch(`alerts[${index}].probeCount`);
+  const expression = watch(`alerts[${index}].expression`);
+
+  const promqlAlertingExp =
+    expression ??
+    `sum(1 - probe_success{job="${job}", instance="${target}"}) by (job, instance) >= ${probeCount ||
+      `<value not selected>`}`;
+
+  return (
+    <div className={styles.promqlSection}>
+      <Label
+        className={styles.unsetMaxWidth}
+        description={
+          <p>
+            This alert will appear as promQL in the{' '}
+            <a className={styles.link} href={alertingUiUrl}>
+              Grafana Cloud Alerting.
+            </a>{' '}
+            If you prefer to write alerts in promQL, you can do so from the Alerting UI.{' '}
+            <a href={'https://prometheus.io/docs/prometheus/latest/querying/basics/'} className={styles.link}>
+              Learn more about PromQL.
+            </a>
+          </p>
+        }
+      >
+        PromQL preview
+      </Label>
+      {expression && (
+        <Input className={styles.displayNone} ref={register()} name={`alerts[${index}].expression`} hidden />
+      )}
+      <code className={styles.promql}>{promqlAlertingExp}</code>
+    </div>
+  );
+};

--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -107,3 +107,5 @@ export function useAlerts(checkId?: number) {
 
   return { alertRules, loading, setRulesForCheck, deleteRulesForCheck: getDeleteRulesForCheck(alertRulerUrl ?? '') };
 }
+
+export type UseAlertsReturnType = ReturnType<typeof useAlerts>;

--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -74,9 +74,7 @@ export function useAlerts(checkId?: number) {
 
         return {
           alert: alert.name,
-          expr:
-            alert.expression ||
-            `sum(1-probe_success{job="${job}", instance="${target}"}) by (job, instance) >= ${alert.probeCount}`,
+          expr: `sum(1-probe_success{job="${job}", instance="${target}"}) by (job, instance) >= ${alert.probeCount}`,
           for: `${alert.timeCount}${alert.timeUnit.value}`,
           annotations,
           labels,

--- a/src/page/ChecksPage.tsx
+++ b/src/page/ChecksPage.tsx
@@ -57,16 +57,19 @@ export const ChecksPage: FC<Props> = ({ id }) => {
 
   const onAddNew = () => setAddNew(true);
 
-  const checkEditorProps = { alertRules, setRulesForCheck, deleteRulesForCheck };
-
   if (loading || !instance.api || alertsLoading) {
     return <div>Loading...</div>;
   }
-  if (selectedCheck) {
-    return <CheckEditor check={selectedCheck} onReturn={onGoBack} {...checkEditorProps} />;
-  }
-  if (addNew) {
-    return <CheckEditor onReturn={onGoBack} {...checkEditorProps} />;
+  if (selectedCheck || addNew) {
+    return (
+      <CheckEditor
+        check={selectedCheck ? selectedCheck : undefined}
+        onReturn={onGoBack}
+        alertRules={alertRules}
+        setRulesForCheck={setRulesForCheck}
+        deleteRulesForCheck={deleteRulesForCheck}
+      />
+    );
   }
   return <CheckList instance={instance} onAddNewClick={onAddNew} checks={checks} />;
 };

--- a/src/page/ChecksPage.tsx
+++ b/src/page/ChecksPage.tsx
@@ -7,6 +7,7 @@ import { getLocationSrv } from '@grafana/runtime';
 import { CheckEditor } from 'components/CheckEditor';
 import { CheckList } from 'components/CheckList';
 import { InstanceContext } from 'components/InstanceContext';
+import { useAlerts } from 'hooks/useAlerts';
 
 interface Props {
   id?: string;
@@ -19,6 +20,9 @@ export const ChecksPage: FC<Props> = ({ id }) => {
   const [checks, setChecks] = useState<Check[]>([]);
   const [addNew, setAddNew] = useState(false);
   const [loading, setLoading] = useState(true);
+  const { alertRules, loading: alertsLoading, setRulesForCheck, deleteRulesForCheck } = useAlerts(
+    id ? parseInt(id, 10) : undefined
+  );
 
   useEffect(() => {
     instance.api?.listChecks().then(checks => {
@@ -53,14 +57,16 @@ export const ChecksPage: FC<Props> = ({ id }) => {
 
   const onAddNew = () => setAddNew(true);
 
-  if (loading || !instance.api) {
+  const checkEditorProps = { alertRules, setRulesForCheck, deleteRulesForCheck };
+
+  if (loading || !instance.api || alertsLoading) {
     return <div>Loading...</div>;
   }
   if (selectedCheck) {
-    return <CheckEditor check={selectedCheck} onReturn={onGoBack} />;
+    return <CheckEditor check={selectedCheck} onReturn={onGoBack} {...checkEditorProps} />;
   }
   if (addNew) {
-    return <CheckEditor onReturn={onGoBack} />;
+    return <CheckEditor onReturn={onGoBack} {...checkEditorProps} />;
   }
   return <CheckList instance={instance} onAddNewClick={onAddNew} checks={checks} />;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,8 +235,9 @@ export interface SettingsFormValues {
   tcp?: TcpSettingsFormValues;
 }
 export interface AlertFormValues {
+  expression?: string;
   name: string;
-  probeCount: number;
+  probeCount?: number;
   timeCount: number;
   timeUnit: SelectableValue<TimeUnits>;
   severity: SelectableValue<AlertSeverity>;
@@ -389,9 +390,13 @@ export interface DashboardMeta {
 }
 
 export enum TimeUnits {
+  Milliseconds = 'ms',
   Seconds = 's',
   Minutes = 'm',
   Hours = 'h',
+  Days = 'd',
+  Weeks = 'w',
+  Years = 'y',
 }
 
 export enum AlertSeverity {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -248,3 +248,9 @@ export const queryMetric = async (
     return { error: (e.message || e.data?.message) ?? 'Error fetching data', data: [] };
   }
 };
+
+export const parseAlertTimeUnits = (time: string) => {
+  const regexp = /(\d+)(\D+)/;
+  const [, timeCount, timeUnit] = regexp.exec(time) ?? ['', '', ''];
+  return { timeCount, timeUnit };
+};


### PR DESCRIPTION
Allows for users to edit previously created alert rules from within a check. Previously users were only allowed to edit alert rules created from SM in the Cloud Alerting UI.

This does create a tricky situation because one of the fields in the alerting form, `probeCount`, isn't a field in the alert rule yaml but is instead encoded in the promql expression. For this case we have to do a pretty rough parsing to find the probeCount value:

![Screenshot_2021-01-04 Synthetic Monitoring Synthetic Monitoring - Grafana](https://user-images.githubusercontent.com/3469390/103592251-6c651180-4ea7-11eb-9b8b-c90ebf241b66.png)

If the parsing fails for some reason, or they have a severity that doesn't map to our options, then users are directed to go to Cloud Alerting UI to edit their alerts:

![Screenshot_2021-01-04 Synthetic Monitoring Synthetic Monitoring - Grafana(1)](https://user-images.githubusercontent.com/3469390/103592559-2e1c2200-4ea8-11eb-9509-28fdb166cf11.png)

