### PR TITLE
fix: add backend host to plugin config page

### DIFF
--- a/src/components/TenantView/TenantView.tsx
+++ b/src/components/TenantView/TenantView.tsx
@@ -21,6 +21,9 @@ export class TenantView extends PureComponent<Props> {
           <LinkedDatasourceView info={settings.metrics} />
           <LinkedDatasourceView info={settings.logs} />
         </Container>
+
+        <h3>Backend address</h3>
+        {settings.apiHost}
       </div>
     );
   }


### PR DESCRIPTION
Adds the apiHost url to the plugin config page
![Screen Shot 2021-06-16 at 10 16 10 AM](https://user-images.githubusercontent.com/8377044/122271546-fd470c80-ce8b-11eb-94c7-96ba77a4932a.png)

closes #289 
closes #263 