### PR TITLE
chore: rework logic to extrac values from alert rules

### DIFF
--- a/src/components/alertingTransformations.ts
+++ b/src/components/alertingTransformations.ts
@@ -1,5 +1,5 @@
-import { AlertFormValues, AlertRule, Label } from 'types';
-import { ALERT_PROBE_SUCCESS_RECORDING_METRIC } from 'components/constants';
+import { AlertDescription, AlertFormValues, AlertRule, AlertSensitivity, Label } from 'types';
+import { ALERT_PROBE_SUCCESS_RECORDING_METRIC, ALERT_RULE_EXPR_REGEX } from 'components/constants';
 
 type PromLabel = { [key: string]: string };
 
@@ -20,4 +20,30 @@ export const transformAlertFormValues = (alertValues: AlertFormValues | undefine
     labels: labelToProm(alertValues?.labels),
     annotations: labelToProm(alertValues?.annotations),
   };
+};
+
+const isAlertSensitivity = (value: string): AlertSensitivity | undefined => {
+  return ((Object.values(AlertSensitivity) as unknown) as string[]).includes(value)
+    ? ((value as unknown) as AlertSensitivity)
+    : undefined;
+};
+
+export const alertDescriptionFromRule = (rule: AlertRule): AlertDescription | undefined => {
+  const result = ALERT_RULE_EXPR_REGEX.exec(rule.expr);
+  if (!result) {
+    return undefined;
+  }
+
+  const sensitivity = isAlertSensitivity(result?.groups?.sensitivity ?? '');
+  if (!sensitivity) {
+    return undefined;
+  }
+
+  const desc: AlertDescription = {
+    metric: result?.groups?.metric ?? '',
+    sensitivity: sensitivity,
+    operator: result?.groups?.operator ?? '',
+    threshold: Number(result?.groups?.threshold),
+  };
+  return desc;
 };

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -250,6 +250,8 @@ export const DEFAULT_ALERT_NAMES_BY_FAMILY_AND_SENSITIVITY = {
   },
 };
 
+export const ALERT_RULE_EXPR_REGEX = /^(?<metric>[A-Za-z0-9:_]+)\{alert_sensitivity="(?<sensitivity>[^"]+)"\}(?:\s*\*\s*\d+)?\s*(?<operator><|<=|==|>|>=)\s*(?<threshold>[+-]?\d+(?:\.\d+)?)$/;
+
 export const ALERT_PROBE_SUCCESS_RECORDING_METRIC = 'instance_job_severity:probe_success:mean5m';
 
 export const ALERT_PROBE_SUCCESS_RECORDING_EXPR = `(sum without(probe, config_version) (rate(probe_all_success_sum[5m]) *

--- a/src/types.ts
+++ b/src/types.ts
@@ -460,6 +460,13 @@ export type AlertRule = {
   record?: string;
 };
 
+export type AlertDescription = {
+  metric: string;
+  sensitivity: AlertSensitivity;
+  operator: string;
+  threshold: number;
+};
+
 export enum CheckSort {
   AToZ,
   ZToA,


### PR DESCRIPTION
This is trying to make the extraction logic more generic, so that it
works with other alerts similar to the existing ones, but not exactly
like them.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>