### PR TITLE
fix: Repeated `dashboard` in Home

### DIFF
--- a/src/page/HomePage.tsx
+++ b/src/page/HomePage.tsx
@@ -170,7 +170,7 @@ const HomePage = () => {
                 key={dashboard.uid}
               >
                 <Icon name="apps" size="lg" className={styles.quickLinkIcon} />
-                View the {dashboard.title} dashboard
+                {scenesEnabled ? `View the ${dashboard.title}` : `View the ${dashboard.title} dashboard`}
               </a>
             );
           })}


### PR DESCRIPTION

**What this PR does / why we need it**:

Under scenes, the dashboard box in the Summary page showed the text dashboards twice for each dashboard.


**Which issue(s) this PR fixes**:

Closes #555
