### PR TITLE
fix: check type selector should be disabled on edit

### DIFF
--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -98,7 +98,13 @@ export const CheckEditor = ({ check, onReturn }: Props) => {
               name="checkType"
               control={formMethods.control}
               render={({ field }) => (
-                <Select {...field} placeholder="Check type" options={CHECK_TYPE_OPTIONS} width={30} />
+                <Select
+                  {...field}
+                  placeholder="Check type"
+                  options={CHECK_TYPE_OPTIONS}
+                  width={30}
+                  disabled={check?.id ? true : false}
+                />
               )}
             />
           </Field>


### PR DESCRIPTION
The check type input isn't getting disabled by the wrapping `<Field>` component for some reason. It shouldn't be possible to change the type of the check once it's been created, and it will cause the app to crash if someone does. 