### PR TITLE
fix(ui): probe label display on probes page

### DIFF
--- a/src/components/ProbeList.test.tsx
+++ b/src/components/ProbeList.test.tsx
@@ -65,7 +65,7 @@ it('renders online probes', async () => {
 
 it('renders labels', async () => {
   renderProbeList();
-  const label = await screen.findByText('chimi=churri');
+  const label = await screen.findByText('chimi:churri');
   expect(label).toBeInTheDocument();
 });
 

--- a/src/components/ProbeList.tsx
+++ b/src/components/ProbeList.tsx
@@ -13,7 +13,7 @@ interface Props {
   onSelectProbe: (probeId: number) => void;
 }
 
-const labelsToString = (labels: Label[]) => labels.map(({ name, value }) => `${name}=${value}`);
+const labelsToString = (labels: Label[]) => labels.map(({ name, value }) => `${name}:${value}`).join(', ');
 
 export const ProbeList = ({ probes, onAddNew, onSelectProbe }: Props) => {
   const { instance, loading: instanceLoading } = useContext(InstanceContext);


### PR DESCRIPTION
Fix display of labels on probes list page.

Before:
![image](https://user-images.githubusercontent.com/9503187/130223300-ada19222-8e58-4826-8d29-4c3ed37e82ef.png)


After:
![image](https://user-images.githubusercontent.com/9503187/130223326-5578ed23-f46a-4508-9bbd-93f8360b5904.png)
