### PR TITLE
fix: store results of import in sm datasource from dashboard import m…

### DIFF
--- a/src/components/PluginTabs.tsx
+++ b/src/components/PluginTabs.tsx
@@ -7,7 +7,7 @@ import { ProbesPage } from 'page/ProbesPage';
 import { InstanceContext } from 'contexts/InstanceContext';
 import { getLocationSrv } from '@grafana/runtime';
 import { DashboardInfo } from 'datasource/types';
-import { listAppDashboards } from 'dashboards/loader';
+import { importAllDashboards, listAppDashboards } from 'dashboards/loader';
 import { Button, HorizontalGroup, Modal } from '@grafana/ui';
 import { hasDismissedDashboardUpdateModal, persistDashboardModalDismiss } from 'sessionStorage';
 import { Alerting } from './Alerting';
@@ -190,13 +190,24 @@ export const PluginTabs = ({ query, onNavChanged, path, meta }: AppRootProps<Glo
         <p>It looks like your Synthetic Monitoring dashboards need an update.</p>
         <HorizontalGroup>
           <Button
-            onClick={() => {
+            onClick={async () => {
+              if (!instance.api) {
+                return;
+              }
+              const responses = await importAllDashboards(instance.metrics?.name ?? '', instance.logs?.name ?? '');
+              const updatedSettings = {
+                ...instance.api.instanceSettings.jsonData,
+                dashboards: responses,
+              };
+              await instance.api?.onOptionsChange(updatedSettings);
+
               getLocationSrv().update({
                 partial: false,
                 path: 'plugins/grafana-synthetic-monitoring-app/',
                 query: {},
               });
               skipDashboardUpdate();
+              window.location.reload();
             }}
           >
             Update

--- a/src/dashboards/loader.ts
+++ b/src/dashboards/loader.ts
@@ -38,7 +38,7 @@ export async function importDashboard(
   const json = await backendSrv.request({
     url: `public/plugins/grafana-synthetic-monitoring-app/dashboards/${path}`,
     method: 'GET',
-    headers: { 'Cache-Control': 'no-cache' },
+    headers: { 'Cache-Control': 'no-store' },
   });
 
   const folder = await findSyntheticMonitoringFolder();
@@ -69,7 +69,7 @@ export async function listAppDashboards(): Promise<DashboardInfo[]> {
     const json = await backendSrv.request({
       url: `public/plugins/grafana-synthetic-monitoring-app/dashboards/${p}`,
       method: 'GET',
-      headers: { 'Cache-Control': 'no-cache' },
+      headers: { 'Cache-Control': 'no-store' },
     });
 
     const dInfo = {


### PR DESCRIPTION
The modal that pops up to ask users to import dashboards wasn't actually importing the dashboards. This PR has the plugin import all the dashboards and store the most recent versions in the SM datasource.