### PR TITLE
Metric reduction form option

### DIFF
--- a/src/checkUsageCalc.test.ts
+++ b/src/checkUsageCalc.test.ts
@@ -1,98 +1,213 @@
 import { calculateUsage } from './checkUsageCalc';
 import { CheckType } from './types';
 
-it('calculates http usage', () => {
-  const baseUsage = calculateUsage({
-    probeCount: 1,
-    checkType: CheckType.HTTP,
-    frequencySeconds: 60,
-  });
-  expect(baseUsage).toStrictEqual({
-    checksPerMonth: 43800,
-    activeSeries: 128,
-    logsGbPerMonth: 0.04,
-  });
+describe('http usage', () => {
+  it('calculates with full metrics', () => {
+    const baseUsage = calculateUsage({
+      probeCount: 1,
+      checkType: CheckType.HTTP,
+      frequencySeconds: 60,
+      useFullMetrics: true,
+    });
+    expect(baseUsage).toStrictEqual({
+      checksPerMonth: 43800,
+      activeSeries: 128,
+      logsGbPerMonth: 0.04,
+    });
 
-  const multipleProbes = calculateUsage({
-    probeCount: 4,
-    checkType: CheckType.HTTP,
-    frequencySeconds: 60,
-  });
-  expect(multipleProbes).toStrictEqual({
-    checksPerMonth: 175200,
-    activeSeries: 512,
-    logsGbPerMonth: 0.14,
-  });
+    const multipleProbes = calculateUsage({
+      probeCount: 4,
+      checkType: CheckType.HTTP,
+      frequencySeconds: 60,
+      useFullMetrics: true,
+    });
+    expect(multipleProbes).toStrictEqual({
+      checksPerMonth: 175200,
+      activeSeries: 512,
+      logsGbPerMonth: 0.14,
+    });
 
-  const differentFrequency = calculateUsage({
-    probeCount: 4,
-    checkType: CheckType.HTTP,
-    frequencySeconds: 10,
+    const differentFrequency = calculateUsage({
+      probeCount: 4,
+      checkType: CheckType.HTTP,
+      frequencySeconds: 10,
+      useFullMetrics: true,
+    });
+    expect(differentFrequency).toStrictEqual({
+      checksPerMonth: 1051200,
+      activeSeries: 512,
+      logsGbPerMonth: 0.84,
+    });
   });
-  expect(differentFrequency).toStrictEqual({
-    checksPerMonth: 1051200,
-    activeSeries: 512,
-    logsGbPerMonth: 0.84,
+  it('calculates with basic metrics', () => {
+    const baseUsage = calculateUsage({
+      probeCount: 1,
+      checkType: CheckType.HTTP,
+      frequencySeconds: 60,
+      useFullMetrics: false,
+    });
+    expect(baseUsage).toStrictEqual({
+      checksPerMonth: 43800,
+      activeSeries: 38,
+      logsGbPerMonth: 0.04,
+    });
+
+    const multipleProbes = calculateUsage({
+      probeCount: 4,
+      checkType: CheckType.HTTP,
+      frequencySeconds: 60,
+      useFullMetrics: false,
+    });
+    expect(multipleProbes).toStrictEqual({
+      checksPerMonth: 175200,
+      activeSeries: 152,
+      logsGbPerMonth: 0.14,
+    });
+
+    const differentFrequency = calculateUsage({
+      probeCount: 4,
+      checkType: CheckType.HTTP,
+      frequencySeconds: 10,
+      useFullMetrics: false,
+    });
+    expect(differentFrequency).toStrictEqual({
+      checksPerMonth: 1051200,
+      activeSeries: 152,
+      logsGbPerMonth: 0.84,
+    });
   });
 });
 
-it('calculates ping usage', () => {
-  const baseUsage = calculateUsage({
-    probeCount: 1,
-    checkType: CheckType.PING,
-    frequencySeconds: 60,
-  });
-  expect(baseUsage).toStrictEqual({
-    checksPerMonth: 43800,
-    activeSeries: 76,
-    logsGbPerMonth: 0.04,
-  });
+describe('ping usage', () => {
+  it('calculates with full metrics', () => {
+    const baseUsage = calculateUsage({
+      probeCount: 1,
+      checkType: CheckType.PING,
+      frequencySeconds: 60,
+      useFullMetrics: true,
+    });
+    expect(baseUsage).toStrictEqual({
+      checksPerMonth: 43800,
+      activeSeries: 76,
+      logsGbPerMonth: 0.04,
+    });
 
-  const multipleProbes = calculateUsage({
-    probeCount: 4,
-    checkType: CheckType.PING,
-    frequencySeconds: 60,
-  });
-  expect(multipleProbes).toStrictEqual({
-    checksPerMonth: 175200,
-    activeSeries: 304,
-    logsGbPerMonth: 0.14,
-  });
+    const multipleProbes = calculateUsage({
+      probeCount: 4,
+      checkType: CheckType.PING,
+      frequencySeconds: 60,
+      useFullMetrics: true,
+    });
+    expect(multipleProbes).toStrictEqual({
+      checksPerMonth: 175200,
+      activeSeries: 304,
+      logsGbPerMonth: 0.14,
+    });
 
-  const differentFrequency = calculateUsage({
-    probeCount: 4,
-    checkType: CheckType.PING,
-    frequencySeconds: 10,
+    const differentFrequency = calculateUsage({
+      probeCount: 4,
+      checkType: CheckType.PING,
+      frequencySeconds: 10,
+      useFullMetrics: true,
+    });
+    expect(differentFrequency).toStrictEqual({
+      checksPerMonth: 1051200,
+      activeSeries: 304,
+      logsGbPerMonth: 0.84,
+    });
   });
-  expect(differentFrequency).toStrictEqual({
-    checksPerMonth: 1051200,
-    activeSeries: 304,
-    logsGbPerMonth: 0.84,
+  it('calculates with basic metrics', () => {
+    const baseUsage = calculateUsage({
+      probeCount: 1,
+      checkType: CheckType.PING,
+      frequencySeconds: 60,
+      useFullMetrics: false,
+    });
+    expect(baseUsage).toStrictEqual({
+      checksPerMonth: 43800,
+      activeSeries: 25,
+      logsGbPerMonth: 0.04,
+    });
+
+    const multipleProbes = calculateUsage({
+      probeCount: 4,
+      checkType: CheckType.PING,
+      frequencySeconds: 60,
+      useFullMetrics: false,
+    });
+    expect(multipleProbes).toStrictEqual({
+      checksPerMonth: 175200,
+      activeSeries: 100,
+      logsGbPerMonth: 0.14,
+    });
+
+    const differentFrequency = calculateUsage({
+      probeCount: 4,
+      checkType: CheckType.PING,
+      frequencySeconds: 10,
+      useFullMetrics: false,
+    });
+    expect(differentFrequency).toStrictEqual({
+      checksPerMonth: 1051200,
+      activeSeries: 100,
+      logsGbPerMonth: 0.84,
+    });
+  });
+});
+describe('TCP usage', () => {
+  it('calculates with full metrics', () => {
+    const baseUsage = calculateUsage({
+      probeCount: 1,
+      checkType: CheckType.TCP,
+      frequencySeconds: 60,
+      useFullMetrics: true,
+    });
+    expect(baseUsage).toStrictEqual({
+      checksPerMonth: 43800,
+      activeSeries: 59,
+      logsGbPerMonth: 0.04,
+    });
+  });
+  it('calculates with basic metrics', () => {
+    const baseUsage = calculateUsage({
+      probeCount: 1,
+      checkType: CheckType.TCP,
+      frequencySeconds: 60,
+      useFullMetrics: false,
+    });
+    expect(baseUsage).toStrictEqual({
+      checksPerMonth: 43800,
+      activeSeries: 23,
+      logsGbPerMonth: 0.04,
+    });
   });
 });
 
-it('calculates TCP usage', () => {
-  const baseUsage = calculateUsage({
-    probeCount: 1,
-    checkType: CheckType.TCP,
-    frequencySeconds: 60,
+describe('DNS usage', () => {
+  it('calculates with full metrics', () => {
+    const baseUsage = calculateUsage({
+      probeCount: 1,
+      checkType: CheckType.DNS,
+      frequencySeconds: 60,
+      useFullMetrics: true,
+    });
+    expect(baseUsage).toStrictEqual({
+      checksPerMonth: 43800,
+      activeSeries: 79,
+      logsGbPerMonth: 0.04,
+    });
   });
-  expect(baseUsage).toStrictEqual({
-    checksPerMonth: 43800,
-    activeSeries: 59,
-    logsGbPerMonth: 0.04,
-  });
-});
-
-it('calculates DNS usage', () => {
-  const baseUsage = calculateUsage({
-    probeCount: 1,
-    checkType: CheckType.DNS,
-    frequencySeconds: 60,
-  });
-  expect(baseUsage).toStrictEqual({
-    checksPerMonth: 43800,
-    activeSeries: 79,
-    logsGbPerMonth: 0.04,
+  it('calculates with basic metrics', () => {
+    const baseUsage = calculateUsage({
+      probeCount: 1,
+      checkType: CheckType.DNS,
+      frequencySeconds: 60,
+      useFullMetrics: false,
+    });
+    expect(baseUsage).toStrictEqual({
+      checksPerMonth: 43800,
+      activeSeries: 28,
+      logsGbPerMonth: 0.04,
+    });
   });
 });

--- a/src/checkUsageCalc.ts
+++ b/src/checkUsageCalc.ts
@@ -4,6 +4,7 @@ interface ActiveSeriesParams {
   probeCount: number;
   checkType: CheckType;
   frequencySeconds: number;
+  useFullMetrics: boolean;
 }
 
 interface UsageValues {
@@ -19,16 +20,24 @@ enum CheckSeries {
   TCP = 59,
 }
 
-const getSeriesPerCheck = (checkType: CheckType) => {
+enum CheckSeriesBasic {
+  PING = 25,
+  HTTP = 38,
+  DNS = 28,
+  TCP = 23,
+}
+
+const getSeriesPerCheck = (checkType: CheckType, useFullMetrics: boolean) => {
+  const Series = useFullMetrics ? CheckSeries : CheckSeriesBasic;
   switch (checkType) {
     case CheckType.PING:
-      return CheckSeries.PING;
+      return Series.PING;
     case CheckType.TCP:
-      return CheckSeries.TCP;
+      return Series.TCP;
     case CheckType.DNS:
-      return CheckSeries.DNS;
+      return Series.DNS;
     case CheckType.HTTP:
-      return CheckSeries.HTTP;
+      return Series.HTTP;
   }
 };
 
@@ -51,8 +60,13 @@ const getLogsGbPerMonth = (probeCount: number, frequencySeconds: number) => {
   return parseFloat(logsGbPerMonth.toFixed(2));
 };
 
-export const calculateUsage = ({ probeCount, checkType, frequencySeconds }: ActiveSeriesParams): UsageValues => {
-  const seriesPerCheck = getSeriesPerCheck(checkType);
+export const calculateUsage = ({
+  probeCount,
+  checkType,
+  frequencySeconds,
+  useFullMetrics,
+}: ActiveSeriesParams): UsageValues => {
+  const seriesPerCheck = getSeriesPerCheck(checkType, useFullMetrics);
   const activeSeries = seriesPerCheck * probeCount;
 
   return {

--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -44,6 +44,7 @@ const defaultCheck = {
       dontFragment: false,
     },
   },
+  basicMetricsOnly: false,
 } as Check;
 
 const getMinimumCheck = (overrides: Partial<Check> = {}) => ({
@@ -125,6 +126,7 @@ it('Updates existing check', async () => {
     probes: [1],
     timeout: 3000,
     frequency: 60000,
+    basicMetricsOnly: false,
     settings: {
       ping: {
         ipVersion: 'V4',
@@ -153,6 +155,7 @@ describe('PING', () => {
       probes: [1],
       timeout: 3000,
       frequency: 60000,
+      basicMetricsOnly: false,
       settings: {
         ping: {
           ipVersion: 'V4',
@@ -178,6 +181,7 @@ describe('PING', () => {
           dontFragment: true,
         },
       },
+      basicMetricsOnly: true,
     };
 
     await renderCheckEditor({ check });
@@ -222,6 +226,7 @@ describe('HTTP', () => {
       probes: [42],
       timeout: 2000,
       frequency: 120000,
+      basicMetricsOnly: true,
       settings: {
         http: {
           method: HttpMethod.GET,
@@ -400,6 +405,7 @@ describe('HTTP', () => {
       probes: [42],
       timeout: 3000,
       frequency: 60000,
+      basicMetricsOnly: false,
       settings: {
         http: {
           method: 'GET',
@@ -455,9 +461,9 @@ describe('DNS', () => {
       userEvent.click(addRegex);
       const expressionInputs = await screen.findAllByPlaceholderText('Type expression');
       await act(() => userEvent.type(expressionInputs[0], 'not inverted validation'));
-      await userEvent.type(expressionInputs[1], 'inverted validation');
+      await act(() => userEvent.type(expressionInputs[1], 'inverted validation'));
       const invertedCheckboxes = await screen.findAllByRole('checkbox');
-      userEvent.click(invertedCheckboxes[1]);
+      userEvent.click(invertedCheckboxes[2]);
       await submitForm();
       expect(instance.api.addCheck).toHaveBeenCalledWith({
         job: 'tacos',
@@ -467,6 +473,7 @@ describe('DNS', () => {
         probes: [1],
         timeout: 3000,
         frequency: 60000,
+        basicMetricsOnly: false,
         settings: {
           dns: {
             ipVersion: 'V4',
@@ -504,7 +511,7 @@ describe('DNS', () => {
       await act(() => userEvent.type(expressionInputs[0], 'not inverted validation'));
       await userEvent.type(expressionInputs[1], 'inverted validation');
       const invertedCheckboxes = await screen.findAllByRole('checkbox');
-      userEvent.click(invertedCheckboxes[1]);
+      userEvent.click(invertedCheckboxes[2]);
       await submitForm();
 
       expect(instance.api.addCheck).toHaveBeenCalledWith({
@@ -515,6 +522,7 @@ describe('DNS', () => {
         probes: [1],
         timeout: 3000,
         frequency: 60000,
+        basicMetricsOnly: false,
         settings: {
           dns: {
             ipVersion: 'V4',
@@ -552,7 +560,7 @@ describe('DNS', () => {
       await act(() => userEvent.type(expressionInputs[0], 'not inverted validation'));
       await userEvent.type(expressionInputs[1], 'inverted validation');
       const invertedCheckboxes = await screen.findAllByRole('checkbox');
-      userEvent.click(invertedCheckboxes[1]);
+      userEvent.click(invertedCheckboxes[2]);
 
       await submitForm();
 
@@ -564,6 +572,7 @@ describe('DNS', () => {
         probes: [1],
         timeout: 3000,
         frequency: 60000,
+        basicMetricsOnly: false,
         settings: {
           dns: {
             ipVersion: 'V4',
@@ -599,6 +608,7 @@ describe('TCP', () => {
     expect(instance.api.addCheck).toHaveBeenCalledWith({
       enabled: true,
       frequency: 60000,
+      basicMetricsOnly: false,
       job: 'tacos',
       labels: [],
       probes: [1],

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -94,7 +94,6 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
   };
 
   const target = formMethods.watch('target', '') as string;
-  const useFullMetrics = formMethods.watch('useFullMetrics');
 
   return (
     <FormContext {...formMethods}>

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -90,7 +90,7 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
     }
     await api?.deleteCheck(id);
     await deleteRulesForCheck(id);
-    onReturn(true);
+    onReturn(false);
   };
 
   const target = formMethods.watch('target', '') as string;

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -8,7 +8,7 @@ import { getDefaultValuesFromCheck, getCheckFromFormValues } from './checkFormTr
 import { validateJob, validateTarget } from 'validation';
 import CheckTarget from 'components/CheckTarget';
 import { Subheader } from 'components/Subheader';
-import { HorizonalCheckboxField } from 'components/HorizonalCheckboxField';
+import { HorizontalCheckboxField } from 'components/HorizonalCheckboxField';
 import { CheckSettings } from './CheckSettings';
 import { ProbeOptions } from './ProbeOptions';
 import { CHECK_TYPE_OPTIONS, fallbackCheck } from 'components/constants';
@@ -94,6 +94,8 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
   };
 
   const target = formMethods.watch('target', '') as string;
+  const useFullMetrics = formMethods.watch('useFullMetrics');
+
   return (
     <FormContext {...formMethods}>
       <form onSubmit={formMethods.handleSubmit(onSubmit)}>
@@ -110,7 +112,7 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
               width={30}
             />
           </Field>
-          <HorizonalCheckboxField
+          <HorizontalCheckboxField
             disabled={!isEditor}
             name="enabled"
             id="check-form-enabled"
@@ -157,6 +159,12 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
             timeout={check?.timeout ?? fallbackCheck.timeout}
             frequency={check?.frequency ?? fallbackCheck.frequency}
             probes={check?.probes ?? fallbackCheck.probes}
+          />
+          <HorizontalCheckboxField
+            id="useFullMetrics"
+            name="useFullMetrics"
+            label="Publish full set of metrics"
+            description={'Metrics are reduced by default'}
           />
           <CheckUsage />
           <CheckSettings typeOfCheck={selectedCheckType} isEditor={isEditor} />

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -263,6 +263,7 @@ export const getDefaultValuesFromCheck = (check: Check = fallbackCheck): CheckFo
 
   return {
     ...check,
+    useFullMetrics: !check.basicMetricsOnly,
     timeout: check.timeout / 1000,
     frequency: check.frequency / 1000,
     probes: check.probes,
@@ -507,5 +508,6 @@ export const getCheckFromFormValues = (
     timeout: formValues.timeout * 1000,
     frequency: formValues.frequency * 1000,
     settings: getSettingsFromFormValues(formValues, defaultValues),
+    basicMetricsOnly: !formValues.useFullMetrics,
   };
 };

--- a/src/components/CheckHealth.test.tsx
+++ b/src/components/CheckHealth.test.tsx
@@ -7,6 +7,7 @@ import { getInstanceMock, instanceSettings } from '../datasource/__mocks__/DataS
 import { AppPluginMeta } from '@grafana/data';
 
 const defaultCheck = {
+  basicMetricsOnly: true,
   id: 2,
   tenantId: 1,
   frequency: 60000,

--- a/src/components/CheckUsage.tsx
+++ b/src/components/CheckUsage.tsx
@@ -29,15 +29,21 @@ const getStyles = (theme: GrafanaTheme) => ({
 export const CheckUsage: FC = () => {
   const styles = useStyles(getStyles);
   const { watch } = useFormContext();
-  const { checkType, frequency, probes }: Partial<CheckFormValues> = watch(['checkType', 'frequency', 'probes']);
+  const { checkType, frequency, probes, useFullMetrics }: Partial<CheckFormValues> = watch([
+    'checkType',
+    'frequency',
+    'probes',
+    'useFullMetrics',
+  ]);
 
-  if (!checkType?.value || !frequency || !probes) {
+  if (!checkType?.value || !frequency || !probes || useFullMetrics === undefined) {
     return null;
   }
   const { checksPerMonth, activeSeries, logsGbPerMonth } = calculateUsage({
     probeCount: probes.length,
     frequencySeconds: frequency,
     checkType: checkType.value,
+    useFullMetrics,
   });
   return (
     <div className={styles.container}>

--- a/src/components/HorizonalCheckboxField.tsx
+++ b/src/components/HorizonalCheckboxField.tsx
@@ -29,7 +29,7 @@ interface Props {
   onChange?: () => void;
 }
 
-export const HorizonalCheckboxField: FC<Props> = ({
+export const HorizontalCheckboxField: FC<Props> = ({
   disabled,
   id,
   name,

--- a/src/components/TLSConfig.tsx
+++ b/src/components/TLSConfig.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { Field, Input, Container, TextArea } from '@grafana/ui';
 import { Collapse } from 'components/Collapse';
-import { HorizonalCheckboxField } from 'components/HorizonalCheckboxField';
+import { HorizontalCheckboxField } from 'components/HorizonalCheckboxField';
 import { CheckType } from 'types';
 import { validateTLSCACert, validateTLSClientCert, validateTLSClientKey, validateTLSServerName } from 'validation';
 
@@ -16,7 +16,7 @@ export const TLSConfig: FC<Props> = ({ isEditor, checkType }) => {
   const { register, errors } = useFormContext();
   return (
     <Collapse label="TLS config" onToggle={() => setShowTLS(!showTLS)} isOpen={showTLS} collapsible>
-      <HorizonalCheckboxField
+      <HorizontalCheckboxField
         id="tls-config-skip-validation"
         name={`settings.${checkType}.tlsConfig.insecureSkipVerify`}
         disabled={!isEditor}

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -177,6 +177,7 @@ export const fallbackCheck = {
       dontFragment: false,
     },
   },
+  basicMetricsOnly: true,
 } as Check;
 
 export const colors = {

--- a/src/components/http/HttpSettings.tsx
+++ b/src/components/http/HttpSettings.tsx
@@ -25,7 +25,7 @@ import { TLSConfig } from 'components/TLSConfig';
 import { NameValueInput } from 'components/NameValueInput';
 import { validateBearerToken, validateHTTPBody, validateHTTPHeaderName, validateHTTPHeaderValue } from 'validation';
 import { GrafanaTheme } from '@grafana/data';
-import { HorizonalCheckboxField } from 'components/HorizonalCheckboxField';
+import { HorizontalCheckboxField } from 'components/HorizonalCheckboxField';
 
 const httpVersionOptions = [
   {
@@ -243,7 +243,7 @@ export const HttpSettingsForm: FC<Props> = ({ isEditor }) => {
         collapsible
       >
         <VerticalGroup spacing="xs">
-          <HorizonalCheckboxField
+          <HorizontalCheckboxField
             label="Include bearer authorization header in request"
             id="http-settings-bearer-authorization"
             disabled={!isEditor}
@@ -272,7 +272,7 @@ export const HttpSettingsForm: FC<Props> = ({ isEditor }) => {
           )}
         </VerticalGroup>
         <VerticalGroup spacing="xs">
-          <HorizonalCheckboxField
+          <HorizontalCheckboxField
             label="Include basic authorization header in request"
             id="http-settings-basic-authorization"
             disabled={!isEditor}
@@ -420,7 +420,7 @@ export const HttpSettingsForm: FC<Props> = ({ isEditor }) => {
           <Field label="IP version" description="The IP protocol of the HTTP request" disabled={!isEditor}>
             <Controller as={Select} name="settings.http.ipVersion" options={IP_OPTIONS} />
           </Field>
-          <HorizonalCheckboxField
+          <HorizontalCheckboxField
             id="http-settings-followRedirects"
             label="Follow redirects"
             disabled={!isEditor}

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,6 +249,7 @@ export interface CheckFormValues extends Omit<Check, 'settings' | 'labels'> {
   settings: SettingsFormValues;
   labels?: Label[];
   alerts?: AlertFormValues[];
+  useFullMetrics: boolean;
 }
 
 export interface Check extends BaseObject {
@@ -258,6 +259,7 @@ export interface Check extends BaseObject {
   offset?: number;
   timeout: number;
   enabled: boolean;
+  basicMetricsOnly: boolean;
 
   labels: Label[]; // Currently list of [name:value]... can it be Labels?
   settings: Settings; //

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -12,6 +12,7 @@ describe('trivial cases', () => {
       labels: [],
       probes: [1],
       enabled: true,
+      basicMetricsOnly: true,
       settings: {
         http: {
           method: HttpMethod.GET,
@@ -33,6 +34,7 @@ describe('trivial cases', () => {
       labels: [],
       probes: [1],
       enabled: true,
+      basicMetricsOnly: true,
       settings: {
         ping: {
           ipVersion: IpVersion.V4,
@@ -53,6 +55,7 @@ describe('trivial cases', () => {
       labels: [],
       probes: [1],
       enabled: true,
+      basicMetricsOnly: true,
       settings: {
         dns: {
           recordType: DnsRecordType.A,
@@ -76,6 +79,7 @@ describe('trivial cases', () => {
       labels: [],
       probes: [1],
       enabled: true,
+      basicMetricsOnly: true,
       settings: {
         tcp: {
           ipVersion: IpVersion.V4,


### PR DESCRIPTION
Adds a field to the form for choosing standard (basic) or advanced metrics. Still need to work out the wording. @teddyba the Checkbox component in Grafana UI doesn't allow for elements in the description field, just a simple string. Meaning we can't put an anchor tag linking to the docs page. I can see about opening a PR to make a change but we also might be able to come up with a different solution.

![Screenshot_2021-01-15 Synthetic Monitoring Synthetic Monitoring - Grafana](https://user-images.githubusercontent.com/3469390/104782272-caf87e00-5738-11eb-9779-59b8c5976397.png)
