### PR TITLE
Routing: only redirect to the Home page if the URL matches the plugin

### DIFF
--- a/src/components/Routing.tsx
+++ b/src/components/Routing.tsx
@@ -75,7 +75,9 @@ export const Routing = ({ onNavChanged, meta, ...rest }: AppRootProps) => {
         <Route path={`${PLUGIN_URL_PATH}${ROUTES.Checks}`}>
           <CheckRouter />
         </Route>
-        <Route exact path="*">
+
+        {/* Default route (only redirect if the path matches the plugin's URL) */}
+        <Route path={PLUGIN_URL_PATH}>
           <Redirect to={`${PLUGIN_URL_PATH}${ROUTES.Home}`} />
         </Route>
       </Switch>


### PR DESCRIPTION
**Related Slack discussion:** https://raintank-corp.slack.com/archives/C01C4K8DETW/p1650966538006679
**Related issue:** https://github.com/grafana/grafana-plugin-examples/pull/71

### What changed?

We noticed a weird issue when trying to navigate between certain app plugins in Grafana: the URL was flickering but the actual navigation never or rarely happened. 

One of the reasons was that a `<Redirect>` component (for serving a "base url") initiated a redirect every time
the plugin was rendered, and like that it was overriding navigation happening between app plugins. Only redirecting when the URL matches the plugin's URL solves the issue. 

The best solution to this problem would be if the app plugin would never render again after we are "navigating away" from it, and this would need to be fixed in the core wrapper. However as this is not straightforward to fix and takes more time we wanted to "attack" the problem from multiple angles and make the plugins more resilient to this issue, too.

https://user-images.githubusercontent.com/9974811/165697717-0215e985-881a-42bd-b34a-5bfecd63b5c9.mov


