### PR TITLE
Match ds on uid

### DIFF
--- a/src/components/DashboardList.tsx
+++ b/src/components/DashboardList.tsx
@@ -49,11 +49,13 @@ export class DashboardList extends PureComponent<Props, State> {
     if (!onChange) {
       return;
     }
-    const smDsName = instance?.api?.instanceSettings.name;
+    const smDsName = instance?.api?.instanceSettings?.name;
+    const metricsUid = instance?.api?.instanceSettings.jsonData?.metrics?.uid;
+    const logsUid = instance?.api?.instanceSettings.jsonData?.logs?.uid;
     const updatedDashboard = await importDashboard(
       dashboard.json,
-      options.metrics.grafanaName,
-      options.logs.grafanaName,
+      metricsUid ?? options.metrics.grafanaName,
+      logsUid ?? options.logs.grafanaName,
       smDsName
     );
 

--- a/src/components/InstanceProvider.tsx
+++ b/src/components/InstanceProvider.tsx
@@ -32,11 +32,18 @@ async function fetchDatasources(
 ): Promise<GrafanaInstances> {
   const dataSourceSrv = getDataSourceSrv();
   const smApi = (await dataSourceSrv.get('Synthetic Monitoring').catch((e) => undefined)) as SMDataSource | undefined;
-  const metricsName = metricInstanceName ?? smApi?.instanceSettings?.jsonData?.metrics?.grafanaName;
-  const metrics = metricsName ? await dataSourceSrv.get(metricsName).catch((e) => undefined) : undefined;
+  const metrics = await dataSourceSrv.get({ uid: 'grafanacloud-metrics' }).catch((e) => {
+    const metricsName = metricInstanceName ?? smApi?.instanceSettings?.jsonData?.metrics?.grafanaName;
+    return dataSourceSrv.get(metricsName).catch((e) => undefined);
+  });
+  // if (!metrics && metricsName) {
+  //   metrics =
+  // }
 
-  const logsName = logsInstanceName ?? smApi?.instanceSettings?.jsonData?.logs?.grafanaName;
-  const logs = logsName ? await dataSourceSrv.get(logsName).catch((e) => undefined) : undefined;
+  const logs = await dataSourceSrv.get('grafanacloud-logs').catch((e) => {
+    const logsName = logsInstanceName ?? smApi?.instanceSettings?.jsonData?.logs?.grafanaName;
+    return dataSourceSrv.get(logsName).catch((e) => undefined);
+  });
 
   const alertRuler = await getRulerDatasource(metrics?.id);
 

--- a/src/components/LinkedDatasourceView.tsx
+++ b/src/components/LinkedDatasourceView.tsx
@@ -1,17 +1,28 @@
-import React from 'react';
-import { LinkedDatasourceInfo } from 'datasource/types';
+import React, { useContext } from 'react';
 import { Spinner } from '@grafana/ui';
 import { useNavigation } from 'hooks/useNavigation';
 import { ROUTES } from 'types';
 import { findLinkedDatasource } from 'utils';
+import { InstanceContext } from 'contexts/InstanceContext';
 
 interface Props {
-  info: LinkedDatasourceInfo;
+  type: 'loki' | 'prometheus';
 }
 
-const LinkedDatasourceView = ({ info }: Props) => {
+const LinkedDatasourceView = ({ type }: Props) => {
   const navigate = useNavigation();
-  const datasource = findLinkedDatasource(info);
+  const { instance, meta } = useContext(InstanceContext);
+  if (!instance.metrics || !instance.logs) {
+    return <Spinner />;
+  }
+
+  const info = type === 'prometheus' ? instance.metrics : instance.logs;
+  const hostedId = type === 'prometheus' ? meta?.jsonData?.metrics.hostedId : meta?.jsonData?.logs.hostedId;
+  const datasource = findLinkedDatasource({
+    grafanaName: info.name,
+    hostedId: hostedId ?? 0,
+    uid: info.uid,
+  });
 
   const handleClick = () => {
     if (datasource?.type === 'synthetic-monitoring-datasource') {

--- a/src/datasource/ConfigEditor.tsx
+++ b/src/datasource/ConfigEditor.tsx
@@ -3,6 +3,7 @@ import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { SMOptions, SecureJsonData } from './types';
 import { Container, LegacyForms } from '@grafana/ui';
 import LinkedDatasourceView from 'components/LinkedDatasourceView';
+import { InstanceProvider } from 'components/InstanceProvider';
 
 interface Props extends DataSourcePluginOptionsEditorProps<SMOptions, SecureJsonData> {}
 
@@ -40,11 +41,12 @@ export class ConfigEditor extends PureComponent<Props> {
       return (secureJsonFields && secureJsonFields.accessToken) as boolean;
     }
     return (
-      <div>
+      // @ts-ignore
+      <InstanceProvider meta={options}>
         {isValid(options.jsonData) && isConfigured() && (
           <Container margin="sm">
-            <LinkedDatasourceView info={options.jsonData.metrics} />
-            <LinkedDatasourceView info={options.jsonData.logs} />
+            <LinkedDatasourceView type="prometheus" />
+            <LinkedDatasourceView type="loki" />
           </Container>
         )}
         <br />
@@ -64,7 +66,7 @@ export class ConfigEditor extends PureComponent<Props> {
             </div>
           </div>
         </div>
-      </div>
+      </InstanceProvider>
     );
   }
 }

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -393,14 +393,14 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
     }
   }
 
-  async onOptionsChange(options: SMOptions) {
+  onOptionsChange = async (options: SMOptions) => {
     const data = {
       ...this.instanceSettings,
       jsonData: options,
       access: 'proxy',
     };
     await getBackendSrv().put(`api/datasources/${this.instanceSettings.id}`, data);
-  }
+  };
 
   async registerSave(apiToken: string, options: SMOptions, accessToken: string): Promise<any> {
     const data = {

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -53,10 +53,20 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   }
 
   getMetricsDS() {
-    return findLinkedDatasource(this.instanceSettings.jsonData.metrics);
+    const info = this.instanceSettings.jsonData.metrics;
+    const ds = findLinkedDatasource({ ...info, uid: 'grafanacloud-metrics' });
+    if (ds) {
+      return ds;
+    }
+    return findLinkedDatasource(info);
   }
 
   getLogsDS() {
+    const info = this.instanceSettings.jsonData.logs;
+    const ds = findLinkedDatasource({ ...info, uid: 'grafanacloud-logs' });
+    if (ds) {
+      return ds;
+    }
     return findLinkedDatasource(this.instanceSettings.jsonData.logs);
   }
 

--- a/src/page/ConfigPage.tsx
+++ b/src/page/ConfigPage.tsx
@@ -42,9 +42,6 @@ export function ConfigPage() {
   if (loading) {
     return <Spinner />;
   }
-  console.log({ instance: instance.api?.instanceSettings.jsonData.metrics });
-  console.log({ metrics: instance.metrics });
-  console.log({ logs: instance.logs });
   return (
     <div>
       <div>

--- a/src/page/ConfigPage.tsx
+++ b/src/page/ConfigPage.tsx
@@ -42,6 +42,9 @@ export function ConfigPage() {
   if (loading) {
     return <Spinner />;
   }
+  console.log({ instance: instance.api?.instanceSettings.jsonData.metrics });
+  console.log({ metrics: instance.metrics });
+  console.log({ logs: instance.logs });
   return (
     <div>
       <div>
@@ -79,8 +82,8 @@ export function ConfigPage() {
           <div className={styles.linkedDatasources}>
             <h3>Linked Data Sources</h3>
             <Container margin="sm">
-              <LinkedDatasourceView info={instance.api.instanceSettings.jsonData.metrics} />
-              <LinkedDatasourceView info={instance.api.instanceSettings.jsonData.logs} />
+              <LinkedDatasourceView type="prometheus" />
+              <LinkedDatasourceView type="loki" />
             </Container>
           </div>
           <div className={styles.backendAddress}>

--- a/src/page/WelcomePage.tsx
+++ b/src/page/WelcomePage.tsx
@@ -254,7 +254,7 @@ export const WelcomePage: FC<Props> = () => {
       });
       const smDatasources = await findSMDataSources();
       const smDatasourceName = smDatasources.length ? smDatasources[0].name : 'Synthetic Monitoring';
-      const dashboards = await importAllDashboards(metricsName, logsName, smDatasourceName);
+      const dashboards = await importAllDashboards(metricsSettings.uid, logsSettings.uid, smDatasourceName);
       const datasourcePayload = {
         apiHost: meta.jsonData.apiHost,
         accessToken,

--- a/src/page/WelcomePage.tsx
+++ b/src/page/WelcomePage.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState, useContext } from 'react';
-import { Button, Alert, useStyles2, Spinner } from '@grafana/ui';
+import { Button, Alert, useStyles2, Spinner, Modal } from '@grafana/ui';
 import { getBackendSrv, config } from '@grafana/runtime';
 import { findSMDataSources, hasRole, initializeDatasource } from 'utils';
 import { importAllDashboards } from 'dashboards/loader';
@@ -107,20 +107,132 @@ function getLogsName(provisionedName?: string) {
   return provisionedName ?? '';
 }
 
+function findDatasourceByNameAndUid(
+  provisionedName: string,
+  type: 'loki' | 'prometheus'
+): {
+  byName: DataSourceInstanceSettings<DataSourceJsonData> | undefined;
+  byUid: DataSourceInstanceSettings<DataSourceJsonData> | undefined;
+} {
+  const byName = config.datasources[provisionedName];
+  const byUid = Object.values(config.datasources).find((ds) => {
+    if (type === 'loki') {
+      return ds.uid === 'grafanacloud-logs';
+    } else {
+      return ds.uid === 'grafanacloud-metrics';
+    }
+  });
+  return {
+    byName,
+    byUid,
+  };
+}
+
+enum DatasourceStatus {
+  NameOnly = 'NameOnly',
+  Match = 'Match',
+  Mismatch = 'Mismatch',
+  UidOnly = 'UidOnly',
+  NotFound = 'NotFound',
+}
+
+function ensureNameAndUidMatch(
+  metricsByName?: DataSourceInstanceSettings<DataSourceJsonData>,
+  metricsByUid?: DataSourceInstanceSettings<DataSourceJsonData>
+): DatasourceStatus {
+  if (!metricsByUid && !metricsByName) {
+    return DatasourceStatus.NotFound;
+  }
+  if (!metricsByUid && metricsByName) {
+    return DatasourceStatus.NameOnly;
+  }
+  if (metricsByUid && !metricsByName) {
+    return DatasourceStatus.UidOnly;
+  }
+  if (metricsByUid && metricsByName) {
+    if (metricsByUid.name === metricsByName.name) {
+      return DatasourceStatus.Match;
+    }
+    return DatasourceStatus.Mismatch;
+  }
+  throw new Error('Invalid provisioning. Could not find datasources');
+}
+
 interface Props {}
 
 export const WelcomePage: FC<Props> = () => {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [datasourceModalOpen, setDataSouceModalOpen] = useState(false);
   const { meta } = useContext(InstanceContext);
   const styles = useStyles2(getStyles);
 
   const metricsName = getMetricsName(meta?.jsonData?.metrics.grafanaName);
-  const metricsDatasource = config.datasources[metricsName] as DataSourceInstanceSettings<DataSourceJsonData>;
+  const { byName: metricsByName, byUid: metricsByUid } = findDatasourceByNameAndUid(metricsName, 'prometheus');
   const logsName = getLogsName(meta?.jsonData?.logs.grafanaName);
-  const logsDatasource = config.datasources[logsName] as DataSourceInstanceSettings<DataSourceJsonData>;
+  const { byName: logsByName, byUid: logsByUid } = findDatasourceByNameAndUid(logsName, 'loki');
   const stackId = meta?.jsonData?.stackId;
-  const onClick = async () => {
+
+  const handleClick = async () => {
+    try {
+      const metricsStatus = ensureNameAndUidMatch(metricsByName, metricsByUid);
+      const logsStatus = ensureNameAndUidMatch(logsByName, logsByUid);
+
+      console.log({ metricsStatus, logsStatus });
+      if (metricsStatus === DatasourceStatus.NotFound) {
+        throw new Error('Invalid plugin configuration. Could not find a metrics datasource');
+      }
+      if (logsStatus === DatasourceStatus.NotFound) {
+        throw new Error('Invalid plugin configuration. Could not find a logs datasource');
+      }
+      // Either the plugin is running on prem and can find a datasource, or the provisioning matches with the default grafana cloud UIDs. Everything is good to go!
+      if (
+        (metricsStatus === DatasourceStatus.Match || metricsStatus === DatasourceStatus.NameOnly) &&
+        metricsByName &&
+        (logsStatus === DatasourceStatus.Match || logsStatus === DatasourceStatus.NameOnly) &&
+        logsByName
+      ) {
+        const metricsHostedId = meta?.jsonData?.metrics.hostedId;
+        if (!metricsHostedId) {
+          throw new Error('Invalid plugin configuration. Could not find metrics datasource hostedId');
+        }
+
+        const logsHostedId = meta?.jsonData?.logs.hostedId;
+        if (!logsHostedId) {
+          throw new Error('Invalid plugin configuration. Could not find logs datasource hostedId');
+        }
+
+        initialize({
+          metricsSettings: metricsByName,
+          metricsHostedId,
+          logsSettings: logsByName,
+          logsHostedId: logsHostedId,
+        });
+        return;
+      }
+
+      if (metricsStatus === DatasourceStatus.UidOnly || logsStatus === DatasourceStatus.UidOnly) {
+        setDataSouceModalOpen(true);
+      }
+
+      console.log('not matching');
+    } catch (e: any) {
+      setError(e?.message ?? 'Invalid plugin configuration. Could not find logs and metrics datasources');
+    }
+  };
+
+  const initialize = async ({
+    metricsSettings,
+    metricsHostedId,
+    logsSettings,
+    logsHostedId,
+  }: {
+    metricsSettings: DataSourceInstanceSettings<DataSourceJsonData>;
+    metricsHostedId: number;
+    logsSettings: DataSourceInstanceSettings<DataSourceJsonData>;
+    logsHostedId: number;
+  }) => {
+    console.log({ metricsSettings, logsSettings });
     trackEvent('provisionedSetupSubmit');
     if (!meta?.jsonData) {
       setError('Invalid plugin configuration');
@@ -203,13 +315,7 @@ export const WelcomePage: FC<Props> = () => {
             </div>
             <DisplayCard className={styles.start}>
               <h3 className={styles.heading}>Ready to start using synthetic monitoring?</h3>
-              <Button
-                onClick={onClick}
-                disabled={
-                  loading || !Boolean(metricsDatasource) || !Boolean(logsDatasource) || !hasRole(OrgRole.Editor)
-                }
-                size="lg"
-              >
+              <Button onClick={handleClick} disabled={loading || !hasRole(OrgRole.Editor)} size="lg">
                 {loading ? <Spinner /> : 'Initialize the plugin'}
               </Button>
             </DisplayCard>
@@ -221,6 +327,44 @@ export const WelcomePage: FC<Props> = () => {
           )}
         </div>
       </div>
+      <Modal isOpen={datasourceModalOpen} title="Datasource selection">
+        <p>
+          It looks like there is a mismatch between the way Synthetic Monitoring was provisioned and the currently
+          available datasources. This can happen when a Grafana instance is renamed, or if provisioning is incorrect.
+          Proceed with found datasources?
+        </p>
+        <dt>Expecting metrics datasource:</dt>
+        <dd>{metricsName}</dd>
+        <dt>Found metrics datasource:</dt>
+        <dd>{metricsByUid?.name}</dd>
+
+        <dt>Expecting logs datasource:</dt>
+        <dd>{logsName}</dd>
+        <dt>Found logs datasource:</dt>
+        <dd>{logsByUid?.name}</dd>
+        <Modal.ButtonRow>
+          <Button variant="secondary" fill="outline" onClick={() => setDataSouceModalOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            disabled={loading}
+            onClick={() => {
+              if (meta?.jsonData?.metrics?.hostedId && meta?.jsonData?.logs.hostedId) {
+                initialize({
+                  metricsSettings: metricsByUid!, // we have already guaranteed that this exists above
+                  metricsHostedId: meta.jsonData.metrics.hostedId,
+                  logsSettings: logsByUid!, // we have already guaranteed that this exists above
+                  logsHostedId: meta.jsonData.logs.hostedId,
+                });
+              } else {
+                setError('Missing datasource hostedId');
+              }
+            }}
+          >
+            {loading ? <Spinner /> : 'Proceed'}
+          </Button>
+        </Modal.ButtonRow>
+      </Modal>
     </PluginPage>
   );
 };


### PR DESCRIPTION
Fixes a problem where renaming a stack causes the synthetics configuration to go sideways. The root issue is that the SM plugin is referencing datasources by name, and the name changes when the stack changes. The fix is to reference datasources by UID instead (which are standard in cloud). 

In cases where the _name_ of the datasource doesn't match but there is a UID that SM can use, a modal will get shown notifying the user of the situation and allow them to proceed

![Screenshot 2023-05-26 at 09 13 02](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/8504144f-b34f-470e-ac26-f5f65e8ecae8)

This doesn't fix the problem for existing stacks that are already initialized without a UID. 