### PR TITLE
fix: renavigate to checks page after deleting check

### DIFF
--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -90,7 +90,7 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
     }
     await api?.deleteCheck(id);
     await deleteRulesForCheck(id);
-    onReturn(true);
+    onReturn(false);
   };
 
   const target = formMethods.watch('target', '') as string;


### PR DESCRIPTION
A fix for check deletion. When the user would delete a check it would open a modal and delete the check via an API but it wasn't closing the modal after deletion and navigating back to the checks page.