### PR TITLE
feat: turn on traceroute

### DIFF
--- a/scripts/custom.ini
+++ b/scripts/custom.ini
@@ -793,7 +793,7 @@ level = debug
 
 [feature_toggles]
 # enable features, separated by spaces
-enable = "traceroute ngalert sm-viz-view homepage"
+enable = "ngalert sm-viz-view homepage"
 
 [date_formats]
 # For information on what formatting patterns that are supported https://momentjs.com/docs/#/displaying/

--- a/src/components/PluginTabs.tsx
+++ b/src/components/PluginTabs.tsx
@@ -186,8 +186,6 @@ export const PluginTabs = ({ query, onNavChanged, path, meta }: AppRootProps<Glo
     }
   };
 
-  console.log(activeTab.id);
-
   return (
     <div>
       {getPage()}

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -19,9 +19,7 @@ import {
   HttpSettings,
   Settings,
   HttpMethod,
-  FeatureName,
 } from 'types';
-import { config } from '@grafana/runtime';
 
 export const DNS_RESPONSE_CODES = enumToStringArray(DnsResponseCodes).map((responseCode) => ({
   label: responseCode,
@@ -122,6 +120,10 @@ export const CHECK_FILTER_OPTIONS = [
     label: 'TCP',
     value: CheckType.TCP,
   },
+  {
+    label: 'Traceroute',
+    value: CheckType.Traceroute,
+  },
 ];
 
 export const CHECK_TYPE_OPTIONS = [
@@ -141,18 +143,11 @@ export const CHECK_TYPE_OPTIONS = [
     label: 'TCP',
     value: CheckType.TCP,
   },
+  {
+    label: 'Traceroute',
+    value: CheckType.Traceroute,
+  },
 ];
-
-if (config.featureToggles[FeatureName.Traceroute]) {
-  CHECK_FILTER_OPTIONS.push({
-    label: 'Traceroute',
-    value: CheckType.Traceroute,
-  });
-  CHECK_TYPE_OPTIONS.push({
-    label: 'Traceroute',
-    value: CheckType.Traceroute,
-  });
-}
 
 export const HTTP_SSL_OPTIONS = [
   {

--- a/src/contexts/FeatureFlagContext.ts
+++ b/src/contexts/FeatureFlagContext.ts
@@ -10,6 +10,10 @@ export interface FeatureFlagContextValue {
 }
 
 export function isFeatureEnabled(name: FeatureName) {
+  // Override traceroute feature flag until we're sure we don't need it anymore
+  if (name === FeatureName.Traceroute) {
+    return true;
+  }
   const featuresParam = urlUtil.getUrlSearchParams()['features'];
   let isEnabledThroughQueryParam = false;
   if (isArray(featuresParam)) {

--- a/src/dashboards/loader.ts
+++ b/src/dashboards/loader.ts
@@ -1,6 +1,5 @@
-import { config, getBackendSrv } from '@grafana/runtime';
+import { getBackendSrv } from '@grafana/runtime';
 import { DashboardInfo, FolderInfo } from 'datasource/types';
-import { FeatureName } from 'types';
 
 export const dashboardPaths = [
   'sm-http.json', // The path
@@ -8,11 +7,8 @@ export const dashboardPaths = [
   'sm-dns.json',
   'sm-tcp.json',
   'sm-summary.json',
+  'sm-traceroute.json',
 ];
-
-if (config.featureToggles[FeatureName.Traceroute]) {
-  dashboardPaths.push('sm-traceroute.json');
-}
 
 async function findSyntheticMonitoringFolder(): Promise<FolderInfo> {
   const backendSrv = getBackendSrv();


### PR DESCRIPTION
Depends on [#374 ](https://github.com/grafana/synthetic-monitoring-agent/pull/239) being deployed to prod (`v0.3.2` of the agent)