### PR TITLE
Add feature flag infrastructure

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,18 +3,21 @@ import { InstanceProvider } from 'components/InstanceProvider';
 import { PluginTabs } from 'components/PluginTabs';
 import { AppRootProps } from '@grafana/data';
 import { GlobalSettings } from 'types';
+import { FeatureFlagProvider } from './FeatureFlagProvider';
 
 export class App extends PureComponent<AppRootProps<GlobalSettings>> {
   render() {
     const { meta } = this.props;
     return (
-      <InstanceProvider
-        metricInstanceName={meta.jsonData?.metrics?.grafanaName}
-        logsInstanceName={meta.jsonData?.logs?.grafanaName}
-        meta={meta}
-      >
-        <PluginTabs {...this.props} />
-      </InstanceProvider>
+      <FeatureFlagProvider>
+        <InstanceProvider
+          metricInstanceName={meta.jsonData?.metrics?.grafanaName}
+          logsInstanceName={meta.jsonData?.logs?.grafanaName}
+          meta={meta}
+        >
+          <PluginTabs {...this.props} />
+        </InstanceProvider>
+      </FeatureFlagProvider>
     );
   }
 }

--- a/src/components/FeatureFlagProvider.tsx
+++ b/src/components/FeatureFlagProvider.tsx
@@ -1,0 +1,8 @@
+import React, { PropsWithChildren } from 'react';
+import { FeatureFlagContext, getFeatureContextValues } from 'contexts/FeatureFlagContext';
+
+interface Props {}
+
+export const FeatureFlagProvider = ({ children }: PropsWithChildren<Props>) => {
+  return <FeatureFlagContext.Provider value={getFeatureContextValues()}>{children}</FeatureFlagContext.Provider>;
+};

--- a/src/contexts/FeatureFlagContext.ts
+++ b/src/contexts/FeatureFlagContext.ts
@@ -10,7 +10,9 @@ interface FeatureFlagContextValue {
 
 function isFeatureEnabled(name: FeatureName) {
   const isEnabledThroughQueryParam = urlUtil.getUrlSearchParams()['features']?.includes(name);
-  return Boolean(config.featureToggles[name]) || isEnabledThroughQueryParam;
+  // @ts-ignore
+  // the type definitions in grafana core for feature toggles aren't quite right
+  return Boolean(config.featureToggles[name]?.live) || isEnabledThroughQueryParam;
 }
 
 export function getFeatureContextValues() {

--- a/src/contexts/FeatureFlagContext.ts
+++ b/src/contexts/FeatureFlagContext.ts
@@ -1,0 +1,23 @@
+import { createContext } from 'react';
+import { FeatureToggles, urlUtil } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { FeatureName } from 'types';
+
+interface FeatureFlagContextValue {
+  featureToggles: FeatureToggles;
+  isFeatureEnabled: (name: FeatureName) => boolean;
+}
+
+function isFeatureEnabled(name: FeatureName) {
+  const isEnabledThroughQueryParam = urlUtil.getUrlSearchParams()['features']?.includes(name);
+  return Boolean(config.featureToggles[name]) || isEnabledThroughQueryParam;
+}
+
+export function getFeatureContextValues() {
+  return {
+    featureToggles: config.featureToggles,
+    isFeatureEnabled,
+  };
+}
+
+export const FeatureFlagContext = createContext<FeatureFlagContextValue>(getFeatureContextValues());

--- a/src/hooks/useFeatureFlag.test.tsx
+++ b/src/hooks/useFeatureFlag.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FeatureFlagProvider } from 'components/FeatureFlagProvider';
+import { useFeatureFlag } from './useFeatureFlag';
+import { FeatureName } from 'types';
+
+const CONFIG_FLAG = 'configFlag';
+const URL_FLAG = 'urlFlag';
+
+jest.mock('@grafana/runtime', () => ({
+  config: {
+    featureToggles: {
+      // changing this key to use the declared const variable results in undefined
+      configFlag: { live: true },
+    },
+  },
+}));
+
+jest.mock('@grafana/data', () => ({
+  urlUtil: {
+    getUrlSearchParams: jest.fn().mockImplementation(() => ({ features: [URL_FLAG] })),
+  },
+}));
+
+interface WrappedProps {
+  name: FeatureName;
+}
+
+const Wrapped = ({ name }: WrappedProps) => {
+  const { isEnabled } = useFeatureFlag(name);
+  return (
+    <div>
+      <h1>A flagged feature</h1>
+      {isEnabled ? <div>the feature is enabled</div> : <div>not enabled</div>}
+    </div>
+  );
+};
+
+const renderFeatureFlags = (name: string) => {
+  const cast = (name as unknown) as FeatureName;
+  render(
+    <FeatureFlagProvider>
+      <Wrapped name={cast} />
+    </FeatureFlagProvider>
+  );
+};
+
+test('gets flag values from config', async () => {
+  renderFeatureFlags(CONFIG_FLAG);
+  const enabled = await screen.findByText('the feature is enabled');
+  expect(enabled).toBeInTheDocument();
+});
+
+test('disabled for flags that do not exist', async () => {
+  renderFeatureFlags('not a real flag');
+  const notEnabled = await screen.findByText('not enabled');
+  expect(notEnabled).toBeInTheDocument();
+});
+
+test('detects feature flags in url params', async () => {
+  renderFeatureFlags(URL_FLAG);
+  const enabled = await screen.findByText('the feature is enabled');
+  expect(enabled).toBeInTheDocument();
+});

--- a/src/hooks/useFeatureFlag.ts
+++ b/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,10 @@
+import { FeatureName } from 'types';
+import { useContext } from 'react';
+import { FeatureFlagContext } from 'contexts/FeatureFlagContext';
+
+export function useFeatureFlag(featureFlag: FeatureName) {
+  const { isFeatureEnabled } = useContext(FeatureFlagContext);
+  return {
+    isEnabled: isFeatureEnabled(featureFlag),
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -456,3 +456,5 @@ export enum HTTPCompressionAlgo {
   gzip = 'gzip',
   deflate = 'deflate',
 }
+
+export enum FeatureName {}


### PR DESCRIPTION
This PR adds in some infrastructure for using feature flags. It creates a feature flag context and a hook that can read flags that can come from either the URL or the `config.ini` file. 