### PR TITLE
feat: minor ux tweaks to setup page

### DIFF
--- a/src/components/TenantAPISetupForm.tsx
+++ b/src/components/TenantAPISetupForm.tsx
@@ -25,6 +25,14 @@ const TenantAPISetupForm = ({ onSubmit, submissionError }: Props) => {
     defaultValues: { apiHost: DEFAULT_API_HOST, adminApiToken: '' },
   });
 
+  const renderAPIKeyLink = (text: string) => (<a
+    className="external-link"
+    href="//grafana.com/profile/api-keys"
+    target="_blank"
+    rel="noopener noreferrer"
+  >{text}</a>
+  );
+
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <div>
@@ -33,23 +41,11 @@ const TenantAPISetupForm = ({ onSubmit, submissionError }: Props) => {
             title="Initialize Synthetic Monitoring App"
             url={'https://grafana.com/grafana/plugins/grafana-synthetic-monitoring-app/'}
           >
-            <p>
-              To initialize the App and connect it to your Grafana Cloud service you will need a Admin API key for you
-              Grafana.com account. The <b>API key</b> is only needed for the initialization process and will not be
-              stored. Once the initialization is complete you can safely delete the key.
-              <br />
-              <br />
-              <a
-                className="highlight-word"
-                href="//grafana.com/profile/api-keys"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Generate a new API key
-              </a>
-            </p>
+            To initialize the App and connect it to your Grafana Cloud service you will need a admin {renderAPIKeyLink("API key")} for you
+            Grafana.com account. The {renderAPIKeyLink("API key")} is only needed for the initialization process and will not be
+            stored. Once the initialization is complete you can safely delete the key.
           </InfoBox>
-          <Field label="Admin API Key" required invalid={Boolean(errors.adminApiToken)}>
+          <Field label="Admin API Key" required invalid={Boolean(errors.adminApiToken)} description={<>You can generate a new API key {renderAPIKeyLink("here")}.</>}>
             <Input
               {...register('adminApiToken', { required: true })}
               id="tenant-setup-api-key"

--- a/src/components/TenantAPISetupForm.tsx
+++ b/src/components/TenantAPISetupForm.tsx
@@ -25,12 +25,10 @@ const TenantAPISetupForm = ({ onSubmit, submissionError }: Props) => {
     defaultValues: { apiHost: DEFAULT_API_HOST, adminApiToken: '' },
   });
 
-  const renderAPIKeyLink = (text: string) => (<a
-    className="external-link"
-    href="//grafana.com/profile/api-keys"
-    target="_blank"
-    rel="noopener noreferrer"
-  >{text}</a>
+  const renderAPIKeyLink = (text: string) => (
+    <a className="external-link" href="//grafana.com/profile/api-keys" target="_blank" rel="noopener noreferrer">
+      {text}
+    </a>
   );
 
   return (
@@ -41,11 +39,17 @@ const TenantAPISetupForm = ({ onSubmit, submissionError }: Props) => {
             title="Initialize Synthetic Monitoring App"
             url={'https://grafana.com/grafana/plugins/grafana-synthetic-monitoring-app/'}
           >
-            To initialize the App and connect it to your Grafana Cloud service you will need a admin {renderAPIKeyLink("API key")} for you
-            Grafana.com account. The {renderAPIKeyLink("API key")} is only needed for the initialization process and will not be
-            stored. Once the initialization is complete you can safely delete the key.
+            To initialize the App and connect it to your Grafana Cloud service you will need a admin{' '}
+            {renderAPIKeyLink('API key')} for you Grafana.com account. The {renderAPIKeyLink('API key')} is only needed
+            for the initialization process and will not be stored. Once the initialization is complete you can safely
+            delete the key.
           </InfoBox>
-          <Field label="Admin API Key" required invalid={Boolean(errors.adminApiToken)} description={<>You can generate a new API key {renderAPIKeyLink("here")}.</>}>
+          <Field
+            label="Admin API Key"
+            required
+            invalid={Boolean(errors.adminApiToken)}
+            description={<>You can generate a new API key {renderAPIKeyLink('here')}.</>}
+          >
             <Input
               {...register('adminApiToken', { required: true })}
               id="tenant-setup-api-key"


### PR DESCRIPTION
Noticed this strange orange link that goes to grafana.com, never seen an orange link in Grafana so did some minor tweaking to this link. Made links in the text instead and an extra one in the field description. 

Before:
![Screenshot from 2022-10-04 08-22-18](https://user-images.githubusercontent.com/10999/193748866-76453cfd-1e81-4b42-bbf4-ddaf4a45c472.png)

After:
![Screenshot from 2022-10-04 08-21-38](https://user-images.githubusercontent.com/10999/193748882-4ec7c2c9-ecdd-45f1-a0dc-d49ecdf7ec05.png)
