### PR TITLE
feat: [cr] refactor of filtering UX, updates tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# [1.9.9](https://github.com/grafana/synthetic-monitoring-app/compare/v1.9.8...v1.9.9) (2022-2-04)
+
+## Features
+
+- Rearranged checklist filters under a central dropdown
+
 # [1.9.8](https://github.com/grafana/synthetic-monitoring-app/compare/v1.9.7...v1.9.8) (2022-2-01)
 
 # [1.9.7](https://github.com/grafana/synthetic-monitoring-app/compare/v1.9.6...v1.9.7) (2022-1-25)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetic-monitoring-app",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "Grafana Synthetic Monitoring App",
   "scripts": {
     "lint": "eslint --cache --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx .",

--- a/src/components/CheckList/CheckFilterGroup.tsx
+++ b/src/components/CheckList/CheckFilterGroup.tsx
@@ -1,0 +1,94 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { Button, Icon, useStyles } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme } from '@grafana/data';
+import { defaultFilters, CheckFilters } from './CheckList';
+
+const groupStyles = (theme: GrafanaTheme) => ({
+  container: css`
+    position: relative;
+  `,
+  dropdown: css`
+    position: absolute;
+    background-color: rgb(24, 27, 31);
+    border: 1px solid rgba(204, 204, 220, 0.15);
+    border-radius: 2px;
+    z-index: 100;
+    padding: 20px;
+    margin-top: 5px;
+    -webkit-box-shadow: 5px 5px 14px -3px rgba(0, 0, 0, 0.67);
+    box-shadow: 5px 5px 14px -3px rgba(0, 0, 0, 0.67);
+    right: 8px;
+    width: 500px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  `,
+  horizontalGroup: css`
+    margin-top: 20px;
+    margin-bottom: 0px;
+    display: flex;
+    justify-content: flex-end;
+    align-self: flex-end;
+  `,
+  marginRightSmall: css`
+    margin-right: ${theme.spacing.sm};
+  `,
+});
+
+interface Props {
+  children: JSX.Element[] | JSX.Element;
+  onReset: () => void;
+  filters: CheckFilters;
+}
+
+const CheckFilterGroup = ({ children, onReset, filters }: Props) => {
+  const [openFilters, setOpenFilters] = useState(false);
+  const [activeFilters, setActiveFilters] = useState(0);
+  const styles = useStyles(groupStyles);
+
+  const handleFilterOpen = useCallback(() => {
+    setOpenFilters(!openFilters);
+  }, [openFilters]);
+
+  useEffect(() => {
+    let active = 0;
+    // Count which filters have been applied
+    Object.keys(filters).map((key) => {
+      if (key !== 'search' && filters[key] !== defaultFilters[key]) {
+        active += 1;
+      }
+    });
+    setActiveFilters(active);
+  }, [filters]);
+
+  return (
+    <div className={styles.container}>
+      <Button
+        className={styles.marginRightSmall}
+        variant={activeFilters > 0 ? 'primary' : 'secondary'}
+        fill="outline"
+        onClick={handleFilterOpen}
+      >
+        Additional Filters {activeFilters > 0 ? `(${activeFilters} active)` : ''}{' '}
+        <Icon name={openFilters ? 'angle-up' : 'angle-down'} size="lg" />
+      </Button>
+      {openFilters && (
+        <div className={styles.dropdown}>
+          {children}
+          <div className={styles.horizontalGroup}>
+            <Button variant="secondary" fill="text" onClick={onReset}>
+              Reset
+            </Button>
+            <Button style={{ marginLeft: '10px' }} fill="text" variant="primary" onClick={() => setOpenFilters(false)}>
+              Close
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CheckFilterGroup;

--- a/src/components/CheckList/CheckFilterGroup.tsx
+++ b/src/components/CheckList/CheckFilterGroup.tsx
@@ -56,6 +56,7 @@ const CheckFilterGroup = ({ children, onReset, filters }: Props) => {
     let active = 0;
     // Count which filters have been applied
     Object.keys(filters).map((key) => {
+      // Search filter is handled separately
       if (key !== 'search' && filters[key] !== defaultFilters[key]) {
         active += 1;
       }

--- a/src/components/CheckList/CheckFilterGroup.tsx
+++ b/src/components/CheckList/CheckFilterGroup.tsx
@@ -55,7 +55,7 @@ const CheckFilterGroup = ({ children, onReset, filters }: Props) => {
   useEffect(() => {
     let active = 0;
     // Count which filters have been applied
-    Object.keys(filters).map((key) => {
+    Object.keys(filters).forEach((key) => {
       // Search filter is handled separately
       if (key !== 'search' && filters[key] !== defaultFilters[key]) {
         active += 1;

--- a/src/components/CheckList/CheckList.test.tsx
+++ b/src/components/CheckList/CheckList.test.tsx
@@ -214,7 +214,7 @@ test('search matches label name', async () => {
 
 test('clicking label value adds to label filter', async () => {
   renderCheckList();
-  const additionalFilters = await screen.findByText('Additional Filters');
+  const additionalFilters = await screen.findByRole('button', { name: 'Additional Filters', exact: false });
   userEvent.click(additionalFilters);
   const labelValue = await screen.findAllByText('agreat: label');
   act(() => {
@@ -228,7 +228,7 @@ test('clicking label value adds to label filter', async () => {
 
 test('filters by check type', async () => {
   renderCheckList();
-  const additionalFilters = await screen.findByText('Additional Filters');
+  const additionalFilters = await screen.findByRole('button', { name: 'Additional Filters', exact: false });
   userEvent.click(additionalFilters);
   const typeFilter = await screen.findByTestId('check-type-filter');
   userEvent.selectOptions(typeFilter, 'http');
@@ -238,7 +238,7 @@ test('filters by check type', async () => {
 
 test('filters by probe', async () => {
   renderCheckList();
-  const additionalFilters = await screen.findByText('Additional Filters');
+  const additionalFilters = await screen.findByRole('button', { name: 'Additional Filters', exact: false });
   userEvent.click(additionalFilters);
   const probeFilter = await screen.findByTestId('probe-filter');
   userEvent.selectOptions(probeFilter, 'Chicago');
@@ -248,7 +248,7 @@ test('filters by probe', async () => {
 
 test('clicking type chiclet adds it to filter', async () => {
   renderCheckList();
-  const additionalFilters = await screen.findByText('Additional Filters');
+  const additionalFilters = await screen.findByRole('button', { name: 'Additional Filters', exact: false });
   userEvent.click(additionalFilters);
   const httpTypeChiclet = await screen.findAllByText('HTTP');
   userEvent.click(httpTypeChiclet[1]);
@@ -260,7 +260,7 @@ test('clicking type chiclet adds it to filter', async () => {
 
 test('clicking status chiclet adds it to filter', async () => {
   renderCheckList();
-  const additionalFilters = await screen.findByText('Additional Filters');
+  const additionalFilters = await screen.findByRole('button', { name: 'Additional Filters', exact: false });
   userEvent.click(additionalFilters);
   const disabledChiclet = await screen.findAllByText('Disabled');
   userEvent.click(disabledChiclet[1]);
@@ -376,7 +376,7 @@ test('select all performs enable action on all visible checks', async () => {
 
 test('cascader adds labels to label filter', async () => {
   renderCheckList();
-  const additionalFilters = await screen.findByText('Additional Filters');
+  const additionalFilters = await screen.findByRole('button', { name: 'Additional Filters', exact: false });
   userEvent.click(additionalFilters);
   const cascader = await screen.findByRole('button', { name: 'Labels' });
   userEvent.click(cascader);

--- a/src/components/CheckList/CheckList.test.tsx
+++ b/src/components/CheckList/CheckList.test.tsx
@@ -214,6 +214,8 @@ test('search matches label name', async () => {
 
 test('clicking label value adds to label filter', async () => {
   renderCheckList();
+  const additionalFilters = await screen.findByText('Additional Filters');
+  userEvent.click(additionalFilters);
   const labelValue = await screen.findAllByText('agreat: label');
   act(() => {
     userEvent.click(labelValue[1]);
@@ -226,6 +228,8 @@ test('clicking label value adds to label filter', async () => {
 
 test('filters by check type', async () => {
   renderCheckList();
+  const additionalFilters = await screen.findByText('Additional Filters');
+  userEvent.click(additionalFilters);
   const typeFilter = await screen.findByTestId('check-type-filter');
   userEvent.selectOptions(typeFilter, 'http');
   const checks = await screen.findAllByTestId('check-card');
@@ -234,6 +238,8 @@ test('filters by check type', async () => {
 
 test('filters by probe', async () => {
   renderCheckList();
+  const additionalFilters = await screen.findByText('Additional Filters');
+  userEvent.click(additionalFilters);
   const probeFilter = await screen.findByTestId('probe-filter');
   userEvent.selectOptions(probeFilter, 'Chicago');
   const checks = await screen.findAllByTestId('check-card');
@@ -242,6 +248,8 @@ test('filters by probe', async () => {
 
 test('clicking type chiclet adds it to filter', async () => {
   renderCheckList();
+  const additionalFilters = await screen.findByText('Additional Filters');
+  userEvent.click(additionalFilters);
   const httpTypeChiclet = await screen.findAllByText('HTTP');
   userEvent.click(httpTypeChiclet[1]);
   const typeFilter = await screen.findByTestId('check-type-filter');
@@ -252,6 +260,8 @@ test('clicking type chiclet adds it to filter', async () => {
 
 test('clicking status chiclet adds it to filter', async () => {
   renderCheckList();
+  const additionalFilters = await screen.findByText('Additional Filters');
+  userEvent.click(additionalFilters);
   const disabledChiclet = await screen.findAllByText('Disabled');
   userEvent.click(disabledChiclet[1]);
   const statusFilter = await screen.findByTestId('check-status-filter');
@@ -366,6 +376,8 @@ test('select all performs enable action on all visible checks', async () => {
 
 test('cascader adds labels to label filter', async () => {
   renderCheckList();
+  const additionalFilters = await screen.findByText('Additional Filters');
+  userEvent.click(additionalFilters);
   const cascader = await screen.findByRole('button', { name: 'Labels' });
   userEvent.click(cascader);
   const labelMenuItems = await screen.findAllByRole('menuitem');

--- a/src/components/CheckList/EmptyCheckList.tsx
+++ b/src/components/CheckList/EmptyCheckList.tsx
@@ -1,0 +1,25 @@
+import { Alert } from '@grafana/ui';
+import { useNavigation } from 'hooks/useNavigation';
+import React from 'react';
+import { ROUTES } from 'types';
+
+const EmptyCheckList = () => {
+  const navigate = useNavigation();
+
+  return (
+    <Alert
+      severity="info"
+      title="Grafana Cloud Synthetic Monitoring"
+      buttonContent={<span>New Check</span>}
+      onRemove={(event: React.MouseEvent) => navigate(ROUTES.NewCheck)}
+    >
+      This account does not currently have any checks configured. Click the New Check button to start monitoring your
+      services with Grafana Cloud, or{' '}
+      <a href="https://grafana.com/docs/grafana-cloud/synthetic-monitoring/">
+        check out the Synthetic Monitoring docs.
+      </a>
+    </Alert>
+  );
+};
+
+export default EmptyCheckList;


### PR DESCRIPTION
![Screen Shot 2022-02-03 at 9 37 34 AM](https://user-images.githubusercontent.com/7724615/152375346-b2498688-9b1d-4933-9ab8-c33ea18e719a.png)
![Screen Shot 2022-02-03 at 9 38 28 AM](https://user-images.githubusercontent.com/7724615/152375416-6bdbc7e9-e3ac-40f8-92b9-d60a43d5b4bc.png)
![Screen Shot 2022-02-03 at 9 38 38 AM](https://user-images.githubusercontent.com/7724615/152375449-4654bfd8-42d9-4bfd-ab3e-e5c1462e7cf3.png)

Re-arranged filters under a central dropdown, with some state to show when active/inactive. Also cut down on vertical rows after talking with Teddy about it.

Also changed the empty check list alert to use `<Alert />` since `<InfoBox />` is marked as deprecated.