### PR TITLE
chore: include worldmap panel dependency

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -82,6 +82,14 @@
 
   "dependencies": {
     "grafanaDependency": ">=8.3.3",
-    "grafanaVersion": "8.3"
+    "grafanaVersion": "8.3",
+    "plugins": [
+      {
+        "type": "panel",
+        "name": "Worldmap Panel",
+        "id": "grafana-worldmap-panel",
+        "version": "^0.3.2"
+      }
+    ]
   }
 }


### PR DESCRIPTION
keep worldmap dependency around till folks have updated the old dashboards that are using worldmap