### PR TITLE
refactor: move threshold calculation and coloring to a common utility

### DIFF
--- a/src/components/CheckList.tsx
+++ b/src/components/CheckList.tsx
@@ -172,9 +172,11 @@ export const CheckList = ({ instance, onAddNewClick, checks, onCheckUpdate }: Pr
         return checks.sort((a, b) => b.job.localeCompare(a.job));
       case CheckSort.SuccessRate:
         return checks.sort((a, b) => {
-          const checkA = successRateContext.values[SuccessRateTypes.Checks][a.id] ?? 100;
-          const checkB = successRateContext.values[SuccessRateTypes.Checks][b.id] ?? 100;
-          return checkA - checkB;
+          const checkA = successRateContext.values[SuccessRateTypes.Checks][a.id] ?? successRateContext.values.defaults;
+          const checkB = successRateContext.values[SuccessRateTypes.Checks][b.id] ?? successRateContext.values.defaults;
+          const sortA = checkA.noData ? 101 : checkA.value;
+          const sortB = checkB.noData ? 101 : checkB.value;
+          return sortA - sortB;
         });
     }
   };

--- a/src/components/ChecksVisualization/Hexagon.tsx
+++ b/src/components/ChecksVisualization/Hexagon.tsx
@@ -1,8 +1,7 @@
-import { SuccessRateContext } from 'contexts/SuccessRateContext';
+import { SuccessRateContext, SuccessRateTypes } from 'contexts/SuccessRateContext';
 import React, { useContext, useState } from 'react';
 import * as d3hexbin from 'd3-hexbin';
 import { Check } from 'types';
-import { getHexFillColor } from './checksVizUtils';
 import { getLocationSrv, config } from '@grafana/runtime';
 import appEvents from 'grafana/app/core/app_events';
 import { useStyles2 } from '@grafana/ui';
@@ -53,13 +52,17 @@ export const Hexagon = ({ onMouseMove, onMouseOut, check, hexPath, hexRadius }: 
     });
   };
 
-  const fillColor = getHexFillColor(check, values);
+  const successValue = values[SuccessRateTypes.Checks][check.id ?? 0] ?? values.defaults.value;
   return (
     <path
       className={styles.hexagon}
       data-testid="viz-hexagon"
       d={`M${hexPath.x},${hexPath.y}${hexbin.hexagon()}`}
-      fill={hovering ? config.theme2.colors.emphasize(fillColor, config.theme2.colors.hoverFactor) : fillColor}
+      fill={
+        hovering
+          ? config.theme2.colors.emphasize(successValue.thresholdColor, config.theme2.colors.hoverFactor)
+          : successValue.thresholdColor
+      }
       onMouseMove={(e) => {
         if (!hovering) {
           setHovering(true);

--- a/src/components/ChecksVisualization/checksVizUtils.ts
+++ b/src/components/ChecksVisualization/checksVizUtils.ts
@@ -1,27 +1,4 @@
-import { config } from '@grafana/runtime';
-import { SuccessRates } from 'contexts/SuccessRateContext';
 import * as d3 from 'd3';
-import { Check } from 'types';
-
-export const getHexFillColor = (check: Check, successRates: SuccessRates) => {
-  const theme = config.theme2;
-
-  if (!check || !check?.enabled || !check.id) {
-    return theme.colors.text.disabled;
-  }
-
-  const successRate = successRates.checks[check.id];
-
-  if (successRate === undefined) {
-    return theme.colors.text.disabled;
-  }
-
-  if (successRate && successRate > 0.9) {
-    return theme.colors.success.main;
-  } else {
-    return theme.colors.error.main;
-  }
-};
 
 export const getLayout = (checksLength: number, width: number) => {
   if (width === 0) {

--- a/src/components/SuccessRateGauge.test.tsx
+++ b/src/components/SuccessRateGauge.test.tsx
@@ -35,7 +35,7 @@ const renderSuccessRateGauge = (sparkline = false) => {
 test('shows a value if data', async () => {
   renderSuccessRateGauge();
   await waitForElementToBeRemoved(() => screen.queryByText('loading...'));
-  const value = await screen.findByText('100.00%');
+  const value = await screen.findByText('100%');
   expect(value).toBeInTheDocument();
 });
 

--- a/src/components/SuccessRateGauge.tsx
+++ b/src/components/SuccessRateGauge.tsx
@@ -3,7 +3,7 @@ import { BigValueColorMode, BigValueGraphMode, BigValue, Container } from '@graf
 import { DisplayValue, ArrayVector, FieldType } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { useMetricData } from 'hooks/useMetricData';
-import { SuccessRateContext, SuccessRateTypes } from 'contexts/SuccessRateContext';
+import { SuccessRateContext, SuccessRateTypes, SuccessRateValue } from 'contexts/SuccessRateContext';
 
 interface Props {
   type: SuccessRateTypes;
@@ -16,7 +16,7 @@ interface Props {
   onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 }
 
-const getDisplayValue = (value: number | undefined, loading: boolean): DisplayValue => {
+const getDisplayValue = (successRate: SuccessRateValue, loading: boolean): DisplayValue => {
   if (loading) {
     return {
       numeric: 0,
@@ -24,20 +24,12 @@ const getDisplayValue = (value: number | undefined, loading: boolean): DisplayVa
       text: 'loading...',
     };
   }
-  if (value === undefined) {
-    return {
-      numeric: 0,
-      text: 'N/A',
-      title: 'Success rate',
-    };
-  }
 
-  const uptime = value * 100;
   return {
     title: 'Success rate',
-    color: uptime < 99 ? 'red' : 'green',
-    numeric: uptime,
-    text: uptime.toFixed(2) + '%',
+    color: successRate.thresholdColor,
+    numeric: successRate.value,
+    text: successRate.noData ? 'N/A' : successRate.value + '%',
   };
 };
 
@@ -84,7 +76,7 @@ export const SuccessRateGauge = ({ type, id, labelNames, labelValues, height, wi
   });
 
   const { data: sparklineData, loading: sparklineLoading } = useMetricData(sparklineQuery, sparklineOptions);
-  const value = getDisplayValue(values[type]?.[id], loading);
+  const value = getDisplayValue(values[type]?.[id] ?? values.defaults, loading);
   const sparklineValue = getSparklineValue(sparklineData, sparklineLoading, sparkline);
   return (
     <Container>

--- a/src/contexts/SuccessRateContext.ts
+++ b/src/contexts/SuccessRateContext.ts
@@ -1,17 +1,29 @@
+import { config } from '@grafana/runtime';
 import { createContext } from 'react';
+import { getSuccessRateThresholdColor } from 'utils';
 
 export enum SuccessRateTypes {
   Checks = 'checks',
   Probes = 'probes',
 }
 
+export interface SuccessRateValue {
+  value: number;
+  displayValue: string;
+  thresholdColor: string;
+  noData?: boolean;
+}
 export interface SuccessRate {
-  [key: number]: number | undefined;
+  [key: number]: SuccessRateValue;
 }
 
-export type SuccessRates = {
+type SuccessRatesByType = {
   [key in SuccessRateTypes]: SuccessRate;
 };
+
+export interface SuccessRates extends SuccessRatesByType {
+  defaults: SuccessRateValue;
+}
 
 interface SuccessRateContextValue {
   values: SuccessRates;
@@ -19,13 +31,30 @@ interface SuccessRateContextValue {
   updateSuccessRate: (type: SuccessRateTypes, id: number, successRate: number | undefined) => void;
 }
 
-const values: SuccessRates = {
+export const defaultValues: SuccessRates = {
   checks: {},
   probes: {},
+  defaults: {
+    thresholdColor: config.theme2.colors.text.disabled,
+    value: 0,
+    displayValue: 'N/A',
+    noData: true,
+  },
 };
 
 const updateSuccessRate = (type: SuccessRateTypes, id: number, successRate: number | undefined) => {
-  values[type][id] = successRate;
+  const thresholdColor = getSuccessRateThresholdColor(successRate);
+
+  defaultValues[type][id] = {
+    value: successRate ?? 0,
+    displayValue: successRate === undefined ? 'N/A' : successRate.toFixed(1),
+    thresholdColor,
+    noData: successRate === undefined,
+  };
 };
 
-export const SuccessRateContext = createContext<SuccessRateContextValue>({ values, loading: true, updateSuccessRate });
+export const SuccessRateContext = createContext<SuccessRateContextValue>({
+  values: defaultValues,
+  loading: true,
+  updateSuccessRate,
+});

--- a/src/page/ProbesPage.tsx
+++ b/src/page/ProbesPage.tsx
@@ -59,10 +59,6 @@ export const ProbesPage = ({ id }: Props) => {
     return <div>Loading...</div>;
   }
 
-  if (selectedProbe) {
-    return <ProbeEditor probe={selectedProbe} onReturn={onGoBack} />;
-  }
-
   if (isAddingNew) {
     const template = {
       name: '',
@@ -79,7 +75,11 @@ export const ProbesPage = ({ id }: Props) => {
   }
   return (
     <SuccessRateContextProvider probes={probes}>
-      <ProbeList probes={probes} onAddNew={() => setAddingNew(true)} onSelectProbe={onSelectProbe} />
+      {selectedProbe ? (
+        <ProbeEditor probe={selectedProbe} onReturn={onGoBack} />
+      ) : (
+        <ProbeList probes={probes} onAddNew={() => setAddingNew(true)} onSelectProbe={onSelectProbe} />
+      )}
     </SuccessRateContextProvider>
   );
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,6 @@ export function findHostedInstance(
     const instanceUrl = info.url + (info.type === 'logs' ? '' : '/api/prom');
     for (const ds of known) {
       if (ds.url === instanceUrl) {
-        console.log('MAYBE:', basicAuthUser, (ds as any).basicAuthUser, ds);
         if (basicAuthUser === (ds as any).basicAuthUser) {
           return ds;
         }
@@ -274,4 +273,17 @@ export const fromBase64 = (value: string) => {
   } catch {
     return value;
   }
+};
+
+export const getSuccessRateThresholdColor = (value: number | undefined) => {
+  if (value === undefined) {
+    return config.theme2.colors.text.disabled;
+  }
+  if (value >= 99.5) {
+    return config.theme2.colors.success.main;
+  }
+  if (value >= 99) {
+    return config.theme2.colors.warning.main;
+  }
+  return config.theme2.colors.error.main;
 };


### PR DESCRIPTION
- Moves threshold calculation for success rates to a shared utilty
- Adds a warning threshold
- Changes the threshold limits to:
    - \> 99.5% sucess
    - \> 99% warning
    - < 99% error
- Moves threshold colors to a shared utility
