### PR TITLE
fix: show error state if validating the body of an HTTP HEAD request

### DIFF
--- a/src/components/CheckEditor/CheckEditorExisting.test.tsx
+++ b/src/components/CheckEditor/CheckEditorExisting.test.tsx
@@ -43,7 +43,7 @@ const renderExistingCheckEditor = async (route: string) => {
     alertRuler: {} as DataSourceSettings,
   };
   const meta = {} as AppPluginMeta<GlobalSettings>;
-  const featureToggles = ({ traceroute: true } as unknown) as FeatureToggles;
+  const featureToggles = { traceroute: true } as unknown as FeatureToggles;
   const isFeatureEnabled = jest.fn(() => true);
 
   render(
@@ -117,7 +117,7 @@ describe('editing checks', () => {
     expect(alertingValue).toBeInTheDocument();
   });
 
-  it('transforms data from existing HTTP check', async () => {
+  it.only('transforms data from existing HTTP check', async () => {
     const instance = await renderExistingCheckEditor('/edit/1');
 
     const jobInput = await screen.findByLabelText('Job Name', { exact: false });

--- a/src/components/CheckEditor/CheckEditorExisting.test.tsx
+++ b/src/components/CheckEditor/CheckEditorExisting.test.tsx
@@ -117,7 +117,7 @@ describe('editing checks', () => {
     expect(alertingValue).toBeInTheDocument();
   });
 
-  it.only('transforms data from existing HTTP check', async () => {
+  it('transforms data from existing HTTP check', async () => {
     const instance = await renderExistingCheckEditor('/edit/1');
 
     const jobInput = await screen.findByLabelText('Job Name', { exact: false });

--- a/src/components/HorizonalCheckboxField.tsx
+++ b/src/components/HorizonalCheckboxField.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { css, cx } from '@emotion/css';
-import { useStyles, Checkbox, Label } from '@grafana/ui';
-import { GrafanaTheme } from '@grafana/data';
+import { Checkbox, Label, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
 import { useFormContext } from 'react-hook-form';
 
-const getStyles = (theme: GrafanaTheme) => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   container: css`
     display: flex;
     align-items: center;
-    margin-bottom: ${theme.spacing.md};
+    margin-bottom: ${theme.spacing(2)};
+    gap: ${theme.spacing(2)};
   `,
   checkbox: css`
     position: relative;
@@ -39,7 +40,7 @@ export const HorizontalCheckboxField = ({
   value,
   onChange,
 }: Props) => {
-  const styles = useStyles(getStyles);
+  const styles = useStyles2(getStyles);
   const { register } = useFormContext();
   const registered = name ? register(name) : {};
 
@@ -48,7 +49,7 @@ export const HorizontalCheckboxField = ({
       <Checkbox
         disabled={disabled}
         id={id}
-        style={{ position: 'relative', marginRight: '10px' }}
+        style={{ marginRight: '10px' }}
         value={value}
         onChange={onChange}
         {...registered}

--- a/src/components/SliderInput.tsx
+++ b/src/components/SliderInput.tsx
@@ -24,7 +24,7 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
   slider: css`
     width: 250px;
-    margin-right: ${theme.spacing.sm};
+    margin-right: ${theme.spacing.md};
     margin-left: ${theme.spacing.sm};
   `,
   inputGroupWrapper: css`

--- a/src/components/http/HttpSettings.tsx
+++ b/src/components/http/HttpSettings.tsx
@@ -414,9 +414,9 @@ export const HttpSettingsForm = ({ isEditor }: Props) => {
                             if (value?.value === HttpRegexValidationType.Body) {
                               return 'Cannot validate the body of a HEAD request';
                             }
-                            return false;
+                            return;
                           }
-                          return false;
+                          return;
                         },
                       }}
                       name={`${REGEX_FIELD_NAME}.${index}.matchType` as const}

--- a/src/components/http/HttpSettings.tsx
+++ b/src/components/http/HttpSettings.tsx
@@ -153,7 +153,6 @@ const getStyles = (theme: GrafanaTheme) => ({
   `,
   validationInverted: css`
     position: relative;
-    margin-top: -20px;
     justify-self: center;
   `,
   maxWidth: css`
@@ -168,7 +167,7 @@ const getStyles = (theme: GrafanaTheme) => ({
     margin-right: ${theme.spacing.sm};
   `,
   validationAllowMissing: css`
-    justify-self: center;
+    justify-self: start;
   `,
 });
 
@@ -394,12 +393,32 @@ export const HttpSettingsForm = ({ isEditor }: Props) => {
               {fields.map((field, index) => {
                 const isHeaderMatch =
                   watch(`${REGEX_FIELD_NAME}.${index}.matchType`)?.value === HttpRegexValidationType.Header;
+                const disallowBodyMatching = watch('settings.http.method').value === HttpMethod.HEAD;
                 return (
                   <Fragment key={field.id}>
                     <Controller
                       render={({ field }) => (
-                        <Select {...field} placeholder="Field name" options={HTTP_REGEX_VALIDATION_OPTIONS} />
+                        <Select
+                          {...field}
+                          placeholder="Field name"
+                          options={HTTP_REGEX_VALIDATION_OPTIONS}
+                          invalid={
+                            disallowBodyMatching &&
+                            errors?.settings?.http?.regexValidations?.[index]?.matchType?.message
+                          }
+                        />
                       )}
+                      rules={{
+                        validate: (value) => {
+                          if (disallowBodyMatching) {
+                            if (value?.value === HttpRegexValidationType.Body) {
+                              return 'Cannot validate the body of a HEAD request';
+                            }
+                            return false;
+                          }
+                          return false;
+                        },
+                      }}
                       name={`${REGEX_FIELD_NAME}.${index}.matchType` as const}
                     />
                     <div className={styles.validationExpressions}>


### PR DESCRIPTION
Fixes #483 

Shows an error if trying to validate the body of a HEAD request. Also fixes a couple little styling and alignment issues that have been creeping in.

![Screenshot 2023-01-09 at 12 05 00](https://user-images.githubusercontent.com/8377044/211410263-272e29b0-d348-414f-8e6f-29aa2459b6e9.png)
