### PR TITLE
fix: show full error in case of submission error

### DIFF
--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -218,7 +218,9 @@ export const CheckEditor = ({ checks, onReturn }: Props) => {
         {submissionError && (
           <div className={styles.submissionError}>
             <Alert title="Save failed" severity="error">
-              {`${submissionError.status}: ${submissionError.data?.msg ?? 'Something went wrong'}`}
+              {`${submissionError.status}: ${
+                submissionError.data?.msg?.concat(', ', submissionError.data?.err ?? '') ?? 'Something went wrong'
+              }`}
             </Alert>
           </div>
         )}


### PR DESCRIPTION
**What this PR does / why we need it**:

Shows full error in case of submission error

**Which issue(s) this PR fixes**:

Fixes #453

Maybe #435

**Special notes for your reviewer**:

Here is what it looks like with this fix:

![image](https://user-images.githubusercontent.com/9503187/163025734-5a1eb797-023a-42a3-afd4-9396b91fb314.png)

