### PR TITLE
chore: add plugin signing step to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
             - build-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
       - run:
           name: Build and test frontend
-          command: ./node_modules/.bin/grafana-toolkit plugin:ci-build
+          command: ./node_modules/.bin/grafana-toolkit plugin:build
 
   build:
     executor: default_exec
@@ -219,6 +219,7 @@ jobs:
       - run:
           name: 'Publish Release on GitHub'
           command: |
+            ./node_modules/.bin/grafana-toolkit plugin:sign
             ./node_modules/.bin/grafana-toolkit plugin:github-publish
       - store_artifacts:
           path: ci


### PR DESCRIPTION
Updates to the new toolkit process used in grafana 7.4