### PR TITLE
fix: stop infite reloop on local unprovisioned setup

### DIFF
--- a/src/components/Routing.tsx
+++ b/src/components/Routing.tsx
@@ -31,6 +31,9 @@ export const Routing = ({ onNavChanged, meta, ...rest }: AppRootProps) => {
     if (meta.enabled && (!instance.metrics || !instance.logs) && !location.pathname.includes('unprovisioned')) {
       navigate(ROUTES.Unprovisioned);
     }
+    if (meta.enabled && instance.metrics && instance.logs && location.pathname.includes('unprovisioned')) {
+      navigate(ROUTES.Home);
+    }
     if (meta.enabled && !instance.api && !location.pathname.includes('setup')) {
       navigate(ROUTES.Setup);
     }


### PR DESCRIPTION
When trying to initialize an unprovisioned plugin on a local instance, it's possible to get stuck in a never ending redirect loop. This should fix that. 