### PR TITLE
Default server for DNS to domain name

### DIFF
--- a/src/components/CheckEditor/CheckEditor.test.tsx
+++ b/src/components/CheckEditor/CheckEditor.test.tsx
@@ -549,7 +549,7 @@ describe('DNS', () => {
             port: 53,
             protocol: 'UDP',
             recordType: 'A',
-            server: '8.8.8.8',
+            server: 'dns.google',
             validRCodes: [DnsResponseCodes.NOERROR],
             validateAditionalRRS: {
               failIfMatchesRegexp: [],
@@ -604,7 +604,7 @@ describe('DNS', () => {
             port: 53,
             protocol: 'UDP',
             recordType: 'A',
-            server: '8.8.8.8',
+            server: 'dns.google',
             validRCodes: [DnsResponseCodes.NOERROR],
             validateAditionalRRS: {
               failIfMatchesRegexp: [],
@@ -658,7 +658,7 @@ describe('DNS', () => {
             port: 53,
             protocol: 'UDP',
             recordType: 'A',
-            server: '8.8.8.8',
+            server: 'dns.google',
             validRCodes: [DnsResponseCodes.NOERROR],
             validateAditionalRRS: {
               failIfMatchesRegexp: ['inverted validation'],

--- a/src/components/CheckTarget.test.tsx
+++ b/src/components/CheckTarget.test.tsx
@@ -14,7 +14,7 @@ const checkSettingsMock = {
     port: 53,
     protocol: DnsProtocol.TCP,
     recordType: DnsRecordType.A,
-    server: '8.8.8.8',
+    server: 'dns.google',
   },
   tcp: { ipVersion: IpVersion.V4, tls: false },
 };

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -342,7 +342,7 @@ export function fallbackSettings(t: CheckType): Settings {
       return {
         dns: {
           recordType: DnsRecordType.A,
-          server: '8.8.8.8',
+          server: 'dns.google',
           ipVersion: IpVersion.V4,
           protocol: DnsProtocol.UDP,
           port: 53,

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -80,7 +80,7 @@ describe('trivial cases', () => {
       settings: {
         dns: {
           recordType: DnsRecordType.A,
-          server: '8.8.8.8',
+          server: 'dns.google',
           ipVersion: IpVersion.V4,
           protocol: DnsProtocol.TCP,
           port: 53,


### PR DESCRIPTION
Currently the default server for DNS checks is set to an IPv4 address.
But users can choose to use IPv6 instead, at which point the IPv4
default address leads to the check constantly failing. This default will
work for both IPv4 and IPv6 without issue.

See this working in practice on this check here:
https://syntheticmonitoring.grafana.net/a/grafana-synthetic-monitoring-app/?page=checks&id=63