### PR TITLE
fix: [cr] check class correctly in CheckList

### DIFF
--- a/src/components/CheckListItem/CheckListItem.tsx
+++ b/src/components/CheckListItem/CheckListItem.tsx
@@ -162,7 +162,7 @@ export const CheckListItem = ({
         <div className={styles.listCardWrapper}>
           <div className={styles.checkbox}>
             <Checkbox
-              label="Select check"
+              aria-label="Select check"
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 e.stopPropagation();
                 onToggleCheckbox(check.id);
@@ -206,6 +206,7 @@ export const CheckListItem = ({
       <div className={styles.cardWrapper} data-testid="check-card">
         <div className={styles.checkbox}>
           <Checkbox
+            aria-label="Select check"
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
               e.stopPropagation();
               onToggleCheckbox(check.id);

--- a/src/hooks/useUsageCalc.test.tsx
+++ b/src/hooks/useUsageCalc.test.tsx
@@ -77,9 +77,9 @@ describe('http usage', () => {
     });
     expect(withSSL.current).toStrictEqual({
       checksPerMonth: 262800,
-      activeSeries: 122,
+      activeSeries: 118,
       logsGbPerMonth: 0.21,
-      dpm: 732,
+      dpm: 708,
     });
   });
 
@@ -142,9 +142,9 @@ describe('http usage', () => {
     });
     expect(withSSL.current).toStrictEqual({
       checksPerMonth: 262800,
-      activeSeries: 38,
+      activeSeries: 34,
       logsGbPerMonth: 0.21,
-      dpm: 228,
+      dpm: 204,
     });
   });
 });
@@ -212,9 +212,9 @@ describe('tcp usage', () => {
     });
     expect(withSSL.current).toStrictEqual({
       checksPerMonth: 262800,
-      activeSeries: 41,
+      activeSeries: 37,
       logsGbPerMonth: 0.21,
-      dpm: 246,
+      dpm: 222,
     });
   });
 
@@ -246,9 +246,9 @@ describe('tcp usage', () => {
     });
     expect(withSSL.current).toStrictEqual({
       checksPerMonth: 262800,
-      activeSeries: 27,
+      activeSeries: 23,
       logsGbPerMonth: 0.21,
-      dpm: 162,
+      dpm: 138,
     });
   });
 });

--- a/src/hooks/useUsageCalc.ts
+++ b/src/hooks/useUsageCalc.ts
@@ -7,13 +7,13 @@ import { checkType as getCheckType } from 'utils';
 
 const addSSL = (check: Partial<Check>, baseClass: CheckType) => {
   if (baseClass === CheckType.HTTP) {
-    if (check.settings?.http?.tlsConfig) {
+    if (check.settings?.http?.tlsConfig && Object.keys(check.settings.http.tlsConfig).length > 0) {
       return `${baseClass}_ssl`;
     }
   }
 
   if (baseClass === CheckType.TCP) {
-    if (check.settings?.tcp?.tlsConfig) {
+    if (check.settings?.tcp?.tlsConfig && Object.keys(check.settings.tcp.tlsConfig).length > 0) {
       return `${baseClass}_ssl`;
     }
   }


### PR DESCRIPTION
Partially fixes https://github.com/grafana/synthetic-monitoring-app/issues/407

CheckList was calculating all checks as `<check_type>_ssl`, since (I think) the API is returning an empty set of TLS settings for every non-TLS check. This PR makes sure that there are actually settings present inside the check, and both calculations are the same if it is non-tls.

There is however another issue that during new/edit a check, we aren't watching TLS settings in our calculations. This will take a bit more refactoring so I figured a follow-up PR would be best for that.

