### PR TITLE
Gen terraform config

### DIFF
--- a/src/components/AccessToken.tsx
+++ b/src/components/AccessToken.tsx
@@ -1,0 +1,47 @@
+import { Alert, Button, Link, Modal } from '@grafana/ui';
+import { InstanceContext } from 'contexts/InstanceContext';
+import React, { useContext, useState } from 'react';
+import { Clipboard } from 'components/Clipboard';
+
+export const AccessToken = () => {
+  const { instance } = useContext(InstanceContext);
+  const [showModal, setShowModal] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [token, setToken] = useState<string | undefined>();
+
+  const showTokenModal = async () => {
+    try {
+      const token = await instance.api?.createApiToken();
+      setToken(token);
+      setShowModal(true);
+    } catch (e) {
+      const cast = e as Error;
+      setError(cast.message ?? 'There was an error creating a new access token');
+    }
+  };
+  return (
+    <div>
+      <h5>Access tokens</h5>
+      <div>
+        <div>
+          You can use an SM access token to authenticate with the synthetic monitoring api. Check out the{' '}
+          <Link href="https://github.com/grafana/synthetic-monitoring-api-go-client">
+            synthetic monitoring go client
+          </Link>{' '}
+          or the{' '}
+          <Link href="https://registry.terraform.io/providers/grafana/grafana/latest/docs">
+            Grafana Terraform Provider
+          </Link>{' '}
+          to learn more about how to interact with the synthetic monitoring API.
+        </div>
+        <Button onClick={() => showTokenModal()}>Generate access token</Button>
+      </div>
+      <Modal title="Access Token" isOpen={showModal} onDismiss={() => setShowModal(false)}>
+        <>
+          {error && <Alert title={error} />}
+          {token && <Clipboard content={token} />}
+        </>
+      </Modal>
+    </div>
+  );
+};

--- a/src/components/Clipboard/Clipboard.tsx
+++ b/src/components/Clipboard/Clipboard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useStyles } from '@grafana/ui';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { GrafanaTheme } from '@grafana/data';
 import { CopyToClipboard } from './CopyToClipboard';
 
@@ -8,6 +8,8 @@ const getStyles = (theme: GrafanaTheme) => ({
   code: css`
     width: 100%;
     word-break: break-all;
+    overflow-y: scroll;
+    max-height: 100%;
   `,
   container: css`
     display: flex;
@@ -20,13 +22,14 @@ const getStyles = (theme: GrafanaTheme) => ({
 
 interface Props {
   content: string;
+  className?: string;
 }
 
-export function Clipboard({ content }: Props) {
+export function Clipboard({ content, className }: Props) {
   const styles = useStyles(getStyles);
   const [copyClipboard, setCopyclipboard] = useState(false);
   return (
-    <div className={styles.container}>
+    <div className={cx(styles.container, className)}>
       <pre className={styles.code}>{content}</pre>
 
       <CopyToClipboard

--- a/src/components/Clipboard/Clipboard.tsx
+++ b/src/components/Clipboard/Clipboard.tsx
@@ -30,7 +30,9 @@ export function Clipboard({ content, className }: Props) {
   const [copyClipboard, setCopyclipboard] = useState(false);
   return (
     <div className={cx(styles.container, className)}>
-      <pre className={styles.code}>{content}</pre>
+      <pre className={styles.code} data-testid="clipboard-content">
+        {content}
+      </pre>
 
       <CopyToClipboard
         className={styles.button}

--- a/src/components/ProgrammaticManagement.tsx
+++ b/src/components/ProgrammaticManagement.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { TerraformConfig } from 'components/TerraformConfig';
+import { AccessToken } from 'components/AccessToken';
+
+export const ProgrammaticManagement = () => {
+  return (
+    <div>
+      <h3>Programmatic management</h3>
+      <AccessToken />
+      <br />
+      <TerraformConfig />
+    </div>
+  );
+};

--- a/src/components/TenantSetup.tsx
+++ b/src/components/TenantSetup.tsx
@@ -27,6 +27,7 @@ export class TenantSetup extends PureComponent {
         />
         <br />
         <TenantView settings={instance.api.instanceSettings.jsonData} />
+        <br />
       </div>
     );
   }

--- a/src/components/TerraformConfig/TerraformConfig.test.tsx
+++ b/src/components/TerraformConfig/TerraformConfig.test.tsx
@@ -56,6 +56,18 @@ it('displays correct config', async () => {
           settings: { ping: { ip_version: 'V4', dont_fragment: false } },
         },
       },
+      grafana_synthetic_monitoring_probe: {
+        tacos: {
+          labels: {
+            Mr: 'Orange',
+          },
+          latitude: 0,
+          longitude: 0,
+          name: 'tacos',
+          public: false,
+          region: '',
+        },
+      },
     },
   };
   if (!config.textContent) {

--- a/src/components/TerraformConfig/TerraformConfig.test.tsx
+++ b/src/components/TerraformConfig/TerraformConfig.test.tsx
@@ -1,0 +1,65 @@
+import { TerraformConfig } from './TerraformConfig';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { InstanceContext } from 'contexts/InstanceContext';
+import { getInstanceMock } from 'datasource/__mocks__/DataSource';
+import { AppPluginMeta } from '@grafana/data';
+import { GlobalSettings } from 'types';
+
+const renderTerraformConfig = async () => {
+  const api = getInstanceMock();
+  const instance = {
+    api,
+  };
+  const meta = {} as AppPluginMeta<GlobalSettings>;
+  return render(
+    <InstanceContext.Provider value={{ instance, loading: false, meta }}>
+      <TerraformConfig />
+    </InstanceContext.Provider>
+  );
+};
+
+const openConfig = async () => {
+  await renderTerraformConfig();
+  const launchButton = await screen.findByRole('button', { name: 'Generate config' });
+  userEvent.click(launchButton);
+  const modalHeader = await screen.findByRole('heading', { name: 'Terraform config' });
+  expect(modalHeader).toBeInTheDocument();
+};
+
+it('renders without crashing', async () => {
+  await openConfig();
+});
+
+it('displays correct config', async () => {
+  await openConfig();
+  const config = await screen.findByTestId('clipboard-content');
+  const expectedConfig = {
+    terraform: { required_providers: { grafana: { source: 'grafana/grafana' } } },
+    provider: {
+      grafana: {
+        url: '',
+        auth: '<add an api key from grafana.com>',
+        sm_url: 'http://localhost:4030',
+        sm_access_token: '<add an sm access token>',
+      },
+    },
+    resource: {
+      grafana_synthetic_monitoring_check: {
+        a_jobname: {
+          job: 'a jobname',
+          target: 'example.com',
+          enabled: true,
+          probes: [1],
+          labels: {},
+          settings: { ping: { ip_version: 'V4', dont_fragment: false } },
+        },
+      },
+    },
+  };
+  if (!config.textContent) {
+    throw new Error('config has not content');
+  }
+  expect(JSON.parse(config.textContent)).toEqual(expectedConfig);
+});

--- a/src/components/TerraformConfig/TerraformConfig.tsx
+++ b/src/components/TerraformConfig/TerraformConfig.tsx
@@ -41,11 +41,11 @@ export const TerraformConfig = () => {
         return acc;
       }
       const checkConfig = checkToTF(check);
-      const formattedJob = sanitizeName(check.job);
-      if (!acc[formattedJob]) {
-        acc[formattedJob] = checkConfig;
+      const resourceName = sanitizeName(`${check.job}_${check.target}`);
+      if (!acc[resourceName]) {
+        acc[resourceName] = checkConfig;
       } else {
-        throw new Error(`Cannot generate TF config for checks with duplicate job names: ${check.job}`);
+        throw new Error(`Cannot generate TF config for checks with duplicate resource names: ${resourceName}`);
       }
       return acc;
     }, {});

--- a/src/components/TerraformConfig/TerraformConfig.tsx
+++ b/src/components/TerraformConfig/TerraformConfig.tsx
@@ -103,9 +103,8 @@ export const TerraformConfig = () => {
             </Alert>
             <Alert title="Terraform and JSON" severity="info">
               The exported config is using{' '}
-              <Link href="https://www.terraform.io/docs/language/syntax/json.html">Terraform JSON syntax</Link>. Further
-              information on how to use this config can be found{' '}
-              <Link href="https://discuss.hashicorp.com/t/how-to-work-with-json/2345">here</Link>
+              <a href="https://www.terraform.io/docs/language/syntax/json.html">Terraform JSON syntax</a>. You can place
+              this config in a <pre>{'<filename>.tf.json'}</pre> and import as a module.
             </Alert>
             <Clipboard content={JSON.stringify(config, null, 2)} className={styles.clipboard} />
           </>

--- a/src/components/TerraformConfig/TerraformConfig.tsx
+++ b/src/components/TerraformConfig/TerraformConfig.tsx
@@ -1,0 +1,100 @@
+import { Alert, Button, Link, Modal, useStyles2 } from '@grafana/ui';
+import { InstanceContext } from 'contexts/InstanceContext';
+import React, { useContext, useState } from 'react';
+import { Clipboard } from 'components/Clipboard';
+import { checkType } from 'utils';
+import { css } from '@emotion/css';
+import { CheckType } from 'types';
+import { GrafanaTheme2 } from '@grafana/data';
+import { TFCheckConfig, TFConfig } from './terraformTypes';
+import { checkToTF } from './terraformConfigUtils';
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  modal: css`
+    max-height: 100%;
+  `,
+  clipboard: css`
+    max-height: 500px;
+  `,
+  text: css`
+    max-width: 600px;
+  `,
+});
+
+export const TerraformConfig = () => {
+  const { instance } = useContext(InstanceContext);
+  const [showModal, setShowModal] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [config, setConfig] = useState<TFConfig | undefined>();
+  const styles = useStyles2(getStyles);
+
+  const generateTFConfig = async (): Promise<TFConfig> => {
+    const checks = await instance.api?.listChecks();
+    const probes = await instance.api?.listProbes();
+    if (!checks || !probes) {
+      throw new Error("Couldn't generate TF config");
+    }
+    const checksConfig = checks?.reduce<TFCheckConfig>((acc, check) => {
+      const type = checkType(check.settings);
+      if (type === CheckType.Traceroute) {
+        return acc;
+      }
+      const checkConfig = checkToTF(check, probes ?? []);
+      if (!acc[type]) {
+        acc[type] = [checkConfig];
+      } else {
+        acc[type]?.push(checkConfig);
+      }
+      return acc;
+    }, {});
+    return {
+      resource: {
+        grafana_synthetic_monitoring_check: {
+          ...checksConfig,
+        },
+      },
+    };
+  };
+
+  const showConfigModal = async () => {
+    try {
+      const configGen = await generateTFConfig();
+      setConfig(configGen);
+    } catch (e) {
+      const cast = e as Error;
+      setError(cast?.message ?? 'There was an error creating the terraform config');
+    }
+    setShowModal(true);
+  };
+
+  return (
+    <div>
+      <h5>Terraform</h5>
+      <div>You can manage synthetic monitoring checks via Terraform. Export your current checks as config</div>
+      <Button onClick={() => showConfigModal()}>Generate config</Button>
+      <Modal
+        title="Terraform config"
+        isOpen={showModal}
+        onDismiss={() => setShowModal(false)}
+        contentClassName={styles.modal}
+      >
+        {error && <Alert title={error} />}
+        {config && (
+          <>
+            <Alert title="Traceroute checks" severity="warning">
+              Traceroute checks are not yet supported by the Grafana Terraform provider. They have been ignored from the
+              generated config.
+            </Alert>
+            <Alert title="Terraform and JSON" severity="info">
+              The exported config is using{' '}
+              <Link href="https://www.terraform.io/docs/language/syntax/json.html">Terraform JSON syntax</Link>. Further
+              information on how to use this config can be found{' '}
+              <Link href="https://discuss.hashicorp.com/t/how-to-work-with-json/2345">here</Link>
+            </Alert>
+            <Clipboard content={JSON.stringify(config, null, 2)} className={styles.clipboard} />
+          </>
+        )}
+      </Modal>
+    </div>
+  );
+};

--- a/src/components/TerraformConfig/index.ts
+++ b/src/components/TerraformConfig/index.ts
@@ -1,0 +1,1 @@
+export { TerraformConfig } from './TerraformConfig';

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -1,4 +1,4 @@
-import { Check, CheckType, Label, Probe, TLSConfig } from 'types';
+import { Check, CheckType, Label, TLSConfig } from 'types';
 import { checkType } from 'utils';
 import { TFCheck, TFCheckSettings, TFLabels, TFTlsConfig } from './terraformTypes';
 

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -1,0 +1,128 @@
+import { Check, CheckType, Label, Probe, TLSConfig } from 'types';
+import { checkType } from 'utils';
+import { TFCheck, TFCheckSettings, TFLabels, TFTlsConfig } from './terraformTypes';
+
+const checkLabelsToTFLabels = (labels: Label[]): TFLabels =>
+  labels.reduce<TFLabels>((acc, label) => {
+    acc[label.name] = label.value;
+    return acc;
+  }, {});
+
+const tlsConfigToTF = (tlsConfig?: TLSConfig): TFTlsConfig | undefined => {
+  if (!tlsConfig) {
+    return;
+  }
+
+  return {
+    ca_cert: tlsConfig.caCert,
+    client_cert: tlsConfig.clientCert,
+    client_key: tlsConfig.clientKey,
+    insecure_skip_verify: tlsConfig.insecureSkipVerify,
+    server_name: tlsConfig.serverName,
+  };
+};
+
+const settingsToTF = (check: Check): TFCheckSettings => {
+  const type = checkType(check.settings);
+  switch (type) {
+    case CheckType.TCP:
+      if (!check.settings.tcp) {
+        throw new Error('could not translate settings to terraform config');
+      }
+      return {
+        tcp: {
+          ip_version: check.settings.tcp.ipVersion,
+          tls_config: tlsConfigToTF(check.settings.tcp.tlsConfig),
+          tls: check.settings.tcp.tls,
+          query_response: check.settings.tcp.queryResponse,
+        },
+      };
+    case CheckType.PING:
+      if (!check.settings.ping) {
+        throw new Error('could not translate settings to terraform config');
+      }
+      return {
+        ping: {
+          ip_version: check.settings.ping.ipVersion,
+          dont_fragment: check.settings.ping.dontFragment,
+        },
+      };
+    case CheckType.HTTP:
+      if (!check.settings.http) {
+        throw new Error('could not translate settings to terraform config');
+      }
+      return {
+        http: {
+          method: check.settings.http.method,
+          compression: check.settings.http.compression,
+          basic_auth: check.settings.http.basicAuth,
+          bearer_token: check.settings.http.bearerToken,
+          cache_busting_query_param_name: check.settings.http.cacheBustingQueryParamName,
+          fail_if_body_matches_regexp: check.settings.http.failIfBodyMatchesRegexp,
+          fail_if_body_not_matches_regexp: check.settings.http.failIfBodyNotMatchesRegexp,
+          fail_if_header_matches_regexp: check.settings.http.failIfHeaderMatchesRegexp,
+          fail_if_header_not_matches_regexp: check.settings.http.failIfHeaderNotMatchesRegexp,
+          fail_if_not_ssl: check.settings.http.failIfNotSSL,
+          fail_if_ssl: check.settings.http.failIfSSL,
+          ip_version: check.settings.http.ipVersion,
+          no_follow_redirects: check.settings.http.noFollowRedirects,
+          proxy_url: check.settings.http.proxyURL,
+          tls_config: tlsConfigToTF(check.settings.http.tlsConfig),
+          valid_http_versions: check.settings.http.validHTTPVersions,
+          valid_status_codes: check.settings.http.validStatusCodes,
+        },
+      };
+    case CheckType.DNS:
+      if (!check.settings.dns) {
+        throw new Error('could not translate settings to terraform config');
+      }
+      return {
+        dns: {
+          ip_version: check.settings.dns.ipVersion,
+          server: check.settings.dns.server,
+          port: check.settings.dns.port,
+          record_type: check.settings.dns.recordType,
+          protocol: check.settings.dns.protocol,
+          valid_r_codes: check.settings.dns.validRCodes,
+          validate_answer_rrs: {
+            fail_if_matches_regexp: check.settings.dns.validateAnswerRRS?.failIfMatchesRegexp,
+            fail_if_not_matches_regexp: check.settings.dns.validateAnswerRRS?.failIfNotMatchesRegexp,
+          },
+          validate_authority_rrs: {
+            fail_if_matches_regexp: check.settings.dns.validateAuthorityRRS?.failIfMatchesRegexp,
+            fail_if_not_matches_regexp: check.settings.dns.validateAuthorityRRS?.failIfNotMatchesRegexp,
+          },
+          validate_additional_rrs: {
+            fail_if_matches_regexp: check.settings.dns.validateAditionalRRS?.failIfMatchesRegexp,
+            fail_if_not_matches_regexp: check.settings.dns.validateAditionalRRS?.failIfNotMatchesRegexp,
+          },
+        },
+      };
+    default:
+      throw new Error(`could not translate settings for check to terraform config: ${check.job}`);
+  }
+};
+
+const probeIDsToTF = (probeIDs: number[], probes: Probe[]): string[] => {
+  const BASE = 'data.grafana_synthetic_monitoring_probes.main.probes';
+  return probeIDs.reduce<string[]>((acc, probeID) => {
+    const probe = probes.find((probe) => probe.id === probeID);
+    if (probe) {
+      acc.push(`${BASE}.${probe.name}`);
+    }
+    return acc;
+  }, []);
+};
+
+export const checkToTF = (check: Check, probes: Probe[]): TFCheck => {
+  const tfCheck = {
+    job: check.job,
+    target: check.target,
+    enabled: check.enabled,
+    probes: probeIDsToTF(check.probes, probes),
+    labels: checkLabelsToTFLabels(check.labels),
+    settings: settingsToTF(check),
+  };
+
+  return tfCheck;
+};

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -136,7 +136,7 @@ export const sanitizeName = (name: string): string => {
     }
     return char;
   });
-  return sanitized.join('');
+  return sanitized.join('').slice(0, 50);
 };
 
 export const probeToTF = (probe: Probe): TFProbe => ({

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -1,8 +1,8 @@
-import { Check, CheckType, Label, TLSConfig } from 'types';
+import { Check, CheckType, Label, Probe, TLSConfig } from 'types';
 import { checkType } from 'utils';
-import { TFCheck, TFCheckSettings, TFLabels, TFTlsConfig } from './terraformTypes';
+import { TFCheck, TFCheckSettings, TFLabels, TFProbe, TFTlsConfig } from './terraformTypes';
 
-const checkLabelsToTFLabels = (labels: Label[]): TFLabels =>
+const labelsToTFLabels = (labels: Label[]): TFLabels =>
   labels.reduce<TFLabels>((acc, label) => {
     acc[label.name] = label.value;
     return acc;
@@ -121,16 +121,16 @@ export const checkToTF = (check: Check): TFCheck => {
     target: check.target,
     enabled: check.enabled,
     probes: check.probes,
-    labels: checkLabelsToTFLabels(check.labels),
+    labels: labelsToTFLabels(check.labels),
     settings: settingsToTF(check),
   };
 
   return tfCheck;
 };
 
-export const sanitizeJobName = (job: string): string => {
+export const sanitizeName = (name: string): string => {
   const regex = new RegExp(/[^A-Za-z0-9_-]/);
-  const sanitized = job.split('').map((char) => {
+  const sanitized = name.split('').map((char) => {
     if (regex.test(char)) {
       return '_';
     }
@@ -138,3 +138,12 @@ export const sanitizeJobName = (job: string): string => {
   });
   return sanitized.join('');
 };
+
+export const probeToTF = (probe: Probe): TFProbe => ({
+  name: probe.name,
+  latitude: probe.latitude,
+  longitude: probe.longitude,
+  region: probe.region,
+  public: false,
+  labels: labelsToTFLabels(probe.labels),
+});

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -1,11 +1,12 @@
-import { DnsSettings, HttpSettings, BasicAuth, HeaderMatch, TcpSettings, TCPQueryResponse } from 'types';
+import { DnsSettings, HttpSettings, BasicAuth, HeaderMatch, TcpSettings, TCPQueryResponse, Probe } from 'types';
 
 export interface TFConfig {
   provider: any;
   terraform: any;
   // data: any;
   resource: {
-    grafana_synthetic_monitoring_check: TFCheckConfig;
+    grafana_synthetic_monitoring_check?: TFCheckConfig;
+    grafana_synthetic_monitoring_probe?: TFProbeConfig;
   };
 }
 
@@ -111,4 +112,12 @@ export interface TFTlsConfig {
   client_key: string;
   insecure_skip_verify: boolean;
   server_name: string;
+}
+
+export interface TFProbeConfig {
+  [key: string]: TFProbe;
+}
+
+export interface TFProbe extends Omit<Probe, 'online' | 'onlineChange' | 'version' | 'deprecated' | 'labels'> {
+  labels: TFLabels;
 }

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -1,25 +1,23 @@
 import { DnsSettings, HttpSettings, BasicAuth, HeaderMatch, TcpSettings, TCPQueryResponse } from 'types';
 
 export interface TFConfig {
-  // provider: any;
+  provider: any;
+  terraform: any;
+  // data: any;
   resource: {
     grafana_synthetic_monitoring_check: TFCheckConfig;
   };
 }
 
 export interface TFCheckConfig {
-  dns?: TFCheck[];
-  http?: TFCheck[];
-  ping?: TFCheck[];
-  tcp?: TFCheck[];
-  traceroute?: TFCheck[];
+  [key: string]: TFCheck;
 }
 
 export interface TFCheck {
   job: string;
   target: string;
   enabled: boolean;
-  probes: string[];
+  probes: number[];
   labels: TFLabels;
   settings: TFCheckSettings;
 }
@@ -98,7 +96,9 @@ interface TFTcpSettings extends Omit<TcpSettings, 'ipVersion' | 'queryResponse' 
 }
 
 interface TFTracerouteSettings {
-  steve: string;
+  max_hops: number;
+  max_unknown_hops: number;
+  ptr_lookup: boolean;
 }
 
 interface TFHeaderMatch extends Omit<HeaderMatch, 'allowMissing'> {

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -1,0 +1,114 @@
+import { DnsSettings, HttpSettings, BasicAuth, HeaderMatch, TcpSettings, TCPQueryResponse } from 'types';
+
+export interface TFConfig {
+  // provider: any;
+  resource: {
+    grafana_synthetic_monitoring_check: TFCheckConfig;
+  };
+}
+
+export interface TFCheckConfig {
+  dns?: TFCheck[];
+  http?: TFCheck[];
+  ping?: TFCheck[];
+  tcp?: TFCheck[];
+  traceroute?: TFCheck[];
+}
+
+export interface TFCheck {
+  job: string;
+  target: string;
+  enabled: boolean;
+  probes: string[];
+  labels: TFLabels;
+  settings: TFCheckSettings;
+}
+
+export type TFLabels = { [key: string]: string };
+type TFSettings = TFHttpSettings | TFPingSettings | TFTcpSettings | TFDnsSettings | TFTracerouteSettings;
+export type TFCheckSettings = {
+  [key: string]: TFSettings;
+};
+
+interface TFFailIfMatchesNotMatches {
+  fail_if_matches_regexp?: string[];
+  fail_if_not_matches_regexp?: string[];
+}
+
+interface TFDnsSettings
+  extends Omit<
+    DnsSettings,
+    'ipVersion' | 'recordType' | 'validRCodes' | 'validateAnswerRRS' | 'validateAuthorityRRS' | 'validationAditionalRRS'
+  > {
+  ip_version?: string;
+  record_type?: string;
+  valid_r_codes?: string[];
+  validate_answer_rrs: TFFailIfMatchesNotMatches;
+  validate_authority_rrs: TFFailIfMatchesNotMatches;
+  validate_additional_rrs: TFFailIfMatchesNotMatches;
+}
+
+interface TFHttpSettings
+  extends Omit<
+    HttpSettings,
+    | 'ipVersion'
+    | 'validStatusCodes'
+    | 'noFollowRedirects'
+    | 'tlsConfig'
+    | 'proxyURL'
+    | 'bearerToken'
+    | 'basicAuth'
+    | 'failIfSSL'
+    | 'failIfNotSSL'
+    | 'validStatusCodes'
+    | 'validHTTPVersions'
+    | 'failIfBodyMatchesRegexp'
+    | 'failIfBodyNotMatchesRegexp'
+    | 'failIfHeaderMatchesRegexp'
+    | 'failIfHeaderNotMatchesRegexp'
+    | 'cacheBustingQueryParamName'
+  > {
+  basic_auth?: BasicAuth;
+  bearer_token?: string;
+  cache_busting_query_param_name?: string;
+  fail_if_body_matches_regexp?: string[];
+  fail_if_body_not_matches_regexp?: string[];
+  fail_if_header_matches_regexp?: TFHeaderMatch[];
+  fail_if_header_not_matches_regexp?: TFHeaderMatch[];
+  fail_if_not_ssl?: boolean;
+  fail_if_ssl?: boolean;
+  ip_version: string;
+  no_follow_redirects?: boolean;
+  proxy_url?: string;
+  tls_config?: TFTlsConfig;
+  valid_http_versions?: string[];
+  valid_status_codes?: number[];
+}
+
+interface TFPingSettings {
+  ip_version: string;
+  payload_size?: number;
+  dont_fragment: boolean;
+}
+
+interface TFTcpSettings extends Omit<TcpSettings, 'ipVersion' | 'queryResponse' | 'tlsConfig'> {
+  ip_version?: string;
+  query_response?: TCPQueryResponse[];
+  tls_config?: TFTlsConfig;
+}
+
+interface TFTracerouteSettings {
+  steve: string;
+}
+
+interface TFHeaderMatch extends Omit<HeaderMatch, 'allowMissing'> {
+  allow_missing?: string;
+}
+
+export interface TFTlsConfig {
+  ca_cert: string;
+  client_cert: string;
+  client_key: string;
+  insecure_skip_verify: boolean;
+  server_name: string;
+}

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -427,6 +427,18 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       });
   }
 
+  async createApiToken(): Promise<string> {
+    console.log('hello?');
+    return getBackendSrv()
+      .fetch({
+        method: 'POST',
+        url: `${this.instanceSettings.url}/sm/token/create`,
+        data: {},
+      })
+      .toPromise()
+      .then((res: any) => res.data?.token);
+  }
+
   //--------------------------------------------------------------------------------
   // TEST
   //--------------------------------------------------------------------------------

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -428,7 +428,6 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   }
 
   async createApiToken(): Promise<string> {
-    console.log('hello?');
     return getBackendSrv()
       .fetch({
         method: 'POST',

--- a/src/page/ConfigPage.tsx
+++ b/src/page/ConfigPage.tsx
@@ -1,6 +1,7 @@
 import { PluginConfigPageProps, AppPluginMeta } from '@grafana/data';
 import { ConfigActions } from 'components/ConfigActions';
 import { InstanceProvider } from 'components/InstanceProvider';
+import { ProgrammaticManagement } from 'components/ProgrammaticManagement';
 import { TenantSetup } from 'components/TenantSetup';
 import React, { PureComponent } from 'react';
 import { GlobalSettings } from 'types';
@@ -47,6 +48,10 @@ export class ConfigPage extends PureComponent<Props> {
           </div>
           <br />
           <TenantSetup />
+          <br />
+          {plugin.meta.enabled && <ProgrammaticManagement />}
+          <br />
+          <br />
           <br />
           <ConfigActions enabled={plugin.meta.enabled} pluginId={plugin.meta.id} />
         </div>


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-app/issues/375

- Adds a button to generate a new SM access token on the plugin config page
- Adds a button to export current checks and private probes as terraform config in JSON

![terraformconfig](https://user-images.githubusercontent.com/8377044/143934584-b3c5e051-1a64-4ae5-81c7-37bfbbaf724f.gif)
. 