### PR TITLE
fix: try and use UIDs for datasources if they are available

### DIFF
--- a/src/components/TenantView/LinkedDatasourceView.tsx
+++ b/src/components/TenantView/LinkedDatasourceView.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import { LinkedDatsourceInfo } from 'datasource/types';
-import { config } from '@grafana/runtime';
+import { LinkedDatasourceInfo } from 'datasource/types';
 import { Spinner } from '@grafana/ui';
 import { useNavigation } from 'hooks/useNavigation';
 import { ROUTES } from 'types';
+import { findLinkedDatasource } from 'utils';
 
 interface Props {
-  info: LinkedDatsourceInfo;
+  info: LinkedDatasourceInfo;
 }
 
 const LinkedDatasourceView = ({ info }: Props) => {
   const navigate = useNavigation();
-  const datasource = config.datasources[info.grafanaName];
+  const datasource = findLinkedDatasource(info);
 
+  console.log({ datasource, info });
   const handleClick = () => {
     if (datasource?.type === 'synthetic-monitoring-datasource') {
       navigate(ROUTES.Home);

--- a/src/components/TenantView/LinkedDatasourceView.tsx
+++ b/src/components/TenantView/LinkedDatasourceView.tsx
@@ -13,7 +13,6 @@ const LinkedDatasourceView = ({ info }: Props) => {
   const navigate = useNavigation();
   const datasource = findLinkedDatasource(info);
 
-  console.log({ datasource, info });
   const handleClick = () => {
     if (datasource?.type === 'synthetic-monitoring-datasource') {
       navigate(ROUTES.Home);

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -12,9 +12,9 @@ import {
 
 import { SMQuery, SMOptions, QueryType, CheckInfo, DashboardVariable } from './types';
 
-import { config, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
+import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { Probe, Check, RegistrationInfo, HostedInstance } from '../types';
-import { queryLogs } from 'utils';
+import { findLinkedDatasource, queryLogs } from 'utils';
 import { parseTracerouteLogs } from './traceroute-utils';
 
 export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
@@ -23,11 +23,11 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   }
 
   getMetricsDS() {
-    return config.datasources[this.instanceSettings.jsonData.metrics.grafanaName];
+    return findLinkedDatasource(this.instanceSettings.jsonData.metrics);
   }
 
   getLogsDS() {
-    return config.datasources[this.instanceSettings.jsonData.logs.grafanaName];
+    return findLinkedDatasource(this.instanceSettings.jsonData.logs);
   }
 
   async query(options: DataQueryRequest<SMQuery>): Promise<DataQueryResponse> {
@@ -56,7 +56,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
 
         data.push(copy);
       } else if (query.queryType === QueryType.Traceroute) {
-        const logsUrl = this.getLogsDS().url;
+        const logsUrl = this.getLogsDS()?.url;
         if (!logsUrl) {
           return {
             data: [],

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -18,9 +18,10 @@ export const defaultQuery: SMQuery = {
   queryType: QueryType.Probes,
 } as SMQuery;
 
-export interface LinkedDatsourceInfo {
+export interface LinkedDatasourceInfo {
   grafanaName: string;
   hostedId: number;
+  uid?: string;
 }
 
 export interface DashboardInfo {
@@ -42,9 +43,9 @@ export interface FolderInfo {
  */
 export interface SMOptions extends DataSourceJsonData {
   apiHost: string;
-  metrics: LinkedDatsourceInfo;
+  metrics: LinkedDatasourceInfo;
   initialized?: boolean;
-  logs: LinkedDatsourceInfo;
+  logs: LinkedDatasourceInfo;
   dashboards: DashboardInfo[];
 }
 

--- a/src/initialization-utils.ts
+++ b/src/initialization-utils.ts
@@ -112,7 +112,11 @@ export const getOrCreateMetricAndLokiDatasources = async ({
     (await createDatasource(hostedLogs, adminApiToken, smDatasource.id));
 
   // add linked datasource info to sm datasource
-  const dashboards = await importAllDashboards(metricsDatasource.name, logsDatasource.name, smDatasource.name);
+  const dashboards = await importAllDashboards(
+    metricsDatasource.uid ?? metricsDatasource.name,
+    logsDatasource.uid ?? logsDatasource.name,
+    smDatasource.name
+  );
   await getBackendSrv().request({
     url: `api/datasources/${smDatasource.id}`,
     method: 'PUT',
@@ -127,10 +131,12 @@ export const getOrCreateMetricAndLokiDatasources = async ({
         ...smDatasource.jsonData,
         logs: {
           grafanaName: logsDatasource.name,
+          uid: logsDatasource.uid,
           hostedId: hostedLogs.id,
         },
         metrics: {
           grafanaName: metricsDatasource.name,
+          uid: metricsDatasource.uid,
           hostedId: hostedMetrics.id,
         },
         dashboards,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,12 @@
 import { DataSourceSettings, SelectableValue } from '@grafana/data';
-import { LinkedDatsourceInfo } from './datasource/types';
+import { LinkedDatasourceInfo } from './datasource/types';
 import { SMDataSource } from 'datasource/DataSource';
 
 export interface GlobalSettings {
   apiHost: string;
   stackId?: number;
-  metrics: LinkedDatsourceInfo;
-  logs: LinkedDatsourceInfo;
+  metrics: LinkedDatasourceInfo;
+  logs: LinkedDatasourceInfo;
 }
 
 export enum IpVersion {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { DataSourceInstanceSettings } from '@grafana/data';
 
-import { SMOptions, DashboardInfo, LinkedDatsourceInfo, LogQueryResponse } from './datasource/types';
+import { SMOptions, DashboardInfo, LinkedDatasourceInfo, LogQueryResponse } from './datasource/types';
 
 import { config, getBackendSrv } from '@grafana/runtime';
 import { HostedInstance, User, OrgRole, CheckType, Settings, SubmissionErrorWrapper } from 'types';
@@ -16,6 +16,16 @@ export function findSMDataSources(): Array<DataSourceInstanceSettings<SMOptions>
   return Object.values(config.datasources).filter((ds) => {
     return ds.type === 'synthetic-monitoring-datasource';
   }) as Array<DataSourceInstanceSettings<SMOptions>>;
+}
+
+export function findLinkedDatasource(linkedDSInfo: LinkedDatasourceInfo): DataSourceInstanceSettings | undefined {
+  if (linkedDSInfo.uid) {
+    const linkedDS = Object.values(config.datasources).find((ds) => ds.uid === linkedDSInfo.uid);
+    if (linkedDS) {
+      return linkedDS;
+    }
+  }
+  return config.datasources[linkedDSInfo.grafanaName];
 }
 
 /** Given hosted info, link to an existing instance */
@@ -84,8 +94,8 @@ async function getViewerToken(apiToken: string, instance: HostedInstance, smData
 interface DatasourcePayload {
   accessToken: string;
   apiHost: string;
-  metrics: LinkedDatsourceInfo;
-  logs: LinkedDatsourceInfo;
+  metrics: LinkedDatasourceInfo;
+  logs: LinkedDatasourceInfo;
 }
 
 // Used for stubbing out the datasource when plugin is not provisioned


### PR DESCRIPTION
This would be a first step towards fixing https://github.com/grafana/synthetic-monitoring-app/issues/419

I think ultimately to resolve this issue we're gonna need to do a few things that might be worth breaking into a few different PRs:

- Auto-update dashboards on plugin load (we can look at GEM for an example of how to do this)
- Auto-update the SM datasource JSON on load ([also reported as an issue for other reasons](https://github.com/grafana/synthetic-monitoring-app/issues/274))
- Update the cloud provisioning to include the uid
