### PR TITLE
fix: Scenes: Broken summary dashboard link in Home

### DIFF
--- a/src/page/HomePage.tsx
+++ b/src/page/HomePage.tsx
@@ -166,7 +166,7 @@ const HomePage = () => {
             return (
               <a
                 className={styles.quickLink}
-                href={scenesEnabled ? `${PLUGIN_URL_PATH}scene/${dashboard.uid}` : `d/${dashboard.uid}`}
+                href={scenesEnabled ? (dashboard.uid === `` ? `${PLUGIN_URL_PATH}scene` : `${PLUGIN_URL_PATH}scene/${dashboard.uid}`) : `d/${dashboard.uid}`}
                 key={dashboard.uid}
               >
                 <Icon name="apps" size="lg" className={styles.quickLinkIcon} />


### PR DESCRIPTION
**What this PR does / why we need it**:

A slash at the end caused a 404 error.

**Which issue(s) this PR fixes**:

Closes #554
