### PR TITLE
fix: http version 2 value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export enum HttpMethod {
 export enum HttpVersion {
   HTTP1_0 = 'HTTP/1.0',
   HTTP1_1 = 'HTTP/1.1',
-  HTTP2_0 = 'HTTP/2',
+  HTTP2_0 = 'HTTP/2.0',
 }
 
 export enum DnsRecordType {


### PR DESCRIPTION
We're currently sending `HTTP/2` as the http version value for checks that want to accept HTTP/2 checks, however the value needs to be `HTTP/2.0` for the check to succeed, according to this issue in BBE: https://github.com/prometheus/blackbox_exporter/issues/658