### PR TITLE
Specify pem cert

### DIFF
--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -29,6 +29,56 @@ jest.mock('hooks/useAlerts', () => ({
   }),
 }));
 
+const validCert = `-----BEGIN CERTIFICATE-----
+MIICUTCCAfugAwIBAgIBADANBgkqhkiG9w0BAQQFADBXMQswCQYDVQQGEwJDTjEL
+MAkGA1UECBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMC
+VU4xFDASBgNVBAMTC0hlcm9uZyBZYW5nMB4XDTA1MDcxNTIxMTk0N1oXDTA1MDgx
+NDIxMTk0N1owVzELMAkGA1UEBhMCQ04xCzAJBgNVBAgTAlBOMQswCQYDVQQHEwJD
+TjELMAkGA1UEChMCT04xCzAJBgNVBAsTAlVOMRQwEgYDVQQDEwtIZXJvbmcgWWFu
+ZzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCp5hnG7ogBhtlynpOS21cBewKE/B7j
+V14qeyslnr26xZUsSVko36ZnhiaO/zbMOoRcKK9vEcgMtcLFuQTWDl3RAgMBAAGj
+gbEwga4wHQYDVR0OBBYEFFXI70krXeQDxZgbaCQoR4jUDncEMH8GA1UdIwR4MHaA
+FFXI70krXeQDxZgbaCQoR4jUDncEoVukWTBXMQswCQYDVQQGEwJDTjELMAkGA1UE
+CBMCUE4xCzAJBgNVBAcTAkNOMQswCQYDVQQKEwJPTjELMAkGA1UECxMCVU4xFDAS
+BgNVBAMTC0hlcm9uZyBZYW5nggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEE
+BQADQQA/ugzBrjjK9jcWnDVfGHlk3icNRq0oV7Ri32z/+HQX67aRfgZu7KWdI+Ju
+Wm7DCfrPNGVwFWUQOmsPue9rZBgO
+-----END CERTIFICATE-----`;
+
+const validKey = `-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: DES-EDE3-CBC,F57524B7B26F4694
+
+IJ/e6Xrf4pTBSO+CHdcqGocyAj5ysUre5BwTp6Yk2w9P/r7si7YA+pivghbUzYKc
+uy2hFwWG+LVajZXaG0dFXmbDHd9oYlW/SeJhPrxMvxaqC9R/x4MugAMFOhCQGMq3
+XW58R70L48BIuG6TCSOAGIwMDowv5ToL4nZYnqIRT77aACcsM0ozC+LCyqmLvvsU
+NV/YX4ZgMhzaT2eVK+mtOut6m1Wb7t6iUCS14dB/fTF+RaGYYZYMGut/alFaPqj0
+/KKlTNxCRD99+UZDbg3TnxIFSZd00zY75votTZnlLypoB9pUFP5iQglvuQ4pD3Ux
+bzU4cO0/hrdo04wORwWG/DUoAPlq8wjGei5jbEwHQJ8fNBzCl3Zy5Fx3bcAaaXEK
+zB97cyqhr80f2KnyiAKzk7vmyuRtMO/6Y4yE+1mLFE7NWcRkGXLEd3+wEt8DEq2R
+nQibvRTbT26HkO0bcfBAaeOYxHawdNcF2SZ1dUSZeo/teHNBI2JD5xRgtEPekXRs
+bBuCmxUevuh2+Q632oOpNNpFWBJTsyTcp9cAsxTEkbOCicxLN6c1+GvwyIqfSykR
+G08Y5M88n7Ey5GZ43KUbGh60vV5QN/mzhf3SotBl9+wetpm+4AmkKVUQyQVdRrn2
+1jXrkUZcSN8VbYk2tB74/FFXuaaF2WRQNawceXjrvegxz3/AkjZ7ahYI4rgptCqz
+OXvMk+le5tmVKbJfl1G+EZm2CqDLly5makeMKvX3fSWefKoZSbN0NuW28RgSJIQC
+pqja3dWZyGl7Z9dlM+big0nbLhMdIvT8526lD+p+9aMMuBL14MhWGp4IIfvXOPR+
+Ots3ZoGR9vtPQyO6YN5/CtRp1DBbRA48W9xk0BnnjSNpFBLY4ykqZj/cS01Up88x
+UMATqoMLiBwKCyaeibiIXpzqPTagG3PEEJkYPsrG/zql1EktjTtNo4LaYdFuZZzb
+fMmcEpFZLerCIgu2cOnhhKwCHYWbZ2MSVsgoiu6RyqqBblAfNkttthiPtCLY82sQ
+2ejN3NMsq+xlc/ISc21eClUaoUXmvyaSf2E3D4CN3FAi8fD74fP64EiKr+JjMNUC
+DWZ79UdwZcpl2VJ7JUAAyRzEt66U5PwQqv1U8ITjsBjykxRQ68/c/+HCOfg9NYn3
+cmpK5UxdFGj6261c6nVRlLVmV0+mPj1+sWHow5jZiH81IuoL3zqGkKzqy5FkTgs4
+MG3hViN9lHEmMPZdK16EPhCwvff0eBV+vhfPjmGoAE6TK3YY/yh9bfhMliLoc1jr
+NmPxL0FWrNzqWxZwMtDYcXu4KUesBL6/Hr+K9HSUa8zF+4UbELJTPOd1QAU6HF7a
+9BidzGMZ+J2Vjqa/NGpWckBRjWb6S7aItK6rrtORU1QHmpQlYpqEh49sreo6DCrb
+s8yejjKm2gSB/KhTe1nJXcTM16Xa4qWXTv11x46FNTZPUWQ7KoI0AzzScn6StBdo
+YCvzqCrla1em/Kakkws7Qu/pVj9R8ndHzoLktOi3l6lwwy5d4L697DyhP+02+eLt
+SBefoVnBNp449CSHW+brvPEyKD3D5CVpTIDfu2y8+nHszfBL22wuO4T+oem5h55A
+-----END RSA PRIVATE KEY-----`;
+
+const transformedValidCert = btoa(validCert);
+const transformedValidKey = btoa(validKey);
+
 // Data mocks
 
 const defaultCheck = {
@@ -244,9 +294,9 @@ describe('HTTP', () => {
           noFollowRedirects: true,
           tlsConfig: {
             insecureSkipVerify: true,
-            caCert: 'Y2FDZXJ0',
-            clientCert: 'Y2xpZW50Q2VydA==',
-            clientKey: 'Y2xpZW50IGtleQ==',
+            caCert: transformedValidCert,
+            clientCert: transformedValidCert,
+            clientKey: transformedValidKey,
             serverName: 'serverName',
           },
           validStatusCodes: [100],
@@ -283,9 +333,9 @@ describe('HTTP', () => {
     await toggleSection('TLS config');
     expect(await screen.findByLabelText('Disable target certificate validation')).toBeChecked();
     expect(await screen.findByLabelText('Server name', { exact: false })).toHaveValue('serverName');
-    expect(await screen.findByLabelText('CA certificate', { exact: false })).toHaveValue('caCert');
-    expect(await screen.findByLabelText('Client certificate', { exact: false })).toHaveValue('clientCert');
-    expect(await screen.findByLabelText('Client key', { exact: false })).toHaveValue('client key');
+    expect(await screen.findByLabelText('CA certificate', { exact: false })).toHaveValue(validCert);
+    expect(await screen.findByLabelText('Client certificate', { exact: false })).toHaveValue(validCert);
+    expect(await screen.findByLabelText('Client key', { exact: false })).toHaveValue(validKey);
 
     await toggleSection('Authentication');
     expect(await screen.findByPlaceholderText('Bearer token')).toHaveValue('a bear');
@@ -347,11 +397,11 @@ describe('HTTP', () => {
     await toggleSection('TLS config');
     await act(async () => await userEvent.type(screen.getByLabelText('Server Name', { exact: false }), 'serverName'));
     // TextArea components misbehave when using userEvent.type, using paste for now as a workaround
-    await act(async () => await userEvent.paste(screen.getByLabelText('CA Certificate', { exact: false }), 'caCert'));
+    await act(async () => await userEvent.paste(screen.getByLabelText('CA Certificate', { exact: false }), validCert));
     await act(
-      async () => await userEvent.paste(screen.getByLabelText('Client Certificate', { exact: false }), 'clientCert')
+      async () => await userEvent.paste(screen.getByLabelText('Client Certificate', { exact: false }), validCert)
     );
-    await act(async () => await userEvent.paste(screen.getByLabelText('Client Key', { exact: false }), 'client key'));
+    await act(async () => await userEvent.paste(screen.getByLabelText('Client Key', { exact: false }), validKey));
     await toggleSection('TLS config');
 
     // Authentication
@@ -420,9 +470,9 @@ describe('HTTP', () => {
           noFollowRedirects: false,
           tlsConfig: {
             insecureSkipVerify: false,
-            caCert: 'Y2FDZXJ0',
-            clientCert: 'Y2xpZW50Q2VydA==',
-            clientKey: 'Y2xpZW50IGtleQ==',
+            caCert: transformedValidCert,
+            clientCert: transformedValidCert,
+            clientKey: transformedValidKey,
             serverName: 'serverName',
           },
           validStatusCodes: [100],

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -130,16 +130,25 @@ const getHttpSettingsSslValue = (failIfSSL: boolean, failIfNotSSL: boolean): Sel
   return HTTP_SSL_OPTIONS[0];
 };
 
+const getDecodedIfPEM = (cert: string) => {
+  const decoded = fromBase64(cert);
+  if (decoded.indexOf('BEGIN CERTIFICATE')) {
+    return decoded;
+  }
+  return cert;
+};
+
 const getTlsConfigFormValues = (tlsConfig?: TLSConfig) => {
   if (!tlsConfig) {
     return {};
   }
+
   return {
     tlsConfig: {
       ...tlsConfig,
-      caCert: fromBase64(tlsConfig.caCert),
-      clientCert: fromBase64(tlsConfig.clientCert),
-      clientKey: fromBase64(tlsConfig.clientKey),
+      caCert: getDecodedIfPEM(tlsConfig.caCert),
+      clientCert: getDecodedIfPEM(tlsConfig.clientCert),
+      clientKey: getDecodedIfPEM(tlsConfig.clientKey),
     },
   };
 };

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -132,7 +132,7 @@ const getHttpSettingsSslValue = (failIfSSL: boolean, failIfNotSSL: boolean): Sel
 
 const getDecodedIfPEM = (cert: string) => {
   const decoded = fromBase64(cert);
-  if (decoded.indexOf('BEGIN CERTIFICATE')) {
+  if (decoded.indexOf('BEGIN') > 0) {
     return decoded;
   }
   return cert;

--- a/src/components/TLSConfig.tsx
+++ b/src/components/TLSConfig.tsx
@@ -43,7 +43,7 @@ export const TLSConfig = ({ isEditor, checkType }: Props) => {
       <Container>
         <Field
           label="CA certificate"
-          description="The CA cert to use for the targets"
+          description="Certificate must be in the PEM format."
           disabled={!isEditor}
           invalid={Boolean(errors.settings?.[checkType]?.tlsConfig?.caCert)}
           error={errors.settings?.[checkType]?.tlsConfig?.caCert?.message}
@@ -63,7 +63,7 @@ export const TLSConfig = ({ isEditor, checkType }: Props) => {
       <Container>
         <Field
           label="Client certificate"
-          description="The client cert file for the targets"
+          description="The client cert file for the targets. The certificate muse be in the PEM format."
           disabled={!isEditor}
           invalid={Boolean(errors?.settings?.[checkType]?.tlsConfig?.clientCert)}
           error={errors?.settings?.[checkType]?.tlsConfig?.clientCert?.message}
@@ -83,7 +83,7 @@ export const TLSConfig = ({ isEditor, checkType }: Props) => {
       <Container>
         <Field
           label="Client key"
-          description="The client key file for the targets"
+          description="The client key file for the targets. The key must be in the PEM format."
           disabled={!isEditor}
           invalid={Boolean(errors?.settings?.[checkType]?.tlsConfig?.clientKey)}
           error={errors?.settings?.[checkType]?.tlsConfig?.clientKey}

--- a/src/components/TLSConfig.tsx
+++ b/src/components/TLSConfig.tsx
@@ -14,6 +14,7 @@ interface Props {
 export const TLSConfig = ({ isEditor, checkType }: Props) => {
   const [showTLS, setShowTLS] = useState(false);
   const { register, errors } = useFormContext();
+
   return (
     <Collapse label="TLS config" onToggle={() => setShowTLS(!showTLS)} isOpen={showTLS} collapsible>
       <HorizontalCheckboxField
@@ -33,6 +34,7 @@ export const TLSConfig = ({ isEditor, checkType }: Props) => {
           id="tls-config-server-name"
           ref={register({
             validate: validateTLSServerName,
+            required: false,
           })}
           name={`settings.${checkType}.tlsConfig.serverName`}
           type="text"
@@ -52,6 +54,7 @@ export const TLSConfig = ({ isEditor, checkType }: Props) => {
             id="tls-config-ca-certificate"
             ref={register({
               validate: validateTLSCACert,
+              required: false,
             })}
             name={`settings.${checkType}.tlsConfig.caCert`}
             rows={2}
@@ -72,6 +75,7 @@ export const TLSConfig = ({ isEditor, checkType }: Props) => {
             id="tls-config-client-cert"
             ref={register({
               validate: validateTLSClientCert,
+              required: false,
             })}
             name={`settings.${checkType}.tlsConfig.clientCert`}
             rows={2}
@@ -86,11 +90,11 @@ export const TLSConfig = ({ isEditor, checkType }: Props) => {
           description="The client key file for the targets. The key must be in the PEM format."
           disabled={!isEditor}
           invalid={Boolean(errors?.settings?.[checkType]?.tlsConfig?.clientKey)}
-          error={errors?.settings?.[checkType]?.tlsConfig?.clientKey}
+          error={errors?.settings?.[checkType]?.tlsConfig?.clientKey?.message}
         >
           <TextArea
             id="tls-config-client-key"
-            ref={register({ validate: validateTLSClientKey })}
+            ref={register({ validate: validateTLSClientKey, required: false })}
             name={`settings.${checkType}.tlsConfig.clientKey`}
             type="password"
             rows={2}

--- a/src/components/TLSConfig.tsx
+++ b/src/components/TLSConfig.tsx
@@ -45,7 +45,7 @@ export const TLSConfig = ({ isEditor, checkType }: Props) => {
       <Container>
         <Field
           label="CA certificate"
-          description="Certificate must be in the PEM format."
+          description="Certificate must be in PEM format."
           disabled={!isEditor}
           invalid={Boolean(errors.settings?.[checkType]?.tlsConfig?.caCert)}
           error={errors.settings?.[checkType]?.tlsConfig?.caCert?.message}
@@ -66,7 +66,7 @@ export const TLSConfig = ({ isEditor, checkType }: Props) => {
       <Container>
         <Field
           label="Client certificate"
-          description="The client cert file for the targets. The certificate muse be in the PEM format."
+          description="The client cert file for the targets. The certificate muse be in PEM format."
           disabled={!isEditor}
           invalid={Boolean(errors?.settings?.[checkType]?.tlsConfig?.clientCert)}
           error={errors?.settings?.[checkType]?.tlsConfig?.clientCert?.message}
@@ -87,7 +87,7 @@ export const TLSConfig = ({ isEditor, checkType }: Props) => {
       <Container>
         <Field
           label="Client key"
-          description="The client key file for the targets. The key must be in the PEM format."
+          description="The client key file for the targets. The key must be in PEM format."
           disabled={!isEditor}
           invalid={Boolean(errors?.settings?.[checkType]?.tlsConfig?.clientKey)}
           error={errors?.settings?.[checkType]?.tlsConfig?.clientKey?.message}

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -245,3 +245,7 @@ export const getDefaultAlertAnnotations = (percentage: number) => ({
   description: `check job {{ $labels.job }} instance {{ $labels.instance }} has a success rate of {{ printf "%.1f" $value }}%.`,
   summary: `check success below ${percentage}%`,
 });
+
+export const PEM_HEADER = '-----BEGIN CERTIFICATE-----';
+
+export const PEM_FOOTER = '-----END CERTIFICATE-----';

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -1,4 +1,10 @@
-import { validateCheck, CheckValidation } from 'validation';
+import {
+  validateCheck,
+  CheckValidation,
+  validateTLSCACert,
+  validateTLSClientCert,
+  validateTLSClientKey,
+} from 'validation';
 import { Check, CheckType, HttpMethod, IpVersion, DnsRecordType, DnsProtocol, AlertSensitivity } from 'types';
 jest.unmock('utils');
 
@@ -144,6 +150,17 @@ describe('bad targets', () => {
     expect(CheckValidation.target(CheckType.TCP, 'x:y:65536')).toBe('Must be a valid host:port combination');
     expect(CheckValidation.target(CheckType.TCP, 'grafana.com:65536')).toBe('Port must be less than 65535');
     expect(CheckValidation.target(CheckType.TCP, 'grafana.com:0')).toBe('Port must be greater than 0');
+  });
+
+  it('should reject invalid certificates', () => {
+    const invalidCert = 'not a legit cert';
+    expect(validateTLSCACert(invalidCert)).toBe('Certificate must be in the PEM format.');
+    expect(validateTLSClientCert(invalidCert)).toBe('Certificate must be in the PEM format.');
+  });
+
+  it('should reject invalid tls keys', () => {
+    const invalidKey = 'not a legit cert';
+    expect(validateTLSClientKey(invalidKey)).toBe('Key must be in the PEM format.');
   });
 });
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -144,14 +144,23 @@ export const validateTLSServerName = (serverName: string) => {
 };
 
 export const validateTLSCACert = (caCert: string) => {
+  if (caCert.indexOf('-----BEGIN CERTIFICATE-----') < 0 || caCert.indexOf('-----END CERTIFICATE-----') < 0) {
+    return 'Certificate must be in the PEM format.';
+  }
   return undefined;
 };
 
 export const validateTLSClientCert = (clientCert: string) => {
+  if (clientCert.indexOf('-----BEGIN CERTIFICATE-----') < 0 || clientCert.indexOf('-----END CERTIFICATE-----') < 0) {
+    return 'Certificate must be in the PEM format.';
+  }
   return undefined;
 };
 
 export const validateTLSClientKey = (clientKey: string) => {
+  if (clientKey.indexOf('-----BEGIN CERTIFICATE-----') < 0 || clientKey.indexOf('-----END CERTIFICATE-----') < 0) {
+    return 'Certificate must be in the PEM format.';
+  }
   return undefined;
 };
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -3,6 +3,7 @@ import { checkType } from 'utils';
 import * as punycode from 'punycode';
 import { Address4, Address6 } from 'ip-address';
 import validUrl from 'valid-url';
+import { PEM_HEADER, PEM_FOOTER } from 'components/constants';
 
 export const CheckValidation = {
   job: validateJob,
@@ -143,27 +144,27 @@ export const validateTLSServerName = (serverName: string) => {
   return undefined;
 };
 
-export const validateTLSCACert = (caCert: string) => {
+export const validateTLSCACert = (caCert?: string) => {
   if (!caCert) {
     return undefined;
   }
-  if (caCert.indexOf('-----BEGIN CERTIFICATE-----') < 0 || caCert.indexOf('-----END CERTIFICATE-----') < 0) {
+  if (caCert.indexOf(PEM_HEADER) < 0 || caCert.indexOf(PEM_FOOTER) < 0) {
     return 'Certificate must be in the PEM format.';
   }
   return undefined;
 };
 
-export const validateTLSClientCert = (clientCert: string) => {
+export const validateTLSClientCert = (clientCert?: string) => {
   if (!clientCert) {
     return undefined;
   }
-  if (clientCert.indexOf('-----BEGIN CERTIFICATE-----') < 0 || clientCert.indexOf('-----END CERTIFICATE-----') < 0) {
+  if (clientCert.indexOf(PEM_HEADER) < 0 || clientCert.indexOf(PEM_FOOTER) < 0) {
     return 'Certificate must be in the PEM format.';
   }
   return undefined;
 };
 
-export const validateTLSClientKey = (clientKey: string) => {
+export const validateTLSClientKey = (clientKey?: string) => {
   if (!clientKey) {
     return undefined;
   }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -167,10 +167,7 @@ export const validateTLSClientKey = (clientKey: string) => {
   if (!clientKey) {
     return undefined;
   }
-  if (
-    clientKey.indexOf('-----BEGIN RSA PRIVATE KEY-----') < 0 ||
-    clientKey.indexOf('-----END RSA PRIVATE KEY-----') < 0
-  ) {
+  if (clientKey.indexOf('-----BEGIN') < 0 || clientKey.indexOf('-----END') < 0) {
     return 'Key must be in the PEM format.';
   }
   return undefined;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -144,6 +144,9 @@ export const validateTLSServerName = (serverName: string) => {
 };
 
 export const validateTLSCACert = (caCert: string) => {
+  if (!caCert) {
+    return undefined;
+  }
   if (caCert.indexOf('-----BEGIN CERTIFICATE-----') < 0 || caCert.indexOf('-----END CERTIFICATE-----') < 0) {
     return 'Certificate must be in the PEM format.';
   }
@@ -151,6 +154,9 @@ export const validateTLSCACert = (caCert: string) => {
 };
 
 export const validateTLSClientCert = (clientCert: string) => {
+  if (!clientCert) {
+    return undefined;
+  }
   if (clientCert.indexOf('-----BEGIN CERTIFICATE-----') < 0 || clientCert.indexOf('-----END CERTIFICATE-----') < 0) {
     return 'Certificate must be in the PEM format.';
   }
@@ -158,8 +164,14 @@ export const validateTLSClientCert = (clientCert: string) => {
 };
 
 export const validateTLSClientKey = (clientKey: string) => {
-  if (clientKey.indexOf('-----BEGIN CERTIFICATE-----') < 0 || clientKey.indexOf('-----END CERTIFICATE-----') < 0) {
-    return 'Certificate must be in the PEM format.';
+  if (!clientKey) {
+    return undefined;
+  }
+  if (
+    clientKey.indexOf('-----BEGIN RSA PRIVATE KEY-----') < 0 ||
+    clientKey.indexOf('-----END RSA PRIVATE KEY-----') < 0
+  ) {
+    return 'Key must be in the PEM format.';
   }
   return undefined;
 };


### PR DESCRIPTION
This PR adds some validation and guidance for adding certs/keys to HTTP and TCP checks. It does a few things:

- Conditionally presents base64 decoded values to the user for preexisting checks. If the certificate has a valid PEM header and footer, the plugin presents the decoded value, if it does _not_, it presents the raw base64.
- Adds form validation the presence of a PEM header and footer for both certificates and keys
- Adds some help text to notify the user that they have to use a PEM format certificate/key