### PR TITLE
Traceroute multi probe vars

### DIFF
--- a/src/dashboards/sm-traceroute.json
+++ b/src/dashboards/sm-traceroute.json
@@ -735,7 +735,7 @@
         "hide": 0,
         "includeAll": true,
         "label": null,
-        "multi": false,
+        "multi": true,
         "name": "probe",
         "options": [],
         "query": {
@@ -815,5 +815,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring Traceroute",
   "uid": "hk8gHB4nk",
-  "version": 5
+  "version": 6
 }

--- a/src/dashboards/sm-traceroute.json
+++ b/src/dashboards/sm-traceroute.json
@@ -604,11 +604,11 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "sum((rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) / sum((rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range])))",
+          "expr": "sum((rate(probe_all_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_sum{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) by (probe) / sum((rate(probe_all_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]) OR rate(probe_duration_seconds_count{probe=~\"$probe\", instance=\"$instance\", job=\"$job\"}[$__range]))) by (probe)",
           "format": "time_series",
           "instant": true,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{probe}}",
           "refId": "A"
         }
       ],

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -16,6 +16,7 @@ import { config, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { Probe, Check, RegistrationInfo, HostedInstance } from '../types';
 import { queryLogs } from 'utils';
 import { parseTracerouteLogs } from './traceroute-utils';
+import { values } from 'lodash';
 
 export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   constructor(public instanceSettings: DataSourceInstanceSettings<SMOptions>) {
@@ -70,7 +71,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
 
         const dashboardVars = getTemplateSrv().getVariables();
 
-        const queryToExecute = dashboardVars ? this.getQueryFromDashboardVars(dashboardVars, query) : query;
+        const queryToExecute = dashboardVars ? this.getQueryFromVars(dashboardVars, query) : query;
 
         if (!queryToExecute.job || !queryToExecute.instance) {
           return {
@@ -100,14 +101,26 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
     return { data };
   }
 
-  getProbeValueFromVar(probe: string | undefined): string {
-    if (!probe || probe === '$__all') {
-      return '.+';
+  getProbeValueFromVar(probe: string | string[] | undefined): string {
+    const allProbes = '.+';
+    const isArray = Array.isArray(probe);
+
+    if (!isArray && (!probe || probe === '$__all')) {
+      return allProbes;
     }
-    return probe;
+    if (isArray && probe.length > 1) {
+      return probe.join('|');
+    } else if (isArray && probe.length === 1) {
+      if (!probe[0] || probe[0] === '$__all') {
+        return allProbes;
+      }
+      return probe[0];
+    }
+
+    return allProbes;
   }
 
-  getQueryFromDashboardVars(dashboardVars: VariableModel[], query: SMQuery): SMQuery {
+  getQueryFromVars(dashboardVars: VariableModel[], query: SMQuery): SMQuery {
     const job = dashboardVars.find((variable) => variable.name === 'job') as DashboardVariable | undefined;
     const instance = dashboardVars.find((variable) => variable.name === 'instance') as DashboardVariable | undefined;
     const probe = dashboardVars.find((variable) => variable.name === 'probe') as DashboardVariable | undefined;
@@ -122,7 +135,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       ...query,
       job: job?.current?.value ?? query.job,
       instance: instance?.current?.value ?? query.instance,
-      probe: this.getProbeValueFromVar(probe?.current?.value ?? query.probe),
+      probe: this.getProbeValueFromVar(probe.current?.value ?? query.probe),
     };
   }
 

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -16,7 +16,6 @@ import { config, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { Probe, Check, RegistrationInfo, HostedInstance } from '../types';
 import { queryLogs } from 'utils';
 import { parseTracerouteLogs } from './traceroute-utils';
-import { values } from 'lodash';
 
 export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   constructor(public instanceSettings: DataSourceInstanceSettings<SMOptions>) {
@@ -105,11 +104,11 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
     const allProbes = '.+';
     const isArray = Array.isArray(probe);
 
-    if (!isArray && (!probe || probe === '$__all')) {
+    if (!probe || (!isArray && (!probe || probe === '$__all'))) {
       return allProbes;
     }
     if (isArray && probe.length > 1) {
-      return probe.join('|');
+      return (probe as string[]).join('|');
     } else if (isArray && probe.length === 1) {
       if (!probe[0] || probe[0] === '$__all') {
         return allProbes;

--- a/src/datasource/traceroute-utils.ts
+++ b/src/datasource/traceroute-utils.ts
@@ -143,7 +143,7 @@ export const parseTracerouteLogs = (queryResponse: LogQueryResponse): MutableDat
       return acc;
     }
 
-    const hosts = stream.Hosts === '' ? [`??? TTL${stream.TTL}`] : stream.Hosts?.split(',');
+    const hosts = stream.Hosts === '' ? [`??? TTL${stream.TTL + stream.probe}`] : stream.Hosts?.split(',');
     destinations.add(stream.Destination);
     const updatedStream = {
       ...stream,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -257,7 +257,7 @@ export const queryMetric = async (
     return {
       data: response.data?.data?.result ?? [],
     };
-  } catch (e) {
+  } catch (e: any) {
     return { error: (e.message || e.data?.message) ?? 'Error fetching data', data: [] };
   }
 };


### PR DESCRIPTION
This PR does a few things for the traceroute dashboard:

- Adds a multiselect for probes
- Fixes the initial probe select not updating the node graph
- Make the node layout more useful by making unknown TTL nodes probe specific.
- Breaks out the overall trace timing by probe

Before:

![Screen Shot 2021-09-14 at 3 14 43 PM](https://user-images.githubusercontent.com/8377044/133345859-536fc634-932a-4fe2-a750-6557a48b0ac0.png)

After:
![Screen Shot 2021-09-14 at 3 14 08 PM](https://user-images.githubusercontent.com/8377044/133345832-2ac9f023-a2d3-4b95-97c6-100306af969f.png)
