### PR TITLE
chore: update the labels on dns regex validation

### DIFF
--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -28,9 +28,9 @@ export const DNS_RESPONSE_CODES = enumToStringArray(DnsResponseCodes).map((respo
 }));
 
 export const DNS_RESPONSE_MATCH_OPTIONS = [
-  { label: `Validate ${ResponseMatchType.Authority} matches`, value: ResponseMatchType.Authority },
-  { label: `Validate ${ResponseMatchType.Answer} matches`, value: ResponseMatchType.Answer },
-  { label: `Validate ${ResponseMatchType.Additional} matches`, value: ResponseMatchType.Additional },
+  { label: `Fail if ${ResponseMatchType.Authority} matches`, value: ResponseMatchType.Authority },
+  { label: `Fail if ${ResponseMatchType.Answer} matches`, value: ResponseMatchType.Answer },
+  { label: `Fail if ${ResponseMatchType.Additional} matches`, value: ResponseMatchType.Additional },
 ];
 
 export const DNS_RECORD_TYPES = [


### PR DESCRIPTION
fixes #475 

The labels for DNS regex validations were wonky. They were both different in language than for all the other check types and inverted the logic. This clarifies it so that users know the check will fail on a regex match unless the `invert match` option is selected.

![Screenshot 2023-01-09 at 12 30 26](https://user-images.githubusercontent.com/8377044/211412107-48136163-c813-40e3-b1ca-09e8e1e76323.png)
