### PR TITLE
Geomap thresholds bug

### DIFF
--- a/src/dashboards/sm-dns.json
+++ b/src/dashboards/sm-dns.json
@@ -112,7 +112,7 @@
             {
               "type": "value",
               "options": {
-                "Value #A": {
+                "Value": {
                   "text": "Error rate",
                   "index": 0
                 }
@@ -131,7 +131,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Value #A"
+              "options": "Value"
             },
             "properties": [
               {
@@ -167,7 +167,7 @@
               "style": {
                 "color": {
                   "fixed": "dark-green",
-                  "field": "Value #A"
+                  "field": "Value"
                 },
                 "opacity": 0.4,
                 "rotation": {
@@ -177,7 +177,7 @@
                   "mode": "mod"
                 },
                 "size": {
-                  "field": "Value #A",
+                  "field": "Value",
                   "fixed": 5,
                   "max": 10,
                   "min": 4
@@ -201,8 +201,8 @@
             },
             "location": {
               "geohash": "geohash",
-              "latitude": "Value #A",
-              "longitude": "Value #A",
+              "latitude": "Value",
+              "longitude": "Value",
               "mode": "geohash"
             },
             "name": "Layer 1",
@@ -1089,5 +1089,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring DNS",
   "uid": "lgL6odgGz",
-  "version": 18
+  "version": 19
 }

--- a/src/dashboards/sm-http.json
+++ b/src/dashboards/sm-http.json
@@ -111,7 +111,7 @@
             {
               "type": "value",
               "options": {
-                "Value #A": {
+                "Value": {
                   "text": "Error rate",
                   "index": 0
                 }
@@ -130,7 +130,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Value #A"
+              "options": "Value"
             },
             "properties": [
               {
@@ -166,7 +166,7 @@
               "style": {
                 "color": {
                   "fixed": "dark-green",
-                  "field": "Value #A"
+                  "field": "Value"
                 },
                 "opacity": 0.4,
                 "rotation": {
@@ -176,7 +176,7 @@
                   "mode": "mod"
                 },
                 "size": {
-                  "field": "Value #A",
+                  "field": "Value",
                   "fixed": 5,
                   "max": 10,
                   "min": 4
@@ -200,8 +200,8 @@
             },
             "location": {
               "geohash": "geohash",
-              "latitude": "Value #A",
-              "longitude": "Value #A",
+              "latitude": "Value",
+              "longitude": "Value",
               "mode": "geohash"
             },
             "name": "Layer 1",
@@ -1076,5 +1076,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring HTTP",
   "uid": "rq0JrllZz",
-  "version": 31
+  "version": 32
 }

--- a/src/dashboards/sm-ping.json
+++ b/src/dashboards/sm-ping.json
@@ -111,7 +111,7 @@
             {
               "type": "value",
               "options": {
-                "Value #A": {
+                "Value": {
                   "text": "Error rate",
                   "index": 0
                 }
@@ -130,7 +130,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Value #A"
+              "options": "Value"
             },
             "properties": [
               {
@@ -166,7 +166,7 @@
               "style": {
                 "color": {
                   "fixed": "dark-green",
-                  "field": "Value #A"
+                  "field": "Value"
                 },
                 "opacity": 0.4,
                 "rotation": {
@@ -176,7 +176,7 @@
                   "mode": "mod"
                 },
                 "size": {
-                  "field": "Value #A",
+                  "field": "Value",
                   "fixed": 5,
                   "max": 10,
                   "min": 4
@@ -200,8 +200,8 @@
             },
             "location": {
               "geohash": "geohash",
-              "latitude": "Value #A",
-              "longitude": "Value #A",
+              "latitude": "Value",
+              "longitude": "Value",
               "mode": "geohash"
             },
             "name": "Layer 1",
@@ -1000,5 +1000,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring Ping",
   "uid": "EHyn7ueZk",
-  "version": 29
+  "version": 30
 }

--- a/src/dashboards/sm-summary.json
+++ b/src/dashboards/sm-summary.json
@@ -123,7 +123,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Value #A"
+              "options": "Value"
             },
             "properties": [
               {
@@ -160,7 +160,7 @@
               "showLegend": true,
               "style": {
                 "color": {
-                  "field": "Value #A",
+                  "field": "Value",
                   "fixed": "dark-green"
                 },
                 "opacity": 0.4,
@@ -171,7 +171,7 @@
                   "mode": "mod"
                 },
                 "size": {
-                  "field": "Value #A",
+                  "field": "Value",
                   "fixed": 5,
                   "max": 10,
                   "min": 4
@@ -829,6 +829,6 @@
   "timezone": "",
   "title": "Synthetic Monitoring Summary",
   "uid": "fU-WBSqWz",
-  "version": 42,
+  "version": 43,
   "weekStart": ""
 }

--- a/src/dashboards/sm-tcp.json
+++ b/src/dashboards/sm-tcp.json
@@ -111,7 +111,7 @@
             {
               "type": "value",
               "options": {
-                "Value #A": {
+                "Value": {
                   "text": "Error rate",
                   "index": 0
                 }
@@ -130,7 +130,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Value #A"
+              "options": "Value"
             },
             "properties": [
               {
@@ -166,7 +166,7 @@
               "style": {
                 "color": {
                   "fixed": "dark-green",
-                  "field": "Value #A"
+                  "field": "Value"
                 },
                 "opacity": 0.4,
                 "rotation": {
@@ -176,7 +176,7 @@
                   "mode": "mod"
                 },
                 "size": {
-                  "field": "Value #A",
+                  "field": "Value",
                   "fixed": 5,
                   "max": 10,
                   "min": 4
@@ -200,8 +200,8 @@
             },
             "location": {
               "geohash": "geohash",
-              "latitude": "Value #A",
-              "longitude": "Value #A",
+              "latitude": "Value",
+              "longitude": "Value",
               "mode": "geohash"
             },
             "name": "Layer 1",
@@ -955,5 +955,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring TCP",
   "uid": "mh84e5mMk",
-  "version": 20
+  "version": 21
 }


### PR DESCRIPTION
The way we're referencing threshold values for the geomap panel in our dashboards is no longer valid. Currently no matter the value, everything is showing up green. This change makes error rate values drive the size of the bubble and the color.

Before
<img width="677" alt="Screen Shot 2022-03-15 at 14 03 32" src="https://user-images.githubusercontent.com/8377044/158480038-8de21450-adcc-48c8-86e0-888072709b2d.png">


After
<img width="677" alt="Screen Shot 2022-03-15 at 14 02 48" src="https://user-images.githubusercontent.com/8377044/158479944-53d07394-3758-4908-a713-07e4cb7b85a0.png">

