### PR TITLE
fix: use increase() instead of delta() to handle counter resets in Re…

### DIFF
--- a/src/components/SuccessRateContextProvider.tsx
+++ b/src/components/SuccessRateContextProvider.tsx
@@ -146,8 +146,8 @@ export function SuccessRateContextProvider({ checks, probes, children }: PropsWi
       const probeReachabilityQuery =
         'sum(rate(probe_all_success_sum[3h])) by (probe) / sum(rate(probe_all_success_count[3h])) by (probe)';
 
-      const checkUptimeQuery = `sum_over_time((ceil(sum by (instance, job) (idelta(probe_all_success_sum[5m])) / sum by (instance, job) (idelta(probe_all_success_count[5m]))))[3h:]) 
-            / count_over_time((sum by (instance, job) (idelta(probe_all_success_count[5m])))[3h:])`;
+      const checkUptimeQuery = `sum_over_time((ceil(sum by (instance, job) (increase(probe_all_success_sum[5m])) / sum by (instance, job) (increase(probe_all_success_count[5m]))))[3h:])
+            / count_over_time((sum by (instance, job) (increase(probe_all_success_count[5m])))[3h:])`;
 
       const successRateType = checks ? SuccessRateTypes.Checks : SuccessRateTypes.Probes;
 

--- a/src/dashboards/sm-dns.json
+++ b/src/dashboards/sm-dns.json
@@ -289,7 +289,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
+          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (increase(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (increase(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (increase(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
           "hide": false,
           "instant": true,
           "interval": "",

--- a/src/dashboards/sm-dns.json
+++ b/src/dashboards/sm-dns.json
@@ -367,7 +367,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(\n  (\n    delta(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    delta(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
+          "expr": "sum(\n  (\n    increase(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    increase(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    increase(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    increase(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
           "hide": false,
           "instant": true,
           "interval": "",

--- a/src/dashboards/sm-http.json
+++ b/src/dashboards/sm-http.json
@@ -288,7 +288,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
+          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (increase(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (increase(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (increase(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
           "hide": false,
           "instant": true,
           "interval": "",

--- a/src/dashboards/sm-http.json
+++ b/src/dashboards/sm-http.json
@@ -366,7 +366,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(\n  (\n    delta(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    delta(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
+          "expr": "sum(\n  (\n    increase(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    increase(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    increase(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    increase(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
           "hide": false,
           "instant": true,
           "interval": "",

--- a/src/dashboards/sm-ping.json
+++ b/src/dashboards/sm-ping.json
@@ -288,7 +288,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
+          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (increase(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (increase(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (increase(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
           "hide": false,
           "instant": true,
           "interval": "",

--- a/src/dashboards/sm-ping.json
+++ b/src/dashboards/sm-ping.json
@@ -366,7 +366,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(\n  (\n    delta(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    delta(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
+          "expr": "sum(\n  (\n    increase(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    increase(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    increase(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    increase(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
           "hide": false,
           "instant": true,
           "interval": "",

--- a/src/dashboards/sm-summary.json
+++ b/src/dashboards/sm-summary.json
@@ -599,7 +599,7 @@
         {
           "datasource": "${DS_SM_METRICS}",
           "exemplar": false,
-          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum[5m]) * on (instance, job, probe, config_version) sm_check_info{check_name=\"$check_type\"})\n      /\n      sum by (instance, job) (idelta(probe_all_success_count[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count[5m]))\n  )[$__range:]\n)",
+          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (increase(probe_all_success_sum[5m]) * on (instance, job, probe, config_version) sm_check_info{check_name=\"$check_type\"})\n      /\n      sum by (instance, job) (increase(probe_all_success_count[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (increase(probe_all_success_count[5m]))\n  )[$__range:]\n)",
           "format": "table",
           "hide": false,
           "instant": true,

--- a/src/dashboards/sm-tcp.json
+++ b/src/dashboards/sm-tcp.json
@@ -288,7 +288,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (idelta(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (idelta(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
+          "expr": "sum_over_time(\n  (\n    ceil(\n      sum by (instance, job) (increase(probe_all_success_sum{instance=\"$instance\", job=\"$job\"}[5m]))\n      /\n      sum by (instance, job) (increase(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n    )\n  )[$__range:]\n)\n/\ncount_over_time(\n  (\n      sum by (instance, job) (increase(probe_all_success_count{instance=\"$instance\", job=\"$job\"}[5m]))\n  )[$__range:]\n)",
           "hide": false,
           "instant": true,
           "interval": "",

--- a/src/dashboards/sm-tcp.json
+++ b/src/dashboards/sm-tcp.json
@@ -366,7 +366,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(\n  (\n    delta(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    delta(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    delta(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
+          "expr": "sum(\n  (\n    increase(probe_all_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    increase(probe_success_sum{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)\n/\nsum(\n  (\n    increase(probe_all_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n    OR\n    increase(probe_success_count{instance=\"$instance\", job=\"$job\", probe=~\"$probe\"}[$__range])\n  )\n)",
           "hide": false,
           "instant": true,
           "interval": "",


### PR DESCRIPTION
**What this PR does / why we need it**:
we are using delta and idelta in dashboards and uptime calucation query

**Which issue(s) this PR fixes**:
 delta and idelta doesn't handle counter resets, so whenever sm-agent restarts delta returns negative values. we need to use `increase()` to account for counter resets.
 
also, the metric we are using delta and idelta are summery metric types. delta and idelta should only be used on a gauge metric.


## Before and After the fix

**uptime goes to negative when using idelta**
 ![image](https://user-images.githubusercontent.com/9503187/160171839-9bc9fdbb-9206-4617-8447-a8a745ccd903.png)

**uptime goes to negative infinity when using idelta**
![image](https://user-images.githubusercontent.com/9503187/160172249-1897fad0-d0e6-4255-8fc7-b7ef118773ac.png)

 **reachability goes above 1 (100%) when using delta**
 
![image](https://user-images.githubusercontent.com/9503187/160172337-c11c00de-47c2-42f9-8403-b3ea2de0203b.png)

 
 ---
see more:
- https://prometheus.io/docs/prometheus/latest/querying/functions/#delta
- https://prometheus.io/docs/prometheus/latest/querying/functions/#idelta
- https://prometheus.io/docs/prometheus/latest/querying/functions/#increase
- https://prometheus.io/docs/instrumenting/writing_clientlibs/#summary
- https://prometheus.io/docs/instrumenting/writing_clientlibs/#gauge