### PR TITLE
fix: add length validation for label names and values, truncate long …

### DIFF
--- a/src/components/CheckCardLabel.tsx
+++ b/src/components/CheckCardLabel.tsx
@@ -13,6 +13,10 @@ const getStyles = (theme: GrafanaTheme) => ({
   container: css`
     background-color: #9933cc;
     border-radius: 1px;
+    max-width: 600px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   `,
 });
 

--- a/src/components/CheckCardLabel.tsx
+++ b/src/components/CheckCardLabel.tsx
@@ -2,11 +2,12 @@ import { GrafanaTheme } from '@grafana/data';
 import { Tag, useStyles } from '@grafana/ui';
 import React from 'react';
 import { Label } from 'types';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 
 interface Props {
   label: Label;
   onLabelSelect: (label: Label) => void;
+  className?: string;
 }
 
 const getStyles = (theme: GrafanaTheme) => ({
@@ -20,9 +21,13 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
 });
 
-export const CheckCardLabel = ({ label, onLabelSelect }: Props) => {
+export const CheckCardLabel = ({ label, onLabelSelect, className }: Props) => {
   const styles = useStyles(getStyles);
   return (
-    <Tag onClick={() => onLabelSelect(label)} name={`${label.name}: ${label.value}`} className={styles.container} />
+    <Tag
+      onClick={() => onLabelSelect(label)}
+      name={`${label.name}: ${label.value}`}
+      className={cx(styles.container, className)}
+    />
   );
 };

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -594,7 +594,7 @@ export const getCheckFromFormValues = (
     job: formValues.job,
     target: formValues.target,
     enabled: formValues.enabled,
-    labels: formValues.labels ?? defaultValues.labels ?? [],
+    labels: formValues.labels ?? [],
     probes: formValues.probes,
     timeout: formValues.timeout * 1000,
     frequency: formValues.frequency * 1000,

--- a/src/components/CheckListItem/CheckListItemDetails.tsx
+++ b/src/components/CheckListItem/CheckListItemDetails.tsx
@@ -14,6 +14,9 @@ const getStyles = (theme: GrafanaTheme) => ({
     align-items: center;
     width: 284px;
   `,
+  labelWidth: css`
+    max-width: 350px;
+  `,
 });
 
 interface Props {
@@ -38,7 +41,12 @@ export const CheckListItemDetails = ({ frequency, activeSeries, className, label
             content={
               <HorizontalGroup justify="flex-end" wrap>
                 {labels.map((label: Label, index) => (
-                  <CheckCardLabel key={index} label={label} onLabelSelect={onLabelClick} />
+                  <CheckCardLabel
+                    key={index}
+                    label={label}
+                    onLabelSelect={onLabelClick}
+                    className={styles.labelWidth}
+                  />
                 ))}
               </HorizontalGroup>
             }

--- a/src/components/LabelFilterInput.tsx
+++ b/src/components/LabelFilterInput.tsx
@@ -59,8 +59,6 @@ export const LabelFilterInput = ({ checks, labelFilters, onChange, className }: 
     });
   }, [aggregatedLabels]);
 
-  console.log({ labelCascadeOptions });
-
   const labelFilterOptions: Array<SelectableValue<string>> = useMemo(() => {
     return Object.entries(aggregatedLabels).reduce<Array<SelectableValue<string>>>((acc, [name, value]) => {
       return acc.concat(

--- a/src/components/NameValueInput.tsx
+++ b/src/components/NameValueInput.tsx
@@ -31,7 +31,7 @@ export const NameValueInput = ({ name, disabled, limit, label, validateName, val
             `}
           >
             <Input
-              ref={register({ required: true })}
+              ref={register({ required: true, validate: validateName })}
               name={`${name}[${index}].name`}
               type="text"
               placeholder="name"
@@ -46,7 +46,7 @@ export const NameValueInput = ({ name, disabled, limit, label, validateName, val
             `}
           >
             <Input
-              ref={register({ required: true })}
+              ref={register({ required: true, validate: validateValue })}
               name={`${name}[${index}].value`}
               type="text"
               placeholder="value"

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -101,8 +101,8 @@ export function validateLabel(label: Label): string | undefined {
 }
 
 export function validateLabelName(name: string): string | undefined {
-  if (name.length > 32) {
-    return 'Label names must be 32 characters or less';
+  if (name.length > 128) {
+    return 'Label names must be 128 characters or less';
   }
   if (!labelRegex.test(name)) {
     return 'Invalid label name';
@@ -112,8 +112,8 @@ export function validateLabelName(name: string): string | undefined {
 }
 
 export function validateLabelValue(value: string): string | undefined {
-  if (value.length > 32) {
-    return 'Label values must be 32 characters or less';
+  if (value.length > 128) {
+    return 'Label values must be 128 characters or less';
   }
   if (!labelRegex.test(value)) {
     return 'Invalid label value';

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -101,8 +101,8 @@ export function validateLabel(label: Label): string | undefined {
 }
 
 export function validateLabelName(name: string): string | undefined {
-  if (name.length > 128) {
-    return 'Label names must be 128 characters or less';
+  if (name.length > 32) {
+    return 'Label names must be 32 characters or less';
   }
   if (!labelRegex.test(name)) {
     return 'Invalid label name';
@@ -112,8 +112,8 @@ export function validateLabelName(name: string): string | undefined {
 }
 
 export function validateLabelValue(value: string): string | undefined {
-  if (value.length > 128) {
-    return 'Label values must be 128 characters or less';
+  if (value.length > 32) {
+    return 'Label values must be 32 characters or less';
   }
   if (!labelRegex.test(value)) {
     return 'Invalid label value';


### PR DESCRIPTION
fixes #240 
fixes #239 

This PR does a few label related things:
- plumbs in the label name/value validation
~- Increases the validation value to 128 (from 32)~ Length validation increase will be included later
- Truncates arbitrarily long label values in the check list view
- Fixes a bug where deleting all the labels from a check wouldn't get persisted to the API