### PR TITLE
fix: variable interpolation in traceroute dashboard queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [1.9.35](https://github.com/grafana/synthetic-monitoring-app/compare/v1.9.43...v1.9.35) (2023-2-16)
+
+- Fix a bug with rendering data in the node panel for traceroute checks
+
 # [1.9.34](https://github.com/grafana/synthetic-monitoring-app/compare/v1.9.33...v1.9.34) (2023-2-09)
 
 - Fix a bug with the config page not rendering in cloud instances

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthetic-monitoring-app",
-  "version": "1.9.34",
+  "version": "1.9.35",
   "description": "Grafana Synthetic Monitoring App",
   "scripts": {
     "lint": "eslint --cache --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx .",

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -7,7 +7,7 @@ import {
   ArrayDataFrame,
   DataFrame,
   MetricFindValue,
-  VariableModel,
+  TypedVariableModel,
 } from '@grafana/data';
 
 import { SMQuery, SMOptions, QueryType, CheckInfo, DashboardVariable } from './types';
@@ -84,9 +84,10 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
           };
         }
 
-        const finalQuery = `{probe=~"${query.probe ?? '.+'}", job="${query.job}", instance="${
-          query.instance
+        const finalQuery = `{probe=~"${queryToExecute.probe ?? '.+'}", job="${queryToExecute.job}", instance="${
+          queryToExecute.instance
         }", check_name="traceroute"} | logfmt`;
+
         const response = await queryLogs(logsUrl, finalQuery, options.range.from.unix(), options.range.to.unix());
 
         const dataFrames = parseTracerouteLogs(response);
@@ -116,7 +117,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
     return allProbes;
   }
 
-  getQueryFromVars(dashboardVars: VariableModel[], query: SMQuery): SMQuery {
+  getQueryFromVars(dashboardVars: TypedVariableModel[], query: SMQuery): SMQuery {
     const job = dashboardVars.find((variable) => variable.name === 'job') as DashboardVariable | undefined;
     const instance = dashboardVars.find((variable) => variable.name === 'instance') as DashboardVariable | undefined;
     const probe = dashboardVars.find((variable) => variable.name === 'probe') as DashboardVariable | undefined;


### PR DESCRIPTION
This resolves a bug that got reported where dashboard panels were reporting no data in the traceroute node panel