### PR TITLE
chore: add some analytics to the setup flow

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,0 +1,23 @@
+const EVENT_CATEGORY = 'SyntheticMonitoring';
+
+export function trackEvent(action: string, label?: string) {
+  const trackGa = (window as any).ga;
+  if (trackGa) {
+    trackGa('event', 'send', EVENT_CATEGORY, action, label);
+  } else {
+    console.log('Tracking action', EVENT_CATEGORY, action, label);
+  }
+}
+
+export function trackException(description: string, fatal?: boolean) {
+  const trackGa = (window as any).ga;
+  if (trackGa) {
+    trackGa('send', {
+      hitType: 'exception',
+      eventCatgory: EVENT_CATEGORY,
+      exDescription: description,
+    });
+  } else {
+    console.warn('Tracking exception', description);
+  }
+}

--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -17,6 +17,7 @@ import { GrafanaTheme } from '@grafana/data';
 import { CheckUsage } from '../CheckUsage';
 import { CheckFormAlert } from 'components/CheckFormAlert';
 import { InstanceContext } from 'contexts/InstanceContext';
+import { trackEvent, trackException } from 'analytics';
 
 interface Props {
   check?: Check;
@@ -59,18 +60,23 @@ export const CheckEditor = ({ check, onReturn }: Props) => {
   const { execute: onSubmit, error, loading: submitting } = useAsyncCallback(async (checkValues: CheckFormValues) => {
     const updatedCheck = getCheckFromFormValues(checkValues, defaultValues);
     if (check?.id) {
+      trackEvent('editCheckSubmit');
       await api?.updateCheck({
         id: check.id,
         tenantId: check.tenantId,
         ...updatedCheck,
       });
     } else {
+      trackEvent('addNewCheckSubmit');
       await api?.addCheck(updatedCheck);
     }
     onReturn(true);
   });
 
   const submissionError = error as SubmissionError;
+  if (error) {
+    trackException(`addNewCheckSubmitException: ${error}`);
+  }
 
   const onRemoveCheck = async () => {
     const id = check?.id;

--- a/src/components/ProbeEditor.tsx
+++ b/src/components/ProbeEditor.tsx
@@ -19,6 +19,7 @@ import { hasRole } from 'utils';
 import { LabelField } from 'components/LabelField';
 import ProbeStatus from './ProbeStatus';
 import { InstanceContext } from 'contexts/InstanceContext';
+import { trackEvent, trackException } from 'analytics';
 
 interface Props {
   probe: Probe;
@@ -37,6 +38,7 @@ const ProbeEditor = ({ probe, onReturn }: Props) => {
   const formMethods = useForm<Probe>({ defaultValues: probe, mode: 'onChange' });
 
   const { execute: onSave, error } = useAsyncCallback(async (formValues: Probe) => {
+    trackEvent('addNewProbeSubmit');
     // Form values always come back as a string, even for number inputs
     formValues.latitude = Number(formValues.latitude);
     formValues.longitude = Number(formValues.longitude);
@@ -62,6 +64,10 @@ const ProbeEditor = ({ probe, onReturn }: Props) => {
   });
 
   const submissionError = error as SubmissionError;
+
+  if (error) {
+    trackException(`addNewProbeSubmitException: ${error}`);
+  }
 
   if (!probe || !instance) {
     return <div>Loading...</div>;

--- a/src/components/UnprovisionedSetup.tsx
+++ b/src/components/UnprovisionedSetup.tsx
@@ -11,6 +11,7 @@ import {
   saveTenantInstanceIds,
   updatePluginJsonData,
 } from 'initialization-utils';
+import { trackEvent, trackException } from 'analytics';
 
 interface ApiSetupValues {
   adminApiToken: string;
@@ -45,11 +46,13 @@ export const UnprovisionedSetup = ({ pluginId }: Props) => {
   const onSetupSubmit = async (setupValues: ApiSetupValues) => {
     // put api host in plugin jsonData
     try {
+      trackEvent('unprovisionedSetupSubmit');
       await updatePluginJsonData(pluginId, { apiHost: apiSetup?.apiHost ?? DEFAULT_API_HOST });
       const tenantInfo = await initializeTenant(pluginId, setupValues.adminApiToken);
       setTenantInfo(tenantInfo);
       setApiSetup(setupValues);
     } catch (e) {
+      trackException(`unprovisionedSetupSubmit error: ${e.message}`);
       setApiSetupError(e.message);
     }
   };

--- a/src/page/ChecksPage.tsx
+++ b/src/page/ChecksPage.tsx
@@ -9,6 +9,7 @@ import { CheckList } from 'components/CheckList';
 import { InstanceContext } from 'contexts/InstanceContext';
 import { SuccessRateContextProvider } from 'components/SuccessRateContextProvider';
 import { CheckInfoContextProvider } from 'components/CheckInfoContextProvider';
+import { trackEvent } from 'analytics';
 
 interface Props {
   id?: string;
@@ -59,6 +60,7 @@ export class ChecksPage extends PureComponent<Props, State> {
   //-----------------------------------------------------------------
 
   onAddNew = () => {
+    trackEvent('viewAddNewCheck');
     this.setState({
       addNew: true,
     });

--- a/src/page/ProbesPage.tsx
+++ b/src/page/ProbesPage.tsx
@@ -8,6 +8,7 @@ import ProbeEditor from 'components/ProbeEditor';
 import { InstanceContext } from 'contexts/InstanceContext';
 import { ProbeList } from 'components/ProbeList';
 import { SuccessRateContextProvider } from 'components/SuccessRateContextProvider';
+import { trackEvent } from 'analytics';
 
 interface Props {
   id?: string;
@@ -78,7 +79,14 @@ export const ProbesPage = ({ id }: Props) => {
       {selectedProbe ? (
         <ProbeEditor probe={selectedProbe} onReturn={onGoBack} />
       ) : (
-        <ProbeList probes={probes} onAddNew={() => setAddingNew(true)} onSelectProbe={onSelectProbe} />
+        <ProbeList
+          probes={probes}
+          onAddNew={() => {
+            trackEvent('viewAddProbe');
+            setAddingNew(true);
+          }}
+          onSelectProbe={onSelectProbe}
+        />
       )}
     </SuccessRateContextProvider>
   );

--- a/src/page/WelcomePage.tsx
+++ b/src/page/WelcomePage.tsx
@@ -21,6 +21,7 @@ import circledLoki from 'img/circled-loki.svg';
 import { CloudDatasourceJsonData } from 'datasource/types';
 import { isNumber } from 'lodash';
 import { OrgRole } from 'types';
+import { trackEvent, trackException } from 'analytics';
 
 const getStyles = (theme: GrafanaTheme) => {
   const textColor = theme.isDark ? colors.darkText : colors.lightText;
@@ -128,8 +129,10 @@ export const WelcomePage: FC<Props> = () => {
   const logsDatasource = config.datasources[logsName] as DataSourceInstanceSettings<CloudDatasourceJsonData>;
   const stackId = meta?.jsonData?.stackId;
   const onClick = async () => {
+    trackEvent('provisionedSetupSubmit');
     if (!meta?.jsonData) {
       setError('Invalid plugin configuration');
+      trackException('provisionedSetupSubmitError: Invalid plugin configuration');
       return;
     }
     setLoading(true);
@@ -159,6 +162,7 @@ export const WelcomePage: FC<Props> = () => {
     } catch (e) {
       setError(e.data?.msg ?? e.data?.err);
       setLoading(false);
+      trackException(`provisionedSetupSubmitError: ${e.data?.msg ?? e.data?.err}`);
     }
   };
 


### PR DESCRIPTION
Following the example from the onboarding plugin, checking to see if GA is present in the page and sending events. I deliberately only added a few events to start