### PR TITLE
Fix duplicate panel ID in this dashboard

### DIFF
--- a/src/dashboards/sm-ping.json
+++ b/src/dashboards/sm-ping.json
@@ -1000,5 +1000,5 @@
   "timezone": "",
   "title": "Synthetic Monitoring Ping",
   "uid": "EHyn7ueZk",
-  "version": 32
+  "version": 33
 }

--- a/src/dashboards/sm-ping.json
+++ b/src/dashboards/sm-ping.json
@@ -76,7 +76,7 @@
   "links": [],
   "panels": [
     {
-      "id": 34,
+      "id": 33,
       "gridPos": {
         "h": 9,
         "w": 12,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using convential commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:
In support ticket, a customer discovered that they are unable to edit the "Average latency" panel in the "Synthetic Monitoring Ping" dashboard provided by the SM App. The problem (as described in https://community.grafana.com/t/selecting-edit-on-panel-opens-edit-window-for-a-different-panel/5435/2) is that two panels have this in their JSON:

```
      "id": 34,
```

By changing one of the panels to have id=33, that fixes the problem

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

n/a

**Special notes for your reviewer**:

<!-- 
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->

