### PR TITLE
Fix typo in DataSource probes query

### DIFF
--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -28,7 +28,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       if (query.queryType === QueryType.Probes) {
         const probes = await this.listProbes();
         const frame = new ArrayDataFrame(probes);
-        frame.setFieldType('onelineChange', FieldType.time, (s: number) => s * 1000); // seconds to ms
+        frame.setFieldType('onlineChange', FieldType.time, (s: number) => s * 1000); // seconds to ms
         frame.setFieldType('created', FieldType.time, (s: number) => s * 1000); // seconds to ms
         frame.setFieldType('modified', FieldType.time, (s: number) => s * 1000); // seconds to ms
         frame.refId = query.refId;


### PR DESCRIPTION
Fixes #182 

I fixed the typo in "onelineChange", which now is "onlineChange".