### PR TITLE
chore: removed grafana-worldmap-panel dependency in plugin.json

### DIFF
--- a/dev/provisioning/plugins/example.yaml
+++ b/dev/provisioning/plugins/example.yaml
@@ -1,8 +1,5 @@
 # apiVersion: 1
 
-# panel:
-#   - type: grafana-worldmap-panel
-#     disabled: false
 # apps:
 #   - type: grafana-synthetic-monitoring-app
 #     name: grafana-synthetic-monitoring-app

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -83,14 +83,6 @@
   ],
   "dependencies": {
     "grafanaDependency": ">=8.3.3",
-    "grafanaVersion": "8.3",
-    "plugins": [
-      {
-        "type": "panel",
-        "name": "Worldmap Panel",
-        "id": "grafana-worldmap-panel",
-        "version": "^1.0.3"
-      }
-    ]
+    "grafanaVersion": "8.3"
   }
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:

Removes `grafana-worldmap-panel` from the list of dependant plugins in plugin.json.

`grafana-worldmap-panel` is deprecated, and it was replaced with `geomap` in #398

However, the dependency in `plugin.json` was not removed. This will cause Grafana to attempt to install `grafana-worldmap-panel` when installing `synthetic-monitoring-app`, even if it's not required anymore.

This is a problem because `grafana-worldmap-panel` uses Angular, which is being removed and will causes issues when installing `synthetic-monitoring-app` if [Angular is disabled](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#angular_support_enabled) in Grafana via config (which will also be the default in the future)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
