### PR TITLE
Feature: add filtering by custom labels

### DIFF
--- a/src/dashboards/sm-dns.json
+++ b/src/dashboards/sm-dns.json
@@ -22,13 +22,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.0.3"
+      "version": "7.5.7"
     },
     {
       "type": "panel",
       "id": "grafana-worldmap-panel",
       "name": "Worldmap Panel",
-      "version": "0.2.1"
+      "version": "0.3.2"
     },
     {
       "type": "panel",
@@ -78,33 +78,36 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1596752049000,
+  "iteration": 1622685316784,
   "links": [],
   "panels": [
     {
       "circleMaxSize": "10",
       "circleMinSize": "2",
-      "colors": ["#37872D", "#FA6400", "#C4162A"],
+      "colors": [
+        "#37872D",
+        "#FA6400",
+        "#C4162A"
+      ],
       "datasource": "${DS_SM_METRICS}",
       "decimals": 2,
+      "description": "What's the error percentage for each probe that is observing the given target.",
       "esGeoPoint": "geohash",
       "esLocationName": "probe",
       "esMetric": "Count",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
         "h": 9,
-        "w": 14,
+        "w": 12,
         "x": 0,
         "y": 0
       },
       "hideEmpty": false,
       "hideZero": false,
-      "id": 27,
+      "id": 34,
       "initialZoom": 1,
       "locationData": "table",
       "mapCenter": "(0°, 0°)",
@@ -124,7 +127,8 @@
       },
       "targets": [
         {
-          "expr": "100*(1 - (sum((rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])) * on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"dns\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"dns\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
+          "exemplar": true,
+          "expr": "100*(\n  1 - (\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n    /\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n  )\n)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -135,7 +139,7 @@
       "thresholds": "0.5,1",
       "timeFrom": null,
       "timeShift": null,
-      "title": "Downtime",
+      "title": "Error rate by probe",
       "type": "grafana-worldmap-panel",
       "unitPlural": "%",
       "unitSingle": "",
@@ -145,9 +149,9 @@
     {
       "cacheTimeout": null,
       "datasource": "${DS_SM_METRICS}",
+      "description": "The fraction of time the target was up during the whole period.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "decimals": 2,
           "mappings": [
             {
@@ -158,7 +162,88 @@
               "value": "null"
             }
           ],
-          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.99
+              },
+              {
+                "color": "green",
+                "value": 0.995
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 12,
+        "y": 0
+      },
+      "id": 36,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.7",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "${DS_SM_METRICS}",
+      "description": "The percentage of all the checks that have succeeded during the whole time period.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -186,28 +271,35 @@
         "x": 14,
         "y": 0
       },
-      "id": 25,
+      "id": 38,
       "links": [],
       "options": {
         "colorMode": "value",
         "fieldOptions": {
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["mean"],
+          "calcs": [
+            "mean"
+          ],
           "fields": "",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
+          "exemplar": true,
+          "expr": "sum(\n  (\n    delta(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    delta(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "interval": "",
           "legendFormat": "",
           "refId": "B"
@@ -215,18 +307,17 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Uptime",
+      "title": "Reachability",
       "type": "stat"
     },
     {
       "cacheTimeout": null,
       "datasource": "${DS_SM_METRICS}",
+      "description": "The average time to receive an answer across all the checks during the whole time period.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "decimals": 2,
           "mappings": [],
-          "nullValueMode": "connected",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -254,26 +345,32 @@
         "x": 16,
         "y": 0
       },
-      "id": 30,
+      "id": 40,
       "links": [],
       "options": {
         "colorMode": "value",
         "fieldOptions": {
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "fields": "",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "sum((rate(probe_dns_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_dns_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_dns_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_dns_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
+          "expr": "sum((rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -283,7 +380,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Average Latency",
+      "title": "Average latency",
       "type": "stat"
     },
     {
@@ -291,7 +388,6 @@
       "datasource": "${DS_SM_METRICS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [
             {
               "id": 0,
@@ -301,7 +397,6 @@
               "value": "null"
             }
           ],
-          "nullValueMode": "connected",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -326,18 +421,24 @@
       "options": {
         "colorMode": "value",
         "fieldOptions": {
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["mean"],
+          "calcs": [
+            "mean"
+          ],
           "fields": "",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "expr": "avg(probe_dns_answer_rrs{probe=~\"$probe\",instance=\"$instance\", job=\"$job\"})",
@@ -354,24 +455,16 @@
       "type": "stat"
     },
     {
-      "cacheTimeout": null,
       "datasource": "${DS_SM_METRICS}",
+      "description": "How often is the target checked?",
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": null
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
           },
-          "decimals": 0,
-          "mappings": [
-            {
-              "id": 0,
-              "op": "=",
-              "text": "N/A",
-              "type": 1,
-              "value": "null"
-            }
-          ],
-          "nullValueMode": "connected",
+          "mappings": [],
+          "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -391,46 +484,40 @@
         "x": 22,
         "y": 0
       },
-      "id": 17,
-      "links": [],
+      "id": 42,
       "options": {
         "colorMode": "value",
-        "fieldOptions": {
-          "calcs": ["mean"]
-        },
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
-        "orientation": "horizontal",
+        "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["last"],
-          "fields": "",
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^frequency$/",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "sum(topk(1,sm_check_info{probe=~\"$probe\", instance=\"$instance\", check_name=\"dns\"})) by (frequency)",
-          "format": "table",
+          "exemplar": true,
+          "expr": "sum by (frequency) (\n  topk(\n    1,\n    sm_check_info{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}\n  )\n)",
+          "format": "time_series",
           "instant": true,
           "interval": "",
-          "legendFormat": "{{frequency}}",
+          "legendFormat": "",
+          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Frequency",
       "transformations": [
         {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Value": true
-            },
-            "indexByName": {},
-            "renameByName": {}
-          }
+          "id": "labelsToFields",
+          "options": {}
         }
       ],
       "type": "stat"
@@ -444,7 +531,7 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -452,13 +539,13 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 10,
-        "x": 14,
+        "w": 12,
+        "x": 12,
         "y": 2
       },
       "hiddenSeries": false,
-      "id": 8,
-      "interval": "5m",
+      "id": 44,
+      "interval": null,
       "legend": {
         "avg": false,
         "current": false,
@@ -472,9 +559,10 @@
       "linewidth": 0,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -484,9 +572,11 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "100*(1-(sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])))))",
+          "exemplar": true,
+          "expr": "  1 - (\n    sum(\n      (\n        rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n        OR\n        rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n      )\n    )\n    /\n    sum(\n      (\n        rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n        OR\n        rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n      )\n    )\n  )",
           "hide": false,
-          "interval": "",
+          "interval": "1m",
+          "intervalFactor": 1,
           "legendFormat": "errors",
           "refId": "A"
         }
@@ -511,15 +601,17 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:254",
           "decimals": null,
-          "format": "percent",
+          "format": "percentunit",
           "label": "",
           "logBase": 1,
-          "max": "100",
+          "max": "1",
           "min": "0",
           "show": true
         },
         {
+          "$$hashKey": "object:255",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -541,7 +633,7 @@
       "datasource": "${DS_SM_METRICS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -572,9 +664,10 @@
       "linewidth": 0,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.7",
       "pointradius": 1,
       "points": true,
       "renderer": "flot",
@@ -618,7 +711,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Response Latency by Probe",
+      "title": "Response latency by probe",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -635,6 +728,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:907",
           "decimals": null,
           "format": "s",
           "label": null,
@@ -644,6 +738,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:908",
           "decimals": null,
           "format": "short",
           "label": null,
@@ -667,7 +762,7 @@
       "decimals": 0,
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -697,9 +792,10 @@
       "maxDataPoints": "100",
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -759,7 +855,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Resource Records",
+      "title": "Resource records",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -776,6 +872,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:578",
           "decimals": 0,
           "format": "none",
           "label": null,
@@ -785,6 +882,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:579",
           "decimals": null,
           "format": "short",
           "label": null,
@@ -802,9 +900,7 @@
     {
       "datasource": "${DS_SM_LOGS}",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
@@ -815,6 +911,7 @@
       },
       "id": 15,
       "options": {
+        "dedupStrategy": "none",
         "showLabels": false,
         "showTime": true,
         "sortOrder": "Descending",
@@ -833,9 +930,11 @@
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 25,
+  "schemaVersion": 27,
   "style": "dark",
-  "tags": ["synthetic-monitoring"],
+  "tags": [
+    "synthetic-monitoring"
+  ],
   "templating": {
     "list": [
       {
@@ -843,13 +942,18 @@
         "current": {},
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info{check_name=\"dns\"},probe)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": false,
         "name": "probe",
         "options": [],
-        "query": "label_values(sm_check_info{check_name=\"dns\"},probe)",
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"dns\"},probe)",
+          "refId": "${DS_SM_METRICS}-probe-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -865,13 +969,18 @@
         "current": {},
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info{check_name=\"dns\", probe=~\"$probe\"},job)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(sm_check_info{check_name=\"dns\", probe=~\"$probe\"},job)",
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"dns\", probe=~\"$probe\"},job)",
+          "refId": "${DS_SM_METRICS}-job-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -887,13 +996,18 @@
         "current": {},
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info{check_name=\"dns\", job=\"$job\", probe=~\"$probe\"},instance)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(sm_check_info{check_name=\"dns\", job=\"$job\", probe=~\"$probe\"},instance)",
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"dns\", job=\"$job\", probe=~\"$probe\"},instance)",
+          "refId": "${DS_SM_METRICS}-instance-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -911,10 +1025,20 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
   },
   "timezone": "",
   "title": "Synthetic Monitoring - DNS",
   "uid": "lgL6odgGz",
-  "version": 15
+  "version": 16
 }

--- a/src/dashboards/sm-http.json
+++ b/src/dashboards/sm-http.json
@@ -22,13 +22,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.0.3"
+      "version": "7.5.7"
     },
     {
       "type": "panel",
       "id": "grafana-worldmap-panel",
       "name": "Worldmap Panel",
-      "version": "0.2.1"
+      "version": "0.3.2"
     },
     {
       "type": "panel",
@@ -78,7 +78,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1591626907521,
+  "iteration": 1622677792316,
   "links": [],
   "panels": [
     {
@@ -91,24 +91,23 @@
       ],
       "datasource": "${DS_SM_METRICS}",
       "decimals": 2,
+      "description": "What's the error percentage for each probe that is observing the given target.",
       "esGeoPoint": "geohash",
       "esLocationName": "probe",
       "esMetric": "Count",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
         "h": 9,
-        "w": 14,
+        "w": 12,
         "x": 0,
         "y": 0
       },
       "hideEmpty": false,
       "hideZero": false,
-      "id": 27,
+      "id": 34,
       "initialZoom": 1,
       "locationData": "table",
       "mapCenter": "(0°, 0°)",
@@ -128,7 +127,8 @@
       },
       "targets": [
         {
-          "expr": "100*(1 - (sum((rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"http\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"http\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
+          "exemplar": true,
+          "expr": "100*(\n  1 - (\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n    /\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n  )\n)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -139,7 +139,7 @@
       "thresholds": "0.5,1",
       "timeFrom": null,
       "timeShift": null,
-      "title": "Downtime",
+      "title": "Error rate by probe",
       "type": "grafana-worldmap-panel",
       "unitPlural": "%",
       "unitSingle": "",
@@ -149,9 +149,9 @@
     {
       "cacheTimeout": null,
       "datasource": "${DS_SM_METRICS}",
+      "description": "The fraction of time the target was up during the whole period.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "decimals": 2,
           "mappings": [
             {
@@ -162,7 +162,88 @@
               "value": "null"
             }
           ],
-          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.99
+              },
+              {
+                "color": "green",
+                "value": 0.995
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 12,
+        "y": 0
+      },
+      "id": 36,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.7",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "${DS_SM_METRICS}",
+      "description": "The percentage of all the checks that have succeeded during the whole time period.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -190,7 +271,7 @@
         "x": 14,
         "y": 0
       },
-      "id": 25,
+      "id": 38,
       "links": [],
       "options": {
         "colorMode": "value",
@@ -208,14 +289,17 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
+          "exemplar": true,
+          "expr": "sum(\n  (\n    delta(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    delta(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "interval": "",
           "legendFormat": "",
           "refId": "B"
@@ -223,18 +307,17 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Uptime",
+      "title": "Reachability",
       "type": "stat"
     },
     {
       "cacheTimeout": null,
       "datasource": "${DS_SM_METRICS}",
+      "description": "The average time to receive an answer across all the checks during the whole time period.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "decimals": 2,
           "mappings": [],
-          "nullValueMode": "connected",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -262,7 +345,7 @@
         "x": 16,
         "y": 0
       },
-      "id": 30,
+      "id": 40,
       "links": [],
       "options": {
         "colorMode": "value",
@@ -280,9 +363,11 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "expr": "sum((rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
@@ -295,7 +380,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Average Latency",
+      "title": "Average latency",
       "type": "stat"
     },
     {
@@ -303,7 +388,6 @@
       "datasource": "${DS_SM_METRICS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "decimals": 2,
           "mappings": [
             {
@@ -314,7 +398,6 @@
               "value": "null"
             }
           ],
-          "nullValueMode": "connected",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -360,9 +443,11 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "expr": "min(probe_ssl_earliest_cert_expiry{probe=~\"$probe\",instance=\"$instance\", job=\"$job\"}) - time()",
@@ -379,24 +464,16 @@
       "type": "stat"
     },
     {
-      "cacheTimeout": null,
       "datasource": "${DS_SM_METRICS}",
+      "description": "How often is the target checked?",
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": null
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
           },
-          "decimals": 0,
-          "mappings": [
-            {
-              "id": 0,
-              "op": "=",
-              "text": "N/A",
-              "type": 1,
-              "value": "null"
-            }
-          ],
-          "nullValueMode": "connected",
+          "mappings": [],
+          "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -416,50 +493,40 @@
         "x": 22,
         "y": 0
       },
-      "id": 17,
-      "links": [],
+      "id": 42,
       "options": {
         "colorMode": "value",
-        "fieldOptions": {
-          "calcs": [
-            "mean"
-          ]
-        },
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
-        "orientation": "horizontal",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "last"
+            "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/^frequency$/",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "sum(topk(1,sm_check_info{probe=~\"$probe\", instance=\"$instance\", check_name=\"http\"})) by (frequency)",
-          "format": "table",
+          "exemplar": true,
+          "expr": "sum by (frequency) (\n  topk(\n    1,\n    sm_check_info{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}\n  )\n)",
+          "format": "time_series",
           "instant": true,
           "interval": "",
-          "legendFormat": "{{frequency}}",
+          "legendFormat": "",
+          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Frequency",
       "transformations": [
         {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Value": true
-            },
-            "indexByName": {},
-            "renameByName": {}
-          }
+          "id": "labelsToFields",
+          "options": {}
         }
       ],
       "type": "stat"
@@ -473,7 +540,7 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -481,12 +548,12 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 10,
-        "x": 14,
+        "w": 12,
+        "x": 12,
         "y": 2
       },
       "hiddenSeries": false,
-      "id": 8,
+      "id": 44,
       "interval": "5m",
       "legend": {
         "avg": false,
@@ -501,9 +568,10 @@
       "linewidth": 0,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -513,9 +581,11 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "100*(1-(sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])))))",
+          "exemplar": true,
+          "expr": "100*(\n  1 - (\n    sum(\n      (\n        rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n        OR\n        rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n      )\n    )\n    /\n    sum(\n      (\n        rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n        OR\n        rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n      )\n    )\n  )\n)",
           "hide": false,
-          "interval": "",
+          "interval": "1m",
+          "intervalFactor": 1,
           "legendFormat": "errors",
           "refId": "A"
         }
@@ -540,6 +610,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:254",
           "decimals": null,
           "format": "percent",
           "label": "",
@@ -549,6 +620,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:255",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -570,7 +642,7 @@
       "datasource": "${DS_SM_METRICS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -600,9 +672,10 @@
       "maxDataPoints": "100",
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -694,7 +767,7 @@
       "datasource": "${DS_SM_METRICS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -725,9 +798,10 @@
       "linewidth": 0,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.7",
       "pointradius": 1,
       "points": true,
       "renderer": "flot",
@@ -814,9 +888,7 @@
     {
       "datasource": "${DS_SM_LOGS}",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
@@ -825,8 +897,9 @@
         "x": 0,
         "y": 16
       },
-      "id": 15,
+      "id": 46,
       "options": {
+        "dedupStrategy": "none",
         "showLabels": false,
         "showTime": true,
         "sortOrder": "Descending",
@@ -834,18 +907,18 @@
       },
       "targets": [
         {
-          "expr": "{probe=~\"$probe\",instance=\"$instance\", job=\"$job\", probe_success=\"0\"}",
+          "expr": "{probe=~\"$probe\", instance=\"$instance\", job=\"$job\", probe_success=\"0\"}",
           "refId": "A"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Error logs for $probe: $instance",
+      "title": "Logs for failed checks: $probe ⮕ $job / $instance",
       "type": "logs"
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 25,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "synthetic-monitoring"
@@ -857,13 +930,18 @@
         "current": {},
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info,probe)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": false,
         "name": "probe",
         "options": [],
-        "query": "label_values(sm_check_info{check_name=\"http\"},probe)",
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"http\"},probe)",
+          "refId": "${DS_SM_METRICS}-probe-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -879,13 +957,18 @@
         "current": {},
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info{check_name=\"http\", probe=~\"$probe\"},job)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(sm_check_info{check_name=\"http\", probe=~\"$probe\"},job)",
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"http\", probe=~\"$probe\"},job)",
+          "refId": "${DS_SM_METRICS}-job-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -901,13 +984,18 @@
         "current": {},
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info{check_name=\"http\", job=\"$job\", probe=~\"$probe\"},instance)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(sm_check_info{check_name=\"http\", job=\"$job\", probe=~\"$probe\"},instance)",
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"http\", job=\"$job\", probe=~\"$probe\"},instance)",
+          "refId": "${DS_SM_METRICS}-instance-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -940,5 +1028,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring HTTP",
   "uid": "rq0JrllZz",
-  "version": 27
+  "version": 28
 }

--- a/src/dashboards/sm-ping.json
+++ b/src/dashboards/sm-ping.json
@@ -22,13 +22,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.0.3"
+      "version": "7.5.7"
     },
     {
       "type": "panel",
       "id": "grafana-worldmap-panel",
       "name": "Worldmap Panel",
-      "version": "0.2.1"
+      "version": "0.3.2"
     },
     {
       "type": "panel",
@@ -78,7 +78,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1591625960879,
+  "iteration": 1622675262450,
   "links": [],
   "panels": [
     {
@@ -91,18 +91,17 @@
       ],
       "datasource": "${DS_SM_METRICS}",
       "decimals": 2,
+      "description": "What's the error percentage for each probe that is observing the given target.",
       "esGeoPoint": "geohash",
       "esLocationName": "probe",
       "esMetric": "Count",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
         "h": 9,
-        "w": 14,
+        "w": 12,
         "x": 0,
         "y": 0
       },
@@ -128,7 +127,8 @@
       },
       "targets": [
         {
-          "expr": "100*(1 - (sum((rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"ping\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"ping\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
+          "exemplar": true,
+          "expr": "100*(\n  1 - (\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n    /\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n  )\n)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -139,7 +139,7 @@
       "thresholds": "0.5,1",
       "timeFrom": null,
       "timeShift": null,
-      "title": "Downtime",
+      "title": "Error rate by probe",
       "type": "grafana-worldmap-panel",
       "unitPlural": "%",
       "unitSingle": "",
@@ -149,9 +149,9 @@
     {
       "cacheTimeout": null,
       "datasource": "${DS_SM_METRICS}",
+      "description": "The fraction of time the target was up during the whole period.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "decimals": 2,
           "mappings": [
             {
@@ -162,7 +162,6 @@
               "value": "null"
             }
           ],
-          "nullValueMode": "connected",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -187,7 +186,7 @@
       "gridPos": {
         "h": 2,
         "w": 3,
-        "x": 14,
+        "x": 12,
         "y": 0
       },
       "id": 25,
@@ -208,14 +207,17 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
+          "exemplar": true,
+          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "interval": "",
           "legendFormat": "",
           "refId": "B"
@@ -229,12 +231,93 @@
     {
       "cacheTimeout": null,
       "datasource": "${DS_SM_METRICS}",
+      "description": "The percentage of all the checks that have succeeded during the whole time period.",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
+          "decimals": 2,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.99
+              },
+              {
+                "color": "green",
+                "value": 0.995
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 3,
+        "x": 15,
+        "y": 0
+      },
+      "id": 32,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.7",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(\n  (\n    delta(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    delta(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Reachability",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "${DS_SM_METRICS}",
+      "description": "The average time to receive an answer across all the checks during the whole time period.",
+      "fieldConfig": {
+        "defaults": {
           "decimals": 2,
           "mappings": [],
-          "nullValueMode": "connected",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -258,11 +341,11 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 4,
-        "x": 17,
+        "w": 3,
+        "x": 18,
         "y": 0
       },
-      "id": 30,
+      "id": 34,
       "links": [],
       "options": {
         "colorMode": "value",
@@ -280,9 +363,11 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
           "expr": "sum((rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
@@ -295,28 +380,20 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Average Latency",
+      "title": "Average latency",
       "type": "stat"
     },
     {
-      "cacheTimeout": null,
       "datasource": "${DS_SM_METRICS}",
+      "description": "How often is the target checked?",
       "fieldConfig": {
         "defaults": {
-          "custom": {
-            "align": null
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
           },
-          "decimals": 0,
-          "mappings": [
-            {
-              "id": 0,
-              "op": "=",
-              "text": "N/A",
-              "type": 1,
-              "value": "null"
-            }
-          ],
-          "nullValueMode": "connected",
+          "mappings": [],
+          "noValue": "N/A",
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -336,50 +413,40 @@
         "x": 21,
         "y": 0
       },
-      "id": 17,
-      "links": [],
+      "id": 36,
       "options": {
         "colorMode": "value",
-        "fieldOptions": {
-          "calcs": [
-            "mean"
-          ]
-        },
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
-        "orientation": "horizontal",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "last"
+            "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/^frequency$/",
           "values": false
-        }
+        },
+        "text": {},
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.5.7",
       "targets": [
         {
-          "expr": "sum(topk(1,sm_check_info{probe=~\"$probe\", instance=\"$instance\", check_name=\"ping\"})) by (frequency)",
-          "format": "table",
+          "exemplar": true,
+          "expr": "sum by (frequency) (\n  topk(\n    1,\n    sm_check_info{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}\n  )\n)",
+          "format": "time_series",
           "instant": true,
           "interval": "",
-          "legendFormat": "{{frequency}}",
+          "legendFormat": "",
+          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Frequency",
       "transformations": [
         {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Value": true
-            },
-            "indexByName": {},
-            "renameByName": {}
-          }
+          "id": "labelsToFields",
+          "options": {}
         }
       ],
       "type": "stat"
@@ -393,7 +460,7 @@
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -401,12 +468,12 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 7,
-        "w": 10,
-        "x": 14,
+        "w": 12,
+        "x": 12,
         "y": 2
       },
       "hiddenSeries": false,
-      "id": 8,
+      "id": 38,
       "interval": "5m",
       "legend": {
         "avg": false,
@@ -421,9 +488,10 @@
       "linewidth": 0,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -433,9 +501,11 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "100*(1-(sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])))))",
+          "exemplar": true,
+          "expr": "100*(\n  1 - (\n    sum(\n      (\n        rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n        OR\n        rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n      )\n    )\n    /\n    sum(\n      (\n        rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n        OR\n        rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n      )\n    )\n  )\n)",
           "hide": false,
-          "interval": "",
+          "interval": "1m",
+          "intervalFactor": 1,
           "legendFormat": "errors",
           "refId": "A"
         }
@@ -460,6 +530,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:254",
           "decimals": null,
           "format": "percent",
           "label": "",
@@ -469,6 +540,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:255",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -490,7 +562,7 @@
       "datasource": "${DS_SM_METRICS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -520,9 +592,10 @@
       "maxDataPoints": "100",
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -614,7 +687,7 @@
       "datasource": "${DS_SM_METRICS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -645,9 +718,10 @@
       "linewidth": 0,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.7",
       "pointradius": 1,
       "points": true,
       "renderer": "flot",
@@ -734,9 +808,7 @@
     {
       "datasource": "${DS_SM_LOGS}",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
@@ -745,8 +817,9 @@
         "x": 0,
         "y": 16
       },
-      "id": 15,
+      "id": 40,
       "options": {
+        "dedupStrategy": "none",
         "showLabels": false,
         "showTime": true,
         "sortOrder": "Descending",
@@ -754,18 +827,18 @@
       },
       "targets": [
         {
-          "expr": "{probe=~\"$probe\",instance=\"$instance\", job=\"$job\", probe_success=\"0\"}",
+          "expr": "{probe=~\"$probe\", instance=\"$instance\", job=\"$job\", probe_success=\"0\"}",
           "refId": "A"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Error logs for $probe: $instance",
+      "title": "Logs for failed checks: $probe ⮕ $job / $instance",
       "type": "logs"
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 25,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "synthetic-monitoring"
@@ -777,13 +850,18 @@
         "current": {},
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info,probe)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": false,
         "name": "probe",
         "options": [],
-        "query": "label_values(sm_check_info{check_name=\"ping\"},probe)",
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"ping\"},probe)",
+          "refId": "${DS_SM_METRICS}-probe-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -799,13 +877,18 @@
         "current": {},
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info{check_name=\"ping\", probe=~\"$probe\"},job)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "label_values(sm_check_info{check_name=\"ping\", probe=~\"$probe\"},job)",
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"ping\", probe=~\"$probe\"},job)",
+          "refId": "${DS_SM_METRICS}-job-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -821,13 +904,18 @@
         "current": {},
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info{check_name=\"ping\", job=\"$job\", probe=~\"$probe\"},instance)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "label_values(sm_check_info{check_name=\"ping\", job=\"$job\", probe=~\"$probe\"},instance)",
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"ping\", job=\"$job\", probe=~\"$probe\"},instance)",
+          "refId": "${DS_SM_METRICS}-instance-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -860,5 +948,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring Ping",
   "uid": "EHyn7ueZk",
-  "version": 26
+  "version": 27
 }

--- a/src/dashboards/sm-summary.json
+++ b/src/dashboards/sm-summary.json
@@ -22,13 +22,13 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.0.3"
+      "version": "7.5.7"
     },
     {
       "type": "panel",
       "id": "grafana-worldmap-panel",
       "name": "Worldmap Panel",
-      "version": "0.2.1"
+      "version": "0.3.2"
     },
     {
       "type": "panel",
@@ -44,8 +44,8 @@
     },
     {
       "type": "panel",
-      "id": "table-old",
-      "name": "Table (old)",
+      "id": "table",
+      "name": "Table",
       "version": ""
     }
   ],
@@ -67,7 +67,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1592844495556,
+  "iteration": 1622660155942,
   "links": [],
   "panels": [
     {
@@ -100,9 +100,7 @@
       "esLocationName": "probe",
       "esMetric": "Count",
       "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
+        "defaults": {},
         "overrides": []
       },
       "gridPos": {
@@ -145,7 +143,7 @@
       "thresholds": "0.5,1",
       "timeFrom": null,
       "timeShift": null,
-      "title": "$check_type Downtime",
+      "title": "$check_type reachability",
       "type": "grafana-worldmap-panel",
       "unitPlural": "%",
       "unitSingle": "",
@@ -158,9 +156,10 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_SM_METRICS}",
+      "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -196,9 +195,10 @@
       "maxDataPoints": "100",
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -213,9 +213,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - (sum((rate(probe_all_success_sum[$__interval]) OR rate(probe_success_sum[$__interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)) / sum((rate(probe_all_success_count[$__interval]) OR rate(probe_success_count[$__interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)))",
+          "expr": "1 - (sum((rate(probe_all_success_sum[$__rate_interval]) OR rate(probe_success_sum[$__rate_interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)) / sum((rate(probe_all_success_count[$__rate_interval]) OR rate(probe_success_count[$__rate_interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)))",
           "hide": false,
-          "interval": "",
+          "interval": "1m",
+          "intervalFactor": 1,
           "legendFormat": "% Errors",
           "refId": "A"
         }
@@ -224,7 +225,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "$check_type Check Error Percent",
+      "title": "$check_type check error percentage",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -263,15 +264,208 @@
       }
     },
     {
-      "columns": [],
       "datasource": "${DS_SM_METRICS}",
+      "description": "* **instance**: the instance that corresponds to this check.\n* **job**: the job that corresponds to this check.\n* **reachability**: the percentage of all the checks that have succeeded during the whole time period.\n* **latency**: the average time to receive an answer across all the checks during the whole time period.\n* **state**: whether the target was up or down the last time it was checked.\n* **uptime**: the fraction of time the target was up  during the whole period.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "custom": {
+            "align": null,
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #reachability"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "displayName",
+                "value": "reachability"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #latency"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "displayName",
+                "value": "latency"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.5
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #state"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "state"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "from": "",
+                    "id": 1,
+                    "text": "down",
+                    "to": "",
+                    "type": 1,
+                    "value": "0"
+                  },
+                  {
+                    "from": "",
+                    "id": 2,
+                    "text": "up",
+                    "to": "",
+                    "type": 1,
+                    "value": "1"
+                  }
+                ]
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #uptime"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "uptime"
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "instance"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Show details...",
+                    "url": "/a/grafana-synthetic-monitoring-app/?page=redirect&dashboard=$check_type&var-probe=All&var-instance=${__data.fields.instance}&var-job=${__data.fields.job}&from=${__from}&to=${__to}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "job"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Show details...",
+                    "url": "/a/grafana-synthetic-monitoring-app/?page=redirect&dashboard=${__data.fields[1]}&var-probe=All&var-instance=${__data.fields.instance}&var-job=${__data.fields.job}&from=${__from}&to=${__to}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "fontSize": "100%",
       "gridPos": {
         "h": 9,
         "w": 10,
@@ -279,137 +473,73 @@
         "y": 1
       },
       "id": 2,
-      "pageSize": null,
-      "showHeader": true,
-      "sort": {
-        "col": 1,
-        "desc": true
+      "options": {
+        "showHeader": true
       },
-      "styles": [
-        {
-          "alias": "instance",
-          "align": "auto",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "link": true,
-          "linkTooltip": "",
-          "linkUrl": "/a/grafana-synthetic-monitoring-app/?page=redirect&dashboard=${__cell_1}&var-probe=All&var-instance=${__cell}&var-job=${__cell_3}&from=${__from}&to=${__to}",
-          "mappingType": 1,
-          "pattern": "instance",
-          "rangeMaps": [],
-          "type": "string",
-          "valueMaps": []
-        },
-        {
-          "alias": "Uptime",
-          "align": "right",
-          "colorMode": "row",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "#FF780A",
-            "#56A64B"
-          ],
-          "decimals": 2,
-          "pattern": "Value #C",
-          "thresholds": [
-            "0.99",
-            "0.995"
-          ],
-          "type": "number",
-          "unit": "percentunit"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "Time",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        },
-        {
-          "alias": "Latency",
-          "align": "right",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "Value #A",
-          "thresholds": [],
-          "type": "number",
-          "unit": "s"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "check_name",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        },
-        {
-          "alias": "",
-          "align": "left",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "job",
-          "thresholds": [],
-          "type": "string",
-          "unit": "short"
-        }
-      ],
+      "pluginVersion": "7.5.7",
+      "repeat": null,
+      "repeatDirection": "v",
       "targets": [
         {
-          "expr": "sum((rate(probe_all_success_sum[$__range]) OR rate(probe_success_sum[$__range])) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, job, check_name) / sum((rate(probe_all_success_count[$__range]) OR rate(probe_success_count[$__range])) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, check_name, job)",
+          "exemplar": true,
+          "expr": "sum by (instance, job, check_name)\n(\n  (\n    rate(probe_all_success_sum[$__range])\n    OR\n    rate(probe_success_sum[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max\n  by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n)\n/\nsum by (instance, check_name, job)\n(\n  (\n    rate(probe_all_success_count[$__range])\n    OR\n    rate(probe_success_count[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max\n  by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n)",
           "format": "table",
           "instant": true,
           "interval": "",
           "legendFormat": "{{check_name}}-{{instance}}-uptime",
-          "refId": "C"
+          "refId": "reachability"
         },
         {
-          "expr": "sum((rate(probe_all_duration_seconds_sum[$__range]) OR rate(probe_duration_seconds_sum[$__range])) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, job, check_name) / sum((rate(probe_all_duration_seconds_count[$__range]) OR rate(probe_duration_seconds_count[$__range])) * on (instance, job, probe, config_version) group_left(check_name) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, check_name)) by (instance, job, check_name)",
+          "exemplar": true,
+          "expr": "sum by (instance, job, check_name)\n(\n  (\n    rate(probe_all_duration_seconds_sum[$__range])\n    OR\n    rate(probe_duration_seconds_sum[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n)\n/\nsum by (instance, job, check_name)\n(\n  (\n    rate(probe_all_duration_seconds_count[$__range])\n    OR\n    rate(probe_duration_seconds_count[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n)",
           "format": "table",
           "instant": true,
           "interval": "",
           "legendFormat": "{{check_name}}-{{instance}}-latency",
-          "refId": "A"
+          "refId": "latency"
+        },
+        {
+          "exemplar": true,
+          "expr": "ceil(\n  sum by (instance, job, check_name)\n  (\n    (\n      rate(probe_all_success_sum[5m])\n      OR\n      rate(probe_success_sum[5m])\n    )\n    *\n    on (instance, job, probe, config_version)\n    group_left(check_name)\n    max\n    by (instance, job, probe, config_version, check_name)\n    (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n  )\n  /\n  sum by (instance, check_name, job)\n  (\n    (\n      rate(probe_all_success_count[5m])\n      OR\n      rate(probe_success_count[5m])\n    )\n    *\n    on (instance, job, probe, config_version)\n    group_left(check_name)\n    max\n    by (instance, job, probe, config_version, check_name)\n    (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n  )\n)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{check_name}}-{{instance}}-uptime",
+          "refId": "state"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum[5m]) * on (instance, job, probe, config_version) sm_check_info{check_name=\"$check_type\"})\n      /\n      sum by (instance, job) (idelta(probe_all_success_count[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count[5m]))\n  )[$__range:]\n)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "uptime"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "$check_type Checks",
-      "transform": "table",
-      "transformations": [],
-      "type": "table-old"
+      "title": "$check_type checks",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "check_name": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "aliasColors": {},
@@ -417,9 +547,10 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_SM_METRICS}",
+      "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "links": []
         },
         "overrides": []
       },
@@ -449,9 +580,10 @@
       "maxDataPoints": "100",
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.5.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -477,7 +609,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "$check_type Latency",
+      "title": "$check_type latency",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -517,7 +649,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 25,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "synthetic-monitoring"
@@ -529,13 +661,18 @@
         "current": {},
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info, check_name)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Check Type",
         "multi": false,
         "name": "check_type",
         "options": [],
-        "query": "label_values(sm_check_info, check_name)",
+        "query": {
+          "query": "label_values(sm_check_info, check_name)",
+          "refId": "${DS_SM_METRICS}-check_type-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -551,13 +688,18 @@
         "current": {},
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info, region)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": null,
         "multi": true,
         "name": "region",
         "options": [],
-        "query": "label_values(sm_check_info, region)",
+        "query": {
+          "query": "label_values(sm_check_info, region)",
+          "refId": "${DS_SM_METRICS}-region-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -569,22 +711,26 @@
         "useTags": false
       },
       {
-        "current": {
-          "value": "${DS_SM_LOGS}",
-          "text": "${DS_SM_LOGS}"
-        },
+        "description": null,
+        "error": null,
         "hide": 2,
         "label": null,
         "name": "_DS_SM_LOGS",
+        "query": "${DS_SM_LOGS}",
+        "skipUrlSync": false,
+        "type": "constant",
+        "current": {
+          "value": "${DS_SM_LOGS}",
+          "text": "${DS_SM_LOGS}",
+          "selected": false
+        },
         "options": [
           {
             "value": "${DS_SM_LOGS}",
-            "text": "${DS_SM_LOGS}"
+            "text": "${DS_SM_LOGS}",
+            "selected": false
           }
-        ],
-        "query": "${DS_SM_LOGS}",
-        "skipUrlSync": false,
-        "type": "constant"
+        ]
       }
     ]
   },
@@ -608,5 +754,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring Summary",
   "uid": "fU-WBSqWz",
-  "version": 38
+  "version": 39
 }

--- a/src/dashboards/sm-summary.json
+++ b/src/dashboards/sm-summary.json
@@ -67,7 +67,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1622660155942,
+  "iteration": 1622741207696,
   "links": [],
   "panels": [
     {
@@ -81,8 +81,8 @@
       },
       "id": 10,
       "panels": [],
-      "repeat": "check_type",
-      "title": "$check_type",
+      "repeat": "check_type_hidden",
+      "title": "[[check_type_hidden]]",
       "type": "row"
     },
     {
@@ -131,7 +131,7 @@
       },
       "targets": [
         {
-          "expr": "100*(1 - (sum((rate(probe_all_success_sum[${__range_s}s]) OR rate(probe_success_sum[${__range_s}s])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count[${__range_s}s]) OR rate(probe_success_count[${__range_s}s])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
+          "expr": "100*(1 - (sum((rate(probe_all_success_sum[${__range_s}s]) OR rate(probe_success_sum[${__range_s}s])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count[${__range_s}s]) OR rate(probe_success_count[${__range_s}s])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -143,7 +143,7 @@
       "thresholds": "0.5,1",
       "timeFrom": null,
       "timeShift": null,
-      "title": "$check_type reachability",
+      "title": "[[check_type_hidden]] reachability",
       "type": "grafana-worldmap-panel",
       "unitPlural": "%",
       "unitSingle": "",
@@ -213,7 +213,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - (sum((rate(probe_all_success_sum[$__rate_interval]) OR rate(probe_success_sum[$__rate_interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)) / sum((rate(probe_all_success_count[$__rate_interval]) OR rate(probe_success_count[$__rate_interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)))",
+          "expr": "1 - (sum((rate(probe_all_success_sum[$__rate_interval]) OR rate(probe_success_sum[$__rate_interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"}) by (instance, job, probe, config_version)) / sum((rate(probe_all_success_count[$__rate_interval]) OR rate(probe_success_count[$__rate_interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"}) by (instance, job, probe, config_version)))",
           "hide": false,
           "interval": "1m",
           "intervalFactor": 1,
@@ -225,7 +225,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "$check_type check error percentage",
+      "title": "[[check_type_hidden]] check error percentage",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -441,7 +441,7 @@
                 "value": [
                   {
                     "title": "Show details...",
-                    "url": "/a/grafana-synthetic-monitoring-app/?page=redirect&dashboard=$check_type&var-probe=All&var-instance=${__data.fields.instance}&var-job=${__data.fields.job}&from=${__from}&to=${__to}"
+                    "url": "/a/grafana-synthetic-monitoring-app/?page=redirect&dashboard=[[check_type_hidden]]&var-probe=All&var-instance=${__data.fields.instance}&var-job=${__data.fields.job}&from=${__from}&to=${__to}"
                   }
                 ]
               }
@@ -482,7 +482,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (instance, job, check_name)\n(\n  (\n    rate(probe_all_success_sum[$__range])\n    OR\n    rate(probe_success_sum[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max\n  by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n)\n/\nsum by (instance, check_name, job)\n(\n  (\n    rate(probe_all_success_count[$__range])\n    OR\n    rate(probe_success_count[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max\n  by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n)",
+          "expr": "sum by (instance, job, check_name)\n(\n  (\n    rate(probe_all_success_sum[$__range])\n    OR\n    rate(probe_success_sum[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max\n  by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"})\n)\n/\nsum by (instance, check_name, job)\n(\n  (\n    rate(probe_all_success_count[$__range])\n    OR\n    rate(probe_success_count[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max\n  by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"})\n)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -491,7 +491,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum by (instance, job, check_name)\n(\n  (\n    rate(probe_all_duration_seconds_sum[$__range])\n    OR\n    rate(probe_duration_seconds_sum[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n)\n/\nsum by (instance, job, check_name)\n(\n  (\n    rate(probe_all_duration_seconds_count[$__range])\n    OR\n    rate(probe_duration_seconds_count[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n)",
+          "expr": "sum by (instance, job, check_name)\n(\n  (\n    rate(probe_all_duration_seconds_sum[$__range])\n    OR\n    rate(probe_duration_seconds_sum[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"})\n)\n/\nsum by (instance, job, check_name)\n(\n  (\n    rate(probe_all_duration_seconds_count[$__range])\n    OR\n    rate(probe_duration_seconds_count[$__range])\n  )\n  *\n  on (instance, job, probe, config_version)\n  group_left(check_name)\n  max by (instance, job, probe, config_version, check_name)\n  (sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"})\n)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -500,7 +500,7 @@
         },
         {
           "exemplar": true,
-          "expr": "ceil(\n  sum by (instance, job, check_name)\n  (\n    (\n      rate(probe_all_success_sum[5m])\n      OR\n      rate(probe_success_sum[5m])\n    )\n    *\n    on (instance, job, probe, config_version)\n    group_left(check_name)\n    max\n    by (instance, job, probe, config_version, check_name)\n    (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n  )\n  /\n  sum by (instance, check_name, job)\n  (\n    (\n      rate(probe_all_success_count[5m])\n      OR\n      rate(probe_success_count[5m])\n    )\n    *\n    on (instance, job, probe, config_version)\n    group_left(check_name)\n    max\n    by (instance, job, probe, config_version, check_name)\n    (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n  )\n)",
+          "expr": "ceil(\n  sum by (instance, job, check_name)\n  (\n    (\n      rate(probe_all_success_sum[5m])\n      OR\n      rate(probe_success_sum[5m])\n    )\n    *\n    on (instance, job, probe, config_version)\n    group_left(check_name)\n    max\n    by (instance, job, probe, config_version, check_name)\n    (sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"})\n  )\n  /\n  sum by (instance, check_name, job)\n  (\n    (\n      rate(probe_all_success_count[5m])\n      OR\n      rate(probe_success_count[5m])\n    )\n    *\n    on (instance, job, probe, config_version)\n    group_left(check_name)\n    max\n    by (instance, job, probe, config_version, check_name)\n    (sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"})\n  )\n)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -510,7 +510,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum[5m]) * on (instance, job, probe, config_version) sm_check_info{check_name=\"$check_type\"})\n      /\n      sum by (instance, job) (idelta(probe_all_success_count[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count[5m]))\n  )[$__range:]\n)",
+          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum[5m]) * on (instance, job, probe, config_version) sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"})\n      /\n      sum by (instance, job) (idelta(probe_all_success_count[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count[5m]))\n  )[$__range:]\n)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -521,7 +521,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "$check_type checks",
+      "title": "[[check_type_hidden]] checks",
       "transformations": [
         {
           "id": "merge",
@@ -598,7 +598,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum((rate(probe_all_duration_seconds_sum[5m]) OR rate(probe_duration_seconds_sum[5m])) * on (instance, job, probe, config_version) group_left max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version))  by (job, instance) / sum((rate(probe_all_duration_seconds_count[5m]) OR rate(probe_duration_seconds_count[5m])) * on (instance, job, probe, config_version) group_left max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)) by (job, instance)",
+          "expr": "sum((rate(probe_all_duration_seconds_sum[5m]) OR rate(probe_duration_seconds_sum[5m])) * on (instance, job, probe, config_version) group_left max(sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"}) by (instance, job, probe, config_version))  by (job, instance) / sum((rate(probe_all_duration_seconds_count[5m]) OR rate(probe_duration_seconds_count[5m])) * on (instance, job, probe, config_version) group_left max(sm_check_info{check_name=\"[[check_type_hidden]]\", [[label0]]=~\"^[[label0value]]$\", [[label1]]=~\"^[[label1value]]$\", [[label2]]=~\"^[[label2value]]$\"}) by (instance, job, probe, config_version)) by (job, instance)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{job}}/{{ instance }}",
@@ -609,7 +609,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "$check_type latency",
+      "title": "[[check_type_hidden]] latency",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -658,7 +658,11 @@
     "list": [
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "${DS_SM_METRICS}",
         "definition": "label_values(sm_check_info, check_name)",
         "description": null,
@@ -672,33 +676,6 @@
         "query": {
           "query": "label_values(sm_check_info, check_name)",
           "refId": "${DS_SM_METRICS}-check_type-Variable-Query"
-        },
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": ".*",
-        "current": {},
-        "datasource": "${DS_SM_METRICS}",
-        "definition": "label_values(sm_check_info, region)",
-        "description": null,
-        "error": null,
-        "hide": 0,
-        "includeAll": true,
-        "label": null,
-        "multi": true,
-        "name": "region",
-        "options": [],
-        "query": {
-          "query": "label_values(sm_check_info, region)",
-          "refId": "${DS_SM_METRICS}-region-Variable-Query"
         },
         "refresh": 1,
         "regex": "",
@@ -731,6 +708,223 @@
             "selected": false
           }
         ]
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "region",
+          "value": "region"
+        },
+        "datasource": "${DS_SM_METRICS}",
+        "definition": "label_names()",
+        "description": "The first label to use for filtering. Specify its value in the next drop down.",
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "First filter",
+        "multi": false,
+        "name": "label0",
+        "options": [],
+        "query": {
+          "query": "label_names()",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/^alert_sensitivity$|^instance$|^job$|^region$|^probe$|^label_/",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "${DS_SM_METRICS}",
+        "definition": "label_values(sm_check_info{check_name=~\"[[check_type]]\"}, [[label0]])",
+        "description": null,
+        "error": null,
+        "hide": 1,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "label0value",
+        "options": [],
+        "query": {
+          "query": "label_values(sm_check_info{check_name=~\"[[check_type]]\"}, [[label0]])",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "job",
+          "value": "job"
+        },
+        "datasource": "${DS_SM_METRICS}",
+        "definition": "label_names()",
+        "description": "The second label to use for filtering. Specify its value in the next drop down.",
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Second filter",
+        "multi": false,
+        "name": "label1",
+        "options": [],
+        "query": {
+          "query": "label_names()",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/^alert_sensitivity$|^instance$|^job$|^region$|^probe$|^label_/",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "${DS_SM_METRICS}",
+        "definition": "label_values(sm_check_info{check_name=~\"[[check_type]]\"}, [[label1]])",
+        "description": null,
+        "error": null,
+        "hide": 1,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "label1value",
+        "options": [],
+        "query": {
+          "query": "label_values(sm_check_info{check_name=~\"[[check_type]]\"}, [[label1]])",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "instance",
+          "value": "instance"
+        },
+        "datasource": "${DS_SM_METRICS}",
+        "definition": "label_names()",
+        "description": "The third label to use for filtering. Specify its value in the next drop down.",
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Third filter",
+        "multi": false,
+        "name": "label2",
+        "options": [],
+        "query": {
+          "query": "label_names()",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/^alert_sensitivity$|^instance$|^job$|^region$|^probe$|^label_/",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "${DS_SM_METRICS}",
+        "definition": "label_values(sm_check_info{check_name=~\"[[check_type]]\"}, [[label2]])",
+        "description": null,
+        "error": null,
+        "hide": 1,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "label2value",
+        "options": [],
+        "query": {
+          "query": "label_values(sm_check_info{check_name=~\"[[check_type]]\"}, [[label2]])",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "${DS_SM_METRICS}",
+        "definition": "label_values(sm_check_info{[[label0]]=~\"[[label0value]]\", [[label1]]=~\"[[label1value]]\", [[label2]]=~\"[[label2value]]\"}, check_name)",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "check_type_hidden",
+        "options": [],
+        "query": {
+          "query": "label_values(sm_check_info{[[label0]]=~\"[[label0value]]\", [[label1]]=~\"[[label1value]]\", [[label2]]=~\"[[label2value]]\"}, check_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -754,5 +948,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring Summary",
   "uid": "fU-WBSqWz",
-  "version": 39
+  "version": 42
 }

--- a/src/dashboards/sm-tcp.json
+++ b/src/dashboards/sm-tcp.json
@@ -1,820 +1,911 @@
 {
-    "__inputs": [
-      {
-        "name": "DS_SM_METRICS",
-        "label": "Synthetic Monitoring Metrics",
-        "description": "",
-        "type": "datasource",
-        "pluginId": "prometheus",
-        "pluginName": "Prometheus"
-      },
-      {
-        "name": "DS_SM_LOGS",
-        "label": "Synthetic Monitoring Logs",
-        "description": "",
-        "type": "datasource",
-        "pluginId": "loki",
-        "pluginName": "Loki"
-      }
-    ],
-    "__requires": [
-      {
-        "type": "grafana",
-        "id": "grafana",
-        "name": "Grafana",
-        "version": "7.0.3"
-      },
-      {
-        "type": "panel",
-        "id": "grafana-worldmap-panel",
-        "name": "Worldmap Panel",
-        "version": "0.2.1"
-      },
-      {
-        "type": "panel",
-        "id": "graph",
-        "name": "Graph",
-        "version": ""
-      },
-      {
-        "type": "panel",
-        "id": "logs",
-        "name": "Logs",
-        "version": ""
-      },
-      {
-        "type": "datasource",
-        "id": "loki",
-        "name": "Loki",
-        "version": "1.0.0"
-      },
-      {
-        "type": "datasource",
-        "id": "prometheus",
-        "name": "Prometheus",
-        "version": "1.0.0"
-      },
-      {
-        "type": "panel",
-        "id": "stat",
-        "name": "Stat",
-        "version": ""
-      }
-    ],
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": "-- Grafana --",
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "type": "dashboard"
-        }
-      ]
+  "__inputs": [
+    {
+      "name": "DS_SM_METRICS",
+      "label": "Synthetic Monitoring Metrics",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
     },
-    "editable": false,
-    "gnetId": null,
-    "graphTooltip": 0,
-    "id": null,
-    "iteration": 1591628218761,
-    "links": [],
-    "panels": [
+    {
+      "name": "DS_SM_LOGS",
+      "label": "Synthetic Monitoring Logs",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "7.5.7"
+    },
+    {
+      "type": "panel",
+      "id": "grafana-worldmap-panel",
+      "name": "Worldmap Panel",
+      "version": "0.3.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "loki",
+      "name": "Loki",
+      "version": "1.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
       {
-        "circleMaxSize": "10",
-        "circleMinSize": "2",
-        "colors": [
-          "#37872D",
-          "#FA6400",
-          "#C4162A"
-        ],
-        "datasource": "${DS_SM_METRICS}",
-        "decimals": 2,
-        "esGeoPoint": "geohash",
-        "esLocationName": "probe",
-        "esMetric": "Count",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {}
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 14,
-          "x": 0,
-          "y": 0
-        },
-        "hideEmpty": false,
-        "hideZero": false,
-        "id": 27,
-        "initialZoom": 1,
-        "locationData": "table",
-        "mapCenter": "(0°, 0°)",
-        "mapCenterLatitude": 0,
-        "mapCenterLongitude": 0,
-        "maxDataPoints": "",
-        "mouseWheelZoom": false,
-        "showLegend": false,
-        "stickyLabels": false,
-        "tableQueryOptions": {
-          "geohashField": "geohash",
-          "labelField": "probe",
-          "latitudeField": "latitude",
-          "longitudeField": "longitude",
-          "metricField": "Value",
-          "queryType": "geohash"
-        },
-        "targets": [
-          {
-            "expr": "100*(1 - (sum((rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])) * on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"tcp\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])) * on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"tcp\", instance=\"$instance\", job=\"$job\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
-            "format": "table",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "thresholds": "0.5,1",
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Downtime",
-        "type": "grafana-worldmap-panel",
-        "unitPlural": "%",
-        "unitSingle": "",
-        "unitSingular": "%",
-        "valueName": "current"
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1622675806241,
+  "links": [],
+  "panels": [
+    {
+      "circleMaxSize": "10",
+      "circleMinSize": "2",
+      "colors": [
+        "#37872D",
+        "#FA6400",
+        "#C4162A"
+      ],
+      "datasource": "${DS_SM_METRICS}",
+      "decimals": 2,
+      "description": "What's the error percentage for each probe that is observing the given target.\n\nIf some probes can reach the target and others cannot, that might mean there are network issues between the probe and the target and it's possible that the target's users cannot reach it either.",
+      "esGeoPoint": "geohash",
+      "esLocationName": "probe",
+      "esMetric": "Count",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
       },
-      {
-        "cacheTimeout": null,
-        "datasource": "${DS_SM_METRICS}",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {},
-            "decimals": 2,
-            "mappings": [
-              {
-                "id": 0,
-                "op": "=",
-                "text": "N/A",
-                "type": 1,
-                "value": "null"
-              }
-            ],
-            "nullValueMode": "connected",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "red",
-                  "value": null
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 0.99
-                },
-                {
-                  "color": "green",
-                  "value": 0.995
-                }
-              ]
-            },
-            "unit": "percentunit"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 14,
-          "y": 0
-        },
-        "id": 25,
-        "links": [],
-        "options": {
-          "colorMode": "value",
-          "fieldOptions": {
-            "calcs": [
-              "lastNotNull"
-            ]
-          },
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "mean"
-            ],
-            "fields": "",
-            "values": false
-          }
-        },
-        "pluginVersion": "7.0.3",
-        "targets": [
-          {
-            "expr": "sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
-            "hide": false,
-            "instant": false,
-            "interval": "",
-            "legendFormat": "",
-            "refId": "B"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Uptime",
-        "type": "stat"
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
       },
-      {
-        "cacheTimeout": null,
-        "datasource": "${DS_SM_METRICS}",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {},
-            "decimals": 2,
-            "mappings": [],
-            "nullValueMode": "connected",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "yellow",
-                  "value": 1
-                },
-                {
-                  "color": "red",
-                  "value": 2
-                }
-              ]
-            },
-            "unit": "s"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 3,
-          "x": 16,
-          "y": 0
-        },
-        "id": 30,
-        "links": [],
-        "options": {
-          "colorMode": "value",
-          "fieldOptions": {
-            "calcs": [
-              "lastNotNull"
-            ]
-          },
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "last"
-            ],
-            "fields": "",
-            "values": false
-          }
-        },
-        "pluginVersion": "7.0.3",
-        "targets": [
-          {
-            "expr": "sum((rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "",
-            "refId": "B"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Average Latency",
-        "type": "stat"
+      "hideEmpty": false,
+      "hideZero": false,
+      "id": 27,
+      "initialZoom": 1,
+      "locationData": "table",
+      "mapCenter": "(0°, 0°)",
+      "mapCenterLatitude": 0,
+      "mapCenterLongitude": 0,
+      "maxDataPoints": "",
+      "mouseWheelZoom": false,
+      "showLegend": false,
+      "stickyLabels": false,
+      "tableQueryOptions": {
+        "geohashField": "geohash",
+        "labelField": "probe",
+        "latitudeField": "latitude",
+        "longitudeField": "longitude",
+        "metricField": "Value",
+        "queryType": "geohash"
       },
-      {
-        "cacheTimeout": null,
-        "datasource": "${DS_SM_METRICS}",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {},
-            "decimals": 2,
-            "mappings": [
-              {
-                "id": 0,
-                "op": "=",
-                "text": "N/A",
-                "type": 1,
-                "value": "null"
-              }
-            ],
-            "nullValueMode": "connected",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "#d44a3a",
-                  "value": null
-                },
-                {
-                  "color": "rgba(237, 129, 40, 0.89)",
-                  "value": 604800
-                },
-                {
-                  "color": "#299c46",
-                  "value": 2419200
-                }
-              ]
-            },
-            "unit": "s"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 3,
-          "x": 19,
-          "y": 0
-        },
-        "id": 32,
-        "links": [],
-        "options": {
-          "colorMode": "value",
-          "fieldOptions": {
-            "calcs": [
-              "lastNotNull"
-            ]
-          },
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "mean"
-            ],
-            "fields": "",
-            "values": false
-          }
-        },
-        "pluginVersion": "7.0.3",
-        "targets": [
-          {
-            "expr": "min(probe_ssl_earliest_cert_expiry{probe=~\"$probe\",instance=\"$instance\", job=\"$job\"}) - time()",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "",
-            "refId": "B"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "SSL Expiry",
-        "type": "stat"
-      },
-      {
-        "cacheTimeout": null,
-        "datasource": "${DS_SM_METRICS}",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "align": null
-            },
-            "decimals": 0,
-            "mappings": [
-              {
-                "id": 0,
-                "op": "=",
-                "text": "N/A",
-                "type": 1,
-                "value": "null"
-              }
-            ],
-            "nullValueMode": "connected",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "ms"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 2,
-          "w": 2,
-          "x": 22,
-          "y": 0
-        },
-        "id": 17,
-        "links": [],
-        "options": {
-          "colorMode": "value",
-          "fieldOptions": {
-            "calcs": [
-              "mean"
-            ]
-          },
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "last"
-            ],
-            "fields": "",
-            "values": false
-          }
-        },
-        "pluginVersion": "7.0.3",
-        "targets": [
-          {
-            "expr": "sum(topk(1,sm_check_info{probe=~\"$probe\", instance=\"$instance\", check_name=\"tcp\"})) by (frequency)",
-            "format": "table",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{frequency}}",
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Frequency",
-        "transformations": [
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "Value": true
-              },
-              "indexByName": {},
-              "renameByName": {}
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "100*(\n  1 - (\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n    /\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n  )\n)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0.5,1",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Error rate by probe",
+      "type": "grafana-worldmap-panel",
+      "unitPlural": "%",
+      "unitSingle": "",
+      "unitSingular": "%",
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "${DS_SM_METRICS}",
+      "description": "The fraction of time the target was up during the whole period.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
             }
-          }
-        ],
-        "type": "stat"
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "${DS_SM_METRICS}",
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {}
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.99
+              },
+              {
+                "color": "green",
+                "value": 0.995
+              }
+            ]
           },
-          "overrides": []
+          "unit": "percentunit"
         },
-        "fill": 10,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 7,
-          "w": 10,
-          "x": 14,
-          "y": 2
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 12,
+        "y": 0
+      },
+      "id": 25,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
         },
-        "hiddenSeries": false,
-        "id": 8,
-        "interval": "5m",
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": false,
-          "total": false,
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
           "values": false
         },
-        "lines": true,
-        "linewidth": 0,
-        "nullPointMode": "null",
-        "options": {
-          "dataLinks": []
-        },
-        "percentage": false,
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": true,
-        "targets": [
-          {
-            "expr": "100*(1-(sum((rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]))) / sum((rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval]) OR rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__interval])))))",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "errors",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Error Rate : $probe ⮕ $job / $instance",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "decimals": null,
-            "format": "percent",
-            "label": "",
-            "logBase": 1,
-            "max": "100",
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "text": {},
+        "textMode": "auto"
       },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "${DS_SM_METRICS}",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {}
-          },
-          "overrides": []
-        },
-        "fill": 10,
-        "fillGradient": 0,
-        "gridPos": {
-          "h": 7,
-          "w": 24,
-          "x": 0,
-          "y": 9
-        },
-        "hiddenSeries": false,
-        "id": 29,
-        "legend": {
-          "alignAsTable": true,
-          "avg": true,
-          "current": true,
-          "max": false,
-          "min": false,
-          "rightSide": true,
-          "show": true,
-          "sort": "current",
-          "sortDesc": true,
-          "total": false,
-          "values": true
-        },
-        "lines": false,
-        "linewidth": 0,
-        "nullPointMode": "null",
-        "options": {
-          "dataLinks": []
-        },
-        "percentage": false,
-        "pointradius": 1,
-        "points": true,
-        "renderer": "flot",
-        "repeatDirection": null,
-        "seriesOverrides": [
-          {
-            "alias": "transfer",
-            "zindex": 3
-          },
-          {
-            "alias": "processing",
-            "zindex": 2
-          },
-          {
-            "alias": "tls",
-            "zindex": 1
-          },
-          {
-            "alias": "connect",
-            "zindex": 0
-          },
-          {
-            "alias": "resolve",
-            "zindex": -1
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "avg(probe_duration_seconds{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"} * on (instance, job,probe,config_version) group_left probe_success{probe=~\"$probe\",instance=\"$instance\", job=\"$job\"} > 0) by (probe)",
-            "instant": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{probe}}",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Response Latency by Probe",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "transformations": [],
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "decimals": null,
-            "format": "s",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          },
-          {
-            "decimals": null,
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
+      "pluginVersion": "7.5.7",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
         }
-      },
-      {
-        "datasource": "${DS_SM_LOGS}",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {}
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "${DS_SM_METRICS}",
+      "description": "The percentage of all the checks that have succeeded during the whole time period.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.99
+              },
+              {
+                "color": "green",
+                "value": 0.995
+              }
+            ]
           },
-          "overrides": []
+          "unit": "percentunit"
         },
-        "gridPos": {
-          "h": 13,
-          "w": 24,
-          "x": 0,
-          "y": 16
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 14,
+        "y": 0
+      },
+      "id": 33,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
         },
-        "id": 15,
-        "options": {
-          "showLabels": false,
-          "showTime": true,
-          "sortOrder": "Descending",
-          "wrapLogMessage": true
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
         },
-        "targets": [
-          {
-            "expr": "{probe=~\"$probe\",instance=\"$instance\", job=\"$job\", probe_success=\"0\"}",
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Error logs for $probe: $instance",
-        "type": "logs"
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.7",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(\n  (\n    delta(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    delta(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Reachability",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "${DS_SM_METRICS}",
+      "description": "The average time to receive an answer across all the checks during the whole time period.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 3,
+        "x": 16,
+        "y": 0
+      },
+      "id": 30,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.7",
+      "targets": [
+        {
+          "expr": "sum((rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average latency",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "${DS_SM_METRICS}",
+      "description": "The remaining time until the SSL certificate expires, if there's one.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 604800
+              },
+              {
+                "color": "#299c46",
+                "value": 2419200
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 3,
+        "x": 19,
+        "y": 0
+      },
+      "id": 32,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.7",
+      "targets": [
+        {
+          "expr": "min(probe_ssl_earliest_cert_expiry{probe=~\"$probe\",instance=\"$instance\", job=\"$job\"}) - time()",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SSL expiry",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_SM_METRICS}",
+      "description": "How often is the target checked?",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "noValue": "N/A",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 22,
+        "y": 0
+      },
+      "id": 35,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^frequency$/",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.7",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (frequency) (\n  topk(\n    1,\n    sm_check_info{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}\n  )\n)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Frequency",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {}
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_SM_METRICS}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 10,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 2
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "interval": "5m",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 0,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "100*(\n  1 - (\n    sum(\n      (\n        rate(probe_all_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n        OR\n        rate(probe_success_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n      )\n    )\n    /\n    sum(\n      (\n        rate(probe_all_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n        OR\n        rate(probe_success_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__rate_interval])\n      )\n    )\n  )\n)",
+          "hide": false,
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "errors",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Error Rate : $probe ⮕ $job / $instance",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:254",
+          "decimals": null,
+          "format": "percent",
+          "label": "",
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:255",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
       }
-    ],
-    "refresh": "1m",
-    "schemaVersion": 25,
-    "style": "dark",
-    "tags": [
-      "synthetic-monitoring"
-    ],
-    "templating": {
-      "list": [
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_SM_METRICS}",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 10,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 29,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 0,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 1,
+      "points": true,
+      "renderer": "flot",
+      "repeatDirection": null,
+      "seriesOverrides": [
         {
-          "allValue": ".*",
-          "current": {},
-          "datasource": "${DS_SM_METRICS}",
-          "definition": "label_values(sm_check_info{check_name=\"tcp\"},probe)",
-          "hide": 0,
-          "includeAll": true,
-          "label": null,
-          "multi": false,
-          "name": "probe",
-          "options": [],
-          "query": "label_values(sm_check_info{check_name=\"tcp\"},probe)",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 5,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
+          "alias": "transfer",
+          "zindex": 3
         },
         {
-          "allValue": null,
-          "current": {},
-          "datasource": "${DS_SM_METRICS}",
-          "definition": "label_values(sm_check_info{check_name=\"tcp\", probe=~\"$probe\"},job)",
-          "hide": 0,
-          "includeAll": false,
-          "label": null,
-          "multi": false,
-          "name": "job",
-          "options": [],
-          "query": "label_values(sm_check_info{check_name=\"tcp\", probe=~\"$probe\"},job)",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 1,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
+          "alias": "processing",
+          "zindex": 2
         },
         {
-          "allValue": null,
-          "current": {},
-          "datasource": "${DS_SM_METRICS}",
-          "definition": "label_values(sm_check_info{check_name=\"tcp\", job=\"$job\", probe=~\"$probe\"},instance)",
-          "hide": 0,
-          "includeAll": false,
-          "label": null,
-          "multi": false,
-          "name": "instance",
-          "options": [],
-          "query": "label_values(sm_check_info{check_name=\"tcp\", job=\"$job\", probe=~\"$probe\"},instance)",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 5,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
+          "alias": "tls",
+          "zindex": 1
+        },
+        {
+          "alias": "connect",
+          "zindex": 0
+        },
+        {
+          "alias": "resolve",
+          "zindex": -1
         }
-      ]
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg by (probe) (\n  probe_duration_seconds{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}\n  *\n  on (instance, job,probe, config_version)\n  group_left\n  probe_success{probe=~\"$probe\",instance=\"$instance\", job=\"$job\"} > 0\n)\n",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{probe}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Response latency by probe",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transformations": [],
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1784",
+          "decimals": null,
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1785",
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
-    "time": {
-      "from": "now-3h",
-      "to": "now"
-    },
-    "timepicker": {
-      "refresh_intervals": [
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ]
-    },
-    "timezone": "",
-    "title": "Synthetic Monitoring TCP",
-    "uid": "mh84e5mMk",
-    "version": 10
-  }
+    {
+      "datasource": "${DS_SM_LOGS}",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 15,
+      "options": {
+        "dedupStrategy": "none",
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "expr": "{probe=~\"$probe\", instance=\"$instance\", job=\"$job\", probe_success=\"0\"}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Logs for failed checks: $probe ⮕ $job / $instance",
+      "type": "logs"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "synthetic-monitoring"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": "${DS_SM_METRICS}",
+        "definition": "label_values(sm_check_info{check_name=\"tcp\"},probe)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "probe",
+        "options": [],
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"tcp\"},probe)",
+          "refId": "${DS_SM_METRICS}-probe-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_SM_METRICS}",
+        "definition": "label_values(sm_check_info{check_name=\"tcp\", probe=~\"$probe\"},job)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"tcp\", probe=~\"$probe\"},job)",
+          "refId": "${DS_SM_METRICS}-job-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_SM_METRICS}",
+        "definition": "label_values(sm_check_info{check_name=\"tcp\", job=\"$job\", probe=~\"$probe\"},instance)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(sm_check_info{check_name=\"tcp\", job=\"$job\", probe=~\"$probe\"},instance)",
+          "refId": "${DS_SM_METRICS}-instance-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Synthetic Monitoring TCP",
+  "uid": "mh84e5mMk",
+  "version": 18
+}


### PR DESCRIPTION
This adds dropdown menus to the summary dashboard that allow the user to
select a set of three labels to use as filters for the dashboard.

Each filter is composed of _two_ dropdowns: the first one specifies the
label to use for filtering and the second one the corresponding value.

There's a fourth, hidden, dropdown that is used to compute the effective
value of the "check type" dropdown, after applying the filters, so that
the dashboard doesn't show rows with empty panels.

The defaults in the dashboard are such that all the checks are selected.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>