### PR TITLE
fix: unprovisioned setup could get in an infinite loop

### DIFF
--- a/src/components/InstanceProvider.tsx
+++ b/src/components/InstanceProvider.tsx
@@ -110,8 +110,10 @@ export const InstanceProvider = ({
     throw new Error('There was an error finding datasources required for Synthetic Monitoring');
   }
 
+  const provisioned = Boolean(meta.jsonData?.metrics?.grafanaName);
+
   return (
-    <InstanceContext.Provider value={{ meta, instance: instances, loading: instancesLoading }}>
+    <InstanceContext.Provider value={{ meta, instance: instances, loading: instancesLoading, provisioned }}>
       {children}
     </InstanceContext.Provider>
   );

--- a/src/components/Routing.tsx
+++ b/src/components/Routing.tsx
@@ -19,7 +19,7 @@ export const Routing = ({ onNavChanged, meta, ...rest }: AppRootProps) => {
   const queryParams = useQuery();
   const navigate = useNavigation();
   const location = useLocation();
-  const { instance } = useContext(InstanceContext);
+  const { instance, provisioned } = useContext(InstanceContext);
   const initialized = meta.enabled && instance.api;
 
   useEffect(() => {
@@ -28,16 +28,24 @@ export const Routing = ({ onNavChanged, meta, ...rest }: AppRootProps) => {
   }, [meta.info.logos.large, onNavChanged, location.pathname]);
 
   useEffect(() => {
-    if (meta.enabled && (!instance.metrics || !instance.logs) && !location.pathname.includes('unprovisioned')) {
+    // not provisioned and not initialized
+    if (
+      meta.enabled &&
+      (!instance.metrics || !instance.logs) &&
+      !provisioned &&
+      !location.pathname.includes('unprovisioned')
+    ) {
       navigate(ROUTES.Unprovisioned);
     }
+    // not provisioned and just initialized
     if (meta.enabled && instance.metrics && instance.logs && location.pathname.includes('unprovisioned')) {
       navigate(ROUTES.Home);
     }
-    if (meta.enabled && !instance.api && !location.pathname.includes('setup')) {
+    // Provisioned but not initialized
+    if (meta.enabled && !instance.api && provisioned && !location.pathname.includes('setup')) {
       navigate(ROUTES.Setup);
     }
-  }, [meta.enabled, instance.metrics, instance.logs, location.pathname, navigate, instance.api]);
+  }, [meta.enabled, instance.metrics, instance.logs, location.pathname, navigate, instance.api, provisioned]);
 
   const page = queryParams.get('page');
   useEffect(() => {

--- a/src/contexts/InstanceContext.ts
+++ b/src/contexts/InstanceContext.ts
@@ -6,10 +6,12 @@ interface InstanceContextValue {
   loading: boolean;
   instance: GrafanaInstances;
   meta: AppPluginMeta<GlobalSettings> | undefined;
+  provisioned?: boolean;
 }
 
 export const InstanceContext = createContext<InstanceContextValue>({
   instance: {},
   loading: true,
   meta: undefined,
+  provisioned: false,
 });


### PR DESCRIPTION
When running the plugin locally without provisioning it was getting stuck in an infinite redirect loop