### PR TITLE
chore: remove deprecated datasource method

### DIFF
--- a/__mocks__/@grafana/runtime.ts
+++ b/__mocks__/@grafana/runtime.ts
@@ -1,7 +1,9 @@
 import * as runtime from '@grafana/runtime';
 
 export const getBackendSrv = () => ({
-  datasourceRequest: jest.fn().mockImplementation(() => ({ ok: true })),
+  fetch: {
+    toPromise: () => jest.fn().mockResolvedValue({ ok: true }),
+  },
 });
 
 export const getLocationSrv = () => ({

--- a/src/components/ConfigActions.tsx
+++ b/src/components/ConfigActions.tsx
@@ -14,14 +14,16 @@ export const ConfigActions = ({ enabled, pluginId }: Props) => {
   const [showDisableModal, setShowDisableModal] = useState(false);
 
   const handleEnable = async () => {
-    await getBackendSrv().datasourceRequest({
-      url: `/api/plugins/${pluginId}/settings`,
-      method: 'POST',
-      data: {
-        enabled: true,
-        pinned: true,
-      },
-    });
+    await getBackendSrv()
+      .fetch({
+        url: `/api/plugins/${pluginId}/settings`,
+        method: 'POST',
+        data: {
+          enabled: true,
+          pinned: true,
+        },
+      })
+      .toPromise();
     window.location.reload();
   };
 

--- a/src/components/DisablePluginModal.tsx
+++ b/src/components/DisablePluginModal.tsx
@@ -16,14 +16,16 @@ export const DisablePluginModal = ({ isOpen, onDismiss, pluginId }: Props) => {
   const disableTenant = async () => {
     try {
       await instance.api?.disableTenant();
-      await getBackendSrv().datasourceRequest({
-        url: `/api/plugins/${pluginId}/settings`,
-        method: 'POST',
-        headers: { 'X-Grafana-NoCache': 'true' },
-        data: {
-          enabled: false,
-        },
-      });
+      await getBackendSrv()
+        .fetch({
+          url: `/api/plugins/${pluginId}/settings`,
+          method: 'POST',
+          headers: { 'X-Grafana-NoCache': 'true' },
+          data: {
+            enabled: false,
+          },
+        })
+        .toPromise();
       window.location.reload();
     } catch (e) {
       setError(e.message ?? 'Something went wrong trying to disable the plugin. Please contact support.');

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -59,10 +59,11 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
 
   async listProbes(): Promise<Probe[]> {
     return getBackendSrv()
-      .datasourceRequest({
+      .fetch({
         method: 'GET',
         url: `${this.instanceSettings.url}/sm/probe/list`,
       })
+      .toPromise()
       .then((res: any) => {
         return res.data;
       });
@@ -70,11 +71,12 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
 
   async addProbe(probe: Probe): Promise<any> {
     return getBackendSrv()
-      .datasourceRequest({
+      .fetch({
         method: 'POST',
         url: `${this.instanceSettings.url}/sm/probe/add`,
         data: probe,
       })
+      .toPromise()
       .then((res: any) => {
         return res.data;
       });
@@ -82,10 +84,11 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
 
   async deleteProbe(id: number): Promise<any> {
     return getBackendSrv()
-      .datasourceRequest({
+      .fetch({
         method: 'DELETE',
         url: `${this.instanceSettings.url}/sm/probe/delete/${id}`,
       })
+      .toPromise()
       .then((res: any) => {
         return res.data;
       });
@@ -94,11 +97,12 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   async updateProbe(probe: Probe): Promise<any> {
     console.log('updating probe.', probe);
     return getBackendSrv()
-      .datasourceRequest({
+      .fetch({
         method: 'POST',
         url: `${this.instanceSettings.url}/sm/probe/update`,
         data: probe,
       })
+      .toPromise()
       .then((res: any) => {
         return res.data;
       });
@@ -107,11 +111,12 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   async resetProbeToken(probe: Probe): Promise<any> {
     console.log('updating probe.', probe);
     return getBackendSrv()
-      .datasourceRequest({
+      .fetch({
         method: 'POST',
         url: `${this.instanceSettings.url}/sm/probe/update?reset-token=true`,
         data: probe,
       })
+      .toPromise()
       .then((res: any) => {
         return res.data;
       });
@@ -123,20 +128,22 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
 
   async listChecks(): Promise<Check[]> {
     return getBackendSrv()
-      .datasourceRequest({
+      .fetch({
         method: 'GET',
         url: `${this.instanceSettings.url}/sm/check/list`,
       })
+      .toPromise()
       .then((res: any) => (Array.isArray(res.data) ? res.data : []));
   }
 
   async addCheck(check: Check): Promise<any> {
     return getBackendSrv()
-      .datasourceRequest({
+      .fetch({
         method: 'POST',
         url: `${this.instanceSettings.url}/sm/check/add`,
         data: check,
       })
+      .toPromise()
       .then((res: any) => {
         return res.data;
       });
@@ -144,10 +151,11 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
 
   async deleteCheck(id: number): Promise<any> {
     return getBackendSrv()
-      .datasourceRequest({
+      .fetch({
         method: 'DELETE',
         url: `${this.instanceSettings.url}/sm/check/delete/${id}`,
       })
+      .toPromise()
       .then((res: any) => {
         return res.data;
       });
@@ -156,11 +164,12 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   async updateCheck(check: Check): Promise<any> {
     console.log('updating check.', check);
     return getBackendSrv()
-      .datasourceRequest({
+      .fetch({
         method: 'POST',
         url: `${this.instanceSettings.url}/sm/check/update`,
         data: check,
       })
+      .toPromise()
       .then((res: any) => {
         return res.data;
       });
@@ -168,7 +177,8 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
 
   async getTenant(): Promise<any> {
     return getBackendSrv()
-      .datasourceRequest({ method: 'GET', url: `${this.instanceSettings.url}/sm/tenant` })
+      .fetch({ method: 'GET', url: `${this.instanceSettings.url}/sm/tenant` })
+      .toPromise()
       .then((res: any) => {
         return res.data;
       });
@@ -177,7 +187,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   async disableTenant(): Promise<any> {
     const tenant = await this.getTenant();
     return getBackendSrv()
-      .datasourceRequest({
+      .fetch({
         method: 'POST',
         url: `${this.instanceSettings.url}/sm/tenant/update`,
         data: {
@@ -185,6 +195,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
           status: 1,
         },
       })
+      .toPromise()
       .then((res: any) => {
         return res.data;
       });
@@ -215,7 +226,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
     };
     await backendSrv.put(`api/datasources/${this.instanceSettings.id}`, data);
     return backendSrv
-      .datasourceRequest({
+      .fetch({
         method: 'POST',
         url: `${this.instanceSettings.url}/sm/register/init`,
         data: { apiToken },
@@ -225,6 +236,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
           'X-Grafana-NoCache': 'true',
         },
       })
+      .toPromise()
       .then((res: any) => {
         return res.data;
       });
@@ -253,7 +265,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
     console.log('Saved accessToken, now update our configs', info);
 
     // Note the accessToken above must be saved first!
-    return await getBackendSrv().datasourceRequest({
+    return await getBackendSrv().fetch({
       method: 'POST',
       url: `${this.instanceSettings.url}/sm/register/save`,
       headers: {
@@ -271,7 +283,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
 
   async getViewerToken(apiToken: string, instance: HostedInstance): Promise<string> {
     return getBackendSrv()
-      .datasourceRequest({
+      .fetch({
         method: 'POST',
         url: `${this.instanceSettings.url}/sm/register/viewer-token`,
         data: {
@@ -280,6 +292,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
           type: instance.type,
         },
       })
+      .toPromise()
       .then((res: any) => {
         return res.data?.token;
       });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,7 +60,7 @@ export async function createDatasource(hosted: HostedInstance, adminToken: strin
 
 async function getViewerToken(apiToken: string, instance: HostedInstance, smDatasourceId: string): Promise<string> {
   return getBackendSrv()
-    .datasourceRequest({
+    .fetch({
       method: 'POST',
       url: `api/datasources/proxy/${smDatasourceId}/viewer-token`,
       data: {
@@ -74,6 +74,7 @@ async function getViewerToken(apiToken: string, instance: HostedInstance, smData
         'X-Grafana-NoCache': 'true',
       },
     })
+    .toPromise()
     .then((res: any) => {
       return res.data?.token;
     });
@@ -211,6 +212,14 @@ interface MetricQueryResponse {
   data: any[];
 }
 
+interface MetricDatasourceResponseWrapper {
+  data: MetricDatasourceResponse;
+}
+
+interface MetricDatasourceResponse {
+  result: any[];
+}
+
 export interface MetricQueryOptions {
   start: number;
   end: number;
@@ -233,11 +242,13 @@ export const queryMetric = async (
   const path = options?.step ? '/api/v1/query_range' : '/api/v1/query';
 
   try {
-    const response = await backendSrv.datasourceRequest({
-      method: 'GET',
-      url: `${url}${path}`,
-      params,
-    });
+    const response = await backendSrv
+      .fetch<MetricDatasourceResponseWrapper>({
+        method: 'GET',
+        url: `${url}${path}`,
+        params,
+      })
+      .toPromise();
     if (!response.ok) {
       return { error: 'Error fetching data', data: [] };
     }


### PR DESCRIPTION
We were using the deprecated `datasourceRequest` method for all our datasource interactions. Changing to the future proofed `fetch`. The `fetch` method returns an observable, and in order to limit the scope of the change I just converted them to promises.