### PR TITLE
Fix: fix error for non-traceroutes; clear error if check type changes

### DIFF
--- a/src/components/CheckEditor/CheckEditor.tsx
+++ b/src/components/CheckEditor/CheckEditor.tsx
@@ -217,8 +217,9 @@ export const CheckEditor = ({ checks, onReturn }: Props) => {
           {submissionError && (
             <div className={styles.submissionError}>
               <Alert title="Save failed" severity="error">
-                {`${submissionError.status}: ${submissionError.data?.msg?.concat(', ', submissionError.data?.err ?? '') ?? 'Something went wrong'
-                  }`}
+                {`${submissionError.status}: ${
+                  submissionError.data?.msg?.concat(', ', submissionError.data?.err ?? '') ?? 'Something went wrong'
+                }`}
               </Alert>
             </div>
           )}

--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -21,6 +21,7 @@ export const ProbeOptions = ({ frequency, timeout, isEditor, probes }: Props) =>
     control,
     watch,
     formState: { errors },
+    clearErrors,
   } = useFormContext();
   const { instance } = useContext(InstanceContext);
 
@@ -38,6 +39,10 @@ export const ProbeOptions = ({ frequency, timeout, isEditor, probes }: Props) =>
     fetchProbes();
     return () => abortController.abort();
   }, [instance]);
+
+  useEffect(() => {
+    clearErrors();
+  }, [checkType, clearErrors]);
 
   return (
     <div>

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -88,9 +88,7 @@ export function validateFrequency(frequency: number, selectedCheckType: CheckTyp
 }
 
 export function validateTimeout(timeout: number, checkType: CheckType): string | undefined {
-  // const maxTimeout = checkType === CheckType.Traceroute ? 30 : 10;
-  const maxTimeout = 30;
-  // console.log('validation', { maxTimeout, checkType });
+  const maxTimeout = checkType === CheckType.Traceroute ? 30 : 10;
   if (timeout < 1) {
     return 'Timeout must be at least 1 second';
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using convential commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:
1) Traceroute checks have a default and immuatble timeout of 30 seconds; but all other checks should have an adjustable timeout from 1 to 10 seconds. Previously our error message misled users with non-traceroute checks to believe that they could adjust up to 30 seconds, which is inaccurate. So this PR fixes that to reflect the correct params.

2) Also fixed a bug that didnt clear the error messages from the slider input, even if the user changed their `checkType`

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/support-escalations/issues/4312
Fixes https://github.com/grafana/synthetic-monitoring-app/issues/486
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- 
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
<img width="1004" alt="Screenshot 2022-11-07 at 11 25 37 AM" src="https://user-images.githubusercontent.com/27353719/200397073-d00c3ebb-8f66-451e-bf2a-ceeac9f5ad14.png">

<img width="738" alt="Screenshot 2022-11-07 at 11 25 52 AM" src="https://user-images.githubusercontent.com/27353719/200397062-e4f620eb-39a4-47fc-8c19-b8af2229922d.png">

