### PR TITLE
Docker: add a basic docker setup for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+ARG grafana_version=latest
+
+FROM grafana/grafana:${grafana_version}
+
+# Make it as simple as possible to access the grafana instance for development purposes
+# Do NOT enable these settings in a public facing / production grafana instance
+ENV GF_AUTH_ANONYMOUS_ORG_ROLE "Admin"
+ENV GF_AUTH_ANONYMOUS_ENABLED "true"
+ENV GF_AUTH_BASIC_ENABLED "false"
+# Set development mode so plugins can be loaded without the need to sign
+ENV GF_DEFAULT_APP_MODE "development"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.0'
+
+services:
+  grafana:
+    container_name: 'synthetic-monitoring-app'
+    build:
+      context: ./
+      args:
+        grafana_version: ${GRAFANA_VERSION:-8.5.0}
+    ports:
+      - 3000:3000/tcp
+    volumes:
+      - ./dist:/var/lib/grafana/plugins/synthetic-monitoring-app


### PR DESCRIPTION
### What changed?
Introduced a basic Docker setup (`Dockerfile` and `docker-compose.yml`) to make it easier to develop the plugin against a certain Grafana version. (It can be that I have missed something and it already exists in the repo somewhere, in that case please let me know).