### PR TITLE
Use geomap panel

### DIFF
--- a/src/dashboards/sm-dns.json
+++ b/src/dashboards/sm-dns.json
@@ -1087,7 +1087,7 @@
     "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
   },
   "timezone": "",
-  "title": "Synthetic Monitoring - DNS",
+  "title": "Synthetic Monitoring DNS",
   "uid": "lgL6odgGz",
   "version": 18
 }

--- a/src/dashboards/sm-dns.json
+++ b/src/dashboards/sm-dns.json
@@ -22,14 +22,9 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.5.7"
+      "version": "8.3.3"
     },
-    {
-      "type": "panel",
-      "id": "grafana-worldmap-panel",
-      "name": "Worldmap Panel",
-      "version": "0.3.2"
-    },
+
     {
       "type": "panel",
       "id": "graph",
@@ -82,65 +77,152 @@
   "links": [],
   "panels": [
     {
-      "circleMaxSize": "10",
-      "circleMinSize": "2",
-      "colors": ["#37872D", "#FA6400", "#C4162A"],
-      "datasource": "${DS_SM_METRICS}",
-      "decimals": 2,
-      "description": "What's the error percentage for each probe that is observing the given target.",
-      "esGeoPoint": "geohash",
-      "esLocationName": "probe",
-      "esMetric": "Count",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
+      "id": 34,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 0
       },
-      "hideEmpty": false,
-      "hideZero": false,
-      "id": 34,
-      "initialZoom": 1,
-      "locationData": "table",
-      "mapCenter": "(0°, 0°)",
-      "mapCenterLatitude": 0,
-      "mapCenterLongitude": 0,
-      "maxDataPoints": "",
-      "mouseWheelZoom": false,
-      "showLegend": false,
-      "stickyLabels": false,
-      "tableQueryOptions": {
-        "geohashField": "geohash",
-        "labelField": "probe",
-        "latitudeField": "latitude",
-        "longitudeField": "longitude",
-        "metricField": "Value",
-        "queryType": "geohash"
+      "type": "geomap",
+      "title": "Error rate by probe",
+      "datasource": "${DS_SM_METRICS}",
+      "pluginVersion": "8.3.3",
+      "description": "What's the error percentage for each probe that is observing the given target.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#37872D",
+                "value": null
+              },
+              {
+                "color": "#FA6400",
+                "value": 0.5
+              },
+              {
+                "color": "#C4162A",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "Value #A": {
+                  "text": "Error rate",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Error rate"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "view": {
+          "id": "zero",
+          "lat": 0,
+          "lon": 0,
+          "zoom": 1
+        },
+        "controls": {
+          "showZoom": true,
+          "mouseWheelZoom": false,
+          "showAttribution": true,
+          "showScale": false,
+          "showDebug": false
+        },
+        "basemap": {
+          "name": "Basemap",
+          "type": "default"
+        },
+        "layers": [
+          {
+            "config": {
+              "showLegend": false,
+              "style": {
+                "color": {
+                  "fixed": "dark-green",
+                  "field": "Value #A"
+                },
+                "opacity": 0.4,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "Value #A",
+                  "fixed": 5,
+                  "max": 10,
+                  "min": 4
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 5,
+                  "textAlign": "center",
+                  "textBaseline": "top"
+                },
+                "text": {
+                  "fixed": "",
+                  "mode": "field"
+                }
+              }
+            },
+            "location": {
+              "geohash": "geohash",
+              "latitude": "Value #A",
+              "longitude": "Value #A",
+              "mode": "geohash"
+            },
+            "name": "Layer 1",
+            "type": "markers"
+          }
+        ]
       },
       "targets": [
         {
-          "exemplar": true,
           "expr": "100*(\n  1 - (\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n    /\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n  )\n)",
+          "legendFormat": "",
+          "interval": "",
+          "exemplar": false,
+          "datasource": "${DS_SM_METRICS}",
           "format": "table",
           "instant": true,
-          "interval": "",
-          "legendFormat": "",
           "refId": "A"
         }
       ],
-      "thresholds": "0.5,1",
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Error rate by probe",
-      "type": "grafana-worldmap-panel",
-      "unitPlural": "%",
-      "unitSingle": "",
-      "unitSingular": "%",
-      "valueName": "current"
+      "maxDataPoints": ""
     },
     {
       "cacheTimeout": null,
@@ -1007,5 +1089,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring - DNS",
   "uid": "lgL6odgGz",
-  "version": 17
+  "version": 18
 }

--- a/src/dashboards/sm-http.json
+++ b/src/dashboards/sm-http.json
@@ -22,13 +22,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.5.7"
-    },
-    {
-      "type": "panel",
-      "id": "grafana-worldmap-panel",
-      "name": "Worldmap Panel",
-      "version": "0.3.2"
+      "version": "8.3.3"
     },
     {
       "type": "panel",
@@ -82,65 +76,152 @@
   "links": [],
   "panels": [
     {
-      "circleMaxSize": "10",
-      "circleMinSize": "2",
-      "colors": ["#37872D", "#FA6400", "#C4162A"],
-      "datasource": "${DS_SM_METRICS}",
-      "decimals": 2,
-      "description": "What's the error percentage for each probe that is observing the given target.",
-      "esGeoPoint": "geohash",
-      "esLocationName": "probe",
-      "esMetric": "Count",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
+      "id": 34,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 0
       },
-      "hideEmpty": false,
-      "hideZero": false,
-      "id": 34,
-      "initialZoom": 1,
-      "locationData": "table",
-      "mapCenter": "(0°, 0°)",
-      "mapCenterLatitude": 0,
-      "mapCenterLongitude": 0,
-      "maxDataPoints": "",
-      "mouseWheelZoom": false,
-      "showLegend": false,
-      "stickyLabels": false,
-      "tableQueryOptions": {
-        "geohashField": "geohash",
-        "labelField": "probe",
-        "latitudeField": "latitude",
-        "longitudeField": "longitude",
-        "metricField": "Value",
-        "queryType": "geohash"
+      "type": "geomap",
+      "title": "Error rate by probe",
+      "datasource": "${DS_SM_METRICS}",
+      "pluginVersion": "8.3.3",
+      "description": "What's the error percentage for each probe that is observing the given target.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#37872D",
+                "value": null
+              },
+              {
+                "color": "#FA6400",
+                "value": 0.5
+              },
+              {
+                "color": "#C4162A",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "Value #A": {
+                  "text": "Error rate",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Error rate"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "view": {
+          "id": "zero",
+          "lat": 0,
+          "lon": 0,
+          "zoom": 1
+        },
+        "controls": {
+          "showZoom": true,
+          "mouseWheelZoom": false,
+          "showAttribution": true,
+          "showScale": false,
+          "showDebug": false
+        },
+        "basemap": {
+          "name": "Basemap",
+          "type": "default"
+        },
+        "layers": [
+          {
+            "config": {
+              "showLegend": false,
+              "style": {
+                "color": {
+                  "fixed": "dark-green",
+                  "field": "Value #A"
+                },
+                "opacity": 0.4,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "Value #A",
+                  "fixed": 5,
+                  "max": 10,
+                  "min": 4
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 5,
+                  "textAlign": "center",
+                  "textBaseline": "top"
+                },
+                "text": {
+                  "fixed": "",
+                  "mode": "field"
+                }
+              }
+            },
+            "location": {
+              "geohash": "geohash",
+              "latitude": "Value #A",
+              "longitude": "Value #A",
+              "mode": "geohash"
+            },
+            "name": "Layer 1",
+            "type": "markers"
+          }
+        ]
       },
       "targets": [
         {
-          "exemplar": true,
           "expr": "100*(\n  1 - (\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n    /\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n  )\n)",
+          "legendFormat": "",
+          "interval": "",
+          "exemplar": false,
+          "datasource": "${DS_SM_METRICS}",
           "format": "table",
           "instant": true,
-          "interval": "",
-          "legendFormat": "",
           "refId": "A"
         }
       ],
-      "thresholds": "0.5,1",
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Error rate by probe",
-      "type": "grafana-worldmap-panel",
-      "unitPlural": "%",
-      "unitSingle": "",
-      "unitSingular": "%",
-      "valueName": "current"
+      "maxDataPoints": ""
     },
     {
       "cacheTimeout": null,
@@ -995,5 +1076,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring HTTP",
   "uid": "rq0JrllZz",
-  "version": 29
+  "version": 31
 }

--- a/src/dashboards/sm-ping.json
+++ b/src/dashboards/sm-ping.json
@@ -22,13 +22,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.5.7"
-    },
-    {
-      "type": "panel",
-      "id": "grafana-worldmap-panel",
-      "name": "Worldmap Panel",
-      "version": "0.3.2"
+      "version": "8.3.3"
     },
     {
       "type": "panel",
@@ -82,65 +76,152 @@
   "links": [],
   "panels": [
     {
-      "circleMaxSize": "10",
-      "circleMinSize": "2",
-      "colors": ["#37872D", "#FA6400", "#C4162A"],
-      "datasource": "${DS_SM_METRICS}",
-      "decimals": 2,
-      "description": "What's the error percentage for each probe that is observing the given target.",
-      "esGeoPoint": "geohash",
-      "esLocationName": "probe",
-      "esMetric": "Count",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
+      "id": 34,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 0
       },
-      "hideEmpty": false,
-      "hideZero": false,
-      "id": 27,
-      "initialZoom": 1,
-      "locationData": "table",
-      "mapCenter": "(0°, 0°)",
-      "mapCenterLatitude": 0,
-      "mapCenterLongitude": 0,
-      "maxDataPoints": "",
-      "mouseWheelZoom": false,
-      "showLegend": false,
-      "stickyLabels": false,
-      "tableQueryOptions": {
-        "geohashField": "geohash",
-        "labelField": "probe",
-        "latitudeField": "latitude",
-        "longitudeField": "longitude",
-        "metricField": "Value",
-        "queryType": "geohash"
+      "type": "geomap",
+      "title": "Error rate by probe",
+      "datasource": "${DS_SM_METRICS}",
+      "pluginVersion": "8.3.3",
+      "description": "What's the error percentage for each probe that is observing the given target.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#37872D",
+                "value": null
+              },
+              {
+                "color": "#FA6400",
+                "value": 0.5
+              },
+              {
+                "color": "#C4162A",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "Value #A": {
+                  "text": "Error rate",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Error rate"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "view": {
+          "id": "zero",
+          "lat": 0,
+          "lon": 0,
+          "zoom": 1
+        },
+        "controls": {
+          "showZoom": true,
+          "mouseWheelZoom": false,
+          "showAttribution": true,
+          "showScale": false,
+          "showDebug": false
+        },
+        "basemap": {
+          "name": "Basemap",
+          "type": "default"
+        },
+        "layers": [
+          {
+            "config": {
+              "showLegend": false,
+              "style": {
+                "color": {
+                  "fixed": "dark-green",
+                  "field": "Value #A"
+                },
+                "opacity": 0.4,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "Value #A",
+                  "fixed": 5,
+                  "max": 10,
+                  "min": 4
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 5,
+                  "textAlign": "center",
+                  "textBaseline": "top"
+                },
+                "text": {
+                  "fixed": "",
+                  "mode": "field"
+                }
+              }
+            },
+            "location": {
+              "geohash": "geohash",
+              "latitude": "Value #A",
+              "longitude": "Value #A",
+              "mode": "geohash"
+            },
+            "name": "Layer 1",
+            "type": "markers"
+          }
+        ]
       },
       "targets": [
         {
-          "exemplar": true,
           "expr": "100*(\n  1 - (\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n    /\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n  )\n)",
+          "legendFormat": "",
+          "interval": "",
+          "exemplar": false,
+          "datasource": "${DS_SM_METRICS}",
           "format": "table",
           "instant": true,
-          "interval": "",
-          "legendFormat": "",
           "refId": "A"
         }
       ],
-      "thresholds": "0.5,1",
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Error rate by probe",
-      "type": "grafana-worldmap-panel",
-      "unitPlural": "%",
-      "unitSingle": "",
-      "unitSingular": "%",
-      "valueName": "current"
+      "maxDataPoints": ""
     },
     {
       "cacheTimeout": null,
@@ -919,5 +1000,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring Ping",
   "uid": "EHyn7ueZk",
-  "version": 28
+  "version": 29
 }

--- a/src/dashboards/sm-summary.json
+++ b/src/dashboards/sm-summary.json
@@ -209,7 +209,7 @@
         {
           "datasource": "${DS_SM_METRICS}",
           "exemplar": false,
-          "expr": "100 * (1 - (\n  sum by (probe, geohash)\n (\n (\n rate(probe_all_success_sum[$__range])\n OR\n rate(probe_success_sum[$__range])\n)\n *\n on (instance, job, probe, config_version)\n group_left(geohash)\n max\n by (instance, job, probe, config_version, check_name, geohash)\n (sm_check_info{check_name=\"$check_type\", region=~\".*\"})\n) \n / \n sum by (probe, geohash)\n (\n (\n rate(probe_all_success_count[$__range])\n OR\n rate(probe_success_count[$__range])\n)\n *\n on (instance, job, probe, config_version)\n group_left(geohash)\n max\n by (instance, job, probe, config_version, check_name, geohash)\n (sm_check_info{check_name=\"$check_type\", region=~\".*\"})\n)\n))",
+          "expr": "100 * (1 - (\n  sum by (probe, geohash)\n (\n (\n rate(probe_all_success_sum[$__range])\n OR\n rate(probe_success_sum[$__range])\n)\n *\n on (instance, job, probe, config_version)\n group_left(geohash)\n max\n by (instance, job, probe, config_version, check_name, geohash)\n (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n) \n / \n sum by (probe, geohash)\n (\n (\n rate(probe_all_success_count[$__range])\n OR\n rate(probe_success_count[$__range])\n)\n *\n on (instance, job, probe, config_version)\n group_left(geohash)\n max\n by (instance, job, probe, config_version, check_name, geohash)\n (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})\n)\n))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -284,7 +284,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - (sum((rate(probe_all_success_sum[$__rate_interval]) OR rate(probe_success_sum[$__rate_interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)) / sum((rate(probe_all_success_count[$__rate_interval]) OR rate(probe_success_count[$__rate_interval])) *  on (instance, job, probe, config_version) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version)))",
+          "expr": "1 - (  sum( ( rate(probe_all_success_sum[$__range]) OR rate(probe_success_sum[$__range])) * on (instance, job, probe, config_version) group_left(geohash) max by (instance, job, probe, config_version, check_name, geohash) (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})) /  sum( ( rate(probe_all_success_count[$__range]) OR rate(probe_success_count[$__range])) * on (instance, job, probe, config_version) group_left(geohash) max by (instance, job, probe, config_version, check_name, geohash) (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})))",
           "hide": false,
           "interval": "1m",
           "intervalFactor": 1,

--- a/src/dashboards/sm-summary.json
+++ b/src/dashboards/sm-summary.json
@@ -98,22 +98,22 @@
           },
           "decimals": 2,
           "mappings": [],
-          "max": 100,
+          "max": 1,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "dark-red",
+                "color": "dark-green",
                 "value": null
               },
               {
                 "color": "dark-orange",
-                "value": 99
+                "value": 0.5
               },
               {
-                "color": "dark-green",
-                "value": 99.5
+                "color": "dark-red",
+                "value": 1
               }
             ]
           },
@@ -128,7 +128,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "Reachability"
+                "value": "Error rate"
               }
             ]
           }
@@ -209,7 +209,7 @@
         {
           "datasource": "${DS_SM_METRICS}",
           "exemplar": false,
-          "expr": "100 * (\n  sum by (probe, geohash)\n (\n (\n rate(probe_all_success_sum[$__range])\n OR\n rate(probe_success_sum[$__range])\n)\n *\n on (instance, job, probe, config_version)\n group_left(geohash)\n max\n by (instance, job, probe, config_version, check_name, geohash)\n (sm_check_info{check_name=\"$check_type\", region=~\".*\"})\n) \n / \n sum by (probe, geohash)\n (\n (\n rate(probe_all_success_count[$__range])\n OR\n rate(probe_success_count[$__range])\n)\n *\n on (instance, job, probe, config_version)\n group_left(geohash)\n max\n by (instance, job, probe, config_version, check_name, geohash)\n (sm_check_info{check_name=\"$check_type\", region=~\".*\"})\n)\n)",
+          "expr": "100 * (1 - (\n  sum by (probe, geohash)\n (\n (\n rate(probe_all_success_sum[$__range])\n OR\n rate(probe_success_sum[$__range])\n)\n *\n on (instance, job, probe, config_version)\n group_left(geohash)\n max\n by (instance, job, probe, config_version, check_name, geohash)\n (sm_check_info{check_name=\"$check_type\", region=~\".*\"})\n) \n / \n sum by (probe, geohash)\n (\n (\n rate(probe_all_success_count[$__range])\n OR\n rate(probe_success_count[$__range])\n)\n *\n on (instance, job, probe, config_version)\n group_left(geohash)\n max\n by (instance, job, probe, config_version, check_name, geohash)\n (sm_check_info{check_name=\"$check_type\", region=~\".*\"})\n)\n))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -218,7 +218,7 @@
           "refId": "A"
         }
       ],
-      "title": "$check_type reachability",
+      "title": "$check_type error rate",
       "type": "geomap"
     },
     {

--- a/src/dashboards/sm-summary.json
+++ b/src/dashboards/sm-summary.json
@@ -222,40 +222,90 @@
       "type": "geomap"
     },
     {
-      "aliasColors": {},
-      "bars": true,
-      "dashLength": 10,
-      "dashes": false,
       "datasource": "${DS_SM_METRICS}",
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percentunit"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "% Errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C4162A",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
-      "fill": 10,
-      "fillGradient": 0,
       "gridPos": {
         "h": 4,
         "w": 7,
         "x": 7,
         "y": 1
       },
-      "hiddenSeries": false,
       "id": 8,
       "interval": "",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": false,
-      "linewidth": 0,
       "links": [
         {
           "targetBlank": true,
@@ -264,26 +314,21 @@
         }
       ],
       "maxDataPoints": "100",
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.3.0",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "% Errors",
-          "color": "#C4162A"
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
         }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      },
+      "pluginVersion": "8.3.3",
       "targets": [
         {
+          "datasource": "${DS_SM_METRICS}",
+          "exemplar": true,
           "expr": "1 - (  sum( ( rate(probe_all_success_sum[$__range]) OR rate(probe_success_sum[$__range])) * on (instance, job, probe, config_version) group_left(geohash) max by (instance, job, probe, config_version, check_name, geohash) (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})) /  sum( ( rate(probe_all_success_count[$__range]) OR rate(probe_success_count[$__range])) * on (instance, job, probe, config_version) group_left(geohash) max by (instance, job, probe, config_version, check_name, geohash) (sm_check_info{check_name=\"$check_type\", region=~\"$region\"})))",
           "hide": false,
           "interval": "1m",
@@ -292,47 +337,8 @@
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "$check_type check error percentage",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": null,
-          "format": "percentunit",
-          "label": "",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
       "datasource": "${DS_SM_METRICS}",

--- a/src/dashboards/sm-summary.json
+++ b/src/dashboards/sm-summary.json
@@ -23,13 +23,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "8.3.0"
-    },
-    {
-      "type": "panel",
-      "id": "grafana-worldmap-panel",
-      "name": "Worldmap Panel",
-      "version": "0.3.2"
+      "version": "8.3.3"
     },
     {
       "type": "panel",
@@ -95,47 +89,126 @@
       "type": "row"
     },
     {
-      "circleMaxSize": "10",
-      "circleMinSize": "2",
-      "colors": [
-        "#37872D",
-        "#FA6400",
-        "#C4162A"
-      ],
       "datasource": "${DS_SM_METRICS}",
-      "decimals": 2,
       "description": "",
-      "esGeoPoint": "geohash",
-      "esLocationName": "probe",
-      "esMetric": "Count",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-orange",
+                "value": 99
+              },
+              {
+                "color": "dark-green",
+                "value": 99.5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Reachability"
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 9,
         "w": 7,
         "x": 0,
         "y": 1
       },
-      "hideEmpty": false,
-      "hideZero": false,
       "id": 5,
-      "initialZoom": 1,
-      "locationData": "table",
-      "mapCenter": "(0°, 0°)",
-      "mapCenterLatitude": 0,
-      "mapCenterLongitude": 0,
       "maxDataPoints": "",
-      "mouseWheelZoom": false,
-      "showLegend": false,
-      "stickyLabels": false,
-      "tableQueryOptions": {
-        "geohashField": "geohash",
-        "labelField": "probe",
-        "latitudeField": "latitude",
-        "longitudeField": "longitude",
-        "metricField": "Value",
-        "queryType": "geohash"
+      "options": {
+        "basemap": {
+          "name": "Basemap",
+          "type": "default"
+        },
+        "controls": {
+          "mouseWheelZoom": false,
+          "showAttribution": true,
+          "showDebug": false,
+          "showScale": false,
+          "showZoom": true
+        },
+        "layers": [
+          {
+            "config": {
+              "showLegend": true,
+              "style": {
+                "color": {
+                  "field": "Value #A",
+                  "fixed": "dark-green"
+                },
+                "opacity": 0.4,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "Value #A",
+                  "fixed": 5,
+                  "max": 10,
+                  "min": 4
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 0,
+                  "textAlign": "center",
+                  "textBaseline": "middle"
+                }
+              }
+            },
+            "location": {
+              "geohash": "geohash",
+              "mode": "geohash"
+            },
+            "name": "Layer 1",
+            "type": "markers"
+          }
+        ],
+        "view": {
+          "id": "zero",
+          "lat": 0,
+          "lon": 0,
+          "zoom": 1
+        }
       },
+      "pluginVersion": "8.3.3",
       "targets": [
         {
+          "datasource": "${DS_SM_METRICS}",
+          "exemplar": false,
           "expr": "100*(1 - (sum((rate(probe_all_success_sum[${__range_s}s]) OR rate(probe_success_sum[${__range_s}s])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count[${__range_s}s]) OR rate(probe_success_count[${__range_s}s])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
           "format": "table",
           "hide": false,
@@ -145,15 +218,8 @@
           "refId": "A"
         }
       ],
-      "thresholds": "0.5,1",
-      "timeFrom": null,
-      "timeShift": null,
       "title": "$check_type reachability",
-      "type": "grafana-worldmap-panel",
-      "unitPlural": "%",
-      "unitSingle": "",
-      "unitSingular": "%",
-      "valueName": "current"
+      "type": "geomap"
     },
     {
       "aliasColors": {},
@@ -484,9 +550,7 @@
       "options": {
         "footer": {
           "fields": "",
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "show": false
         },
         "showHeader": true
@@ -670,9 +734,7 @@
   "refresh": false,
   "schemaVersion": 31,
   "style": "dark",
-  "tags": [
-    "synthetic-monitoring"
-  ],
+  "tags": ["synthetic-monitoring"],
   "templating": {
     "list": [
       {
@@ -756,21 +818,11 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": [
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ]
+    "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
   },
   "timezone": "",
   "title": "Synthetic Monitoring Summary",
   "uid": "fU-WBSqWz",
-  "version": 40,
+  "version": 41,
   "weekStart": ""
 }

--- a/src/dashboards/sm-summary.json
+++ b/src/dashboards/sm-summary.json
@@ -209,7 +209,7 @@
         {
           "datasource": "${DS_SM_METRICS}",
           "exemplar": false,
-          "expr": "100*(1 - (sum((rate(probe_all_success_sum[${__range_s}s]) OR rate(probe_success_sum[${__range_s}s])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)/ sum((rate(probe_all_success_count[${__range_s}s]) OR rate(probe_success_count[${__range_s}s])) *  on (instance, job, probe, config_version) group_left(geohash) max(sm_check_info{check_name=\"$check_type\", region=~\"$region\"}) by (instance, job, probe, config_version, geohash)) by (probe, geohash)))",
+          "expr": "100 * (\n  sum by (probe, geohash)\n (\n (\n rate(probe_all_success_sum[$__range])\n OR\n rate(probe_success_sum[$__range])\n)\n *\n on (instance, job, probe, config_version)\n group_left(geohash)\n max\n by (instance, job, probe, config_version, check_name, geohash)\n (sm_check_info{check_name=\"$check_type\", region=~\".*\"})\n) \n / \n sum by (probe, geohash)\n (\n (\n rate(probe_all_success_count[$__range])\n OR\n rate(probe_success_count[$__range])\n)\n *\n on (instance, job, probe, config_version)\n group_left(geohash)\n max\n by (instance, job, probe, config_version, check_name, geohash)\n (sm_check_info{check_name=\"$check_type\", region=~\".*\"})\n)\n)",
           "format": "table",
           "hide": false,
           "instant": true,

--- a/src/dashboards/sm-tcp.json
+++ b/src/dashboards/sm-tcp.json
@@ -22,13 +22,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "7.5.7"
-    },
-    {
-      "type": "panel",
-      "id": "grafana-worldmap-panel",
-      "name": "Worldmap Panel",
-      "version": "0.3.2"
+      "version": "8.3.3"
     },
     {
       "type": "panel",
@@ -82,65 +76,152 @@
   "links": [],
   "panels": [
     {
-      "circleMaxSize": "10",
-      "circleMinSize": "2",
-      "colors": ["#37872D", "#FA6400", "#C4162A"],
-      "datasource": "${DS_SM_METRICS}",
-      "decimals": 2,
-      "description": "What's the error percentage for each probe that is observing the given target.\n\nIf some probes can reach the target and others cannot, that might mean there are network issues between the probe and the target and it's possible that the target's users cannot reach it either.",
-      "esGeoPoint": "geohash",
-      "esLocationName": "probe",
-      "esMetric": "Count",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
+      "id": 34,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 0
       },
-      "hideEmpty": false,
-      "hideZero": false,
-      "id": 27,
-      "initialZoom": 1,
-      "locationData": "table",
-      "mapCenter": "(0°, 0°)",
-      "mapCenterLatitude": 0,
-      "mapCenterLongitude": 0,
-      "maxDataPoints": "",
-      "mouseWheelZoom": false,
-      "showLegend": false,
-      "stickyLabels": false,
-      "tableQueryOptions": {
-        "geohashField": "geohash",
-        "labelField": "probe",
-        "latitudeField": "latitude",
-        "longitudeField": "longitude",
-        "metricField": "Value",
-        "queryType": "geohash"
+      "type": "geomap",
+      "title": "Error rate by probe",
+      "datasource": "${DS_SM_METRICS}",
+      "pluginVersion": "8.3.3",
+      "description": "What's the error percentage for each probe that is observing the given target.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#37872D",
+                "value": null
+              },
+              {
+                "color": "#FA6400",
+                "value": 0.5
+              },
+              {
+                "color": "#C4162A",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "Value #A": {
+                  "text": "Error rate",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #A"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Error rate"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "view": {
+          "id": "zero",
+          "lat": 0,
+          "lon": 0,
+          "zoom": 1
+        },
+        "controls": {
+          "showZoom": true,
+          "mouseWheelZoom": false,
+          "showAttribution": true,
+          "showScale": false,
+          "showDebug": false
+        },
+        "basemap": {
+          "name": "Basemap",
+          "type": "default"
+        },
+        "layers": [
+          {
+            "config": {
+              "showLegend": false,
+              "style": {
+                "color": {
+                  "fixed": "dark-green",
+                  "field": "Value #A"
+                },
+                "opacity": 0.4,
+                "rotation": {
+                  "fixed": 0,
+                  "max": 360,
+                  "min": -360,
+                  "mode": "mod"
+                },
+                "size": {
+                  "field": "Value #A",
+                  "fixed": 5,
+                  "max": 10,
+                  "min": 4
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 5,
+                  "textAlign": "center",
+                  "textBaseline": "top"
+                },
+                "text": {
+                  "fixed": "",
+                  "mode": "field"
+                }
+              }
+            },
+            "location": {
+              "geohash": "geohash",
+              "latitude": "Value #A",
+              "longitude": "Value #A",
+              "mode": "geohash"
+            },
+            "name": "Layer 1",
+            "type": "markers"
+          }
+        ]
       },
       "targets": [
         {
-          "exemplar": true,
           "expr": "100*(\n  1 - (\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_sum{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n    /\n    sum by (probe, geohash)\n    (\n      (\n        rate(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n        OR\n        rate(probe_success_count{instance=\"$instance\", job=\"$job\"}[$__range])\n      )\n      *\n      on (instance, job, probe, config_version)\n      group_left(geohash)\n      max by (instance, job, probe, config_version, geohash)\n      (\n        sm_check_info{instance=\"$instance\", job=\"$job\"}\n      )\n    )\n  )\n)",
+          "legendFormat": "",
+          "interval": "",
+          "exemplar": false,
+          "datasource": "${DS_SM_METRICS}",
           "format": "table",
           "instant": true,
-          "interval": "",
-          "legendFormat": "",
           "refId": "A"
         }
       ],
-      "thresholds": "0.5,1",
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Error rate by probe",
-      "type": "grafana-worldmap-panel",
-      "unitPlural": "%",
-      "unitSingle": "",
-      "unitSingular": "%",
-      "valueName": "current"
+      "maxDataPoints": ""
     },
     {
       "cacheTimeout": null,
@@ -874,5 +955,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring TCP",
   "uid": "mh84e5mMk",
-  "version": 19
+  "version": 20
 }

--- a/src/datasource/__mocks__/DataSource.ts
+++ b/src/datasource/__mocks__/DataSource.ts
@@ -64,7 +64,7 @@ export const instanceSettings: DataSourceInstanceSettings<SMOptions> = {
       {
         json: 'sm-dns.json',
         latestVersion: 9,
-        title: 'Synthetic Monitoring - DNS',
+        title: 'Synthetic Monitoring DNS',
         uid: 'lgL6odgGz',
         version: 9,
       },

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -81,15 +81,7 @@
   ],
 
   "dependencies": {
-    "grafanaDependency": ">=8.3.2",
-    "grafanaVersion": "8.3",
-    "plugins": [
-      {
-        "type": "panel",
-        "name": "Worldmap Panel",
-        "id": "grafana-worldmap-panel",
-        "version": "^0.3.2"
-      }
-    ]
+    "grafanaDependency": ">=8.3.3",
+    "grafanaVersion": "8.3"
   }
 }


### PR DESCRIPTION
This PR 
- removes the dependency on worldmap panel and uses the built in Geomap panel. 
- updates the error percentage chart on the summary dashboard to use the new timeseries panel
- Fixes the Y axis of the error percentage chart (otherwise they all look identical even if they have largely differing values)
- Changes the summary map panel to represent error rate instead of reachability (this keeps things consistent with the other dashboards, and makes problems more obvious)
- Changes the name of the DNS dashboard so it's consistent with the other dashboards