### PR TITLE
fix: add plugin enable action

### DIFF
--- a/src/components/ConfigActions.test.tsx
+++ b/src/components/ConfigActions.test.tsx
@@ -6,12 +6,12 @@ import { getInstanceMock } from 'datasource/__mocks__/DataSource';
 import { AppPluginMeta } from '@grafana/data';
 import { GlobalSettings } from 'types';
 
-const renderConfigActions = ({ hasApi = true } = {}) => {
+const renderConfigActions = ({ hasApi = true, enabled = true } = {}) => {
   const instance = hasApi ? getInstanceMock() : undefined;
   const meta = {} as AppPluginMeta<GlobalSettings>;
   return render(
     <InstanceContext.Provider value={{ instance: { api: instance }, loading: false, meta }}>
-      <ConfigActions />
+      <ConfigActions enabled={enabled} pluginId="steve" />
     </InstanceContext.Provider>
   );
 };
@@ -22,7 +22,13 @@ it('shows disable option when activated', async () => {
   expect(disableButton).toBeInTheDocument();
 });
 
-it('shows setup action when disabled', async () => {
+it('shows enable action when disabled', async () => {
+  await renderConfigActions({ hasApi: false, enabled: false });
+  const enableButton = await screen.findByRole('button', { name: 'Enable plugin' });
+  expect(enableButton).toBeInTheDocument();
+});
+
+it('shows setup action when not intialized', async () => {
   await renderConfigActions({ hasApi: false });
   const setupButton = await screen.findByRole('button', { name: 'Setup' });
   expect(setupButton).toBeInTheDocument();

--- a/src/components/DisablePluginModal.tsx
+++ b/src/components/DisablePluginModal.tsx
@@ -1,3 +1,4 @@
+import { getBackendSrv } from '@grafana/runtime';
 import { Alert, Button, HorizontalGroup, Modal, Spinner } from '@grafana/ui';
 import React, { useContext, useState } from 'react';
 import { InstanceContext } from './InstanceContext';
@@ -5,15 +6,25 @@ import { InstanceContext } from './InstanceContext';
 type Props = {
   isOpen: boolean;
   onDismiss: () => void;
+  pluginId: string;
 };
 
-export const DisablePluginModal = ({ isOpen, onDismiss }: Props) => {
+export const DisablePluginModal = ({ isOpen, onDismiss, pluginId }: Props) => {
   const { instance, loading } = useContext(InstanceContext);
   const [error, setError] = useState();
 
   const disableTenant = async () => {
     try {
       await instance.api?.disableTenant();
+      await getBackendSrv().datasourceRequest({
+        url: `/api/plugins/${pluginId}/settings`,
+        method: 'POST',
+        headers: { 'X-Grafana-NoCache': 'true' },
+        data: {
+          enabled: false,
+        },
+      });
+      window.location.reload();
     } catch (e) {
       setError(e.message ?? 'Something went wrong trying to disable the plugin. Please contact support.');
     }

--- a/src/page/ConfigPage.tsx
+++ b/src/page/ConfigPage.tsx
@@ -44,25 +44,11 @@ export class ConfigPage extends PureComponent<Props> {
                 </a>
               </p>
             </div>
-            <div>
-              <p>
-                Synthetic Monitoring is a blackbox monitoring solution provided as part of{' '}
-                <a
-                  className="highlight-word"
-                  href="https://grafana.com/products/cloud/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Grafana Cloud
-                </a>
-                .
-              </p>
-            </div>
           </div>
           <br />
           <TenantSetup />
           <br />
-          <ConfigActions />
+          <ConfigActions enabled={plugin.meta.enabled} pluginId={plugin.meta.id} />
         </div>
       </InstanceProvider>
     );


### PR DESCRIPTION
When I updated the config page, I mistakenly believed it would no longer be possible for users (both on-prem and in cloud) to have the plugin installed but disabled, and removed the enable function. This PR does a few things:


- Adds and "enable" action to the plugin config page
- Disables the plugin in Grafana on disable (instead of just with the SM API)
- Pins the plugin on enable