### PR TITLE
fix: expose proxy url setting in http check form

### DIFF
--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -296,6 +296,7 @@ describe('HTTP', () => {
           failIfSSL: false,
           bearerToken: 'a bear',
           basicAuth: { username: 'steve', password: 'stevessecurepassword' },
+          proxyURL: 'https://grafana.com',
           cacheBustingQueryParamName: 'busted',
           failIfBodyMatchesRegexp: ['body matches'],
           failIfBodyNotMatchesRegexp: ['body not maches'],
@@ -321,6 +322,7 @@ describe('HTTP', () => {
     expect(await within(httpSection).findByPlaceholderText('name')).toHaveValue('headerName');
     expect(await within(httpSection).findByPlaceholderText('value')).toHaveValue('headerValue');
     expect(within(httpSection).getByTestId('http-compression')).toHaveValue('gzip');
+    expect(await screen.findByLabelText('Proxy URL', { exact: false })).toHaveValue('https://grafana.com');
 
     await toggleSection('TLS config');
     expect(await screen.findByLabelText('Disable target certificate validation')).toBeChecked();
@@ -386,6 +388,10 @@ describe('HTTP', () => {
     await act(async () => await userEvent.type(await screen.findByPlaceholderText('value'), 'headerValue'));
     const compression = await screen.findByTestId('http-compression');
     userEvent.selectOptions(compression, 'deflate');
+
+    const proxyUrlInput = await screen.findByLabelText('Proxy URL', { exact: false });
+    await userEvent.paste(proxyUrlInput, 'https://grafana.com');
+
     await toggleSection('HTTP settings');
 
     // TLS Config
@@ -463,6 +469,7 @@ describe('HTTP', () => {
           body: 'requestbody',
           compression: 'deflate',
           ipVersion: 'V4',
+          proxyURL: 'https://grafana.com',
           noFollowRedirects: false,
           tlsConfig: {
             insecureSkipVerify: false,

--- a/src/components/http/HttpSettings.tsx
+++ b/src/components/http/HttpSettings.tsx
@@ -261,6 +261,11 @@ export const HttpSettingsForm = ({ isEditor }: Props) => {
             />
           </Field>
         </HorizontalGroup>
+        <Container>
+          <Field label="Proxy URL" description="HTTP proxy server to use to connect to the target" disabled={!isEditor}>
+            <Input id="proxyUrl" {...register('settings.http.proxyURL')} type="text" />
+          </Field>
+        </Container>
       </Collapse>
       <TLSConfig isEditor={isEditor} checkType={CheckType.HTTP} />
       <Collapse

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,7 +222,7 @@ export interface HttpSettingsFormValues
   regexValidations: HttpRegexValidationFormValue[];
   followRedirects: boolean;
   compression: SelectableValue<HTTPCompressionAlgo>;
-  proxyUrl: string;
+  proxyURL?: string;
 }
 
 export interface PingSettings {

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,6 +164,7 @@ export interface HttpSettings {
   noFollowRedirects: boolean;
   tlsConfig?: TLSConfig;
   compression: HTTPCompressionAlgo | undefined;
+  proxyURL?: string;
 
   // Authentication
   bearerToken?: string;
@@ -221,6 +222,7 @@ export interface HttpSettingsFormValues
   regexValidations: HttpRegexValidationFormValue[];
   followRedirects: boolean;
   compression: SelectableValue<HTTPCompressionAlgo>;
+  proxyUrl: string;
 }
 
 export interface PingSettings {


### PR DESCRIPTION
This pr is to fix a gap we had in exposing http settings. BBE and the agent [support specifying a URL to proxy http check through](https://github.com/grafana/synthetic-monitoring-agent/blob/d4b802d910a1fd9e1288ecd7619e0cb51a74cf43/pkg/pb/synthetic_monitoring/checks.pb.go#L963), but we don't have an input for it in the plugin. 

This just adds a text input to allow users to specify a proxy url for http checks.