### PR TITLE
chore: remove worldmap dependency

### DIFF
--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -41,7 +41,6 @@ docker run \
   -v "$(pwd)/scripts/local-provisioning:/etc/grafana/provisioning"  \
   -v "$(pwd)/scripts/custom.ini:/etc/grafana/grafana.ini"\
   -v grafana-storage:/var/lib/grafana \
-  -e "GF_INSTALL_PLUGINS=grafana-worldmap-panel" \
   -t \
   --name="$NAME" \
   grafana/grafana":$grafanaVersion"

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -82,15 +82,8 @@
     }
   ],
   "dependencies": {
-    "grafanaDependency": ">=8.3.3",
-    "grafanaVersion": "8.3",
-    "plugins": [
-      {
-        "type": "panel",
-        "name": "Worldmap Panel",
-        "id": "grafana-worldmap-panel",
-        "version": "^0.3.3"
-      }
-    ]
+    "grafanaDependency": ">=9.0.0",
+    "grafanaVersion": "9.0",
+    "plugins": []
   }
 }


### PR DESCRIPTION
We haven't used the worldmap panel for over a year, but we had to keep the dependency around for users on older grafana instances (I think? The reason has been lost to the sands of time). The time window for supporting that switch has long passed, I think, so it's time to remove it completely.  