### PR TITLE
Compression algo

### DIFF
--- a/__mocks__/@grafana/ui.tsx
+++ b/__mocks__/@grafana/ui.tsx
@@ -1,7 +1,7 @@
 import * as ui from '@grafana/ui';
 import React from 'react';
 
-const Select = ({ options, value, onChange, multiple = false, prefix, ...rest }: any) => {
+const Select = ({ options, value, onChange, multiple = false, prefix, id, ...rest }: any) => {
   function handleChange(event) {
     const option = options.find((option) => {
       return String(option.value) === event.currentTarget.value;
@@ -16,9 +16,15 @@ const Select = ({ options, value, onChange, multiple = false, prefix, ...rest }:
   return (
     <div>
       {prefix}
-      <select data-testid={rest['data-testid'] ?? 'select'} value={value} onChange={handleChange} multiple={multiple}>
-        {options.map(({ label, value }) => (
-          <option key={value} value={value}>
+      <select
+        id={id}
+        data-testid={rest['data-testid'] ?? 'select'}
+        value={value?.value ?? value}
+        onChange={handleChange}
+        multiple={multiple}
+      >
+        {options.map(({ label, value }, index) => (
+          <option key={index} value={value}>
             {label}
           </option>
         ))}

--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -10,6 +10,7 @@ import {
   HttpVersion,
   GlobalSettings,
   AlertSensitivity,
+  HTTPCompressionAlgo,
 } from 'types';
 import { CheckEditor } from './CheckEditor';
 import { getInstanceMock } from '../../datasource/__mocks__/DataSource';
@@ -288,6 +289,7 @@ describe('HTTP', () => {
       settings: {
         http: {
           method: HttpMethod.GET,
+          compression: HTTPCompressionAlgo.gzip,
           headers: ['headerName:headerValue'],
           body: 'requestbody',
           ipVersion: IpVersion.V6,
@@ -329,6 +331,7 @@ describe('HTTP', () => {
     expect(await screen.findByLabelText('Request body', { exact: false })).toHaveValue('requestbody');
     expect(await within(httpSection).findByPlaceholderText('name')).toHaveValue('headerName');
     expect(await within(httpSection).findByPlaceholderText('value')).toHaveValue('headerValue');
+    expect(within(httpSection).getByTestId('http-compression')).toHaveValue('gzip');
 
     await toggleSection('TLS config');
     expect(await screen.findByLabelText('Disable target certificate validation')).toBeChecked();
@@ -391,6 +394,10 @@ describe('HTTP', () => {
     await userEvent.click(await screen.findByRole('button', { name: 'Add header' }));
     await act(async () => await userEvent.type(await screen.findByPlaceholderText('name'), 'headerName'));
     await act(async () => await userEvent.type(await screen.findByPlaceholderText('value'), 'headerValue'));
+    const compression = await screen.findByLabelText('The compression algorithm to expect in the response body', {
+      exact: false,
+    });
+    userEvent.selectOptions(compression, 'deflate');
     await toggleSection('HTTP settings');
 
     // TLS Config
@@ -466,6 +473,7 @@ describe('HTTP', () => {
           method: 'GET',
           headers: ['headerName:headerValue'],
           body: 'requestbody',
+          compression: 'deflate',
           ipVersion: 'V4',
           noFollowRedirects: false,
           tlsConfig: {

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -60,7 +60,7 @@ export function fallbackSettings(t: CheckType): Settings {
           method: HttpMethod.GET,
           ipVersion: IpVersion.V4,
           noFollowRedirects: false,
-          compression: HTTPCompressionAlgo.None,
+          compression: HTTPCompressionAlgo.none,
         },
       };
     }

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -40,6 +40,7 @@ import {
   HTTP_REGEX_VALIDATION_OPTIONS,
   fallbackCheck,
   ALERT_SENSITIVITY_OPTIONS,
+  HTTP_COMPRESSION_ALGO_OPTIONS,
 } from 'components/constants';
 import { checkType, fromBase64, toBase64 } from 'utils';
 import isBase64 from 'is-base64';
@@ -59,7 +60,7 @@ export function fallbackSettings(t: CheckType): Settings {
           method: HttpMethod.GET,
           ipVersion: IpVersion.V4,
           noFollowRedirects: false,
-          compression: undefined,
+          compression: HTTPCompressionAlgo.None,
         },
       };
     }
@@ -221,7 +222,7 @@ const getHttpSettingsFormValues = (settings: Settings): HttpSettingsFormValues =
     ipVersion: selectableValueFrom(httpSettings.ipVersion),
     headers: headersToLabels(httpSettings.headers),
     regexValidations,
-    compression: compression ? selectableValueFrom(compression) : selectableValueFrom(HTTPCompressionAlgo.None),
+    compression: compression ? selectableValueFrom(compression) : HTTP_COMPRESSION_ALGO_OPTIONS[0],
   };
 };
 

--- a/src/components/CheckList.test.tsx
+++ b/src/components/CheckList.test.tsx
@@ -216,7 +216,7 @@ test('clicking status chiclet adds it to filter', async () => {
   userEvent.click(disabledChiclet[1]);
   const statusFilter = await screen.findByTestId('check-status-filter');
   const checks = await screen.findAllByLabelText('check-card');
-  expect(statusFilter).toHaveValue('0');
+  expect(statusFilter).toHaveValue('2');
   expect(checks.length).toBe(1);
 });
 

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -285,9 +285,9 @@ export const CHECK_LIST_VIEW_TYPE_LS_KEY = 'grafana.sm.checklist.viewType';
 export const INVALID_WEB_URL_MESSAGE = 'Target must be a valid web URL';
 
 export const HTTP_COMPRESSION_ALGO_OPTIONS = [
-  { label: 'None', value: HTTPCompressionAlgo.None },
-  { label: 'Identity', value: HTTPCompressionAlgo.Identity },
-  { label: 'BR', value: HTTPCompressionAlgo.Br },
-  { label: 'GZIP', value: HTTPCompressionAlgo.Gzip },
-  { label: 'Deflate', value: HTTPCompressionAlgo.Deflate },
+  { label: 'none', value: HTTPCompressionAlgo.None },
+  { label: 'identity', value: HTTPCompressionAlgo.identity },
+  { label: 'br', value: HTTPCompressionAlgo.br },
+  { label: 'gzip', value: HTTPCompressionAlgo.gzip },
+  { label: 'deflate', value: HTTPCompressionAlgo.deflate },
 ];

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -14,6 +14,7 @@ import {
   CheckSort,
   CheckEnabledStatus,
   CheckListViewType,
+  HTTPCompressionAlgo,
 } from 'types';
 
 export const DNS_RESPONSE_CODES = enumToStringArray(DnsResponseCodes).map((responseCode) => ({
@@ -270,6 +271,7 @@ export const CHECK_LIST_VIEW_TYPE_OPTIONS = [
   { description: 'Card view', value: CheckListViewType.Card, icon: 'check-square' },
   { description: 'List view', value: CheckListViewType.List, icon: 'list-ul' },
 ];
+
 export const PEM_HEADER = '-----BEGIN CERTIFICATE-----';
 
 export const PEM_FOOTER = '-----END CERTIFICATE-----';
@@ -277,3 +279,11 @@ export const PEM_FOOTER = '-----END CERTIFICATE-----';
 export const CHECK_LIST_VIEW_TYPE_LS_KEY = 'grafana.sm.checklist.viewType';
 
 export const INVALID_WEB_URL_MESSAGE = 'Target must be a valid web URL';
+
+export const HTTP_COMPRESSION_ALGO_OPTIONS = [
+  { label: 'None', value: HTTPCompressionAlgo.None },
+  { label: 'Identity', value: HTTPCompressionAlgo.Identity },
+  { label: 'BR', value: HTTPCompressionAlgo.Br },
+  { label: 'GZIP', value: HTTPCompressionAlgo.Gzip },
+  { label: 'Deflate', value: HTTPCompressionAlgo.Deflate },
+];

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -285,7 +285,7 @@ export const CHECK_LIST_VIEW_TYPE_LS_KEY = 'grafana.sm.checklist.viewType';
 export const INVALID_WEB_URL_MESSAGE = 'Target must be a valid web URL';
 
 export const HTTP_COMPRESSION_ALGO_OPTIONS = [
-  { label: 'none', value: HTTPCompressionAlgo.None },
+  { label: 'none', value: HTTPCompressionAlgo.none },
   { label: 'identity', value: HTTPCompressionAlgo.identity },
   { label: 'br', value: HTTPCompressionAlgo.br },
   { label: 'gzip', value: HTTPCompressionAlgo.gzip },

--- a/src/components/http/HttpSettings.tsx
+++ b/src/components/http/HttpSettings.tsx
@@ -19,7 +19,12 @@ import { css } from 'emotion';
 import { useFormContext, Controller, useFieldArray } from 'react-hook-form';
 import { HttpMethod, HttpVersion, CheckType, HttpRegexValidationType } from 'types';
 import { Collapse } from 'components/Collapse';
-import { HTTP_REGEX_VALIDATION_OPTIONS, HTTP_SSL_OPTIONS, IP_OPTIONS } from '../constants';
+import {
+  HTTP_COMPRESSION_ALGO_OPTIONS,
+  HTTP_REGEX_VALIDATION_OPTIONS,
+  HTTP_SSL_OPTIONS,
+  IP_OPTIONS,
+} from '../constants';
 import { LabelField } from 'components/LabelField';
 import { TLSConfig } from 'components/TLSConfig';
 import { NameValueInput } from 'components/NameValueInput';
@@ -232,6 +237,15 @@ export const HttpSettingsForm = ({ isEditor }: Props) => {
               validateName={validateHTTPHeaderName}
               validateValue={validateHTTPHeaderValue}
             />
+          </Field>
+        </Container>
+        <Container>
+          <Field
+            label="Compression option"
+            description="The compression algorithm to expect in the response body"
+            disabled={!isEditor}
+          >
+            <Controller as={Select} name="settings.http.compression" options={HTTP_COMPRESSION_ALGO_OPTIONS} />
           </Field>
         </Container>
       </Collapse>

--- a/src/components/http/HttpSettings.tsx
+++ b/src/components/http/HttpSettings.tsx
@@ -239,15 +239,21 @@ export const HttpSettingsForm = ({ isEditor }: Props) => {
             />
           </Field>
         </Container>
-        <Container>
+        <HorizontalGroup>
           <Field
             label="Compression option"
             description="The compression algorithm to expect in the response body"
             disabled={!isEditor}
           >
-            <Controller as={Select} name="settings.http.compression" options={HTTP_COMPRESSION_ALGO_OPTIONS} />
+            <Controller
+              id="http-compression"
+              data-testid="http-compression"
+              as={Select}
+              name="settings.http.compression"
+              options={HTTP_COMPRESSION_ALGO_OPTIONS}
+            />
           </Field>
-        </Container>
+        </HorizontalGroup>
       </Collapse>
       <TLSConfig isEditor={isEditor} checkType={CheckType.HTTP} />
       <Collapse

--- a/src/types.ts
+++ b/src/types.ts
@@ -450,8 +450,8 @@ export enum CheckListViewType {
 
 export enum HTTPCompressionAlgo {
   None = '',
-  Identity = 'identity',
-  Br = 'br',
-  Gzip = 'gzip',
-  Deflate = 'deflate',
+  identity = 'identity',
+  br = 'br',
+  gzip = 'gzip',
+  deflate = 'deflate',
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -443,3 +443,11 @@ export enum CheckListViewType {
   Card,
   List,
 }
+
+export enum HTTPCompressionAlgo {
+  None = '',
+  Identity = 'identity',
+  Br = 'br',
+  Gzip = 'gzip',
+  Deflate = 'deflate',
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -449,7 +449,7 @@ export enum CheckListViewType {
 }
 
 export enum HTTPCompressionAlgo {
-  None = '',
+  none = '',
   identity = 'identity',
   br = 'br',
   gzip = 'gzip',

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -33,7 +33,7 @@ describe('trivial cases', () => {
       basicMetricsOnly: true,
       settings: {
         http: {
-          compression: HTTPCompressionAlgo.None,
+          compression: HTTPCompressionAlgo.none,
           method: HttpMethod.GET,
           ipVersion: IpVersion.V4,
           noFollowRedirects: false,

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -7,7 +7,16 @@ import {
   validateLabelName,
   validateLabelValue,
 } from 'validation';
-import { Check, CheckType, HttpMethod, IpVersion, DnsRecordType, DnsProtocol, AlertSensitivity } from 'types';
+import {
+  Check,
+  CheckType,
+  HttpMethod,
+  IpVersion,
+  DnsRecordType,
+  DnsProtocol,
+  AlertSensitivity,
+  HTTPCompressionAlgo,
+} from 'types';
 jest.unmock('utils');
 
 describe('trivial cases', () => {
@@ -24,6 +33,7 @@ describe('trivial cases', () => {
       basicMetricsOnly: true,
       settings: {
         http: {
+          compression: HTTPCompressionAlgo.None,
           method: HttpMethod.GET,
           ipVersion: IpVersion.V4,
           noFollowRedirects: false,


### PR DESCRIPTION
Closes #237 
Depends on https://github.com/grafana/synthetic-monitoring-agent/issues/124

Adds a selector for HTTP checks to allow decompressing compressed responses.

![Screen Shot 2021-05-05 at 10 45 13 AM](https://user-images.githubusercontent.com/8377044/117193159-03c36e00-ad8f-11eb-8663-42a1b81f152f.png)
