### PR TITLE
fix: add a description tooltip to uptime and reachability stats 

### DIFF
--- a/src/components/BigValueTitle.tsx
+++ b/src/components/BigValueTitle.tsx
@@ -1,0 +1,39 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
+import React from 'react';
+
+interface Props {
+  title?: string;
+  infoText?: string;
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    container: css`
+      display: inline-flex;
+      gap: ${theme.spacing(1)};
+      align-items: center;
+      font-size: ${theme.typography.bodySmall.fontSize};
+      line-height: ${theme.typography.bodySmall.lineHeight};
+    `,
+  };
+}
+
+export function BigValueTitle({ title, infoText }: Props) {
+  const styles = useStyles2(getStyles);
+  if (infoText) {
+    return (
+      <Tooltip content={infoText} placement="top">
+        <div className={styles.container}>
+          <span aria-label={`${title} - ${infoText}`}>{title}</span>
+          <Icon name="info-circle" />
+        </div>
+      </Tooltip>
+    );
+  }
+  if (title) {
+    return <div className={styles.container}>{title}</div>;
+  }
+  return '';
+}

--- a/src/components/CheckListItem/CheckListItem.tsx
+++ b/src/components/CheckListItem/CheckListItem.tsx
@@ -240,8 +240,6 @@ export const CheckListItem = ({
                     title="Uptime"
                     type={SuccessRateTypes.Checks}
                     id={check.id}
-                    labelNames={['instance', 'job']}
-                    labelValues={[check.target, check.job]}
                     height={75}
                     width={150}
                   />
@@ -249,8 +247,6 @@ export const CheckListItem = ({
                     title="Reachability"
                     type={SuccessRateTypes.Checks}
                     id={check.id}
-                    labelNames={['instance', 'job']}
-                    labelValues={[check.target, check.job]}
                     height={75}
                     width={150}
                   />

--- a/src/components/LatencyGauge.tsx
+++ b/src/components/LatencyGauge.tsx
@@ -5,6 +5,8 @@ import { config } from '@grafana/runtime';
 import { useMetricData } from 'hooks/useMetricData';
 import { SuccessRateContext, ThresholdSettings } from 'contexts/SuccessRateContext';
 import { getLatencySuccessRateThresholdColor } from 'utils';
+import { BigValueTitle } from './BigValueTitle';
+import { LATENCY_DESCRIPTION } from './constants';
 
 interface Props {
   target: string;
@@ -18,7 +20,8 @@ const getDisplayValue = (data: any[], loading: boolean, thresholds: ThresholdSet
   if (loading) {
     return {
       numeric: 0,
-      title: 'Latency',
+      // @ts-ignore
+      title: <BigValueTitle title="Latency" infoText={LATENCY_DESCRIPTION} />,
       text: 'loading...',
     };
   }
@@ -26,7 +29,8 @@ const getDisplayValue = (data: any[], loading: boolean, thresholds: ThresholdSet
     return {
       numeric: 0,
       text: 'N/A',
-      title: 'Latency',
+      // @ts-ignore
+      title: <BigValueTitle title="Latency" infoText={LATENCY_DESCRIPTION} />,
     };
   }
 
@@ -34,7 +38,8 @@ const getDisplayValue = (data: any[], loading: boolean, thresholds: ThresholdSet
   const color = getLatencySuccessRateThresholdColor(thresholds, 'latency', latency);
 
   return {
-    title: 'Latency',
+    // @ts-ignore
+    title: <BigValueTitle title="Latency" infoText={LATENCY_DESCRIPTION} />,
     color: color,
     numeric: latency,
     text: latency.toFixed(0) + 'ms',

--- a/src/components/ProbeList.tsx
+++ b/src/components/ProbeList.tsx
@@ -70,8 +70,6 @@ export const ProbeList = ({ probes, onAddNew, onSelectProbe }: Props) => {
                 title="Reachability"
                 type={SuccessRateTypes.Probes}
                 id={probe.id!} // We are guarunteeing the presence of the ID in the filter before this map
-                labelNames={['probe']}
-                labelValues={[probe.name]}
                 height={60}
                 width={150}
               />

--- a/src/components/ProbeStatus.tsx
+++ b/src/components/ProbeStatus.tsx
@@ -87,15 +87,7 @@ const ProbeStatus = ({ probe, onResetToken }: Props) => {
           </Container>
         )}
       </div>
-      <SuccessRateGauge
-        title="Reachability"
-        id={probe.id!}
-        type={SuccessRateTypes.Probes}
-        labelNames={['probe']}
-        labelValues={[probe.name]}
-        height={200}
-        width={300}
-      />
+      <SuccessRateGauge title="Reachability" id={probe.id!} type={SuccessRateTypes.Probes} height={200} width={300} />
     </Container>
   );
 };

--- a/src/components/SuccessRateGauge.test.tsx
+++ b/src/components/SuccessRateGauge.test.tsx
@@ -15,8 +15,6 @@ const renderSuccessRateGauge = () => {
         title="Reachability"
         id={4}
         type={SuccessRateTypes.Checks}
-        labelNames={['tacos']}
-        labelValues={['burritos']}
         height={200}
         width={200}
         onClick={jest.fn()}

--- a/src/components/SuccessRateGauge.tsx
+++ b/src/components/SuccessRateGauge.tsx
@@ -4,13 +4,13 @@ import { DisplayValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { SuccessRateContext, SuccessRateTypes, SuccessRateValue, ThresholdSettings } from 'contexts/SuccessRateContext';
 import { getSuccessRateThresholdColor } from 'utils';
+import { BigValueTitle } from 'components/BigValueTitle';
+import { REACHABILITY_DESCRIPTION, UPTIME_DESCRIPTION } from './constants';
 
 interface Props {
   title: 'Reachability' | 'Uptime';
   type: SuccessRateTypes;
   id: number;
-  labelNames: string[];
-  labelValues: string[];
   height: number;
   width: number;
   onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
@@ -38,16 +38,19 @@ const getDisplayValue = (
 
   // Pick color based on tenant threshold settings
   const color = getSuccessRateThresholdColor(thresholds, thresholdKey, successRateKey!);
+  const infoText = title === 'Reachability' ? REACHABILITY_DESCRIPTION : UPTIME_DESCRIPTION;
 
   return {
-    title,
+    // @ts-ignore The BigValue component only allows strings for a title, but we're looking to pass in a component.
+    // There's nothing technically stopping us from this, but it is a hack
+    title: <BigValueTitle title={title} infoText={infoText} />,
     color: color,
     numeric: successRateKey || 0,
     text: successRate.noData ? 'N/A' : displayValueKey!,
   };
 };
 
-export const SuccessRateGauge = ({ title, type, id, labelNames, labelValues, height, width, onClick }: Props) => {
+export const SuccessRateGauge = ({ title, type, id, height, width, onClick }: Props) => {
   const { values, loading, thresholds } = useContext(SuccessRateContext);
 
   const value = getDisplayValue(title, values[type]?.[id] ?? values.defaults, loading, thresholds);

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -478,3 +478,9 @@ export const ASSERTION_SUBJECT_OPTIONS: Array<SelectableValue<AssertionSubjectVa
   { label: 'Headers', value: AssertionSubjectVariant.ResponseHeaders },
   { label: 'HTTP status code', value: AssertionSubjectVariant.HttpStatusCode },
 ];
+
+export const UPTIME_DESCRIPTION = 'The fraction of time the target was up during the whole period.';
+export const REACHABILITY_DESCRIPTION =
+  'The percentage of all the checks that have succeeded during the whole time period.';
+export const LATENCY_DESCRIPTION =
+  'The average time to receive an answer across all the checks during the whole time period.';

--- a/src/scenes/Common/reachabilityStat.ts
+++ b/src/scenes/Common/reachabilityStat.ts
@@ -1,5 +1,6 @@
 import { SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, ThresholdsMode } from '@grafana/schema';
+import { REACHABILITY_DESCRIPTION } from 'components/constants';
 import { ExplorablePanel } from 'scenes/ExplorablePanel';
 
 function getQueryRunner(metrics: DataSourceRef) {
@@ -29,7 +30,7 @@ export function getReachabilityStat(metrics: DataSourceRef) {
   return new ExplorablePanel({
     pluginId: 'stat',
     title: 'Reachability',
-    description: 'The percentage of all the checks that have succeeded during the whole time period.',
+    description: REACHABILITY_DESCRIPTION,
     $data: runner,
     fieldConfig: {
       overrides: [],

--- a/src/scenes/Common/uptimeStat.ts
+++ b/src/scenes/Common/uptimeStat.ts
@@ -1,5 +1,6 @@
 import { SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, ThresholdsMode } from '@grafana/schema';
+import { UPTIME_DESCRIPTION } from 'components/constants';
 import { ExplorablePanel } from 'scenes/ExplorablePanel';
 
 function getQueryRunner(metrics: DataSourceRef) {
@@ -23,23 +24,11 @@ export function getUptimeStat(metrics: DataSourceRef) {
   return new ExplorablePanel({
     pluginId: 'stat',
     title: 'Uptime',
-    description: 'The fraction of time the target was up during the whole period.',
+    description: UPTIME_DESCRIPTION,
     $data: getQueryRunner(metrics),
     fieldConfig: {
       defaults: {
         decimals: 2,
-        // mappings: [
-        //   {
-        //     // op: '=',
-        //     // text: 'N/A',
-        //     type: MappingType.ValueToText,
-        //     options: {
-        //       [SpecialValueMatch.Empty]: {
-        //         text: 'N/A',
-        //       },
-        //     },
-        //   },
-        // ],
         thresholds: {
           mode: ThresholdsMode.Absolute,
           steps: [


### PR DESCRIPTION
Thanks for the feedback on the first try! Here's the next take. It's still a little small on the probes view, but overall much better than the first attempt: 

![Screenshot 2023-10-23 at 14 25 20](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/ac5811d9-5b75-496d-9d2c-d7b54da7c171)

![Screenshot 2023-10-23 at 14 28 50](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/829040f1-e05f-4f7a-bbfd-25de1fae8e7b)

I opted not to wrap BigValue, but instead just created a BigValueTitle component. Wrapping BigValue felt like it was an opportunity to redefine the API of the BigValue component, but that was more bite than I wanted to chew today 😅. Happy to change that if it feels important.