### PR TITLE
Feat: Add Router and FeatureFlagProvider to the customRender to reduce test boilerplate

### DIFF
--- a/src/components/CheckEditor/CheckEditorExisting.test.tsx
+++ b/src/components/CheckEditor/CheckEditorExisting.test.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
-import { locationService } from '@grafana/runtime';
-import { Router, Route } from 'react-router-dom';
 
 import { render } from 'test/render';
 import { ROUTES } from 'types';
@@ -33,15 +31,10 @@ beforeEach(() => jest.resetAllMocks());
 const onReturn = jest.fn();
 
 const renderExistingCheckEditor = async (route: string) => {
-  locationService.push(`${PLUGIN_URL_PATH}${ROUTES.Checks}${route}`);
-
-  const res = render(
-    <Router history={locationService.getHistory()}>
-      <Route path={`${PLUGIN_URL_PATH}${ROUTES.Checks}/edit/:id`}>
-        <CheckEditor onReturn={onReturn} checks={BASIC_CHECK_LIST} />
-      </Route>
-    </Router>
-  );
+  const res = render(<CheckEditor onReturn={onReturn} checks={BASIC_CHECK_LIST} />, {
+    route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/edit/:id`,
+    path: `${PLUGIN_URL_PATH}${ROUTES.Checks}${route}`,
+  });
 
   await waitFor(() => expect(screen.getByText('Probe options')).toBeInTheDocument());
   return res;
@@ -189,16 +182,16 @@ describe('editing checks', () => {
     await user.click(invertMatch);
 
     await submitForm(onReturn, user);
-    expect(instance.api.addCheck).toHaveBeenCalledTimes(0);
-    expect(instance.api.updateCheck).toHaveBeenCalledWith(EDITED_HTTP_CHECK);
+    expect(instance.api?.addCheck).toHaveBeenCalledTimes(0);
+    expect(instance.api?.updateCheck).toHaveBeenCalledWith(EDITED_HTTP_CHECK);
   });
 
   it('transforms data correctly for TCP check', async () => {
     const { instance, user } = await renderExistingCheckEditor('/edit/4');
 
     await submitForm(onReturn, user);
-    expect(instance.api.addCheck).toHaveBeenCalledTimes(0);
-    expect(instance.api.updateCheck).toHaveBeenCalledWith(EDITED_TCP_CHECK);
+    expect(instance.api?.addCheck).toHaveBeenCalledTimes(0);
+    expect(instance.api?.updateCheck).toHaveBeenCalledWith(EDITED_TCP_CHECK);
   });
 
   it('transforms data correctly for DNS check', async () => {
@@ -218,8 +211,8 @@ describe('editing checks', () => {
     const invertedCheckboxes = await screen.findAllByRole('checkbox');
     await user.click(invertedCheckboxes[2]);
     await submitForm(onReturn, user);
-    expect(instance.api.addCheck).toHaveBeenCalledTimes(0);
-    expect(instance.api.updateCheck).toHaveBeenCalledWith(EDITED_DNS_CHECK);
+    expect(instance.api?.addCheck).toHaveBeenCalledTimes(0);
+    expect(instance.api?.updateCheck).toHaveBeenCalledWith(EDITED_DNS_CHECK);
   });
 
   it('handles custom alert severities', async () => {

--- a/src/components/CheckEditor/CheckEditorNew.test.tsx
+++ b/src/components/CheckEditor/CheckEditorNew.test.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
-import { FeatureToggles } from '@grafana/data';
 
 import { render } from 'test/render';
 import { CheckType, ROUTES } from 'types';
 import { PLUGIN_URL_PATH } from 'components/constants';
-import { FeatureFlagProvider } from 'components/FeatureFlagProvider';
 import { CheckEditor } from './CheckEditor';
 import { submitForm, fillBasicCheckFields, fillDnsValidationFields, fillTCPQueryResponseFields } from './testHelpers';
 import { BASIC_HTTP_CHECK, BASIC_PING_CHECK, BASIC_TCP_CHECK, BASIC_DNS_CHECK } from './testConstants';
@@ -25,18 +23,10 @@ beforeEach(() => jest.resetAllMocks());
 const onReturn = jest.fn();
 
 const renderNewCheckEditor = async (checkType?: CheckType) => {
-  const featureToggles = { traceroute: true, 'multi-http': false } as unknown as FeatureToggles;
-  const isFeatureEnabled = jest.fn(() => false);
-
-  const res = render(
-    <FeatureFlagProvider overrides={{ featureToggles, isFeatureEnabled }}>
-      <CheckEditor onReturn={onReturn} />
-    </FeatureFlagProvider>,
-    {
-      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
-      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${checkType}`,
-    }
-  );
+  const res = render(<CheckEditor onReturn={onReturn} />, {
+    route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+    path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${checkType}`,
+  });
 
   await waitFor(() => expect(screen.getByText('Probe options')).toBeInTheDocument());
   return res;

--- a/src/components/CheckEditor/CheckEditorNew.test.tsx
+++ b/src/components/CheckEditor/CheckEditorNew.test.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { FeatureToggles } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
-import { Route, Router } from 'react-router-dom';
 
 import { render } from 'test/render';
 import { CheckType, ROUTES } from 'types';
@@ -27,18 +25,17 @@ beforeEach(() => jest.resetAllMocks());
 const onReturn = jest.fn();
 
 const renderNewCheckEditor = async (checkType?: CheckType) => {
-  locationService.push(`${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${checkType}`);
   const featureToggles = { traceroute: true, 'multi-http': false } as unknown as FeatureToggles;
   const isFeatureEnabled = jest.fn(() => false);
 
   const res = render(
     <FeatureFlagProvider overrides={{ featureToggles, isFeatureEnabled }}>
-      <Router history={locationService.getHistory()}>
-        <Route path={`${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`}>
-          <CheckEditor onReturn={onReturn} />
-        </Route>
-      </Router>
-    </FeatureFlagProvider>
+      <CheckEditor onReturn={onReturn} />
+    </FeatureFlagProvider>,
+    {
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${checkType}`,
+    }
   );
 
   await waitFor(() => expect(screen.getByText('Probe options')).toBeInTheDocument());
@@ -97,7 +94,7 @@ describe('new checks', () => {
 
     await fillBasicCheckFields('Job name', 'https://grafana.com', user);
     await submitForm(onReturn, user);
-    expect(instance.api.addCheck).toHaveBeenCalledWith(BASIC_HTTP_CHECK);
+    expect(instance.api?.addCheck).toHaveBeenCalledWith(BASIC_HTTP_CHECK);
   });
 
   it('can create a new PING check', async () => {
@@ -105,7 +102,7 @@ describe('new checks', () => {
 
     await fillBasicCheckFields('Job name', 'grafana.com', user);
     await submitForm(onReturn, user);
-    expect(instance.api.addCheck).toHaveBeenCalledWith(BASIC_PING_CHECK);
+    expect(instance.api?.addCheck).toHaveBeenCalledWith(BASIC_PING_CHECK);
   });
 
   it('can create a new TCP check', async () => {
@@ -115,7 +112,7 @@ describe('new checks', () => {
 
     await fillTCPQueryResponseFields(user);
     await submitForm(onReturn, user);
-    expect(instance.api.addCheck).toHaveBeenCalledWith(BASIC_TCP_CHECK);
+    expect(instance.api?.addCheck).toHaveBeenCalledWith(BASIC_TCP_CHECK);
   });
 
   it('can create a new DNS check', async () => {
@@ -125,6 +122,6 @@ describe('new checks', () => {
     await fillDnsValidationFields(user);
 
     await submitForm(onReturn, user);
-    expect(instance.api.addCheck).toHaveBeenCalledWith(BASIC_DNS_CHECK);
+    expect(instance.api?.addCheck).toHaveBeenCalledWith(BASIC_DNS_CHECK);
   });
 });

--- a/src/components/CheckList/CheckList.test.tsx
+++ b/src/components/CheckList/CheckList.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { screen, waitForElementToBeRemoved } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 
 import { render, createInstance } from 'test/render';
 import { CheckList } from './CheckList';
@@ -121,13 +120,12 @@ const renderCheckList = ({ checks = defaultChecks } = {} as RenderChecklist) => 
   const instance = createInstance();
 
   return render(
-    <MemoryRouter initialEntries={[`${PLUGIN_URL_PATH}${ROUTES.Checks}`]}>
-      <SuccessRateContextProvider checks={checks}>
-        <CheckList instance={instance} checks={checks} onCheckUpdate={onCheckUpdate} />
-      </SuccessRateContextProvider>
-    </MemoryRouter>,
+    <SuccessRateContextProvider checks={checks}>
+      <CheckList instance={instance} checks={checks} onCheckUpdate={onCheckUpdate} />
+    </SuccessRateContextProvider>,
     {
       instance,
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
     }
   );
 };
@@ -380,8 +378,8 @@ test('select all performs disable action on all visible checks', async () => {
   await user.click(disableButton);
 
   // await waitFor(() => expect(selectAll).not.toBeChecked());
-  expect(instance.api.updateCheck).toHaveBeenCalledTimes(3);
-  expect(instance.api.updateCheck).toHaveBeenCalledWith({
+  expect(instance.api?.updateCheck).toHaveBeenCalledTimes(3);
+  expect(instance.api?.updateCheck).toHaveBeenCalledWith({
     created: 1597928913.872104,
     enabled: false,
     frequency: 60000,
@@ -396,7 +394,7 @@ test('select all performs disable action on all visible checks', async () => {
     tenantId: 1,
     timeout: 2500,
   });
-  expect(instance.api.updateCheck).toHaveBeenCalledWith({
+  expect(instance.api?.updateCheck).toHaveBeenCalledWith({
     created: 1597928965.8595479,
     enabled: false,
     frequency: 60000,
@@ -411,7 +409,7 @@ test('select all performs disable action on all visible checks', async () => {
     tenantId: 1,
     timeout: 2500,
   });
-  expect(instance.api.updateCheck).toHaveBeenCalledWith({
+  expect(instance.api?.updateCheck).toHaveBeenCalledWith({
     created: 1597928927.7490728,
     enabled: false,
     frequency: 60000,

--- a/src/components/MultiHttp/MultiHttpNew.test.tsx
+++ b/src/components/MultiHttp/MultiHttpNew.test.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
-import { locationService } from '@grafana/runtime';
-import { Route, Router } from 'react-router-dom';
 
 import { render } from 'test/render';
 import { CheckType, ROUTES } from 'types';
@@ -16,15 +14,10 @@ beforeEach(() => jest.resetAllMocks());
 const onReturn = jest.fn();
 
 const renderNewMultiForm = async () => {
-  locationService.push(`${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.MULTI_HTTP}`);
-
-  const res = render(
-    <Router history={locationService.getHistory()}>
-      <Route path={`${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.MULTI_HTTP}`}>
-        <MultiHttpSettingsForm checks={BASIC_CHECK_LIST} onReturn={onReturn} />
-      </Route>
-    </Router>
-  );
+  const res = render(<MultiHttpSettingsForm checks={BASIC_CHECK_LIST} onReturn={onReturn} />, {
+    route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.MULTI_HTTP}`,
+    path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.MULTI_HTTP}`,
+  });
 
   await waitFor(() => expect(screen.getByText('Probe options')).toBeInTheDocument());
   return res;
@@ -80,8 +73,8 @@ describe('new checks', () => {
 
     await submitForm(onReturn, user);
 
-    expect(instance.api.addCheck).toHaveBeenCalledTimes(1);
-    expect(instance.api.addCheck).toHaveBeenCalledWith(
+    expect(instance.api?.addCheck).toHaveBeenCalledTimes(1);
+    expect(instance.api?.addCheck).toHaveBeenCalledWith(
       expect.objectContaining({
         settings: {
           multihttp: {

--- a/src/components/MultiHttp/MultiHttpSettingsForm.test.tsx
+++ b/src/components/MultiHttp/MultiHttpSettingsForm.test.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
-import { Route, Router } from 'react-router-dom';
-import { locationService } from '@grafana/runtime';
 
 import { render } from 'test/render';
 import { PLUGIN_URL_PATH } from 'components/constants';
@@ -16,15 +14,10 @@ beforeEach(() => jest.resetAllMocks());
 const onReturn = jest.fn();
 
 async function renderForm(route: string) {
-  locationService.push(`${PLUGIN_URL_PATH}${ROUTES.Checks}${route}`);
-
-  const res = render(
-    <Router history={locationService.getHistory()}>
-      <Route path={`${PLUGIN_URL_PATH}${ROUTES.Checks}/edit/:id`}>
-        <MultiHttpSettingsForm checks={BASIC_CHECK_LIST} onReturn={onReturn} />
-      </Route>
-    </Router>
-  );
+  const res = render(<MultiHttpSettingsForm checks={BASIC_CHECK_LIST} onReturn={onReturn} />, {
+    route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/edit/:id`,
+    path: `${PLUGIN_URL_PATH}${ROUTES.Checks}${route}`,
+  });
   await waitFor(() => expect(screen.getByText('Probe options')).toBeInTheDocument());
   return res;
 }
@@ -92,8 +85,8 @@ describe('editing multihttp check', () => {
     await user.click(submitButton);
 
     await waitFor(() => expect(onReturn).toHaveBeenCalledWith(true));
-    expect(instance.api.updateCheck).toHaveBeenCalledTimes(1);
-    expect(instance.api.updateCheck).toHaveBeenCalledWith({ id: 6, tenantId: undefined, ...BASIC_MULTIHTTP_CHECK });
+    expect(instance.api?.updateCheck).toHaveBeenCalledTimes(1);
+    expect(instance.api?.updateCheck).toHaveBeenCalledWith({ id: 6, tenantId: undefined, ...BASIC_MULTIHTTP_CHECK });
   });
 
   it('allows user to edit and resubmit form', async () => {
@@ -144,13 +137,13 @@ describe('editing multihttp check', () => {
     await user.click(submitButton);
 
     await waitFor(() => expect(onReturn).toHaveBeenCalledWith(true));
-    expect(instance.api.updateCheck).toHaveBeenCalledTimes(1);
-    expect(instance.api.updateCheck).toHaveBeenCalledWith(
+    expect(instance.api?.updateCheck).toHaveBeenCalledTimes(1);
+    expect(instance.api?.updateCheck).toHaveBeenCalledWith(
       expect.objectContaining({
         job: 'basicmultiedited',
       })
     );
-    expect(instance.api.updateCheck).toHaveBeenCalledWith(
+    expect(instance.api?.updateCheck).toHaveBeenCalledWith(
       expect.objectContaining({
         settings: {
           multihttp: {

--- a/src/components/ProbeEditor/ProbeEditor.test.tsx
+++ b/src/components/ProbeEditor/ProbeEditor.test.tsx
@@ -137,7 +137,7 @@ it('saves new probe', async () => {
   expect(saveButton).toBeEnabled();
   await user.click(saveButton);
   await screen.findByText('Probe Authentication Token');
-  expect(instance.api.addProbe).toHaveBeenCalledWith(TEST_PROBE);
+  expect(instance.api?.addProbe).toHaveBeenCalledWith(TEST_PROBE);
 });
 
 it('updates existing probe', async () => {
@@ -145,5 +145,5 @@ it('updates existing probe', async () => {
   const saveButton = await screen.findByRole('button', { name: 'Save' });
   await user.click(saveButton);
   await waitFor(() => expect(onReturn).toHaveBeenCalledWith(true));
-  expect(instance.api.updateProbe).toHaveBeenCalledWith(DEFAULT_PROBES[0]);
+  expect(instance.api?.updateProbe).toHaveBeenCalledWith(DEFAULT_PROBES[0]);
 });

--- a/src/components/QueryParams.tsx
+++ b/src/components/QueryParams.tsx
@@ -23,7 +23,7 @@ function init(target: URL) {
     .replace('?', '')
     .split('&')
     .map((queryParam) => {
-      const [name, value] = queryParam.split('=');
+      const [name, value = ''] = queryParam.split('=');
       return { name, value };
     });
   return formatted;

--- a/src/components/Thresholds/ThresholdGlobalSettings.test.tsx
+++ b/src/components/Thresholds/ThresholdGlobalSettings.test.tsx
@@ -10,16 +10,10 @@ const onDismiss = jest.fn();
 const onSuccess = jest.fn();
 const onError = jest.fn();
 
-const renderThresholdSettingsForm = (defaultValues = false) => {
+const renderThresholdSettingsForm = () => {
   const instance = {
     api: getInstanceMock(),
   };
-
-  if (defaultValues) {
-    instance.api.getTenantSettings = jest.fn(() =>
-      Promise.resolve({ thresholds: { uptime: {}, reachability: {}, latency: {} } })
-    );
-  }
 
   return render(
     <SuccessRateContextProvider checks={[]}>
@@ -40,11 +34,12 @@ test('shows the form', async () => {
 });
 
 test('has default values in form', async () => {
-  renderThresholdSettingsForm(true);
+  const { user } = renderThresholdSettingsForm();
   const upperLimitInputs = await screen.findAllByTestId('upper-limit');
   const lowerLimitInputs = await screen.findAllByTestId('lower-limit');
+  await user.click(screen.getByText('Reset all to defaults'));
   // Uptime/reachability
-  expect(upperLimitInputs[0]).toHaveValue(90);
+  expect(upperLimitInputs[0]).toHaveValue(99);
   expect(lowerLimitInputs[0]).toHaveValue(75);
   // Latency
   expect(upperLimitInputs[2]).toHaveValue(200);

--- a/src/hooks/useUsageCalc.test.tsx
+++ b/src/hooks/useUsageCalc.test.tsx
@@ -9,7 +9,7 @@ import { useUsageCalc } from './useUsageCalc';
 interface Wrapper {}
 
 const renderUsage = async (check: Partial<Check>) => {
-  const Wrapper = createWrapper();
+  const { Wrapper } = createWrapper();
 
   const wrapper = ({ children }: PropsWithChildren<Wrapper>) => (
     <Wrapper>

--- a/src/page/ChecksPage.test.tsx
+++ b/src/page/ChecksPage.test.tsx
@@ -1,28 +1,21 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
-import { FeatureToggles } from '@grafana/data';
 
 import { ROUTES } from 'types';
 import { render } from 'test/render';
 import { CheckRouter } from './CheckRouter';
 import { PLUGIN_URL_PATH } from 'components/constants';
-import { FeatureFlagProvider } from 'components/FeatureFlagProvider';
 
 jest.setTimeout(20000);
 
 const renderChecksPage = (multiHttpEnabled = false) => {
-  const featureToggles = { 'multi-http': multiHttpEnabled } as unknown as FeatureToggles;
-  const isFeatureEnabled = jest.fn(() => multiHttpEnabled);
+  const featureToggles = { 'multi-http': multiHttpEnabled };
 
-  return render(
-    <FeatureFlagProvider overrides={{ featureToggles, isFeatureEnabled }}>
-      <CheckRouter />
-    </FeatureFlagProvider>,
-    {
-      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
-      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
-    }
-  );
+  return render(<CheckRouter />, {
+    featureToggles,
+    path: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
+    route: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
+  });
 };
 
 test('renders checks', async () => {

--- a/src/page/ChecksPage.test.tsx
+++ b/src/page/ChecksPage.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route } from 'react-router-dom';
 import { FeatureToggles } from '@grafana/data';
 
 import { ROUTES } from 'types';
@@ -17,12 +16,12 @@ const renderChecksPage = (multiHttpEnabled = false) => {
 
   return render(
     <FeatureFlagProvider overrides={{ featureToggles, isFeatureEnabled }}>
-      <MemoryRouter initialEntries={[`${PLUGIN_URL_PATH}${ROUTES.Checks}`]}>
-        <Route path={`${PLUGIN_URL_PATH}${ROUTES.Checks}`}>
-          <CheckRouter />
-        </Route>
-      </MemoryRouter>
-    </FeatureFlagProvider>
+      <CheckRouter />
+    </FeatureFlagProvider>,
+    {
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
+    }
   );
 };
 

--- a/src/page/ProbesPage.test.tsx
+++ b/src/page/ProbesPage.test.tsx
@@ -4,19 +4,14 @@ import { screen, waitFor } from '@testing-library/react';
 import { render } from 'test/render';
 import { ProbeRouter } from './ProbeRouter';
 import { ROUTES } from 'types';
-import { MemoryRouter, Route } from 'react-router-dom';
 import { PLUGIN_URL_PATH } from 'components/constants';
-jest.unmock('@grafana/runtime');
 jest.setTimeout(10000);
 
 const renderProbesPage = () => {
-  return render(
-    <MemoryRouter initialEntries={[`${PLUGIN_URL_PATH}${ROUTES.Probes}`]}>
-      <Route path={`${PLUGIN_URL_PATH}${ROUTES.Probes}`}>
-        <ProbeRouter />
-      </Route>
-    </MemoryRouter>
-  );
+  return render(<ProbeRouter />, {
+    path: `${PLUGIN_URL_PATH}${ROUTES.Probes}`,
+    route: `${PLUGIN_URL_PATH}${ROUTES.Probes}`,
+  });
 };
 
 const getAddNew = async () => {

--- a/src/test/render.tsx
+++ b/src/test/render.tsx
@@ -1,8 +1,7 @@
 import React, { type ReactElement, type ReactNode } from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { Router } from 'react-router';
-import { Route } from 'react-router-dom';
+import { Route, Router } from 'react-router-dom';
 import { AppPluginMeta, DataSourceSettings } from '@grafana/data';
 import userEventLib from '@testing-library/user-event';
 

--- a/src/test/render.tsx
+++ b/src/test/render.tsx
@@ -1,5 +1,8 @@
 import React, { type ReactElement, type ReactNode } from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router';
+import { Route } from 'react-router-dom';
 import { AppPluginMeta, DataSourceSettings } from '@grafana/data';
 import userEventLib from '@testing-library/user-event';
 
@@ -17,30 +20,47 @@ export const createInstance = (options?: GrafanaInstances) => {
   };
 };
 
-export const createWrapper = ({ instance = createInstance() }: { instance?: GrafanaInstances } = {}) => {
+type WrapperProps = {
+  instance?: GrafanaInstances;
+  path?: string;
+  route?: string;
+};
+
+export const createWrapper = ({ instance = createInstance(), path, route }: WrapperProps = {}) => {
   const meta = {} as AppPluginMeta<GlobalSettings>;
+  const history = createMemoryHistory({
+    initialEntries: path ? [path] : undefined,
+  });
 
   // eslint-disable-next-line react/display-name
-  return ({ children }: { children: ReactNode }) => (
-    <InstanceContext.Provider value={{ instance, loading: false, meta }}>{children}</InstanceContext.Provider>
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <InstanceContext.Provider value={{ instance, loading: false, meta }}>
+      <Router history={history}>
+        <Route path={route}>{children}</Route>
+      </Router>
+    </InstanceContext.Provider>
   );
+
+  return { Wrapper, instance, history };
 };
 
 type CustomRenderOptions = Omit<RenderOptions, 'wrapper'> & {
   instance?: GrafanaInstances;
+  path?: string;
+  route?: string;
 };
 
 const customRender = (ui: ReactElement, options: CustomRenderOptions = {}) => {
-  const { instance: instanceOptions, ...rest } = options;
-  const instance = createInstance(instanceOptions);
+  const { instance: instanceOptions, path, route, ...rest } = options;
   const user = userEventLib.setup();
+  const { Wrapper, history, instance } = createWrapper({ instance: instanceOptions, path, route });
 
   return {
     user,
     instance,
     history,
     ...render(ui, {
-      wrapper: createWrapper({ instance }),
+      wrapper: Wrapper,
       ...rest,
     }),
   };


### PR DESCRIPTION
# Problem
Part 2 of reducing the boilerplate to writing comprehensive tests. 

# Solution
Added a Router and the FeatureFlagProvider to the customRender. Now utilising routes and feature flags is as simple as adding additional options to the render function, rather than importing the correct dependencies.