### PR TITLE
fix: update tcp query response to send and parse base64

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@testing-library/user-event": "^12.0.17",
     "@types/eslint": "^7.2.4",
     "@types/ip-address": "latest",
+    "@types/is-base64": "^1.1.0",
     "@types/lodash": "latest",
     "@types/valid-url": "^1.0.3",
     "eslint-plugin-import": "^2.22.0",
@@ -44,6 +45,7 @@
   },
   "dependencies": {
     "ip-address": "^6.3.0",
+    "is-base64": "^1.1.0",
     "punycode": "^2.1.1",
     "react-async-hook": "^3.6.1",
     "react-hook-form": "5.1.3",

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -194,7 +194,7 @@ export const CheckEditor: FC<Props> = ({ check, onReturn }) => {
         {submissionError && (
           <div className={styles.submissionError}>
             <Alert title="Save failed" severity="error">
-              {`${submissionError.status}: ${submissionError.message}`}
+              {`${submissionError.status}: ${submissionError.message ?? submissionError.msg ?? 'Something went wrong'}`}
             </Alert>
           </div>
         )}

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -37,7 +37,7 @@ import {
   HTTP_REGEX_VALIDATION_OPTIONS,
   fallbackCheck,
 } from 'components/constants';
-import { checkType } from 'utils';
+import { checkType, toBase64 } from 'utils';
 import isBase64 from 'is-base64';
 
 export function selectableValueFrom<T>(value: T, label?: string): SelectableValue<T> {
@@ -190,11 +190,19 @@ const getTcpQueryResponseFormValues = (queryResponses?: TCPQueryResponse[]) => {
     return undefined;
   }
   return queryResponses.map(({ send, expect, startTLS }) => {
-    return {
-      startTLS,
-      send: atob(send),
-      expect: atob(expect),
-    };
+    try {
+      return {
+        startTLS,
+        send: atob(send),
+        expect: atob(expect),
+      };
+    } catch {
+      return {
+        startTLS,
+        send,
+        expect,
+      };
+    }
   });
 };
 
@@ -415,8 +423,8 @@ const getTcpQueryResponseFromFormFields = (queryResponses?: TCPQueryResponse[]) 
   return queryResponses.map(({ send, expect, startTLS }) => {
     return {
       startTLS,
-      send: isBase64(send) ? send : btoa(send),
-      expect: isBase64(expect) ? expect : btoa(expect),
+      send: isBase64(send) ? send : toBase64(send),
+      expect: isBase64(expect) ? expect : toBase64(expect),
     };
   });
 };

--- a/src/components/TLSConfig.tsx
+++ b/src/components/TLSConfig.tsx
@@ -46,7 +46,7 @@ export const TLSConfig: FC<Props> = ({ isEditor, checkType }) => {
           description="The CA cert to use for the targets"
           disabled={!isEditor}
           invalid={Boolean(errors.settings?.[checkType]?.tlsConfig?.caCert)}
-          error={errors.settings?.[checkType]?.tlsConfig?.caCert}
+          error={errors.settings?.[checkType]?.tlsConfig?.caCert?.message}
         >
           <TextArea
             id="tls-config-ca-certificate"
@@ -66,7 +66,7 @@ export const TLSConfig: FC<Props> = ({ isEditor, checkType }) => {
           description="The client cert file for the targets"
           disabled={!isEditor}
           invalid={Boolean(errors?.settings?.[checkType]?.tlsConfig?.clientCert)}
-          error={errors?.settings?.[checkType]?.tlsConfig?.clientCert}
+          error={errors?.settings?.[checkType]?.tlsConfig?.clientCert?.message}
         >
           <TextArea
             id="tls-config-client-cert"

--- a/src/types.ts
+++ b/src/types.ts
@@ -380,6 +380,7 @@ export enum HttpRegexValidationType {
 export interface SubmissionError {
   status?: string;
   message?: string;
+  msg?: string;
 }
 
 export interface DashboardMeta {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -248,3 +248,11 @@ export const queryMetric = async (
     return { error: (e.message || e.data?.message) ?? 'Error fetching data', data: [] };
   }
 };
+
+export const toBase64 = (value: string) => {
+  try {
+    return btoa(value);
+  } catch {
+    return value;
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2273,6 +2273,11 @@
   dependencies:
     "@types/jsbn" "*"
 
+"@types/is-base64@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/is-base64/-/is-base64-1.1.0.tgz#8f0e0874ba0df223a413e46fa12e681708d19080"
+  integrity sha512-rigoMG77vfIXWjYUDBMPCY0qVzY1dGtEILSsjCcvDH/UgB2ENTZl0uKQknJq4W4nEUqVZqX0M9Uw/VRZ/vwzWQ==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -7860,6 +7865,11 @@ is-arrayish@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
   integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
+is-base64@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-base64/-/is-base64-1.1.0.tgz#8ce1d719895030a457c59a7dcaf39b66d99d56b4"
+  integrity sha512-Nlhg7Z2dVC4/PTvIFkgVVNvPHSO2eR/Yd0XzhGiXCXEvWnptXlXa/clQ8aePPiMuxEGcWfzWbGw2Fe3d+Y3v1g==
 
 is-binary-path@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Resolves #186 

The api is expecting a base64 encoded byte value, and we are sending a plain string. This PR translates user input to base64 if it isn't base64 already, and translates it back when editing.

There is also a little fix for ca cert fields that were passing the entire errors object to field errors instead of the just the error message, which makes the FieldError component error out. 