### PR TITLE
Add multihttp to terraform

### DIFF
--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -120,11 +120,12 @@ const settingsToTF = (check: Check): TFCheckSettings => {
       return {
         multihttp: {
           entries: escaped.entries.map((entry) => {
+            const { queryFields, ...request } = entry.request;
             const transformed: TFMultiHttpEntry = {
               ...entry,
               request: {
-                ...entry.request,
-                query_fields: entry.request.queryFields,
+                ...request,
+                query_fields: queryFields,
                 body: {
                   content_type: entry.request.body?.contentType,
                 },

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -1,6 +1,6 @@
-import { Check, CheckType, Label, Probe, TLSConfig } from 'types';
+import { Check, CheckType, Label, MultiHttpSettings, Probe, TLSConfig } from 'types';
 import { checkType } from 'utils';
-import { TFCheck, TFCheckSettings, TFLabels, TFProbe, TFTlsConfig } from './terraformTypes';
+import { TFCheck, TFCheckSettings, TFLabels, TFProbe, TFTlsConfig, TFMultiHttpEntry } from './terraformTypes';
 
 const labelsToTFLabels = (labels: Label[]): TFLabels =>
   labels.reduce<TFLabels>((acc, label) => {
@@ -108,6 +108,36 @@ const settingsToTF = (check: Check): TFCheckSettings => {
           max_hops: check.settings.traceroute.maxHops,
           max_unknown_hops: check.settings.traceroute.maxUnknownHops,
           ptr_lookup: check.settings.traceroute.ptrLookup,
+        },
+      };
+    case CheckType.MULTI_HTTP:
+      if (!check.settings.multihttp) {
+        throw new Error(`could not translate settings to terraform config for check ${check.job}`);
+      }
+      const escapeString = JSON.stringify(check.settings.multihttp);
+      const replaced = escapeString.replace(/\$\{/g, '$$${');
+      const escaped = JSON.parse(replaced) as MultiHttpSettings;
+      return {
+        multihttp: {
+          entries: escaped.entries.map((entry) => {
+            const transformed: TFMultiHttpEntry = {
+              ...entry,
+              request: {
+                ...entry.request,
+                query_fields: entry.request.queryFields,
+                body: {
+                  content_type: entry.request.body?.contentType,
+                },
+              },
+            };
+            if (entry.request.postData) {
+              transformed.request.post_data = {
+                mime_type: entry.request.postData.mimeType,
+                text: entry.request.postData.text,
+              };
+            }
+            return transformed;
+          }),
         },
       };
     default:

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -1,3 +1,4 @@
+import { MultiHttpEntry, QueryParams, RequestProps } from 'components/MultiHttp/MultiHttpTypes';
 import { DnsSettings, HttpSettings, BasicAuth, HeaderMatch, TcpSettings, TCPQueryResponse, Probe } from 'types';
 
 export interface TFOutput {
@@ -29,7 +30,13 @@ export interface TFCheck {
 }
 
 export type TFLabels = { [key: string]: string };
-type TFSettings = TFHttpSettings | TFPingSettings | TFTcpSettings | TFDnsSettings | TFTracerouteSettings;
+type TFSettings =
+  | TFHttpSettings
+  | TFPingSettings
+  | TFTcpSettings
+  | TFDnsSettings
+  | TFTracerouteSettings
+  | TFMultiHTTPSettings;
 export type TFCheckSettings = {
   [key: string]: TFSettings;
 };
@@ -107,6 +114,27 @@ interface TFTracerouteSettings {
   max_hops: number;
   max_unknown_hops: number;
   ptr_lookup: boolean;
+}
+
+interface TFMultiHTTPSettings {
+  entries: TFMultiHttpEntry[];
+}
+
+export interface TFMultiHttpEntry extends Omit<MultiHttpEntry, 'request'> {
+  request: TFMultiHttpRequest;
+}
+
+interface TFMultiHttpRequest extends Omit<RequestProps, 'queryFields' | 'postData' | 'body'> {
+  query_fields?: QueryParams[];
+  post_data?: {
+    mime_type: string;
+    text: string;
+  };
+  body: {
+    content_type?: string;
+    content_encoding?: string;
+    payload?: string;
+  };
 }
 
 interface TFHeaderMatch extends Omit<HeaderMatch, 'allowMissing'> {

--- a/src/hooks/useTerraformConfig.test.tsx
+++ b/src/hooks/useTerraformConfig.test.tsx
@@ -244,7 +244,6 @@ describe('terraform config generation', () => {
     await waitFor(() => {
       expect(result.current.config).not.toBeUndefined();
     });
-    console.log(result.current.config);
     expect(result.current.config).toEqual({
       provider: {
         grafana: {

--- a/src/hooks/useTerraformConfig.test.tsx
+++ b/src/hooks/useTerraformConfig.test.tsx
@@ -278,7 +278,6 @@ describe('terraform config generation', () => {
                       },
                       headers: [],
                       method: 'GET',
-                      queryFields: [{}],
                       query_fields: [{}],
                       url: 'https://www.grafana-dev.com',
                     },
@@ -292,7 +291,6 @@ describe('terraform config generation', () => {
                       },
                       headers: [],
                       method: 'POST',
-                      queryFields: [],
                       query_fields: [],
                       url: 'https://secondrequest.com',
                     },
@@ -312,7 +310,6 @@ describe('terraform config generation', () => {
                       },
                       headers: [],
                       method: 'GET',
-                      queryFields: [],
                       query_fields: [],
                       // We need double dollar signs here because of terraform interpolation
                       url: '$${avariable}',

--- a/src/hooks/useTerraformConfig.test.tsx
+++ b/src/hooks/useTerraformConfig.test.tsx
@@ -193,4 +193,159 @@ describe('terraform config generation', () => {
       },
     });
   });
+
+  test('handles multihttp checks', async () => {
+    const wrapper = ({ children }: PropsWithChildren<{}>) => {
+      const api = getInstanceMock();
+      api.listChecks = jest.fn().mockImplementation(() =>
+        Promise.resolve([
+          {
+            job: 'stuff',
+            target: 'https://www.grafana-dev.com',
+            enabled: true,
+            labels: [],
+            probes: [57],
+            timeout: 17000,
+            frequency: 120000,
+            alertSensitivity: 'none',
+            settings: {
+              multihttp: {
+                entries: [
+                  {
+                    request: { method: 'GET', url: 'https://www.grafana-dev.com', headers: [], queryFields: [{}] },
+                    variables: [],
+                    checks: [{ type: 0, subject: 2, condition: 2, value: '200' }],
+                  },
+                  {
+                    request: { url: 'https://secondrequest.com', method: 'POST', headers: [], queryFields: [] },
+                    variables: [{ type: 0, name: 'avariable', expression: 'great.variable.path' }],
+                    checks: [],
+                  },
+                  {
+                    request: { url: '${avariable}', method: 'GET', headers: [], queryFields: [] },
+                    variables: [],
+                    checks: [],
+                  },
+                ],
+              },
+            },
+            basicMetricsOnly: true,
+          },
+        ])
+      );
+      const instance = {
+        api,
+      };
+      const meta = {} as AppPluginMeta<GlobalSettings>;
+
+      return <InstanceContext.Provider value={{ instance, loading: false, meta }}>{children}</InstanceContext.Provider>;
+    };
+    const { result } = renderHook(() => useTerraformConfig(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.config).not.toBeUndefined();
+    });
+    console.log(result.current.config);
+    expect(result.current.config).toEqual({
+      provider: {
+        grafana: {
+          auth: '<add an api key from grafana.com>',
+          sm_access_token: '<add an sm access token>',
+          sm_url: 'http://localhost:4030',
+          url: '',
+        },
+      },
+      resource: {
+        grafana_synthetic_monitoring_check: {
+          'stuff_https___www_grafana-dev_com': {
+            enabled: true,
+            job: 'stuff',
+            labels: {},
+            probes: [57],
+            settings: {
+              multihttp: {
+                entries: [
+                  {
+                    checks: [
+                      {
+                        condition: 2,
+                        subject: 2,
+                        type: 0,
+                        value: '200',
+                      },
+                    ],
+                    request: {
+                      body: {
+                        content_type: undefined,
+                      },
+                      headers: [],
+                      method: 'GET',
+                      queryFields: [{}],
+                      query_fields: [{}],
+                      url: 'https://www.grafana-dev.com',
+                    },
+                    variables: [],
+                  },
+                  {
+                    checks: [],
+                    request: {
+                      body: {
+                        content_type: undefined,
+                      },
+                      headers: [],
+                      method: 'POST',
+                      queryFields: [],
+                      query_fields: [],
+                      url: 'https://secondrequest.com',
+                    },
+                    variables: [
+                      {
+                        expression: 'great.variable.path',
+                        name: 'avariable',
+                        type: 0,
+                      },
+                    ],
+                  },
+                  {
+                    checks: [],
+                    request: {
+                      body: {
+                        content_type: undefined,
+                      },
+                      headers: [],
+                      method: 'GET',
+                      queryFields: [],
+                      query_fields: [],
+                      // We need double dollar signs here because of terraform interpolation
+                      url: '$${avariable}',
+                    },
+                    variables: [],
+                  },
+                ],
+              },
+            },
+            target: 'https://www.grafana-dev.com',
+          },
+        },
+        grafana_synthetic_monitoring_probe: {
+          tacos: {
+            labels: {
+              Mr: 'Orange',
+            },
+            latitude: 0,
+            longitude: 0,
+            name: 'tacos',
+            public: false,
+            region: 'EMEA',
+          },
+        },
+      },
+      terraform: {
+        required_providers: {
+          grafana: {
+            source: 'grafana/grafana',
+          },
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
Makes the "Generate Config" button in the Terraform section of the plugin config page handle MultiHTTP checks