### PR TITLE
fix: add some help text around less frequent checks and alert flapping

### DIFF
--- a/src/components/CheckFormAlert.tsx
+++ b/src/components/CheckFormAlert.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react';
 import { css } from '@emotion/css';
-import { GrafanaTheme } from '@grafana/data';
-import { Field, Select, useStyles } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Field, Select, useStyles2 } from '@grafana/ui';
 import { Collapse } from './Collapse';
 import { Controller } from 'react-hook-form';
 import { ALERT_SENSITIVITY_OPTIONS } from './constants';
@@ -10,9 +10,9 @@ interface Props {
   checkId?: number;
 }
 
-const getStyles = (theme: GrafanaTheme) => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   marginBottom: css`
-    margin-bottom: ${theme.spacing.md};
+    margin-bottom: ${theme.spacing(2)};
   `,
   link: css`
     text-decoration: underline;
@@ -21,22 +21,25 @@ const getStyles = (theme: GrafanaTheme) => ({
 
 export const CheckFormAlert: FC<Props> = () => {
   const [showAlerting, setShowAlerting] = useState(false);
-  const styles = useStyles(getStyles);
+  const styles = useStyles2(getStyles);
 
   return (
     <Collapse label="Alerting" onToggle={() => setShowAlerting(!showAlerting)} isOpen={showAlerting} collapsible>
       <div className={styles.marginBottom}>
-        Synthetic Monitoring provides some default alert rules via Cloud Alerting. By selecting an alert sensitivity,
-        the metrics this check publishes will be associated with a Cloud Alerting rule. Default rules can be created and
-        edited in the &nbsp;
-        <a
-          href="a/grafana-synthetic-monitoring-app/?page=alerts"
-          target="_blank"
-          rel="noopener noreferrer"
-          className={styles.link}
-        >
-          alerts tab.
-        </a>
+        <p>
+          Synthetic Monitoring provides some default alert rules via Cloud Alerting. By selecting an alert sensitivity,
+          the metrics this check publishes will be associated with a Cloud Alerting rule. Default rules can be created
+          and edited in the &nbsp;
+          <a
+            href="a/grafana-synthetic-monitoring-app/?page=alerts"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.link}
+          >
+            alerts tab.
+          </a>
+        </p>
+        <p>Tip: adding multiple probes can help to prevent alert flapping for less frequent checks</p>
       </div>
       <Field label="Select alert sensitivity">
         <Controller


### PR DESCRIPTION
![Screen Shot 2021-07-08 at 10 54 33 AM](https://user-images.githubusercontent.com/8377044/124975797-e3a46b00-dfda-11eb-9d7c-0cdb2c4f0388.png)

This adds a little help note to the alerting section of the create check form. I also updated to the new theme utilities while I was making changes in the component. 