### PR TITLE
feat: add an info tooltip to the stat panels

### DIFF
--- a/src/components/CheckListItem/CheckListItem.tsx
+++ b/src/components/CheckListItem/CheckListItem.tsx
@@ -12,6 +12,7 @@ import { CheckListItemDetails } from './CheckListItemDetails';
 import { CheckStatusType } from './CheckStatusType';
 import { SuccessRateTypes } from 'contexts/SuccessRateContext';
 import { useUsageCalc } from 'hooks/useUsageCalc';
+import { REACHABILITY_DESCRIPTION, UPTIME_DESCRIPTION } from 'components/constants';
 
 interface Props {
   check: FilteredCheck;
@@ -238,23 +239,21 @@ export const CheckListItem = ({
                 <>
                   <SuccessRateGauge
                     title="Uptime"
+                    infoText={UPTIME_DESCRIPTION}
                     type={SuccessRateTypes.Checks}
                     id={check.id}
-                    labelNames={['instance', 'job']}
-                    labelValues={[check.target, check.job]}
                     height={75}
-                    width={150}
+                    width={125}
                   />
                   <SuccessRateGauge
                     title="Reachability"
+                    infoText={REACHABILITY_DESCRIPTION}
                     type={SuccessRateTypes.Checks}
                     id={check.id}
-                    labelNames={['instance', 'job']}
-                    labelValues={[check.target, check.job]}
                     height={75}
-                    width={150}
+                    width={125}
                   />
-                  <LatencyGauge target={check.target} job={check.job} height={75} width={175} />
+                  <LatencyGauge target={check.target} job={check.job} height={75} width={125} />
                 </>
               )}
             </div>

--- a/src/components/LatencyGauge.tsx
+++ b/src/components/LatencyGauge.tsx
@@ -1,10 +1,12 @@
-import React, { useContext } from 'react';
-import { BigValueColorMode, BigValueGraphMode, BigValue } from '@grafana/ui';
-import { DisplayValue } from '@grafana/data';
+import { css, cx } from '@emotion/css';
+import { DisplayValue, GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { useMetricData } from 'hooks/useMetricData';
+import { BigValue, BigValueColorMode, BigValueGraphMode, IconButton, Tooltip, useStyles2 } from '@grafana/ui';
 import { SuccessRateContext, ThresholdSettings } from 'contexts/SuccessRateContext';
+import { useMetricData } from 'hooks/useMetricData';
+import React, { useContext } from 'react';
 import { getLatencySuccessRateThresholdColor } from 'utils';
+import { LATENCY_DESCRIPTION } from './constants';
 
 interface Props {
   target: string;
@@ -14,11 +16,36 @@ interface Props {
   onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 }
 
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    titleContainer: css`
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: ${theme.spacing(1)};
+      height: 20px;
+      justify-content: flex-start;
+    `,
+    title: css`
+      padding-left: ${theme.spacing(2)};
+    `,
+    container: css`
+      display: flex;
+      flex-direction: column;
+      margin-top: ${theme.spacing(1)};
+      margin-x: ${theme.spacing(1)};
+      height: 100%;
+    `,
+    infoIcon: css`
+      cursor: default;
+    `,
+  };
+}
+
 const getDisplayValue = (data: any[], loading: boolean, thresholds: ThresholdSettings): DisplayValue => {
   if (loading) {
     return {
       numeric: 0,
-      title: 'Latency',
       text: 'loading...',
     };
   }
@@ -26,7 +53,6 @@ const getDisplayValue = (data: any[], loading: boolean, thresholds: ThresholdSet
     return {
       numeric: 0,
       text: 'N/A',
-      title: 'Latency',
     };
   }
 
@@ -34,7 +60,6 @@ const getDisplayValue = (data: any[], loading: boolean, thresholds: ThresholdSet
   const color = getLatencySuccessRateThresholdColor(thresholds, 'latency', latency);
 
   return {
-    title: 'Latency',
     color: color,
     numeric: latency,
     text: latency.toFixed(0) + 'ms',
@@ -44,17 +69,28 @@ const getDisplayValue = (data: any[], loading: boolean, thresholds: ThresholdSet
 export const LatencyGauge = ({ target, job, height, width }: Props) => {
   const { thresholds } = useContext(SuccessRateContext);
   const query = `sum((rate(probe_all_duration_seconds_sum{probe=~".*", instance="${target}", job="${job}"}[6h]) OR rate(probe_duration_seconds_sum{probe=~".*", instance="${target}", job="${job}"}[6h]))) / sum((rate(probe_all_duration_seconds_count{probe=~".*", instance="${target}", job="${job}"}[6h]) OR rate(probe_duration_seconds_count{probe=~".*", instance="${target}", job="${job}"}[6h])))`;
+  const styles = useStyles2(getStyles);
 
   const { data, loading } = useMetricData(query);
   const value = getDisplayValue(data, loading, thresholds);
   return (
-    <BigValue
-      theme={config.theme2}
-      colorMode={BigValueColorMode.Value}
-      height={height}
-      width={width}
-      graphMode={BigValueGraphMode.Area}
-      value={value}
-    />
+    <div className={cx(styles.container)} style={{ width }}>
+      <div className={styles.titleContainer}>
+        <div className={styles.title} style={{ fontSize: Math.round(height / 6) }}>
+          Latency
+        </div>
+        <Tooltip content={LATENCY_DESCRIPTION} placement="top-start">
+          <IconButton name="info-circle" size="sm" aria-label={'Latency gauge info'} className={styles.infoIcon} />
+        </Tooltip>
+      </div>
+      <BigValue
+        theme={config.theme2}
+        colorMode={BigValueColorMode.Value}
+        height={height}
+        width={width}
+        graphMode={BigValueGraphMode.Area}
+        value={value}
+      />
+    </div>
   );
 };

--- a/src/components/ProbeList.tsx
+++ b/src/components/ProbeList.tsx
@@ -70,8 +70,6 @@ export const ProbeList = ({ probes, onAddNew, onSelectProbe }: Props) => {
                 title="Reachability"
                 type={SuccessRateTypes.Probes}
                 id={probe.id!} // We are guarunteeing the presence of the ID in the filter before this map
-                labelNames={['probe']}
-                labelValues={[probe.name]}
                 height={60}
                 width={150}
               />

--- a/src/components/ProbeStatus.tsx
+++ b/src/components/ProbeStatus.tsx
@@ -6,6 +6,7 @@ import { hasRole } from 'utils';
 import { SuccessRateGauge } from './SuccessRateGauge';
 import { GrafanaTheme2, OrgRole } from '@grafana/data';
 import { SuccessRateTypes } from 'contexts/SuccessRateContext';
+import { REACHABILITY_DESCRIPTION } from './constants';
 
 interface Props {
   probe: Probe;
@@ -21,14 +22,14 @@ interface BadgeStatus {
 const getStyles = (theme: GrafanaTheme2) => ({
   legend: css`
     margin: 0 ${theme.spacing(1)} 0 0;
+    font-size: 33px;
     width: auto;
   `,
   container: css`
-    padding-left: ${theme.spacing(1)};
     margin-bottom: ${theme.spacing(2)};
   `,
   badgeContainer: css`
-    margin-bottom: ${theme.spacing(1)};
+    margin-bottom: ${theme.spacing(3)};
     display: flex;
     align-items: center;
   `,
@@ -91,8 +92,7 @@ const ProbeStatus = ({ probe, onResetToken }: Props) => {
         title="Reachability"
         id={probe.id!}
         type={SuccessRateTypes.Probes}
-        labelNames={['probe']}
-        labelValues={[probe.name]}
+        infoText={REACHABILITY_DESCRIPTION}
         height={200}
         width={300}
       />

--- a/src/components/SuccessRateGauge.test.tsx
+++ b/src/components/SuccessRateGauge.test.tsx
@@ -15,8 +15,6 @@ const renderSuccessRateGauge = () => {
         title="Reachability"
         id={4}
         type={SuccessRateTypes.Checks}
-        labelNames={['tacos']}
-        labelValues={['burritos']}
         height={200}
         width={200}
         onClick={jest.fn()}

--- a/src/components/SuccessRateGauge.tsx
+++ b/src/components/SuccessRateGauge.tsx
@@ -1,18 +1,19 @@
-import React, { useContext } from 'react';
-import { BigValueColorMode, BigValueGraphMode, BigValue, Container } from '@grafana/ui';
-import { DisplayValue } from '@grafana/data';
+import { css, cx } from '@emotion/css';
+import { DisplayValue, GrafanaTheme2 } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { BigValue, BigValueColorMode, BigValueGraphMode, IconButton, Tooltip, useStyles2 } from '@grafana/ui';
 import { SuccessRateContext, SuccessRateTypes, SuccessRateValue, ThresholdSettings } from 'contexts/SuccessRateContext';
+import React, { useContext } from 'react';
 import { getSuccessRateThresholdColor } from 'utils';
 
 interface Props {
   title: 'Reachability' | 'Uptime';
   type: SuccessRateTypes;
   id: number;
-  labelNames: string[];
-  labelValues: string[];
   height: number;
   width: number;
+  infoText?: string;
+  className?: string;
   onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 }
 
@@ -25,7 +26,6 @@ const getDisplayValue = (
   if (loading) {
     return {
       numeric: 0,
-      title,
       text: 'loading...',
     };
   }
@@ -40,19 +40,55 @@ const getDisplayValue = (
   const color = getSuccessRateThresholdColor(thresholds, thresholdKey, successRateKey!);
 
   return {
-    title,
+    title: '',
     color: color,
     numeric: successRateKey || 0,
     text: successRate.noData ? 'N/A' : displayValueKey!,
   };
 };
 
-export const SuccessRateGauge = ({ title, type, id, labelNames, labelValues, height, width, onClick }: Props) => {
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    titleContainer: css`
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: ${theme.spacing(1)};
+      height: 20px;
+      justify-content: flex-start;
+      margin-x: ${theme.spacing(1)};
+    `,
+    title: css`
+      padding-left: ${theme.spacing(2)};
+    `,
+    container: css`
+      display: flex;
+      flex-direction: column;
+      margin-top: ${theme.spacing(1)};
+      margin-x: ${theme.spacing(1)};
+      height: 100%;
+    `,
+    infoIcon: css`
+      cursor: default;
+    `,
+  };
+}
+
+export const SuccessRateGauge = ({ title, type, id, height, width, infoText, onClick, className }: Props) => {
   const { values, loading, thresholds } = useContext(SuccessRateContext);
+  const styles = useStyles2(getStyles);
 
   const value = getDisplayValue(title, values[type]?.[id] ?? values.defaults, loading, thresholds);
   return (
-    <Container>
+    <div className={cx(styles.container, className)} style={{ width }}>
+      <div className={styles.titleContainer} style={{ fontSize: Math.round(height / 6) }}>
+        <div className={styles.title}>{title}</div>
+        {infoText && (
+          <Tooltip content={infoText} placement="top-start">
+            <IconButton name="info-circle" size="sm" aria-label={`${title} info`} className={styles.infoIcon} />
+          </Tooltip>
+        )}
+      </div>
       <BigValue
         theme={config.theme2}
         colorMode={BigValueColorMode.Value}
@@ -62,6 +98,6 @@ export const SuccessRateGauge = ({ title, type, id, labelNames, labelValues, hei
         value={value}
         onClick={onClick}
       />
-    </Container>
+    </div>
   );
 };

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -478,3 +478,9 @@ export const ASSERTION_SUBJECT_OPTIONS: Array<SelectableValue<AssertionSubjectVa
   { label: 'Headers', value: AssertionSubjectVariant.ResponseHeaders },
   { label: 'HTTP status code', value: AssertionSubjectVariant.HttpStatusCode },
 ];
+
+export const UPTIME_DESCRIPTION = 'The fraction of time the target was up during the whole period.';
+export const REACHABILITY_DESCRIPTION =
+  'The percentage of all the checks that have succeeded during the whole time period.';
+export const LATENCY_DESCRIPTION =
+  'The average time to receive an answer across all the checks during the whole time period.';

--- a/src/scenes/Common/uptimeStat.ts
+++ b/src/scenes/Common/uptimeStat.ts
@@ -1,5 +1,6 @@
 import { SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, ThresholdsMode } from '@grafana/schema';
+import { UPTIME_DESCRIPTION } from 'components/constants';
 import { ExplorablePanel } from 'scenes/ExplorablePanel';
 
 function getQueryRunner(metrics: DataSourceRef) {
@@ -23,7 +24,7 @@ export function getUptimeStat(metrics: DataSourceRef) {
   return new ExplorablePanel({
     pluginId: 'stat',
     title: 'Uptime',
-    description: 'The fraction of time the target was up during the whole period.',
+    description: UPTIME_DESCRIPTION,
     $data: getQueryRunner(metrics),
     fieldConfig: {
       defaults: {


### PR DESCRIPTION
<img width="1120" alt="Screenshot 2023-10-17 at 13 12 13" src="https://github.com/grafana/synthetic-monitoring-app/assets/8377044/f8cae5c6-239e-4ebe-a1b6-4b306f6b4c7e">

Adds an info tooltip to the uptime/reachability and latency gauges. It's a bit of a hack because the Stat component doesn't allow passing an info tooltip. `PanelChrome`, which is meant for this, has hardcoded styling that doesn't work with the way we're rendering these gauges, so I did a little workaround