### PR TITLE
fix: remove limit on resource name lenght

### DIFF
--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -135,7 +135,7 @@ export const sanitizeName = (name: string): string => {
     }
     return char;
   });
-  return sanitized.join('').slice(0, 50);
+  return sanitized.join('');
 };
 
 export const probeToTF = (probe: Probe): TFProbe => ({


### PR DESCRIPTION
I cannot find anything that says that resource names in terraform have a limit. I can find some blurb here and there about specific providers imposing limits on resource names, but that doesn't seem to come from terraform.

I tried with longer resource names and they work. I cannot find anything in the Grafana provider that limits that, either.

Fixes: grafana/support-escalations#4118 #482 
Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>