### PR TITLE
chore: expose errors when fetching alerts

### DIFF
--- a/src/components/Alerting.test.tsx
+++ b/src/components/Alerting.test.tsx
@@ -34,12 +34,14 @@ const mockAlertsHook = () => {
     .spyOn(useAlerts, 'useAlerts')
     .mockImplementationOnce(() => ({
       alertRules: [],
+      alertError: '',
       setDefaultRules,
       setRules,
       deleteRulesForCheck,
     }))
     .mockImplementation(() => ({
       alertRules: useAlerts.defaultRules.rules as AlertRule[],
+      alertError: '',
       setDefaultRules,
       setRules,
       deleteRulesForCheck,

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -106,7 +106,6 @@ export const Alerting: FC = () => {
       </div>
     );
   }
-  console.log({ alertRules, alertError });
 
   return (
     <div>

--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -1,5 +1,5 @@
 import { GrafanaTheme } from '@grafana/data';
-import { Button, HorizontalGroup, Icon, Modal, Spinner, useStyles } from '@grafana/ui';
+import { Button, HorizontalGroup, Icon, Modal, Spinner, useStyles, Alert } from '@grafana/ui';
 import React, { FC, useState, useContext } from 'react';
 import { css } from 'emotion';
 import { useAlerts } from 'hooks/useAlerts';
@@ -37,7 +37,7 @@ const getStyles = (theme: GrafanaTheme) => ({
 
 export const Alerting: FC = () => {
   const styles = useStyles(getStyles);
-  const { alertRules, setDefaultRules, setRules } = useAlerts();
+  const { alertRules, setDefaultRules, setRules, alertError } = useAlerts();
   const [updatingDefaultRules, setUpdatingDefaultRules] = useState(false);
   const [showResetModal, setShowResetModal] = useState(false);
   const { instance } = useContext(InstanceContext);
@@ -106,6 +106,7 @@ export const Alerting: FC = () => {
       </div>
     );
   }
+  console.log({ alertRules, alertError });
 
   return (
     <div>
@@ -138,7 +139,12 @@ export const Alerting: FC = () => {
         </a>
       </p>
       {!alertRules && <Spinner />}
-      {alertRules?.length === 0 && (
+      {alertError && (
+        <Alert title="Error fetching alert rules" severity="error">
+          {alertError}
+        </Alert>
+      )}
+      {alertRules?.length === 0 && !Boolean(alertError) && (
         <div className={styles.emptyCard}>
           <span className={styles.defaultAlerts}>
             You do not have any default alerts for Synthetic Monitoring yet. Click below to get some default alerts. You

--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -72,7 +72,7 @@ const fetchSMRules = (alertRulerUrl: string): Promise<RuleResponse> =>
       if (e.status === 404) {
         return { rules: [] };
       }
-      return { rules: [], error: e.data?.message ?? 'We ran into a problem and could fetch the alert rules' };
+      return { rules: [], error: e.data?.message ?? 'We ran into a problem and could not fetch the alert rules' };
     });
 
 const getDeleteRulesForCheck = (datasourceUrl: string) => (checkId: number) => {


### PR DESCRIPTION
Current errors fetching alert rules result in an endless spinner. This PR surfaces the error in the UI and stops the spinning.