### PR TITLE
fix: update percentage unit to match recording rule

### DIFF
--- a/src/components/AlertRuleForm.tsx
+++ b/src/components/AlertRuleForm.tsx
@@ -60,7 +60,7 @@ const getAlertFormValues = (rule: AlertRule): AlertFormValues | undefined => {
     value,
   }));
 
-  const probePercentage = parseFloat(rule.expr.split(' < ')?.[1]) * 100;
+  const probePercentage = parseFloat(rule.expr.split(' < ')?.[1]);
 
   if (!timeOption || !probePercentage || !sensitivityOption) {
     return undefined;

--- a/src/components/Alerting.test.tsx
+++ b/src/components/Alerting.test.tsx
@@ -115,9 +115,9 @@ it('adds default alerts and edits alerts', async () => {
         an_annotation_name: 'an annotation value',
         description:
           'check job {{ $labels.job }} instance {{ $labels.instance }} has a success rate of {{ printf "%.1f" $value }}%.',
-        summary: 'check success below 0.95%',
+        summary: 'check success below 95%',
       },
-      expr: 'instance_job_severity:probe_success:mean5m{alert_sensitivity="high"} < 0.25',
+      expr: 'instance_job_severity:probe_success:mean5m{alert_sensitivity="high"} < 25',
       for: '2s',
       labels: {
         a_label_name: 'a_label_value',
@@ -129,9 +129,9 @@ it('adds default alerts and edits alerts', async () => {
       annotations: {
         description:
           'check job {{ $labels.job }} instance {{ $labels.instance }} has a success rate of {{ printf "%.1f" $value }}%.',
-        summary: 'check success below 0.9%',
+        summary: 'check success below 90%',
       },
-      expr: 'instance_job_severity:probe_success:mean5m{alert_sensitivity="medium"} < 0.9',
+      expr: 'instance_job_severity:probe_success:mean5m{alert_sensitivity="medium"} < 90',
       for: '5m',
       labels: {
         namespace: 'synthetic_monitoring',
@@ -142,9 +142,9 @@ it('adds default alerts and edits alerts', async () => {
       annotations: {
         description:
           'check job {{ $labels.job }} instance {{ $labels.instance }} has a success rate of {{ printf "%.1f" $value }}%.',
-        summary: 'check success below 0.75%',
+        summary: 'check success below 75%',
       },
-      expr: 'instance_job_severity:probe_success:mean5m{alert_sensitivity="low"} < 0.75',
+      expr: 'instance_job_severity:probe_success:mean5m{alert_sensitivity="low"} < 75',
       for: '5m',
       labels: {
         namespace: 'synthetic_monitoring',

--- a/src/components/alertingTransformations.ts
+++ b/src/components/alertingTransformations.ts
@@ -14,7 +14,7 @@ export const transformAlertFormValues = (alertValues: AlertFormValues | undefine
   return {
     alert: alertValues?.name ?? '',
     expr: `${ALERT_RECORDING_METRIC}{alert_sensitivity="${alertValues?.sensitivity?.value}"} < ${
-      alertValues?.probePercentage ? alertValues.probePercentage / 100 : ''
+      alertValues?.probePercentage ?? ''
     }`,
     for: `${alertValues?.timeCount}${alertValues?.timeUnit?.value}`,
     labels: labelToProm(alertValues?.labels),

--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -13,9 +13,9 @@ import { AlertRule, AlertSensitivity } from 'types';
 import { InstanceContext } from 'components/InstanceContext';
 
 enum AlertThresholds {
-  High = 0.95,
-  Medium = 0.9,
-  Low = 0.75,
+  High = 95,
+  Medium = 90,
+  Low = 75,
 }
 
 export const defaultRules = {


### PR DESCRIPTION
We had a unit mismatch between our recording rule and our alert rule thresholds. The rule thresholds were expecting a percentage of 1 (i.e. `.95`), but the recording rule was multiplying by 100, so our thresholds are alerting on `.95%` instead of `95%`. 