### PR TITLE
fix: make HTTP the default check type

### DIFF
--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -1,16 +1,12 @@
 import { SelectableValue } from '@grafana/data';
 import {
   CheckType,
-  DnsRecordType,
-  DnsProtocol,
   CheckFormValues,
   Settings,
   SettingsFormValues,
   PingSettingsFormValues,
-  IpVersion,
   PingSettings,
   HttpSettings,
-  HttpMethod,
   HttpSettingsFormValues,
   HttpRegexValidationFormValue,
   Label,
@@ -25,11 +21,9 @@ import {
   HttpSslOption,
   HttpRegexValidationType,
   HeaderMatch,
-  DnsResponseCodes,
   AlertSensitivity,
   TCPQueryResponse,
   TLSConfig,
-  HTTPCompressionAlgo,
 } from 'types';
 
 import {
@@ -42,6 +36,7 @@ import {
   ALERT_SENSITIVITY_OPTIONS,
   HTTP_COMPRESSION_ALGO_OPTIONS,
   DNS_RESPONSE_MATCH_OPTIONS,
+  fallbackSettings,
 } from 'components/constants';
 import { checkType, fromBase64, toBase64 } from 'utils';
 import isBase64 from 'is-base64';
@@ -52,52 +47,6 @@ export function selectableValueFrom<T>(value: T, label?: string): SelectableValu
   const labelValue = String(value);
   return { label: label ?? labelValue, value };
 }
-
-export function fallbackSettings(t: CheckType): Settings {
-  switch (t) {
-    case CheckType.HTTP: {
-      return {
-        http: {
-          method: HttpMethod.GET,
-          ipVersion: IpVersion.V4,
-          noFollowRedirects: false,
-          compression: HTTPCompressionAlgo.none,
-        },
-      };
-    }
-    case CheckType.PING: {
-      return {
-        ping: {
-          ipVersion: IpVersion.V4,
-          dontFragment: false,
-        },
-      };
-    }
-    case CheckType.DNS: {
-      return {
-        dns: {
-          recordType: DnsRecordType.A,
-          server: '8.8.8.8',
-          ipVersion: IpVersion.V4,
-          protocol: DnsProtocol.UDP,
-          port: 53,
-          validRCodes: [DnsResponseCodes.NOERROR],
-        },
-      };
-    }
-    case CheckType.TCP: {
-      return {
-        tcp: {
-          ipVersion: IpVersion.V4,
-          tls: false,
-        },
-      };
-    }
-    default:
-      throw new Error(`Cannot find values for invalid check type ${t}`);
-  }
-}
-
 const getPingSettingsFormValues = (settings: Settings): PingSettingsFormValues => {
   const pingSettings = settings.ping ?? (fallbackSettings(CheckType.PING) as PingSettings);
   return {

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -16,6 +16,9 @@ import {
   CheckListViewType,
   HTTPCompressionAlgo,
   ResponseMatchType,
+  HttpSettings,
+  Settings,
+  HttpMethod,
 } from 'types';
 
 export const DNS_RESPONSE_CODES = enumToStringArray(DnsResponseCodes).map((responseCode) => ({
@@ -185,10 +188,7 @@ export const fallbackCheck = {
   probes: [],
   alertSensitivity: AlertSensitivity.None,
   settings: {
-    ping: {
-      ipVersion: IpVersion.V4,
-      dontFragment: false,
-    },
+    http: fallbackSettings(CheckType.HTTP) as HttpSettings,
   },
   basicMetricsOnly: true,
 } as Check;
@@ -301,3 +301,48 @@ export const HTTP_COMPRESSION_ALGO_OPTIONS = [
   { label: 'gzip', value: HTTPCompressionAlgo.gzip },
   { label: 'deflate', value: HTTPCompressionAlgo.deflate },
 ];
+
+export function fallbackSettings(t: CheckType): Settings {
+  switch (t) {
+    case CheckType.HTTP: {
+      return {
+        http: {
+          method: HttpMethod.GET,
+          ipVersion: IpVersion.V4,
+          noFollowRedirects: false,
+          compression: HTTPCompressionAlgo.none,
+        },
+      };
+    }
+    case CheckType.PING: {
+      return {
+        ping: {
+          ipVersion: IpVersion.V4,
+          dontFragment: false,
+        },
+      };
+    }
+    case CheckType.DNS: {
+      return {
+        dns: {
+          recordType: DnsRecordType.A,
+          server: '8.8.8.8',
+          ipVersion: IpVersion.V4,
+          protocol: DnsProtocol.UDP,
+          port: 53,
+          validRCodes: [DnsResponseCodes.NOERROR],
+        },
+      };
+    }
+    case CheckType.TCP: {
+      return {
+        tcp: {
+          ipVersion: IpVersion.V4,
+          tls: false,
+        },
+      };
+    }
+    default:
+      throw new Error(`Cannot find values for invalid check type ${t}`);
+  }
+}


### PR DESCRIPTION
HTTP is the most common check type. We had been showing PING as the default option, but it makes more sense to have HTTP be first.

Closes #330 