### PR TITLE
feat: display probe region and probe type on probe list page

### DIFF
--- a/src/components/ProbeList.tsx
+++ b/src/components/ProbeList.tsx
@@ -48,12 +48,18 @@ export const ProbeList = ({ probes, onAddNew, onSelectProbe }: Props) => {
           const onlineTxt = probe.online ? 'Online' : 'Offline';
           const onlineIcon = probe.online ? 'heart' : 'heart-break';
           const color = probe.online ? 'green' : 'red';
+          const probeTypeText = probe.public ? 'Public' : 'Private';
+          const probeTypeIcon = probe.public ? 'cloud' : 'lock';
           return (
             <div key={probe.id} className="add-data-source-item" onClick={() => onSelectProbe(probe.id!)}>
               <div className="add-data-source-item-text-wrapper">
                 <span className="add-data-source-item-text">{probe.name}</span>
                 <span className="add-data-source-item-desc">
                   <Badge color={color} icon={onlineIcon} text={onlineTxt} />
+                  <a> </a>
+                  <Badge color="blue" icon="compass" text={probe.region} />
+                  <a> </a>
+                  <Badge color="blue" icon={probeTypeIcon} text={probeTypeText} />
                   <div>{labelsToString(probe.labels)}</div>
                   <div>Version: {probe.version}</div>
                 </span>


### PR DESCRIPTION
**What this PR does / why we need it**:

Show probe region and type on list page

**Which issue(s) this PR fixes**:

Fixes #454

**Special notes for your reviewer**:

UI before this feat:
![image](https://user-images.githubusercontent.com/9503187/163054804-cae4d8f8-f89e-4c29-8427-b6c7acbe311c.png)

UI After this feat
![image](https://user-images.githubusercontent.com/9503187/163054630-33055f13-4105-4ca1-af6f-7d3238ce5ca8.png)

