### PR TITLE
fix: allow trailing dots in DNS targets

### DIFF
--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -104,7 +104,7 @@ describe('trivial cases', () => {
   });
 });
 
-describe('bad targets', () => {
+describe('http', () => {
   it('should reject non-http URLs', () => {
     const testcases: string[] = ['ftp://example.org/', 'schema://example.org/'];
     testcases.forEach((testcase: string) => {
@@ -116,19 +116,10 @@ describe('bad targets', () => {
     expect(CheckValidation.target(CheckType.HTTP, 'https://hostname/')).toEqual('Target must have a valid hostname');
     expect(CheckValidation.target(CheckType.HTTP, 'https://suraj/dev')).toEqual('Target must have a valid hostname');
   });
-
   it('should reject URLs without schema', () => {
     const testcases: string[] = ['example.org'];
     testcases.forEach((testcase: string) => {
       expect(CheckValidation.target(CheckType.HTTP, testcase)).toEqual('Target must be a valid web URL');
-    });
-  });
-
-  it('should reject ping and dns targets without domains', () => {
-    const testcases: string[] = ['grafana'];
-    testcases.forEach((testcase: string) => {
-      expect(CheckValidation.target(CheckType.PING, testcase)).toBe('Target must be a valid hostname');
-      expect(CheckValidation.target(CheckType.DNS, testcase)).toBe('Target must be a valid hostname');
     });
   });
 
@@ -137,36 +128,6 @@ describe('bad targets', () => {
     expect(CheckValidation.target(CheckType.HTTP, url)).toBe('Target must be a valid web URL');
   });
 
-  it('should reject ping targets with invalid hostnames', () => {
-    const testcases: string[] = ['x.', '.y', 'x=y.org'];
-    testcases.forEach((testcase: string) => {
-      expect(CheckValidation.target(CheckType.PING, testcase)).toBe('Target must be a valid hostname');
-      expect(CheckValidation.target(CheckType.DNS, testcase)).toBe('Target must be a valid hostname');
-    });
-  });
-
-  it('should reject tcp targets without valid ports', () => {
-    expect(CheckValidation.target(CheckType.TCP, 'x:y')).toBe('Must be a valid host:port combination');
-    expect(CheckValidation.target(CheckType.TCP, 'x:y:')).toBe('Must be a valid host:port combination');
-    expect(CheckValidation.target(CheckType.TCP, 'x:y:0')).toBe('Must be a valid host:port combination');
-    expect(CheckValidation.target(CheckType.TCP, 'x:y:65536')).toBe('Must be a valid host:port combination');
-    expect(CheckValidation.target(CheckType.TCP, 'grafana.com:65536')).toBe('Port must be less than 65535');
-    expect(CheckValidation.target(CheckType.TCP, 'grafana.com:0')).toBe('Port must be greater than 0');
-  });
-
-  it('should reject invalid certificates', () => {
-    const invalidCert = 'not a legit cert';
-    expect(validateTLSCACert(invalidCert)).toBe('Certificate must be in the PEM format.');
-    expect(validateTLSClientCert(invalidCert)).toBe('Certificate must be in the PEM format.');
-  });
-
-  it('should reject invalid tls keys', () => {
-    const invalidKey = 'not a legit cert';
-    expect(validateTLSClientKey(invalidKey)).toBe('Key must be in the PEM format.');
-  });
-});
-
-describe('good targets', () => {
   it('should accept http schema as HTTP target', () => {
     const testcases: string[] = ['http://grafana.com/'];
     testcases.forEach((testcase: string) => {
@@ -210,6 +171,18 @@ describe('good targets', () => {
       expect(CheckValidation.target(CheckType.HTTP, testcase)).toBe(undefined);
     });
   });
+});
+
+describe('PING', () => {
+  it('should reject hostnames without domains', () => {
+    expect(CheckValidation.target(CheckType.PING, 'grafana')).toBe('Target must be a valid hostname');
+  });
+  it('should reject ping targets with invalid hostnames', () => {
+    const testcases: string[] = ['x.', '.y', 'x=y.org'];
+    testcases.forEach((testcase: string) => {
+      expect(CheckValidation.target(CheckType.PING, testcase)).toBe('Target must be a valid hostname');
+    });
+  });
 
   it('should accept IPv4 as ping target', () => {
     const testcases: string[] = [
@@ -240,12 +213,69 @@ describe('good targets', () => {
       expect(CheckValidation.target(CheckType.PING, testcase)).toBe(undefined);
     });
   });
+});
+
+describe('DNS', () => {
+  it('should reject single element domains', () => {
+    expect(CheckValidation.target(CheckType.DNS, 'grafana')).toBe('Invalid number of elements in hostname');
+  });
+
+  it('should reject dns targets with invalid element length', () => {
+    expect(CheckValidation.target(CheckType.DNS, '.y')).toBe(
+      'Invalid domain element length. Each element must be between 1 and 62 characters'
+    );
+  });
+
+  it('should reject dns targets with invalid characters', () => {
+    expect(CheckValidation.target(CheckType.DNS, 'x=y.org')).toBe(
+      'Invalid character in domain name. Only letters, numbers and "-" are allowed'
+    );
+  });
+
+  it('should reject ip address', () => {
+    expect(CheckValidation.target(CheckType.DNS, '127.0.0.1')).toBe('IP addresses are not valid DNS targets');
+  });
+
+  it('IP address disguised as multi-label fully qualified  dns name is invalid', () => {
+    expect(CheckValidation.target(CheckType.DNS, '127.0.0.1.')).toBe('A domain TLD cannot contain only numbers');
+  });
+
+  it('should accept dns targets with trailing .', () => {
+    expect(CheckValidation.target(CheckType.DNS, 'grafana.')).toBe(undefined);
+  });
+
+  it('should accept valid hostnames', () => {
+    expect(CheckValidation.target(CheckType.DNS, 'grafana.com')).toBe(undefined);
+  });
+});
+
+describe('tcp', () => {
+  it('should reject tcp targets without valid ports', () => {
+    expect(CheckValidation.target(CheckType.TCP, 'x:y')).toBe('Must be a valid host:port combination');
+    expect(CheckValidation.target(CheckType.TCP, 'x:y:')).toBe('Must be a valid host:port combination');
+    expect(CheckValidation.target(CheckType.TCP, 'x:y:0')).toBe('Must be a valid host:port combination');
+    expect(CheckValidation.target(CheckType.TCP, 'x:y:65536')).toBe('Must be a valid host:port combination');
+    expect(CheckValidation.target(CheckType.TCP, 'grafana.com:65536')).toBe('Port must be less than 65535');
+    expect(CheckValidation.target(CheckType.TCP, 'grafana.com:0')).toBe('Port must be greater than 0');
+  });
 
   it('should accept tcp targets with host:port', () => {
     const testcases: string[] = ['x.y:25', '1.2.3.4:25', '[2001:0db8:1001:1001:1001:1001:1001:1001]:8080'];
     testcases.forEach((testcase: string) => {
       expect(CheckValidation.target(CheckType.TCP, testcase)).toBe(undefined);
     });
+  });
+});
+
+describe('certificates', () => {
+  it('should reject invalid certificates', () => {
+    const invalidCert = 'not a legit cert';
+    expect(validateTLSCACert(invalidCert)).toBe('Certificate must be in the PEM format.');
+    expect(validateTLSClientCert(invalidCert)).toBe('Certificate must be in the PEM format.');
+  });
+  it('should reject invalid tls keys', () => {
+    const invalidKey = 'not a legit cert';
+    expect(validateTLSClientKey(invalidKey)).toBe('Key must be in the PEM format.');
   });
 });
 


### PR DESCRIPTION
fixes #258 

This updates the frontend DNS target validation to mimic what's happening in the [SM agent DNS target validation](https://github.com/grafana/synthetic-monitoring-agent/blob/e6657cf8cd5697e84d812b9c03d3260c981f4769/pkg/pb/synthetic_monitoring/checks_extra.go#L482)

