### PR TITLE
fix: include ptr lookup in traceroute settings

### DIFF
--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -251,7 +251,7 @@ const getTracerouteSettingsFormValues = (settings: Settings): TracerouteSettings
   return {
     firstHop: String(tracerouteSettings.firstHop ?? 1),
     maxHops: String(tracerouteSettings.maxHops),
-    retries: String(tracerouteSettings.retries ?? 0),
+    ptrLookup: tracerouteSettings.ptrLookup,
     maxUnknownHops: String(tracerouteSettings.maxUnknownHops),
   };
 };
@@ -555,7 +555,7 @@ const getTracerouteSettings = (
   return {
     firstHop: parseInt(String(updatedSettings.firstHop), 10),
     maxHops: parseInt(String(updatedSettings.maxHops), 10),
-    retries: 0,
+    ptrLookup: updatedSettings.ptrLookup,
     maxUnknownHops: parseInt(String(updatedSettings.maxUnknownHops), 10),
   };
 };

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -249,7 +249,6 @@ const getTracerouteSettingsFormValues = (settings: Settings): TracerouteSettings
   const tracerouteSettings = settings.traceroute ?? (fallbackSettings(CheckType.Traceroute) as TracerouteSettings);
 
   return {
-    firstHop: String(tracerouteSettings.firstHop ?? 1),
     maxHops: String(tracerouteSettings.maxHops),
     ptrLookup: tracerouteSettings.ptrLookup,
     maxUnknownHops: String(tracerouteSettings.maxUnknownHops),
@@ -553,7 +552,6 @@ const getTracerouteSettings = (
   const fallbackValues = fallbackSettings(CheckType.Traceroute).traceroute as TracerouteSettings;
   const updatedSettings = settings ?? defaultSettings ?? fallbackValues;
   return {
-    firstHop: parseInt(String(updatedSettings.firstHop), 10),
     maxHops: parseInt(String(updatedSettings.maxHops), 10),
     ptrLookup: updatedSettings.ptrLookup,
     maxUnknownHops: parseInt(String(updatedSettings.maxUnknownHops), 10),

--- a/src/components/TracerouteSettingsForm.tsx
+++ b/src/components/TracerouteSettingsForm.tsx
@@ -26,13 +26,6 @@ export const TracerouteSettingsForm = ({ isEditor }: Props) => {
         `}
       >
         <LabelField isEditor={isEditor} />
-        <Field label="First hop" description="Starting TTL value" disabled={!isEditor}>
-          <Input
-            id="traceroute-settings-first-hop"
-            {...register('settings.traceroute.firstHop', { min: 1, max: 63 })}
-            disabled={!isEditor}
-          />
-        </Field>
         <Field label="Max hops" description="Maximum TTL for the trace" disabled={!isEditor}>
           <Input
             id="traceroute-settings-max-hops"

--- a/src/components/TracerouteSettingsForm.tsx
+++ b/src/components/TracerouteSettingsForm.tsx
@@ -4,6 +4,7 @@ import { Field, Input } from '@grafana/ui';
 import { Collapse } from 'components/Collapse';
 import { LabelField } from 'components/LabelField';
 import { useFormContext } from 'react-hook-form';
+import { HorizontalCheckboxField } from './HorizonalCheckboxField';
 
 interface Props {
   isEditor: boolean;
@@ -52,6 +53,13 @@ export const TracerouteSettingsForm = ({ isEditor }: Props) => {
             disabled={!isEditor}
           />
         </Field>
+        <HorizontalCheckboxField
+          id="traceroute-settings-ptr-lookup"
+          label="PTR lookup"
+          name="settings.traceroute.ptrLookup"
+          description="Reverse lookup hostnames from IP addresses"
+          disabled={!isEditor}
+        />
       </div>
     </Collapse>
   );

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -361,7 +361,6 @@ export function fallbackSettings(t: CheckType): Settings {
     case CheckType.Traceroute: {
       return {
         traceroute: {
-          firstHop: 1,
           maxHops: 64,
           maxUnknownHops: 15,
           ptrLookup: true,

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -363,8 +363,8 @@ export function fallbackSettings(t: CheckType): Settings {
         traceroute: {
           firstHop: 1,
           maxHops: 64,
-          retries: 0,
           maxUnknownHops: 15,
+          ptrLookup: true,
         },
       };
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,15 +229,15 @@ export interface HttpSettingsFormValues
 export interface TracerouteSettings {
   firstHop: number;
   maxHops: number;
-  retries: number;
   maxUnknownHops: number;
+  ptrLookup: boolean;
 }
 
 export interface TracerouteSettingsFormValues {
   firstHop: string;
   maxHops: string;
-  retries: string;
   maxUnknownHops: string;
+  ptrLookup: boolean;
 }
 
 export interface PingSettings {

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,14 +227,12 @@ export interface HttpSettingsFormValues
 }
 
 export interface TracerouteSettings {
-  firstHop: number;
   maxHops: number;
   maxUnknownHops: number;
   ptrLookup: boolean;
 }
 
 export interface TracerouteSettingsFormValues {
-  firstHop: string;
   maxHops: string;
   maxUnknownHops: string;
   ptrLookup: boolean;


### PR DESCRIPTION
This PR adds a field for PTR lookup (which attemps a reverse DNS search for each hop's IP address). It also sets that on by default since it's a nicer output than just an IP address. Also generally aligns the configurable settings with what is available in the agent. 

![Screen Shot 2021-11-03 at 1 29 27 PM](https://user-images.githubusercontent.com/8377044/140195503-483f86ec-72f0-44e3-a81c-328924744366.png)


Depends on https://github.com/grafana/synthetic-monitoring-agent/pull/239