### PR TITLE
Sync ds json data

### DIFF
--- a/src/auto-update.test.ts
+++ b/src/auto-update.test.ts
@@ -1,0 +1,190 @@
+import { autoUpdate } from 'auto-update';
+import * as runtime from '@grafana/runtime';
+import * as initUtils from 'initialization-utils';
+import * as loader from 'dashboards/loader';
+import * as appEvents from 'grafana/app/core/app_events';
+
+// Module mocks
+jest.unmock('@grafana/data');
+jest.mock('grafana/app/core/app_events', () => ({
+  emit: jest.fn(),
+}));
+jest.mock('@grafana/runtime', () => {
+  const actual = jest.requireActual('@grafana/runtime');
+  return {
+    __esModule: true,
+    ...actual,
+    config: {
+      datasources: {},
+    },
+  };
+});
+jest.mock('utils', () => {
+  const rest = jest.requireActual('utils');
+  return {
+    __esModule: true,
+    ...rest,
+    getPluginSettings: jest.fn(() => {
+      return {
+        apiHost: 'sm_api.com',
+        logs: {
+          grafanaName: 'logs name',
+        },
+        metrics: {
+          grafanaName: 'metrics name',
+        },
+      };
+    }),
+  };
+});
+jest.mock('initialization-utils', () => {
+  const actual = jest.requireActual('initialization-utils');
+  return {
+    __esModule: true,
+    ...actual,
+    updateSMDatasource: jest.fn(),
+  };
+});
+jest.mock('dashboards/loader', () => {
+  const actual = jest.requireActual('dashboards/loader');
+  return {
+    __esModule: true,
+    ...actual,
+    listAppDashboards: jest.fn(() => Promise.resolve([{ title: 'a dashie', uid: 'dashie uid', version: 1 }])),
+    importAllDashboards: jest.fn(),
+  };
+});
+
+it('skips updates if none is required', () => {
+  autoUpdate();
+  expect(appEvents.emit).not.toHaveBeenCalled();
+});
+
+it('updates datasource', async () => {
+  runtime.config.datasources = {
+    //@ts-ignore
+    'Synthetic Monitoring': {
+      type: 'synthetic-monitoring-datasource',
+      name: 'a totally rad datasource',
+      jsonData: {},
+    },
+  };
+  await autoUpdate();
+  expect(initUtils.updateSMDatasource).toHaveBeenCalledWith('a totally rad datasource', {
+    apiHost: 'sm_api.com',
+    logs: {
+      grafanaName: 'logs name',
+    },
+    metrics: {
+      grafanaName: 'metrics name',
+    },
+  });
+  expect(appEvents.emit).not.toHaveBeenCalled();
+});
+
+it('updates dashboards', async () => {
+  runtime.config.datasources = {
+    //@ts-ignore
+    'Synthetic Monitoring': {
+      type: 'synthetic-monitoring-datasource',
+      name: 'a totally rad datasource',
+      jsonData: {
+        //@ts-ignore
+        dashboards: [
+          {
+            json: 'sm-summary.json',
+            latestVersion: 41,
+            title: 'Synthetic Monitoring Summary',
+            uid: 'fU-WBSqWz',
+            version: 41,
+          },
+          {
+            json: 'sm-http.json',
+            latestVersion: 31,
+            title: 'Synthetic Monitoring HTTP',
+            uid: 'rq0JrllZz',
+            version: 31,
+          },
+          {
+            json: 'sm-ping.json',
+            latestVersion: 29,
+            title: 'Synthetic Monitoring Ping',
+            uid: 'EHyn7ueZk',
+            version: 29,
+          },
+          {
+            json: 'sm-dns.json',
+            latestVersion: 18,
+            title: 'Synthetic Monitoring DNS',
+            uid: 'lgL6odgGz',
+            version: 18,
+          },
+          {
+            json: 'sm-tcp.json',
+            latestVersion: 20,
+            title: 'Synthetic Monitoring TCP',
+            uid: 'mh84e5mMk',
+            version: 20,
+          },
+          {
+            json: 'sm-traceroute.json',
+            latestVersion: 6,
+            title: 'Synthetic Monitoring Traceroute',
+            uid: 'hk8gHB4nk',
+            version: 6,
+          },
+        ],
+      },
+    },
+  };
+  //@ts-ignore
+  loader.listAppDashboards = jest.fn(() =>
+    Promise.resolve([
+      {
+        json: 'sm-summary.json',
+        latestVersion: 42,
+        title: 'Synthetic Monitoring Summary',
+        uid: 'fU-WBSqWz',
+        version: 42,
+      },
+      {
+        json: 'sm-http.json',
+        latestVersion: 32,
+        title: 'Synthetic Monitoring HTTP',
+        uid: 'rq0JrllZz',
+        version: 32,
+      },
+      {
+        json: 'sm-ping.json',
+        latestVersion: 30,
+        title: 'Synthetic Monitoring Ping',
+        uid: 'EHyn7ueZk',
+        version: 30,
+      },
+      {
+        json: 'sm-dns.json',
+        latestVersion: 19,
+        title: 'Synthetic Monitoring DNS',
+        uid: 'lgL6odgGz',
+        version: 19,
+      },
+      {
+        json: 'sm-tcp.json',
+        latestVersion: 21,
+        title: 'Synthetic Monitoring TCP',
+        uid: 'mh84e5mMk',
+        version: 21,
+      },
+      {
+        json: 'sm-traceroute.json',
+        latestVersion: 7,
+        title: 'Synthetic Monitoring Traceroute',
+        uid: 'hk8gHB4nk',
+        version: 7,
+      },
+    ])
+  );
+  await autoUpdate();
+  expect(loader.importAllDashboards).toHaveBeenCalledWith('metrics name', 'logs name', 'a totally rad datasource');
+  expect(appEvents.emit).toHaveBeenCalledWith({ name: 'alert-success' }, ['Synthetic Monitoring dashboards updated']);
+});

--- a/src/auto-update.test.ts
+++ b/src/auto-update.test.ts
@@ -55,8 +55,19 @@ jest.mock('dashboards/loader', () => {
   };
 });
 
+beforeEach(() => {
+  //@ts-ignore
+  loader.importAllDashboards.mockReset();
+  //@ts-ignore
+  initUtils.updateSMDatasource.mockReset();
+  //@ts-ignore
+  appEvents.emit.mockReset();
+});
+
 it('skips updates if none is required', () => {
   autoUpdate();
+  expect(loader.importAllDashboards).not.toHaveBeenCalled();
+  expect(initUtils.updateSMDatasource).not.toHaveBeenCalled();
   expect(appEvents.emit).not.toHaveBeenCalled();
 });
 
@@ -79,6 +90,7 @@ it('updates datasource', async () => {
       grafanaName: 'metrics name',
     },
   });
+  expect(loader.importAllDashboards).not.toHaveBeenCalled();
   expect(appEvents.emit).not.toHaveBeenCalled();
 });
 
@@ -89,6 +101,14 @@ it('updates dashboards', async () => {
       type: 'synthetic-monitoring-datasource',
       name: 'a totally rad datasource',
       jsonData: {
+        //@ts-ignore
+        apiHost: 'sm_api.com',
+        logs: {
+          grafanaName: 'logs name',
+        },
+        metrics: {
+          grafanaName: 'metrics name',
+        },
         //@ts-ignore
         dashboards: [
           {
@@ -185,6 +205,8 @@ it('updates dashboards', async () => {
     ])
   );
   await autoUpdate();
+
+  expect(initUtils.updateSMDatasource).not.toHaveBeenCalled();
   expect(loader.importAllDashboards).toHaveBeenCalledWith('metrics name', 'logs name', 'a totally rad datasource');
   expect(appEvents.emit).toHaveBeenCalledWith({ name: 'alert-success' }, ['Synthetic Monitoring dashboards updated']);
 });

--- a/src/auto-update.ts
+++ b/src/auto-update.ts
@@ -1,0 +1,73 @@
+import { findSMDataSources, getPluginSettings } from 'utils';
+import { updateSMDatasource } from 'initialization-utils';
+import { importAllDashboards, listAppDashboards } from 'dashboards/loader';
+import appEvents from 'grafana/app/core/app_events';
+import { DashboardMeta, GlobalSettings } from 'types';
+import { AppEvents } from '@grafana/data';
+import { DashboardInfo } from 'datasource/types';
+
+const needToUpdateDSJson = (ds: GlobalSettings, plugin: GlobalSettings): boolean => {
+  if (
+    !ds.logs ||
+    !ds.metrics ||
+    ds.logs.grafanaName !== plugin.logs.grafanaName ||
+    ds.logs.grafanaName !== plugin.logs.grafanaName ||
+    ds.metrics.grafanaName !== plugin.metrics.grafanaName ||
+    ds.apiHost !== plugin.apiHost
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+export async function getDashboardsNeedingUpdate(dsDashboards: DashboardInfo[] = []): Promise<DashboardMeta[]> {
+  const latestDashboards = await listAppDashboards();
+  return dsDashboards
+    .map((existingDashboard) => {
+      const templateDashboard = latestDashboards.find((template) => template.uid === existingDashboard.uid);
+      const templateVersion = templateDashboard?.latestVersion ?? -1;
+      if (templateDashboard && templateVersion > existingDashboard.version) {
+        return {
+          ...existingDashboard,
+          version: templateDashboard.latestVersion,
+          latestVersion: templateDashboard.latestVersion,
+        };
+      }
+      return null;
+    })
+    .filter(Boolean) as DashboardMeta[];
+}
+
+export const autoUpdate = async () => {
+  try {
+    const smDatasources = findSMDataSources();
+    // if there is no SM datasource, we have nothing to do. If there is more than 1 we don't know what to do.
+    if (smDatasources.length !== 1) {
+      return;
+    }
+    const pluginSettings = await getPluginSettings();
+    if (!pluginSettings) {
+      return;
+    }
+    const smDS = smDatasources[0];
+    const dsUpdateNeeded = needToUpdateDSJson(smDS.jsonData, pluginSettings);
+    if (dsUpdateNeeded) {
+      await updateSMDatasource(smDS.name, pluginSettings);
+    }
+
+    const dashboardsToUpdate = await getDashboardsNeedingUpdate(smDS.jsonData.dashboards);
+    if (dashboardsToUpdate.length > 0) {
+      importAllDashboards(
+        pluginSettings.metrics.uid ?? pluginSettings.metrics.grafanaName,
+        pluginSettings.logs.uid ?? pluginSettings.logs.grafanaName,
+        smDS.name
+      );
+
+      appEvents.emit(AppEvents.alertSuccess, ['Synthetic Monitoring dashboards updated']);
+    }
+  } catch (e) {
+    // Should fail silently
+    console.error(`Synthetic Monitoring failed to update resources: ${e}`);
+  }
+};

--- a/src/components/DashboardUpdateModal.tsx
+++ b/src/components/DashboardUpdateModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { DashboardMeta } from 'types';
 import { InstanceContext } from 'contexts/InstanceContext';
-import { importAllDashboards, listAppDashboards } from 'dashboards/loader';
+import { getDashboardsNeedingUpdate, importAllDashboards } from 'dashboards/loader';
 import { Button, HorizontalGroup, Modal } from '@grafana/ui';
 import { hasDismissedDashboardUpdateModal, persistDashboardModalDismiss } from 'sessionStorage';
 import { useNavigation } from 'hooks/useNavigation';
@@ -21,24 +21,8 @@ export const DashboardUpdateModal = () => {
   // Prompt user to update dashboards that are out of date
   useEffect(() => {
     if (!hasDismissedDashboardUpdate) {
-      listAppDashboards().then((latestDashboards) => {
-        const existingDashboards = dashboards ?? [];
-        const dashboardsNeedingUpdate = existingDashboards
-          .map((existingDashboard) => {
-            const templateDashboard = latestDashboards.find((template) => template.uid === existingDashboard.uid);
-            const templateVersion = templateDashboard?.latestVersion ?? -1;
-            if (templateDashboard && templateVersion > existingDashboard.version) {
-              return {
-                ...existingDashboard,
-                version: templateDashboard.latestVersion,
-                latestVersion: templateDashboard.latestVersion,
-              };
-            }
-            return null;
-          })
-          .filter(Boolean) as DashboardMeta[];
-
-        setDashboardsNeedingUpdate(dashboardsNeedingUpdate);
+      getDashboardsNeedingUpdate().then((toUpdate) => {
+        setDashboardsNeedingUpdate(toUpdate);
       });
     }
   }, [dashboards, hasDismissedDashboardUpdate]);

--- a/src/components/DashboardUpdateModal.tsx
+++ b/src/components/DashboardUpdateModal.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { DashboardMeta } from 'types';
 import { InstanceContext } from 'contexts/InstanceContext';
-import { getDashboardsNeedingUpdate, importAllDashboards } from 'dashboards/loader';
+import { importAllDashboards } from 'dashboards/loader';
 import { Button, HorizontalGroup, Modal } from '@grafana/ui';
 import { hasDismissedDashboardUpdateModal, persistDashboardModalDismiss } from 'sessionStorage';
 import { useNavigation } from 'hooks/useNavigation';
+import { getDashboardsNeedingUpdate } from 'auto-update';
 
 export const DashboardUpdateModal = () => {
   const { instance } = useContext(InstanceContext);

--- a/src/components/Routing.tsx
+++ b/src/components/Routing.tsx
@@ -31,6 +31,9 @@ export const Routing = ({ onNavChanged, meta, ...rest }: AppRootProps) => {
     if (meta.enabled && (!instance.metrics || !instance.logs) && !location.pathname.includes('unprovisioned')) {
       navigate(ROUTES.Unprovisioned);
     }
+    if (meta.enabled && instance.metrics && instance.logs && location.pathname.includes('unprovisioned')) {
+      navigate(ROUTES.Home);
+    }
     if (meta.enabled && !instance.api && !location.pathname.includes('setup')) {
       navigate(ROUTES.Setup);
     }

--- a/src/dashboards/loader.ts
+++ b/src/dashboards/loader.ts
@@ -1,6 +1,5 @@
 import { getBackendSrv } from '@grafana/runtime';
 import { DashboardInfo, FolderInfo } from 'datasource/types';
-import { DashboardMeta } from 'types';
 
 export const dashboardPaths = [
   'sm-http.json', // The path
@@ -97,22 +96,4 @@ export async function listAppDashboards(): Promise<DashboardInfo[]> {
 export async function removeDashboard(dashboard: DashboardInfo): Promise<any> {
   const backendSrv = getBackendSrv();
   return backendSrv.delete(`/api/dashboards/uid/${dashboard.uid}`);
-}
-
-export async function getDashboardsNeedingUpdate(dsDashboards: DashboardInfo[] = []): Promise<DashboardMeta[]> {
-  const latestDashboards = await listAppDashboards();
-  return dsDashboards
-    .map((existingDashboard) => {
-      const templateDashboard = latestDashboards.find((template) => template.uid === existingDashboard.uid);
-      const templateVersion = templateDashboard?.latestVersion ?? -1;
-      if (templateDashboard && templateVersion > existingDashboard.version) {
-        return {
-          ...existingDashboard,
-          version: templateDashboard.latestVersion,
-          latestVersion: templateDashboard.latestVersion,
-        };
-      }
-      return null;
-    })
-    .filter(Boolean) as DashboardMeta[];
 }

--- a/src/dashboards/loader.ts
+++ b/src/dashboards/loader.ts
@@ -1,5 +1,6 @@
 import { getBackendSrv } from '@grafana/runtime';
 import { DashboardInfo, FolderInfo } from 'datasource/types';
+import { DashboardMeta } from 'types';
 
 export const dashboardPaths = [
   'sm-http.json', // The path
@@ -96,4 +97,22 @@ export async function listAppDashboards(): Promise<DashboardInfo[]> {
 export async function removeDashboard(dashboard: DashboardInfo): Promise<any> {
   const backendSrv = getBackendSrv();
   return backendSrv.delete(`/api/dashboards/uid/${dashboard.uid}`);
+}
+
+export async function dashboardsNeedingUpdate(dsDashboards: DashboardInfo[] = []): Promise<DashboardMeta[]> {
+  const latestDashboards = await listAppDashboards();
+  return dsDashboards
+    .map((existingDashboard) => {
+      const templateDashboard = latestDashboards.find((template) => template.uid === existingDashboard.uid);
+      const templateVersion = templateDashboard?.latestVersion ?? -1;
+      if (templateDashboard && templateVersion > existingDashboard.version) {
+        return {
+          ...existingDashboard,
+          version: templateDashboard.latestVersion,
+          latestVersion: templateDashboard.latestVersion,
+        };
+      }
+      return null;
+    })
+    .filter(Boolean) as DashboardMeta[];
 }

--- a/src/dashboards/loader.ts
+++ b/src/dashboards/loader.ts
@@ -99,7 +99,7 @@ export async function removeDashboard(dashboard: DashboardInfo): Promise<any> {
   return backendSrv.delete(`/api/dashboards/uid/${dashboard.uid}`);
 }
 
-export async function dashboardsNeedingUpdate(dsDashboards: DashboardInfo[] = []): Promise<DashboardMeta[]> {
+export async function getDashboardsNeedingUpdate(dsDashboards: DashboardInfo[] = []): Promise<DashboardMeta[]> {
   const latestDashboards = await listAppDashboards();
   return dsDashboards
     .map((existingDashboard) => {

--- a/src/initialization-utils.ts
+++ b/src/initialization-utils.ts
@@ -102,8 +102,7 @@ export const updateSMDatasource = async (dsName: string, pluginSettings: GlobalS
       metrics: pluginSettings.metrics,
     },
   };
-  console.log('whats the deal?', updateInfo);
-  const resp = await getBackendSrv()
+  return getBackendSrv()
     .fetch({
       url: `/api/datasources/${smDatasource.id}`,
       method: 'PUT',
@@ -111,8 +110,6 @@ export const updateSMDatasource = async (dsName: string, pluginSettings: GlobalS
       data: updateInfo,
     })
     .toPromise();
-  console.log(resp);
-  return resp;
 };
 
 interface CreateDatasourcesArgs {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,11 @@
-import { AppPlugin } from '@grafana/data';
+import { AppPlugin, PluginMeta } from '@grafana/data';
 import { GlobalSettings } from './types';
 import { App } from 'components/App';
 import { ConfigPage } from 'page/ConfigPage';
+import { findSMDataSources } from 'utils';
+import { getBackendSrv } from '@grafana/runtime';
+import { updateSMDatasource } from 'initialization-utils';
+import { dashboardsNeedingUpdate, importAllDashboards, importDashboard } from 'dashboards/loader';
 
 export const plugin = new AppPlugin<GlobalSettings>().setRootPage(App).addConfigPage({
   title: 'Config',
@@ -9,3 +13,49 @@ export const plugin = new AppPlugin<GlobalSettings>().setRootPage(App).addConfig
   body: ConfigPage,
   id: 'config',
 });
+
+const getPluginSettings = async () =>
+  await getBackendSrv()
+    .fetch<PluginMeta<GlobalSettings>>({
+      url: `/api/plugins/grafana-synthetic-monitoring-app/settings`,
+      method: 'GET',
+      headers: { 'Cache-Control': 'no-store' },
+    })
+    .toPromise()
+    .then((response) => response?.data?.jsonData);
+
+const needToUpdateDSJson = (ds: GlobalSettings, plugin: GlobalSettings): boolean => {
+  if (
+    ds.logs.grafanaName !== plugin.logs.grafanaName ||
+    ds.logs.grafanaName !== plugin.logs.grafanaName ||
+    ds.metrics.grafanaName !== plugin.metrics.grafanaName ||
+    ds.apiHost !== plugin.apiHost
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const preloadInit = async () => {
+  const smDatasources = findSMDataSources();
+  const pluginSettings = await getPluginSettings();
+  // if there is no SM datasource, we have nothing to do. If there is more than 1 we don't know what to do.
+  if (smDatasources?.length === 1 && pluginSettings) {
+    const smDS = smDatasources[0];
+    const dsUpdateNeeded = needToUpdateDSJson(smDS.jsonData, pluginSettings);
+    if (dsUpdateNeeded) {
+      await updateSMDatasource(smDS.name, pluginSettings);
+    }
+
+    const dashboardsToUpdate = await dashboardsNeedingUpdate(smDS.jsonData.dashboards);
+    if (dashboardsToUpdate.length > 0) {
+      importAllDashboards(
+        pluginSettings.metrics.uid ?? pluginSettings.metrics.grafanaName,
+        pluginSettings.logs.uid ?? pluginSettings.metrics.grafanaName,
+        smDS.name
+      );
+    }
+  }
+};
+
+preloadInit();

--- a/src/module.ts
+++ b/src/module.ts
@@ -48,7 +48,6 @@ const preloadInit = async () => {
     }
 
     const dashboardsToUpdate = await getDashboardsNeedingUpdate(smDS.jsonData.dashboards);
-    console.log({ dashboardsToUpdate });
     if (dashboardsToUpdate.length > 0) {
       importAllDashboards(
         pluginSettings.metrics.uid ?? pluginSettings.metrics.grafanaName,

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,12 +1,8 @@
-import { AppPlugin, PluginMeta, AppEvents } from '@grafana/data';
+import { AppPlugin } from '@grafana/data';
 import { GlobalSettings } from './types';
 import { App } from 'components/App';
 import { ConfigPage } from 'page/ConfigPage';
-import { findSMDataSources } from 'utils';
-import { getBackendSrv } from '@grafana/runtime';
-import { updateSMDatasource } from 'initialization-utils';
-import { getDashboardsNeedingUpdate, importAllDashboards } from 'dashboards/loader';
-import appEvents from 'grafana/app/core/app_events';
+import { autoUpdate } from 'auto-update';
 
 export const plugin = new AppPlugin<GlobalSettings>().setRootPage(App).addConfigPage({
   title: 'Config',
@@ -15,54 +11,4 @@ export const plugin = new AppPlugin<GlobalSettings>().setRootPage(App).addConfig
   id: 'config',
 });
 
-const getPluginSettings = async () =>
-  await getBackendSrv()
-    .fetch<PluginMeta<GlobalSettings>>({
-      url: `/api/plugins/grafana-synthetic-monitoring-app/settings`,
-      method: 'GET',
-      headers: { 'Cache-Control': 'no-store' },
-    })
-    .toPromise()
-    .then((response) => response?.data?.jsonData);
-
-const needToUpdateDSJson = (ds: GlobalSettings, plugin: GlobalSettings): boolean => {
-  if (
-    ds.logs.grafanaName !== plugin.logs.grafanaName ||
-    ds.logs.grafanaName !== plugin.logs.grafanaName ||
-    ds.metrics.grafanaName !== plugin.metrics.grafanaName ||
-    ds.apiHost !== plugin.apiHost
-  ) {
-    return true;
-  }
-  return false;
-};
-
-const preloadInit = async () => {
-  const smDatasources = findSMDataSources();
-  // if there is no SM datasource, we have nothing to do. If there is more than 1 we don't know what to do.
-  if (smDatasources.length !== 1) {
-    return;
-  }
-  const pluginSettings = await getPluginSettings();
-  if (!pluginSettings) {
-    return;
-  }
-  const smDS = smDatasources[0];
-  const dsUpdateNeeded = needToUpdateDSJson(smDS.jsonData, pluginSettings);
-  if (dsUpdateNeeded) {
-    await updateSMDatasource(smDS.name, pluginSettings);
-  }
-
-  const dashboardsToUpdate = await getDashboardsNeedingUpdate(smDS.jsonData.dashboards);
-  if (dashboardsToUpdate.length > 0) {
-    importAllDashboards(
-      pluginSettings.metrics.uid ?? pluginSettings.metrics.grafanaName,
-      pluginSettings.logs.uid ?? pluginSettings.metrics.grafanaName,
-      smDS.name
-    );
-
-    appEvents.emit(AppEvents.alertSuccess, ['Synthetic Monitoring dashboards updated']);
-  }
-};
-
-preloadInit();
+autoUpdate();

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,7 +5,7 @@ import { ConfigPage } from 'page/ConfigPage';
 import { findSMDataSources } from 'utils';
 import { getBackendSrv } from '@grafana/runtime';
 import { updateSMDatasource } from 'initialization-utils';
-import { dashboardsNeedingUpdate, importAllDashboards, importDashboard } from 'dashboards/loader';
+import { getDashboardsNeedingUpdate, importAllDashboards } from 'dashboards/loader';
 
 export const plugin = new AppPlugin<GlobalSettings>().setRootPage(App).addConfigPage({
   title: 'Config',
@@ -47,7 +47,8 @@ const preloadInit = async () => {
       await updateSMDatasource(smDS.name, pluginSettings);
     }
 
-    const dashboardsToUpdate = await dashboardsNeedingUpdate(smDS.jsonData.dashboards);
+    const dashboardsToUpdate = await getDashboardsNeedingUpdate(smDS.jsonData.dashboards);
+    console.log({ dashboardsToUpdate });
     if (dashboardsToUpdate.length > 0) {
       importAllDashboards(
         pluginSettings.metrics.uid ?? pluginSettings.metrics.grafanaName,

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -2,7 +2,7 @@
   "type": "app",
   "name": "Synthetic Monitoring",
   "id": "grafana-synthetic-monitoring-app",
-
+  "preload": true,
   "info": {
     "author": {
       "name": "Grafana Labs",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
-import { DataSourceInstanceSettings } from '@grafana/data';
+import { DataSourceInstanceSettings, PluginMeta } from '@grafana/data';
 
 import { SMOptions, DashboardInfo, LinkedDatasourceInfo, LogQueryResponse } from './datasource/types';
 
 import { config, getBackendSrv } from '@grafana/runtime';
-import { HostedInstance, User, OrgRole, CheckType, Settings, SubmissionErrorWrapper } from 'types';
+import { HostedInstance, User, OrgRole, CheckType, Settings, SubmissionErrorWrapper, GlobalSettings } from 'types';
 
 import { SMDataSource } from 'datasource/DataSource';
 import { IconName } from '@grafana/ui';
@@ -17,6 +17,16 @@ export function findSMDataSources(): Array<DataSourceInstanceSettings<SMOptions>
     return ds.type === 'synthetic-monitoring-datasource';
   }) as Array<DataSourceInstanceSettings<SMOptions>>;
 }
+
+export const getPluginSettings = async () =>
+  await getBackendSrv()
+    .fetch<PluginMeta<GlobalSettings>>({
+      url: `/api/plugins/grafana-synthetic-monitoring-app/settings`,
+      method: 'GET',
+      headers: { 'Cache-Control': 'no-store' },
+    })
+    .toPromise()
+    .then((response) => response?.data?.jsonData);
 
 export function findLinkedDatasource(linkedDSInfo: LinkedDatasourceInfo): DataSourceInstanceSettings | undefined {
   if (linkedDSInfo.uid) {


### PR DESCRIPTION
Closes #419 
Closes #274 

This will leverage the `preload: true` plugin setting to update to sync provisioned data with the SM datasource whether a use navigates to the plugin or not. Currently if things change users have to delete the SM datasource and reinitialize the plugin.

This also checks to see whether dashboards have changed and updates them.

TODO: tests!