### PR TITLE
fix: allow non admin viewers to view alerts

### DIFF
--- a/src/components/Alerting.tsx
+++ b/src/components/Alerting.tsx
@@ -1,4 +1,4 @@
-import { GrafanaTheme2, OrgRole } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Button, HorizontalGroup, Icon, Modal, Spinner, useStyles2, Alert } from '@grafana/ui';
 import React, { FC, useState, useContext } from 'react';
 import { css } from '@emotion/css';
@@ -7,7 +7,6 @@ import { AlertRuleForm } from './AlertRuleForm';
 import { AlertFormValues, AlertRule } from 'types';
 import { InstanceContext } from 'contexts/InstanceContext';
 import { transformAlertFormValues } from './alertingTransformations';
-import { hasRole } from 'utils';
 import useUnifiedAlertsEnabled from 'hooks/useUnifiedAlertsEnabled';
 import { config } from '@grafana/runtime';
 
@@ -78,20 +77,6 @@ export const Alerting: FC = () => {
     });
     return await setRules([...recordingRules, ...updatedRules]);
   };
-
-  if (!hasRole(OrgRole.Admin)) {
-    return (
-      <div>
-        {!config.featureToggles.topnav && <h2>Alerts</h2>}
-        <Icon className={styles.icon} name="exclamation-triangle" />
-        Synthetic Monitoring uses &nbsp;
-        <a href="https://grafana.com/docs/grafana-cloud/alerting/" className={styles.link}>
-          Alerting
-        </a>
-        , which is not accessible for users without an admin role.
-      </div>
-    );
-  }
 
   if (!instance.alertRuler && !isUnifiedAlertingEnabled) {
     return (


### PR DESCRIPTION
Users with a viewer role will get a warning if they try and change things, editors will be able to edit

![Screenshot 2023-09-19 at 13 56 43](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/0d678875-c939-4c29-b789-cbc42747f352)

