### PR TITLE
fix: rename the success rate panels to reachability

### DIFF
--- a/src/components/SuccessRateGauge.tsx
+++ b/src/components/SuccessRateGauge.tsx
@@ -20,13 +20,13 @@ const getDisplayValue = (successRate: SuccessRateValue, loading: boolean): Displ
   if (loading) {
     return {
       numeric: 0,
-      title: 'Success rate',
+      title: 'Reachability',
       text: 'loading...',
     };
   }
 
   return {
-    title: 'Success rate',
+    title: 'Reachability',
     color: successRate.thresholdColor,
     numeric: successRate.value,
     text: successRate.noData ? 'N/A' : successRate.value + '%',


### PR DESCRIPTION
We need to align the naming of our measurements. The app was showing `Success Rate`, which is referred to as `Reachability` in the dashboards, so I changed the app to match the dashboards.

![Screen Shot 2021-07-09 at 8 49 21 AM](https://user-images.githubusercontent.com/8377044/125111605-9388df80-e092-11eb-9f21-daae4a80b630.png)
![Screen Shot 2021-07-09 at 8 49 58 AM](https://user-images.githubusercontent.com/8377044/125111668-a69baf80-e092-11eb-8c4d-8712830f33ef.png)
