### PR TITLE
Make config internal to the app

### DIFF
--- a/src/components/ConfigPageWrapper.tsx
+++ b/src/components/ConfigPageWrapper.tsx
@@ -1,0 +1,23 @@
+import { PluginConfigPageProps, AppPluginMeta } from '@grafana/data';
+import { InstanceProvider } from 'components/InstanceProvider';
+import { ConfigPage } from 'page/ConfigPage';
+import React, { PureComponent } from 'react';
+import { GlobalSettings } from 'types';
+
+interface Props extends PluginConfigPageProps<AppPluginMeta<GlobalSettings>> {}
+
+export class ConfigPageWrapper extends PureComponent<Props> {
+  render() {
+    const { plugin } = this.props;
+
+    return (
+      <InstanceProvider
+        metricInstanceName={plugin.meta.jsonData?.metrics?.grafanaName}
+        logsInstanceName={plugin.meta.jsonData?.logs?.grafanaName}
+        meta={plugin.meta}
+      >
+        <ConfigPage />
+      </InstanceProvider>
+    );
+  }
+}

--- a/src/components/Routing.tsx
+++ b/src/components/Routing.tsx
@@ -16,6 +16,7 @@ import { DashboardRedirecter } from './DashboardRedirecter';
 import { ROUTES } from 'types';
 import { config } from '@grafana/runtime';
 import { PluginPage } from 'components/PluginPage';
+import { ConfigPage } from 'page/ConfigPage';
 
 export const Routing = ({ onNavChanged, meta, ...rest }: AppRootProps) => {
   const queryParams = useQuery();
@@ -88,6 +89,11 @@ export const Routing = ({ onNavChanged, meta, ...rest }: AppRootProps) => {
       </Route>
       <Route path={`${PLUGIN_URL_PATH}${ROUTES.Checks}`}>
         <CheckRouter />
+      </Route>
+      <Route path={`${PLUGIN_URL_PATH}${ROUTES.Config}`}>
+        <PluginPage>
+          <ConfigPage />
+        </PluginPage>
       </Route>
 
       {/* Default route (only redirect if the path matches the plugin's URL) */}

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,11 +1,11 @@
 import { AppPlugin } from '@grafana/data';
 import { GlobalSettings } from './types';
 import { App } from 'components/App';
-import { ConfigPage } from 'page/ConfigPage';
+import { ConfigPageWrapper } from 'components/ConfigPageWrapper';
 
 export const plugin = new AppPlugin<GlobalSettings>().setRootPage(App).addConfigPage({
   title: 'Config',
   icon: 'cog',
-  body: ConfigPage,
+  body: ConfigPageWrapper,
   id: 'config',
 });

--- a/src/page/ConfigPage.tsx
+++ b/src/page/ConfigPage.tsx
@@ -1,61 +1,52 @@
-import { PluginConfigPageProps, AppPluginMeta } from '@grafana/data';
+import { Spinner } from '@grafana/ui';
 import { ConfigActions } from 'components/ConfigActions';
-import { InstanceProvider } from 'components/InstanceProvider';
 import { ProgrammaticManagement } from 'components/ProgrammaticManagement';
 import { TenantSetup } from 'components/TenantSetup';
-import React, { PureComponent } from 'react';
-import { GlobalSettings } from 'types';
+import { InstanceContext } from 'contexts/InstanceContext';
+import React, { useContext } from 'react';
 
-interface Props extends PluginConfigPageProps<AppPluginMeta<GlobalSettings>> {}
-
-export class ConfigPage extends PureComponent<Props> {
-  render() {
-    const { plugin } = this.props;
-
-    return (
-      <InstanceProvider
-        metricInstanceName={plugin.meta.jsonData?.metrics?.grafanaName}
-        logsInstanceName={plugin.meta.jsonData?.logs?.grafanaName}
-        meta={plugin.meta}
-      >
-        <div>
-          <div className="card-item">
-            <div>
-              <h4>Synthetic Monitoring App</h4>
-            </div>
-            <div>
-              <p>
-                Synthetic Monitoring is a blackbox monitoring solution provided as part of{' '}
-                <a
-                  className="highlight-word"
-                  href="https://grafana.com/products/cloud/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Grafana Cloud
-                </a>
-                . If you don&apos;t already have a Grafana Cloud service,{' '}
-                <a
-                  className="highlight-word"
-                  href="https://grafana.com/signup/cloud"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  sign up now{' '}
-                </a>
-              </p>
-            </div>
-          </div>
-          <br />
-          <TenantSetup />
-          <br />
-          {plugin.meta.enabled && <ProgrammaticManagement />}
-          <br />
-          <br />
-          <br />
-          <ConfigActions enabled={plugin.meta.enabled} pluginId={plugin.meta.id} />
-        </div>
-      </InstanceProvider>
-    );
+export function ConfigPage() {
+  const { meta, loading } = useContext(InstanceContext);
+  if (loading) {
+    return <Spinner />;
   }
+  return (
+    <div>
+      <div className="card-item">
+        <div>
+          <h4>Synthetic Monitoring App</h4>
+        </div>
+        <div>
+          <p>
+            Synthetic Monitoring is a blackbox monitoring solution provided as part of{' '}
+            <a
+              className="highlight-word"
+              href="https://grafana.com/products/cloud/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Grafana Cloud
+            </a>
+            . If you don&apos;t already have a Grafana Cloud service,{' '}
+            <a
+              className="highlight-word"
+              href="https://grafana.com/signup/cloud"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              sign up now{' '}
+            </a>
+          </p>
+        </div>
+      </div>
+      <br />
+      <TenantSetup />
+      <br />
+      {meta?.enabled && <ProgrammaticManagement />}
+      <br />
+      <br />
+      <br />
+      <ConfigActions enabled={meta?.enabled} pluginId={meta?.id ?? 'grafana-synthetic-monitoring-app'} />
+    </div>
+  );
 }

--- a/src/page/pageDefinitions.ts
+++ b/src/page/pageDefinitions.ts
@@ -32,6 +32,11 @@ const pages: NavModelItem[] = [
     id: 'alerts',
     url: `${PLUGIN_URL_PATH}alerts`,
   },
+  {
+    text: 'Config',
+    id: 'config',
+    url: `${PLUGIN_URL_PATH}config`,
+  },
 ];
 
 export const getNavModel = (logo: string, path: string) => {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -77,7 +77,7 @@
     {
       "type": "page",
       "name": "Config",
-      "path": "/plugins/grafana-synthetic-monitoring-app",
+      "path": "/a/grafana-synthetic-monitoring-app/config",
       "addToNav": true
     }
   ],

--- a/src/types.ts
+++ b/src/types.ts
@@ -505,6 +505,7 @@ export enum ROUTES {
   Checks = 'checks',
   NewCheck = 'checks/new',
   EditCheck = 'checks/edit',
+  Config = 'config',
 }
 
 export interface CheckPageParams {


### PR DESCRIPTION
We bumped into a problem where some grafana instances can hide SM from the plugin catalog. That means that when a user clicks on the `config` item in the sidebar, they get sent to a page that doesn't exist and get a generic `plugin not found` error.

It also means they can't access some features like getting a terraform config or updating dashboards. If we take the contents of the config page and render them internally in the plugin we can avoid this complication. Updated:

![Screenshot 2023-02-06 at 09 30 35](https://user-images.githubusercontent.com/8377044/217056470-8b52dd5a-5975-462f-b642-221a5897269c.png)

With top nav enabled:

![Screenshot 2023-02-06 at 09 31 05](https://user-images.githubusercontent.com/8377044/217056527-ba8d9dc3-de0d-44f8-890b-abebaff27e93.png)
