### PR TITLE
Viz icon overlay

### DIFF
--- a/src/components/CheckList.tsx
+++ b/src/components/CheckList.tsx
@@ -14,7 +14,18 @@ import {
   CheckType,
 } from 'types';
 import appEvents from 'grafana/app/core/app_events';
-import { Button, Icon, Select, Input, Pagination, InfoBox, Checkbox, useStyles, RadioButtonGroup } from '@grafana/ui';
+import {
+  Button,
+  Icon,
+  Select,
+  Input,
+  Pagination,
+  InfoBox,
+  Checkbox,
+  useStyles,
+  RadioButtonGroup,
+  InlineSwitch,
+} from '@grafana/ui';
 import { unEscapeStringFromRegex, escapeStringForRegex, GrafanaTheme, AppEvents, SelectableValue } from '@grafana/data';
 import { hasRole, checkType as getCheckType, matchStrings } from 'utils';
 import {
@@ -160,6 +171,7 @@ export const CheckList = ({ instance, onAddNewClick, checks, onCheckUpdate }: Pr
   const [selectAll, setSelectAll] = useState(false);
   const [viewType, setViewType] = useState(getViewTypeFromLS() ?? CheckListViewType.Card);
   const [sortType, setSortType] = useState<CheckSort>(CheckSort.AToZ);
+  const [showVizIconOverlay, setShowVizIconOverlay] = useState(false);
   const [bulkActionInProgress, setBulkActionInProgress] = useState(false);
   const styles = useStyles(getStyles);
   const successRateContext = useContext(SuccessRateContext);
@@ -563,6 +575,15 @@ export const CheckList = ({ instance, onAddNewClick, checks, onCheckUpdate }: Pr
             options={CHECK_LIST_VIEW_TYPE_OPTIONS}
           />
         )}
+        {viewType === CheckListViewType.Viz && (
+          <InlineSwitch
+            label="Show icons"
+            showLabel
+            transparent
+            value={showVizIconOverlay}
+            onChange={(e) => setShowVizIconOverlay(e.currentTarget.checked)}
+          />
+        )}
         <div className={styles.flexGrow} />
         <Select
           prefix={
@@ -579,7 +600,7 @@ export const CheckList = ({ instance, onAddNewClick, checks, onCheckUpdate }: Pr
       </div>
       {viewType === CheckListViewType.Viz ? (
         <div className={styles.vizContainer}>
-          <ChecksVisualization checks={filteredChecks} />
+          <ChecksVisualization checks={filteredChecks} showIcons={showVizIconOverlay} />
         </div>
       ) : (
         <div>

--- a/src/components/CheckList.tsx
+++ b/src/components/CheckList.tsx
@@ -34,6 +34,7 @@ import {
   CHECK_LIST_STATUS_OPTIONS,
   CHECK_LIST_VIEW_TYPE_OPTIONS,
   CHECK_LIST_VIEW_TYPE_LS_KEY,
+  CHECK_LIST_ICON_OVERLAY_LS_KEY,
 } from './constants';
 import { CheckListItem } from './CheckListItem';
 import { css } from '@emotion/css';
@@ -149,6 +150,20 @@ interface Props {
   onCheckUpdate: () => void;
 }
 
+const getIconOverlayToggleFromLS = () => {
+  const lsValue = window.localStorage.getItem(CHECK_LIST_ICON_OVERLAY_LS_KEY);
+
+  if (!lsValue) {
+    return false;
+  }
+
+  try {
+    return Boolean(JSON.parse(lsValue));
+  } catch {
+    return false;
+  }
+};
+
 const getViewTypeFromLS = () => {
   const lsValue = window.localStorage.getItem(CHECK_LIST_VIEW_TYPE_LS_KEY);
   if (lsValue) {
@@ -171,7 +186,7 @@ export const CheckList = ({ instance, onAddNewClick, checks, onCheckUpdate }: Pr
   const [selectAll, setSelectAll] = useState(false);
   const [viewType, setViewType] = useState(getViewTypeFromLS() ?? CheckListViewType.Card);
   const [sortType, setSortType] = useState<CheckSort>(CheckSort.AToZ);
-  const [showVizIconOverlay, setShowVizIconOverlay] = useState(false);
+  const [showVizIconOverlay, setShowVizIconOverlay] = useState(getIconOverlayToggleFromLS());
   const [bulkActionInProgress, setBulkActionInProgress] = useState(false);
   const styles = useStyles(getStyles);
   const successRateContext = useContext(SuccessRateContext);
@@ -581,7 +596,10 @@ export const CheckList = ({ instance, onAddNewClick, checks, onCheckUpdate }: Pr
             showLabel
             transparent
             value={showVizIconOverlay}
-            onChange={(e) => setShowVizIconOverlay(e.currentTarget.checked)}
+            onChange={(e) => {
+              window.localStorage.setItem(CHECK_LIST_ICON_OVERLAY_LS_KEY, String(e.currentTarget.checked));
+              setShowVizIconOverlay(e.currentTarget.checked);
+            }}
           />
         )}
         <div className={styles.flexGrow} />

--- a/src/components/ChecksVisualization/ChecksVisualization.test.tsx
+++ b/src/components/ChecksVisualization/ChecksVisualization.test.tsx
@@ -113,7 +113,7 @@ const renderChecksViz = ({ checks = defaultChecks }: RenderArgs = {}) => {
     <InstanceContext.Provider value={{ instance: { api: instance }, loading: false, meta }}>
       <SuccessRateContextProvider checks={checks}>
         <div style={{ height: '500px', width: '500px' }}>
-          <ChecksVisualization checks={checks} />
+          <ChecksVisualization checks={checks} showIcons />
         </div>
       </SuccessRateContextProvider>
     </InstanceContext.Provider>

--- a/src/components/ChecksVisualization/ChecksVisualization.tsx
+++ b/src/components/ChecksVisualization/ChecksVisualization.tsx
@@ -1,10 +1,10 @@
-import React, { useRef, useState, useCallback, useContext } from 'react';
+import React, { useRef, useState, useCallback } from 'react';
 import { VirtualElement } from '@popperjs/core';
 import * as d3hexbin from 'd3-hexbin';
 import { Check } from 'types';
 import { useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
-import { SuccessRateContext, SuccessRateTypes } from 'contexts/SuccessRateContext';
+import { SuccessRateTypes } from 'contexts/SuccessRateContext';
 import { getLayout } from './checksVizUtils';
 import { GrafanaTheme2 } from '@grafana/data';
 import { usePopper } from 'react-popper';
@@ -15,6 +15,7 @@ import { IconOverlay } from './IconOverlay';
 
 interface Props {
   checks: Check[];
+  showIcons: boolean;
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
@@ -33,8 +34,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
 });
 
-export function ChecksVisualization({ checks }: Props) {
-  const { values: successRates } = useContext(SuccessRateContext);
+export function ChecksVisualization({ checks, showIcons }: Props) {
   const styles = useStyles2(getStyles);
   const popperElement = useRef<HTMLDivElement>(null);
   const [hoveredCheck, setHoveredCheck] = useState<Check>();
@@ -108,13 +108,15 @@ export function ChecksVisualization({ checks }: Props) {
                   ))}
                 </g>
               </svg>
-              <IconOverlay
-                width={svgWidth}
-                height={adjustedHeight}
-                hexCenters={hexCenters}
-                hexRadius={hexRadius}
-                checks={checks}
-              />
+              {showIcons && (
+                <IconOverlay
+                  width={svgWidth}
+                  height={adjustedHeight}
+                  hexCenters={hexCenters}
+                  hexRadius={hexRadius}
+                  checks={checks}
+                />
+              )}
             </>
           );
         }}

--- a/src/components/ChecksVisualization/IconOverlay.tsx
+++ b/src/components/ChecksVisualization/IconOverlay.tsx
@@ -1,0 +1,41 @@
+import { Icon } from '@grafana/ui';
+import { SuccessRateContext } from 'contexts/SuccessRateContext';
+import React, { useContext } from 'react';
+import { Check } from 'types';
+
+interface Props {
+  width: number;
+  height: number;
+  hexRadius: number;
+  hexCenters: never[] | Array<[number, number]>;
+  checks: Check[];
+}
+
+export const IconOverlay = ({ width, height, hexCenters, hexRadius, checks }: Props) => {
+  const { values: successRates } = useContext(SuccessRateContext);
+  return (
+    <div
+      style={{
+        width,
+        position: 'absolute',
+        pointerEvents: 'none',
+        height,
+      }}
+    >
+      {hexCenters.map(([x, y], index) => {
+        console.log(x, y);
+        return (
+          <Icon
+            key={index}
+            name={successRates.checks?.[checks[index]?.id ?? 0]?.icon}
+            style={{
+              position: 'absolute',
+              left: x + hexRadius - 7, // Subtract 7 because it's half the width of the icon element
+              top: y + hexRadius - 7, // Subtract 7 because it's half the width of the icon element
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/ChecksVisualization/IconOverlay.tsx
+++ b/src/components/ChecksVisualization/IconOverlay.tsx
@@ -7,7 +7,7 @@ interface Props {
   width: number;
   height: number;
   hexRadius: number;
-  hexCenters: never[] | Array<[number, number]>;
+  hexCenters: Array<[number, number]>;
   checks: Check[];
 }
 
@@ -23,7 +23,6 @@ export const IconOverlay = ({ width, height, hexCenters, hexRadius, checks }: Pr
       }}
     >
       {hexCenters.map(([x, y], index) => {
-        console.log(x, y);
         return (
           <Icon
             key={index}

--- a/src/components/ChecksVisualization/IconOverlay.tsx
+++ b/src/components/ChecksVisualization/IconOverlay.tsx
@@ -1,7 +1,9 @@
-import { Icon } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, useStyles2 } from '@grafana/ui';
 import { SuccessRateContext } from 'contexts/SuccessRateContext';
 import React, { useContext } from 'react';
 import { Check } from 'types';
+import { css } from '@emotion/css';
 
 interface Props {
   width: number;
@@ -11,14 +13,24 @@ interface Props {
   checks: Check[];
 }
 
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css`
+    position: absolute;
+    pointer-events: none;
+  `,
+  icon: css`
+    position: absolute;
+  `,
+});
+
 export const IconOverlay = ({ width, height, hexCenters, hexRadius, checks }: Props) => {
   const { values: successRates } = useContext(SuccessRateContext);
+  const styles = useStyles2(getStyles);
   return (
     <div
+      className={styles.container}
       style={{
         width,
-        position: 'absolute',
-        pointerEvents: 'none',
         height,
       }}
     >
@@ -27,8 +39,8 @@ export const IconOverlay = ({ width, height, hexCenters, hexRadius, checks }: Pr
           <Icon
             key={index}
             name={successRates.checks?.[checks[index]?.id ?? 0]?.icon}
+            className={styles.icon}
             style={{
-              position: 'absolute',
               left: x + hexRadius - 7, // Subtract 7 because it's half the width of the icon element
               top: y + hexRadius - 7, // Subtract 7 because it's half the width of the icon element
             }}

--- a/src/components/SuccessRateContextProvider.tsx
+++ b/src/components/SuccessRateContextProvider.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, useContext, useEffect, useState } from 'react';
 import { Check, Probe } from 'types';
-import { getSuccessRateThresholdColor, queryMetric } from 'utils';
+import { getSuccessRateIcon, getSuccessRateThresholdColor, queryMetric } from 'utils';
 import { InstanceContext } from 'contexts/InstanceContext';
 import {
   SuccessRates,
@@ -54,6 +54,7 @@ const parseCheckResults = (checks: Check[] | undefined, data: any) => {
           value: parseFloat(float.toFixed(1)),
           displayValue: `${float.toFixed(1)}%`,
           thresholdColor: getSuccessRateThresholdColor(float),
+          icon: getSuccessRateIcon(float),
         };
       }
     }

--- a/src/components/SuccessRateContextProvider.tsx
+++ b/src/components/SuccessRateContextProvider.tsx
@@ -87,6 +87,7 @@ const parseProbeResults = (probes: Probe[] | undefined, data: any) => {
           value: parseFloat(float.toFixed(1)),
           displayValue: float.toFixed(1),
           thresholdColor: getSuccessRateThresholdColor(float),
+          icon: getSuccessRateIcon(float),
         };
       }
     }

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -290,6 +290,8 @@ export const PEM_FOOTER = '-----END CERTIFICATE-----';
 
 export const CHECK_LIST_VIEW_TYPE_LS_KEY = 'grafana.sm.checklist.viewType';
 
+export const CHECK_LIST_ICON_OVERLAY_LS_KEY = 'grafana.sm.checklist.iconOverlay';
+
 export const INVALID_WEB_URL_MESSAGE = 'Target must be a valid web URL';
 
 export const HTTP_COMPRESSION_ALGO_OPTIONS = [

--- a/src/contexts/SuccessRateContext.ts
+++ b/src/contexts/SuccessRateContext.ts
@@ -1,4 +1,5 @@
 import { config } from '@grafana/runtime';
+import { IconName } from '@grafana/ui';
 import { createContext } from 'react';
 import { getSuccessRateThresholdColor } from 'utils';
 
@@ -12,6 +13,7 @@ export interface SuccessRateValue {
   displayValue: string;
   thresholdColor: string;
   noData?: boolean;
+  icon: IconName;
 }
 export interface SuccessRate {
   [key: number]: SuccessRateValue;
@@ -39,6 +41,7 @@ export const defaultValues: SuccessRates = {
     value: 0,
     displayValue: 'N/A',
     noData: true,
+    icon: 'minus',
   },
 };
 
@@ -50,6 +53,7 @@ const updateSuccessRate = (type: SuccessRateTypes, id: number, successRate: numb
     displayValue: successRate === undefined ? 'N/A' : successRate.toFixed(1),
     thresholdColor,
     noData: successRate === undefined,
+    icon: 'minus',
   };
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import { config, getBackendSrv } from '@grafana/runtime';
 import { HostedInstance, User, OrgRole, CheckType, Settings } from 'types';
 
 import { SMDataSource } from 'datasource/DataSource';
+import { IconName } from '@grafana/ui';
 
 /**
  * Find all synthetic-monitoring datasources
@@ -286,4 +287,17 @@ export const getSuccessRateThresholdColor = (value: number | undefined) => {
     return config.theme2.colors.warning.main;
   }
   return config.theme2.colors.error.main;
+};
+
+export const getSuccessRateIcon = (value: number | undefined): IconName => {
+  if (value === undefined) {
+    return 'minus';
+  }
+  if (value >= 99.5) {
+    return 'check';
+  }
+  if (value >= 99) {
+    return 'exclamation-triangle';
+  }
+  return 'x';
 };


### PR DESCRIPTION
Our check visualization view isn't very accessible, because the only dimension differentiating the check status is color. This PR adds a toggle which will overlay icons onto the viz so they it's easier to see a distinction.

Without icons simulating achromatopsia:
![Screen Shot 2021-06-22 at 1 48 05 PM](https://user-images.githubusercontent.com/8377044/123004013-85cc1e00-d360-11eb-954c-44618cb4174b.png)

With icons simulating achromatopsia:
![Screen Shot 2021-06-22 at 1 48 10 PM](https://user-images.githubusercontent.com/8377044/123004006-81a00080-d360-11eb-835c-71235d1ce2b4.png)


![Uploading iconoverlay.gif…]()
