### PR TITLE
fix: update provisioning examples to match readme

### DIFF
--- a/dev/provisioning/datasources/example.yaml
+++ b/dev/provisioning/datasources/example.yaml
@@ -5,18 +5,19 @@
 #     access: proxy
 #     url: https://logs-prod-us-central1.grafana.net
 #     basicAuth: true
-#     basicAuthUser: <instanceID>
-#     basicAuthPassword: <grafana.com api key>
+#     basicAuthUser: <Grafana Cloud Loki instance ID>
 #     jsonData:
 #       maxLines: 1000
+#     secureJsonData:
+#       basicAuthPassword: <viewer token from grafana.com>
 
 #   - name: grafanacloud-<orgslug>-prom
 #     type: prometheus
 #     access: proxy
 #     url: https://prometheus-us-central1.grafana.net/api/prom
 #     basicAuth: true
-#     basicAuthUser: <instanceID>
+#     basicAuthUser: <Grafana Cloud Prom instance ID>
 #     jsonData:
 #       timeInterval: 1s
 #     secureJsonData:
-#       basicAuthPassword: <grafana.com api key>
+#       basicAuthPassword: <viewer token from grafana.com>


### PR DESCRIPTION
# Problem
When setting up my dev environment I used the examples that were provided in the provisioning folders. I noticed later on that the `readMe.md` had the correct shape that was expected with more accurate comments of what is expected for `basicAuthPassword` and `basicAuthUser`.