### PR TITLE
Fix: Multihttp tabs styling and open first request tab with error

### DIFF
--- a/src/components/MultiHttp/MultiHttpCollapse.tsx
+++ b/src/components/MultiHttp/MultiHttpCollapse.tsx
@@ -30,11 +30,9 @@ export const MultiHttpCollapse = ({
           onToggle();
         }}
       >
-        <>
-          <Icon name={isOpen ? 'angle-down' : 'angle-right'} className={styles.headerIcon} />
-          <div className={styles.label}>{label}</div>
-          {!isOpen && invalid && <Icon name="exclamation-triangle" className={styles.errorIcon} />}
-        </>
+        <Icon name={isOpen ? 'angle-down' : 'angle-right'} className={styles.headerIcon} />
+        <div className={styles.label}>{label}</div>
+        {!isOpen && invalid && <Icon name="exclamation-triangle" className={styles.errorIcon} />}
       </button>
       <div className={cx(styles.body, { [styles.hidden]: !isOpen })}>{children}</div>
     </div>
@@ -50,9 +48,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     background: none;
     padding: ${theme.spacing(2)};
     width: 100%;
-  `,
-  headerExpanded: css`
-    padding-bottom: ${theme.spacing(1)};
   `,
   headerIcon: css`
     margin-right: ${theme.spacing(1)};

--- a/src/components/MultiHttp/MultiHttpCollapse.tsx
+++ b/src/components/MultiHttp/MultiHttpCollapse.tsx
@@ -22,10 +22,11 @@ export const MultiHttpCollapse = ({
   const styles = useStyles2(getStyles);
 
   return (
-    <div className={cx([!className ? 'panel-container' : className, styles.container])}>
-      <div
+    <div className={cx([!className ? 'panel-container' : className])}>
+      <button
         className={styles.header}
-        onClick={() => {
+        onClick={(e) => {
+          e.preventDefault();
           onToggle();
         }}
       >
@@ -34,24 +35,21 @@ export const MultiHttpCollapse = ({
           <div className={styles.label}>{label}</div>
           {!isOpen && invalid && <Icon name="exclamation-triangle" className={styles.errorIcon} />}
         </>
-      </div>
+      </button>
       <div className={cx(styles.body, { [styles.hidden]: !isOpen })}>{children}</div>
     </div>
   );
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  container: css`
-    border-left: none;
-    border-right: none;
-    border-bottom: none;
-    padding: ${theme.spacing(2)};
-  `,
   header: css`
     display: flex;
     align-items: center;
     transition: all 0.1s linear;
-    cursor: pointer;
+    border: none;
+    background: none;
+    padding: ${theme.spacing(2)};
+    width: 100%;
   `,
   headerExpanded: css`
     padding-bottom: ${theme.spacing(1)};
@@ -64,7 +62,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     font-size: ${theme.typography.h4.fontSize};
   `,
   body: css`
-    padding-top: ${theme.spacing(1)};
+    padding: ${theme.spacing(2)};
   `,
   hidden: css`
     display: none;

--- a/src/components/MultiHttp/MultiHttpSettingsForm.tsx
+++ b/src/components/MultiHttp/MultiHttpSettingsForm.tsx
@@ -81,7 +81,7 @@ export const MultiHttpSettingsForm = ({ checks, onReturn }: Props) => {
     check.settings.multihttp?.entries?.map((_, index, arr) => index === arr.length - 1) ?? [true]
   );
 
-  const formMethods = useForm<CheckFormValues>({ defaultValues, reValidateMode: 'onBlur' });
+  const formMethods = useForm<CheckFormValues>({ defaultValues, reValidateMode: 'onBlur', shouldFocusError: false });
 
   const {
     register,
@@ -132,8 +132,9 @@ export const MultiHttpSettingsForm = ({ checks, onReturn }: Props) => {
   });
 
   const submissionError = error as unknown as SubmissionErrorWrapper;
-
+  console.log(error);
   if (submissionError) {
+    console.log(`called?`);
     reportError(
       submissionError.data?.err ?? 'Multihttp submission error',
       check?.id ? FaroEvent.UPDATE_CHECK : FaroEvent.CREATE_CHECK

--- a/src/components/MultiHttp/MultiHttpSettingsForm.tsx
+++ b/src/components/MultiHttp/MultiHttpSettingsForm.tsx
@@ -1,6 +1,7 @@
-import React, { useContext, useState, useMemo, useReducer, useEffect } from 'react';
+import React, { useContext, useState, useMemo, useEffect } from 'react';
 import { FormProvider, useForm, Controller, useFieldArray, DeepMap, FieldError } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
+import { useAsyncCallback } from 'react-async-hook';
 
 import {
   Alert,
@@ -15,54 +16,33 @@ import {
   Legend,
   HorizontalGroup,
 } from '@grafana/ui';
-import { getDefaultValuesFromCheck, getCheckFromFormValues } from 'components/CheckEditor/checkFormTransformations';
-import { ProbeOptions } from 'components/CheckEditor/ProbeOptions';
-import { METHOD_OPTIONS } from 'components/constants';
-import { MultiHttpCollapse } from 'components/MultiHttp/MultiHttpCollapse';
-import { multiHttpFallbackCheck } from './consts';
-import { validateTarget } from 'validation';
-import { TabSection } from './Tabs/TabSection';
-import { getMultiHttpFormStyles } from './MultiHttpSettingsForm.styles';
-import { CheckFormValues, Check, CheckPageParams, CheckType, SubmissionErrorWrapper } from 'types';
-import { InstanceContext } from 'contexts/InstanceContext';
-import { PluginPage } from 'components/PluginPage';
 import { config } from '@grafana/runtime';
 import { OrgRole } from '@grafana/data';
+
+import { CheckFormValues, Check, CheckPageParams, CheckType, SubmissionErrorWrapper } from 'types';
 import { hasRole } from 'utils';
-import { AvailableVariables } from './AvailableVariables';
-import { useAsyncCallback } from 'react-async-hook';
 import { FaroEvent, reportEvent, reportError } from 'faro';
+import { validateTarget } from 'validation';
+import { METHOD_OPTIONS } from 'components/constants';
+import { InstanceContext } from 'contexts/InstanceContext';
+import { getDefaultValuesFromCheck, getCheckFromFormValues } from 'components/CheckEditor/checkFormTransformations';
+import { ProbeOptions } from 'components/CheckEditor/ProbeOptions';
+import { PluginPage } from 'components/PluginPage';
 import { CheckFormAlert } from 'components/CheckFormAlert';
 import { HorizontalCheckboxField } from 'components/HorizonalCheckboxField';
 import { CheckUsage } from 'components/CheckUsage';
 import { CheckTestButton } from 'components/CheckTestButton';
 
+import { TabSection } from './Tabs/TabSection';
+import { multiHttpFallbackCheck } from './consts';
+import { AvailableVariables } from './AvailableVariables';
+import { MultiHttpCollapse } from './MultiHttpCollapse';
+import { getMultiHttpFormErrors, useMultiHttpCollapseState } from './MultiHttpSettingsForm.utils';
+import { getMultiHttpFormStyles } from './MultiHttpSettingsForm.styles';
+
 interface Props {
   checks?: Check[];
   onReturn?: (reload?: boolean) => void;
-}
-
-function reducer(state: boolean[], action: { type: string; index?: number }) {
-  switch (action.type) {
-    case 'addNewRequest':
-      const newState = state.map((isOpen, index) => {
-        return false;
-      });
-      newState.push(true);
-      return newState;
-    case 'removeRequest':
-      return state.filter((_, index) => index !== action.index);
-    case 'toggle': {
-      return state.map((isOpen, index) => {
-        if (action.index === index) {
-          return !isOpen;
-        }
-        return isOpen;
-      });
-    }
-    default:
-      return state;
-  }
 }
 
 export const MultiHttpSettingsForm = ({ checks, onReturn }: Props) => {
@@ -76,11 +56,7 @@ export const MultiHttpSettingsForm = ({ checks, onReturn }: Props) => {
     instance: { api },
   } = useContext(InstanceContext);
   const defaultValues = useMemo(() => getDefaultValuesFromCheck(check), [check]);
-  const [collapseState, dispatchCollapse] = useReducer(
-    reducer,
-    check.settings.multihttp?.entries?.map((_, index, arr) => index === arr.length - 1) ?? [true]
-  );
-
+  const [collapseState, dispatchCollapse] = useMultiHttpCollapseState(check);
   const formMethods = useForm<CheckFormValues>({ defaultValues, reValidateMode: 'onBlur', shouldFocusError: true });
 
   const {
@@ -98,7 +74,6 @@ export const MultiHttpSettingsForm = ({ checks, onReturn }: Props) => {
     name: 'settings.multihttp.entries',
   });
   const isEditor = hasRole(OrgRole.Editor);
-
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   const {
@@ -155,17 +130,15 @@ export const MultiHttpSettingsForm = ({ checks, onReturn }: Props) => {
   const requests = watch('settings.multihttp.entries') as any[];
 
   const onError = (errs: DeepMap<CheckFormValues, FieldError>) => {
-    console.log(errs);
-    const errKeys = Object.keys(errs);
-    const entries = errs.settings?.multihttp?.entries;
-    const isMultiHttpError = errKeys.length === 1 && entries;
+    const res = getMultiHttpFormErrors(errs);
 
-    if (isMultiHttpError) {
-      const firstCollapsibleError = entries.findIndex(Boolean);
-
-      if (!collapseState[firstCollapsibleError]) {
-        dispatchCollapse({ type: 'toggle', index: firstCollapsibleError });
-      }
+    if (res) {
+      dispatchCollapse({
+        type: 'updateRequestPanel',
+        open: true,
+        index: res.index,
+        tab: res.tab,
+      });
     }
   };
 
@@ -223,10 +196,10 @@ export const MultiHttpSettingsForm = ({ checks, onReturn }: Props) => {
                       key={field.id}
                       className={styles.collapseTarget}
                       invalid={Boolean(errors?.settings?.multihttp?.entries?.[index])}
-                      isOpen={collapseState[index]}
+                      isOpen={collapseState[index].open}
                       onToggle={() => dispatchCollapse({ type: 'toggle', index })}
                     >
-                      <VerticalGroup height={'100%'}>
+                      <VerticalGroup>
                         <HorizontalGroup spacing="lg" align="flex-start">
                           <Field
                             label="Request target"
@@ -277,7 +250,13 @@ export const MultiHttpSettingsForm = ({ checks, onReturn }: Props) => {
 
                         <AvailableVariables index={index} />
 
-                        <TabSection index={index} />
+                        <TabSection
+                          index={index}
+                          activeTab={collapseState[index].activeTab}
+                          onTabClick={(tab) => {
+                            dispatchCollapse({ type: 'updateRequestPanel', index, tab });
+                          }}
+                        />
                       </VerticalGroup>
                     </MultiHttpCollapse>
                   );

--- a/src/components/MultiHttp/MultiHttpSettingsForm.tsx
+++ b/src/components/MultiHttp/MultiHttpSettingsForm.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useMemo, useReducer } from 'react';
+import React, { useContext, useState, useMemo, useReducer, useEffect } from 'react';
 import { FormProvider, useForm, Controller, useFieldArray } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 
@@ -132,14 +132,15 @@ export const MultiHttpSettingsForm = ({ checks, onReturn }: Props) => {
   });
 
   const submissionError = error as unknown as SubmissionErrorWrapper;
-  console.log(error);
-  if (submissionError) {
-    console.log(`called?`);
-    reportError(
-      submissionError.data?.err ?? 'Multihttp submission error',
-      check?.id ? FaroEvent.UPDATE_CHECK : FaroEvent.CREATE_CHECK
-    );
-  }
+
+  useEffect(() => {
+    if (submissionError) {
+      reportError(
+        submissionError.data?.err ?? 'Multihttp submission error',
+        check.id ? FaroEvent.UPDATE_CHECK : FaroEvent.CREATE_CHECK
+      );
+    }
+  }, [check.id, submissionError]);
 
   const onRemoveCheck = async () => {
     const id = check?.id;

--- a/src/components/MultiHttp/MultiHttpSettingsForm.utils.ts
+++ b/src/components/MultiHttp/MultiHttpSettingsForm.utils.ts
@@ -1,0 +1,122 @@
+import { useReducer } from 'react';
+import { DeepMap, FieldError } from 'react-hook-form';
+
+import { Check, CheckFormValues } from 'types';
+import { MultiHttpFormTabs } from './MultiHttpTypes';
+
+const tabOrder = [
+  MultiHttpFormTabs.Headers,
+  MultiHttpFormTabs.QueryParams,
+  MultiHttpFormTabs.Assertions,
+  MultiHttpFormTabs.Variables,
+  MultiHttpFormTabs.Body,
+];
+
+type FormErrors = DeepMap<CheckFormValues, FieldError>;
+
+export const tabErrorMap = (errors: FormErrors, index: number, tab: MultiHttpFormTabs) => {
+  const entry = errors?.settings?.multihttp?.entries?.[index];
+
+  const tabErrorPathMap = {
+    [MultiHttpFormTabs.Headers]: entry?.request?.headers?.length,
+    [MultiHttpFormTabs.QueryParams]: entry?.request?.queryFields?.length,
+    [MultiHttpFormTabs.Assertions]: entry?.checks?.length,
+    [MultiHttpFormTabs.Variables]: entry?.variables?.length,
+    [MultiHttpFormTabs.Body]: false, // Body tab does not have any validation
+  };
+
+  return tabErrorPathMap[tab];
+};
+
+type RequestPanelState = {
+  open: boolean;
+  activeTab: MultiHttpFormTabs;
+};
+
+type Action = {
+  type: string;
+  index?: number;
+  open?: boolean;
+  tab?: MultiHttpFormTabs;
+};
+
+function reducer(state: RequestPanelState[], action: Action) {
+  switch (action.type) {
+    case 'addNewRequest':
+      const newState = state.map((value) => {
+        return {
+          ...value,
+          open: false,
+        };
+      });
+      return [
+        ...newState,
+        {
+          open: true,
+          activeTab: MultiHttpFormTabs.Headers,
+        },
+      ];
+    case 'removeRequest':
+      return state.filter((_, index) => index !== action.index);
+    case 'toggle': {
+      return state.map((value, index) => {
+        if (action.index === index) {
+          return {
+            ...value,
+            open: !value.open,
+          };
+        }
+        return value;
+      });
+    }
+    case 'updateRequestPanel': {
+      return state.map((value, index) => {
+        if (action.index === index) {
+          return {
+            ...value,
+            open: action.open || value.open,
+            activeTab: action.tab || value.activeTab,
+          };
+        }
+        return value;
+      });
+    }
+    default:
+      return state;
+  }
+}
+
+export function useMultiHttpCollapseState(check: Check) {
+  const initialState = check.settings.multihttp?.entries?.map((_, index, arr) => ({
+    open: index === arr.length - 1,
+    activeTab: MultiHttpFormTabs.Headers,
+  })) ?? [{ open: true, activeTab: MultiHttpFormTabs.Headers }];
+
+  return useReducer(reducer, initialState);
+}
+
+export function getMultiHttpFormErrors(errs: FormErrors) {
+  const errKeys = Object.keys(errs);
+  const entries = errs.settings?.multihttp?.entries;
+  const isMultiHttpError = errKeys.length === 1 && entries;
+
+  if (isMultiHttpError) {
+    const firstCollapsibleError = entries.findIndex(Boolean);
+    const firstTabWithErrors = tabOrder
+      .map((tab) => {
+        if (tabErrorMap(errs, firstCollapsibleError, tab)) {
+          return tab;
+        }
+
+        return false;
+      })
+      .filter(Boolean);
+
+    return {
+      index: firstCollapsibleError,
+      tab: firstTabWithErrors[0] || MultiHttpFormTabs.Headers,
+    };
+  }
+
+  return false;
+}

--- a/src/components/MultiHttp/MultiHttpTypes.ts
+++ b/src/components/MultiHttp/MultiHttpTypes.ts
@@ -1,5 +1,13 @@
 import { MultiHttpAssertionType } from 'types';
 
+export enum MultiHttpFormTabs {
+  Headers = 'headers',
+  QueryParams = 'query',
+  Assertions = 'checks',
+  Body = 'body',
+  Variables = 'variables',
+}
+
 export type MultiHttpVariable = {
   type: number;
   name: string;

--- a/src/components/MultiHttp/Tabs/AssertionsTab.tsx
+++ b/src/components/MultiHttp/Tabs/AssertionsTab.tsx
@@ -1,4 +1,4 @@
-import { useStyles2, HorizontalGroup, Select, Button, Icon, Input, Field, IconButton } from '@grafana/ui';
+import { useStyles2, Select, Button, Icon, Input, Field, IconButton } from '@grafana/ui';
 import {
   ASSERTION_CONDITION_OPTIONS,
   ASSERTION_SUBJECT_OPTIONS,
@@ -27,12 +27,12 @@ export function AssertionsTab({ index, active }: MultiHttpTabProps) {
         description="Use assertions to validate that the system is responding with the expected content"
       >
         <>
-          <br />
           {fields.map((field, assertionIndex) => {
             const assertionTypeName = `${assertionFieldName}[${assertionIndex}].type` ?? '';
             const errorPath = formState.errors.settings?.multihttp?.entries?.[index]?.checks?.[assertionIndex];
+
             return (
-              <HorizontalGroup spacing="md" key={field.id} align="flex-end">
+              <div className={styles.fieldsContainer} key={field.id} id="chris">
                 <Controller
                   name={assertionTypeName}
                   render={({ field: typeField }) => {
@@ -57,17 +57,17 @@ export function AssertionsTab({ index, active }: MultiHttpTabProps) {
                   rules={{ required: 'Assertion type is required' }}
                 />
                 <AssertionFields fieldName={`${assertionFieldName}[${assertionIndex}]`} errors={errorPath} />
-                <IconButton
-                  className={styles.removeIconWithLabel}
-                  name="minus-circle"
-                  size="md"
-                  type="button"
-                  onClick={() => {
-                    remove(assertionIndex);
-                  }}
-                  tooltip="Delete"
-                />
-              </HorizontalGroup>
+
+                <div className={styles.iconContainer}>
+                  <IconButton
+                    name="minus-circle"
+                    onClick={() => {
+                      remove(assertionIndex);
+                    }}
+                    tooltip="Delete"
+                  />
+                </div>
+              </div>
             );
           })}
         </>
@@ -94,32 +94,32 @@ function AssertionFields({ fieldName, errors }: { fieldName: string; errors: any
   switch (assertionType?.value) {
     case MultiHttpAssertionType.Text:
       return (
-        <HorizontalGroup spacing="sm" align="flex-start">
+        <>
           <AssertionSubjectField fieldName={fieldName} error={errors?.subject} />
           <AssertionConditionField fieldName={fieldName} error={errors?.condition} />
           <AssertionValueField fieldName={fieldName} error={errors?.value} />
-        </HorizontalGroup>
+        </>
       );
     case MultiHttpAssertionType.JSONPathValue:
       return (
-        <HorizontalGroup spacing="sm" align="flex-start">
+        <>
           <AssertionExpressionField fieldName={fieldName} error={errors?.expression} />
           <AssertionConditionField fieldName={fieldName} error={errors?.condition} />
           <AssertionValueField fieldName={fieldName} error={errors?.value} />
-        </HorizontalGroup>
+        </>
       );
     case MultiHttpAssertionType.JSONPath:
       return (
-        <HorizontalGroup spacing="sm" align="flex-start">
+        <>
           <AssertionExpressionField fieldName={fieldName} error={errors?.expression} />
-        </HorizontalGroup>
+        </>
       );
     case MultiHttpAssertionType.Regex:
       return (
-        <HorizontalGroup spacing="sm" align="flex-start">
+        <>
           <AssertionSubjectField fieldName={fieldName} error={errors?.subject} />
           <AssertionExpressionField fieldName={fieldName} error={errors?.expression} />
-        </HorizontalGroup>
+        </>
       );
     default:
       return null;

--- a/src/components/MultiHttp/Tabs/TabSection.tsx
+++ b/src/components/MultiHttp/Tabs/TabSection.tsx
@@ -1,15 +1,17 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useStyles2, TabsBar, Tab, Icon, useTheme2 } from '@grafana/ui';
-import { RequestTabs } from 'components/MultiHttp/Tabs/Tabs';
-import { getMultiHttpFormStyles } from './../MultiHttpSettingsForm.styles';
-import { useFormContext } from 'react-hook-form';
-import { MultiHttpFormTabs } from 'types';
 import { SelectableValue } from '@grafana/data';
-import { RequestMethods } from '../MultiHttpTypes';
+import { useFormContext } from 'react-hook-form';
+
+import { RequestTabs } from 'components/MultiHttp/Tabs/Tabs';
+import { MultiHttpFormTabs, RequestMethods } from 'components/MultiHttp/MultiHttpTypes';
+import { tabErrorMap } from 'components/MultiHttp/MultiHttpSettingsForm.utils';
+import { getMultiHttpFormStyles } from './../MultiHttpSettingsForm.styles';
 
 interface RequestTabsProps {
-  label?: string;
+  activeTab: MultiHttpFormTabs;
   index: number;
+  onTabClick: (tab: MultiHttpFormTabs) => void;
 }
 
 function TabErrorWarning() {
@@ -29,10 +31,8 @@ export function getIsBodyDisabled(method: SelectableValue<RequestMethods>) {
   }
 }
 
-export const TabSection = ({ index }: RequestTabsProps) => {
-  const [activeTab, setActiveTab] = useState<MultiHttpFormTabs>('header');
+export const TabSection = ({ activeTab, index, onTabClick }: RequestTabsProps) => {
   const styles = useStyles2(getMultiHttpFormStyles);
-
   const { formState, watch } = useFormContext();
   const requestMethod = watch(`settings.multihttp.entries.${index}.request.method`);
   const headers = watch(`settings.multihttp.entries.${index}.request.headers`);
@@ -40,7 +40,6 @@ export const TabSection = ({ index }: RequestTabsProps) => {
   const assertions = watch(`settings.multihttp.entries.${index}.checks`);
   const variables = watch(`settings.multihttp.entries.${index}.variables`);
   const errors = formState.errors?.settings?.multihttp?.entries[index];
-
   const isBodyDisabled = getIsBodyDisabled(requestMethod);
 
   return (
@@ -48,56 +47,56 @@ export const TabSection = ({ index }: RequestTabsProps) => {
       <TabsBar className={styles.tabsBar}>
         <Tab
           label={'Headers'}
-          active={activeTab === 'header'}
+          active={activeTab === MultiHttpFormTabs.Headers}
           onChangeTab={() => {
-            setActiveTab('header');
+            onTabClick(MultiHttpFormTabs.Headers);
           }}
           default={true}
           className={styles.tabs}
           counter={headers?.length ?? 0}
-          suffix={errors?.request?.headers?.length ? TabErrorWarning : undefined}
+          suffix={tabErrorMap(errors, index, MultiHttpFormTabs.Headers) ? TabErrorWarning : undefined}
         />
 
         <Tab
           label={'Query Params'}
-          active={activeTab === 'queryParams'}
+          active={activeTab === MultiHttpFormTabs.QueryParams}
           onChangeTab={() => {
-            setActiveTab('queryParams');
+            onTabClick(MultiHttpFormTabs.QueryParams);
           }}
           className={styles.tabs}
           counter={queryParams?.length ?? 0}
-          suffix={errors?.request?.queryFields?.length ? TabErrorWarning : undefined}
+          suffix={tabErrorMap(errors, index, MultiHttpFormTabs.QueryParams) ? TabErrorWarning : undefined}
         />
         <Tab
           label={'Assertions'}
-          active={activeTab === 'assertions'}
+          active={activeTab === MultiHttpFormTabs.Assertions}
           onChangeTab={() => {
-            setActiveTab('assertions');
+            onTabClick(MultiHttpFormTabs.Assertions);
           }}
           className={styles.tabs}
           counter={assertions?.length ?? 0}
-          suffix={errors?.checks?.length ? TabErrorWarning : undefined}
+          suffix={tabErrorMap(errors, index, MultiHttpFormTabs.Assertions) ? TabErrorWarning : undefined}
         />
         <Tab
           label="Variables"
-          active={activeTab === 'variables'}
+          active={activeTab === MultiHttpFormTabs.Variables}
           onChangeTab={() => {
-            setActiveTab('variables');
+            onTabClick(MultiHttpFormTabs.Variables);
           }}
           className={styles.tabs}
           counter={variables?.length ?? 0}
-          suffix={errors?.variables?.length ? TabErrorWarning : undefined}
+          suffix={tabErrorMap(errors, index, MultiHttpFormTabs.Variables) ? TabErrorWarning : undefined}
         />
         {!isBodyDisabled && (
           <Tab
             className={styles.tabs}
             disabled={isBodyDisabled}
             label={'Body'}
-            active={activeTab === 'body'}
+            active={activeTab === MultiHttpFormTabs.Body}
             onChangeTab={() => {
-              setActiveTab('body');
+              onTabClick(MultiHttpFormTabs.Body);
             }}
-            suffix={errors?.body ? TabErrorWarning : undefined}
+            suffix={tabErrorMap(errors, index, MultiHttpFormTabs.Body) ? TabErrorWarning : undefined}
           />
         )}
       </TabsBar>

--- a/src/components/MultiHttp/Tabs/Tabs.tsx
+++ b/src/components/MultiHttp/Tabs/Tabs.tsx
@@ -1,7 +1,6 @@
-import { css, cx } from '@emotion/css';
 import React from 'react';
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
-
+import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import {
   Button,
@@ -15,11 +14,13 @@ import {
   TextArea,
   useStyles2,
 } from '@grafana/ui';
+
+import { MultiHttpVariableType } from 'types';
 import { MULTI_HTTP_VARIABLE_TYPE_OPTIONS } from 'components/constants';
-import { MultiHttpFormTabs, MultiHttpVariableType } from 'types';
+import { MultiHttpFormTabs } from 'components/MultiHttp/MultiHttpTypes';
 import { AssertionsTab } from './AssertionsTab';
-import { getMultiHttpFormStyles } from '../MultiHttpSettingsForm.styles';
 import { getIsBodyDisabled } from './TabSection';
+import { getMultiHttpFormStyles } from '../MultiHttpSettingsForm.styles';
 
 export interface MultiHttpTabProps {
   label?: string;
@@ -336,11 +337,11 @@ export const RequestTabs = ({ activeTab, index }: RequestTabsProps) => {
   const hideBody = getIsBodyDisabled(method);
   return (
     <TabContent className={styles.tabsContent}>
-      <HeadersTab label="header" index={index} active={activeTab === 'header'} />
-      {!hideBody && <BodyTab index={index} active={activeTab === 'body'} />}
-      <QueryParamsTab index={index} label="queryParams" active={activeTab === 'queryParams'} />
-      <VariablesTab index={index} label="variables" active={activeTab === 'variables'} />
-      <AssertionsTab index={index} label="assertions" active={activeTab === 'assertions'} />
+      <HeadersTab label="header" index={index} active={activeTab === MultiHttpFormTabs.Headers} />
+      {!hideBody && <BodyTab index={index} active={activeTab === MultiHttpFormTabs.Body} />}
+      <QueryParamsTab index={index} label="queryParams" active={activeTab === MultiHttpFormTabs.QueryParams} />
+      <VariablesTab index={index} label="variables" active={activeTab === MultiHttpFormTabs.Variables} />
+      <AssertionsTab index={index} label="assertions" active={activeTab === MultiHttpFormTabs.Assertions} />
     </TabContent>
   );
 };

--- a/src/components/MultiHttp/Tabs/Tabs.tsx
+++ b/src/components/MultiHttp/Tabs/Tabs.tsx
@@ -49,7 +49,7 @@ export const HeadersTab = ({ label = 'header', index, active }: MultiHttpTabProp
             const headersNamePrefix = `settings.multihttp.entries[${index}].request.headers[${i}]`;
 
             return (
-              <div className={cx({ [styles.tabInputContainer]: i === 0 })} key={field.id}>
+              <div key={field.id}>
                 <HorizontalGroup spacing="md" align="flex-start" className={styles.headersQueryInputs}>
                   <HorizontalGroup spacing="md" align="flex-start" className={styles.headersQueryInputs}>
                     <Field
@@ -166,7 +166,7 @@ const QueryParamsTab = ({ index, label, active }: MultiHttpTabProps) => {
           {fields.map((field, i) => {
             const queryParamsNamePrefix = `settings.multihttp.entries[${index}].request.queryFields[${i}]`;
             return (
-              <div className={cx({ [styles.tabInputContainer]: i === 0 })} key={field.id}>
+              <div key={field.id}>
                 <HorizontalGroup align="flex-start" spacing="md">
                   <HorizontalGroup spacing="md" align="flex-start">
                     <Field invalid={errors?.[i]?.name} error={errors?.[i]?.name?.message}>
@@ -240,79 +240,74 @@ const VariablesTab = ({ index, active }: MultiHttpTabProps) => {
             const errorPath = formState.errors.settings?.multihttp?.entries[index]?.variables?.[variableIndex];
 
             return (
-              <div className={cx({ [styles.tabInputContainer]: variableIndex === 0 })} key={field.id}>
-                <HorizontalGroup key={field.id} align="flex-end">
-                  <Controller
-                    name={variableTypeName}
-                    render={({ field: typeField }) => {
-                      return (
-                        <Field
-                          label="Variable type"
-                          description="The method of getting a value"
-                          invalid={errorPath?.type}
-                        >
-                          <Select
-                            id={`multihttp-variable-type-${index}-${variableIndex}`}
-                            className={styles.minInputWidth}
-                            {...typeField}
-                            options={MULTI_HTTP_VARIABLE_TYPE_OPTIONS}
-                            menuPlacement="bottom"
-                          />
-                        </Field>
-                      );
-                    }}
-                    rules={{ required: true }}
+              <div className={styles.fieldsContainer} key={field.id}>
+                <Controller
+                  name={variableTypeName}
+                  render={({ field: typeField }) => {
+                    return (
+                      <Field
+                        label="Variable type"
+                        description="The method of getting a value"
+                        invalid={errorPath?.type}
+                      >
+                        <Select
+                          id={`multihttp-variable-type-${index}-${variableIndex}`}
+                          className={styles.minInputWidth}
+                          {...typeField}
+                          options={MULTI_HTTP_VARIABLE_TYPE_OPTIONS}
+                          menuPlacement="bottom"
+                        />
+                      </Field>
+                    );
+                  }}
+                  rules={{ required: true }}
+                />
+                <Field
+                  label="Variable name"
+                  description="The name of the variable"
+                  invalid={errorPath?.name}
+                  error={errorPath?.name?.message}
+                >
+                  <Input
+                    placeholder="Variable name"
+                    id={`multihttp-variable-name-${index}-${variableIndex}`}
+                    invalid={formState.errors.settings?.multihttp?.entries[index]?.variables?.[variableIndex]?.type}
+                    {...register(`${variableFieldName}[${variableIndex}].name`, {
+                      required: 'Variable name is required',
+                    })}
                   />
+                </Field>
+                {variableTypeValue === MultiHttpVariableType.CSS_SELECTOR && (
                   <Field
-                    label="Variable name"
-                    description="The name of the variable"
-                    invalid={errorPath?.name}
-                    error={errorPath?.name?.message}
+                    label="Attribute"
+                    description="Name of the attribute to extract the value from. Leave blank to get contents of tag"
+                    invalid={errorPath?.attribute}
+                    error={errorPath?.attribute?.message}
                   >
                     <Input
-                      placeholder="Variable name"
-                      id={`multihttp-variable-name-${index}-${variableIndex}`}
-                      invalid={formState.errors.settings?.multihttp?.entries[index]?.variables?.[variableIndex]?.type}
-                      {...register(`${variableFieldName}[${variableIndex}].name`, {
-                        required: 'Variable name is required',
-                      })}
+                      placeholder="Attribute"
+                      id={`multihttp-variable-attribute-${index}-${variableIndex}`}
+                      {...register(`${variableFieldName}[${variableIndex}].attribute`)}
                     />
                   </Field>
-                  {variableTypeValue === MultiHttpVariableType.CSS_SELECTOR && (
-                    <Field
-                      label="Attribute"
-                      description="Name of the attribute to extract the value from. Leave blank to get contents of tag"
-                      invalid={errorPath?.attribute}
-                      error={errorPath?.attribute?.message}
-                    >
-                      <Input
-                        placeholder="Attribute"
-                        id={`multihttp-variable-attribute-${index}-${variableIndex}`}
-                        {...register(`${variableFieldName}[${variableIndex}].attribute`)}
-                      />
-                    </Field>
-                  )}
-                  <Field
-                    label="Variable expression"
-                    description="Expression to extract the value"
-                    invalid={errorPath?.expression}
-                    error={errorPath?.expression?.message}
-                  >
-                    <Input
-                      placeholder="Variable expression"
-                      id={`multihttp-variable-expression-${index}-${variableIndex}`}
-                      {...register(`${variableFieldName}[${variableIndex}].expression`, {
-                        required: 'Expression is required',
-                      })}
-                    />
-                  </Field>
-                  <IconButton
-                    name="trash-alt"
-                    onClick={() => remove(variableIndex)}
-                    className={styles.removeIconWithLabel}
-                    tooltip="Delete"
+                )}
+                <Field
+                  label="Variable expression"
+                  description="Expression to extract the value"
+                  invalid={errorPath?.expression}
+                  error={errorPath?.expression?.message}
+                >
+                  <Input
+                    placeholder="Variable expression"
+                    id={`multihttp-variable-expression-${index}-${variableIndex}`}
+                    {...register(`${variableFieldName}[${variableIndex}].expression`, {
+                      required: 'Expression is required',
+                    })}
                   />
-                </HorizontalGroup>
+                </Field>
+                <div className={styles.iconContainer}>
+                  <IconButton name="minus-circle" onClick={() => remove(variableIndex)} tooltip="Delete" />
+                </div>
               </div>
             );
           })}
@@ -354,9 +349,16 @@ export const getMultiHttpTabStyles = (theme: GrafanaTheme2) => ({
   removeIcon: css`
     margin-top: 6px;
   `,
-  removeIconWithLabel: css`
-    margin-bottom: ${theme.spacing(3)};
+  fieldsContainer: css({
+    alignItems: 'baseline',
+    display: 'flex',
+    gap: theme.spacing(2),
+    marginTop: theme.spacing(2),
+  }),
+  iconContainer: css`
     margin-left: ${theme.spacing(2)};
+    position: relative;
+    top: ${theme.spacing(4)};
   `,
   headersQueryInputs: css`
     margin: 100px 0;
@@ -375,8 +377,5 @@ export const getMultiHttpTabStyles = (theme: GrafanaTheme2) => ({
   `,
   inactive: css`
     display: none;
-  `,
-  tabInputContainer: css`
-    margin-top: ${theme.spacing(2)};
   `,
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -582,8 +582,6 @@ export interface VizViewSceneAppConfig extends DashboardSceneAppConfig {
   onFilterChange: (filters: CheckFiltersType) => void;
 }
 
-export type MultiHttpFormTabs = 'header' | 'queryParams' | 'assertions' | 'body' | 'variables';
-
 export enum MultiHttpVariableType {
   JSON_PATH = 0,
   REGEX = 1,


### PR DESCRIPTION
**Before**

- Field / Error misalignments.

<img width="922" alt="image" src="https://github.com/grafana/synthetic-monitoring-app/assets/6906380/961f6f87-3aed-4cdb-8eae-b996b0beb832">

- Request header non-keyboard accessible

- Difficult to spot errors on save

https://github.com/grafana/synthetic-monitoring-app/assets/6906380/7a9dfbf4-0d17-4bcf-a76a-b304497cc03e

**After**

- Aligned fields / errors.

<img width="1381" alt="image" src="https://github.com/grafana/synthetic-monitoring-app/assets/6906380/e5ec5e6c-8d66-41f9-b3e0-27b8841f166b">

- Keyboard-accessible request header

<img width="1417" alt="image" src="https://github.com/grafana/synthetic-monitoring-app/assets/6906380/0ff2c224-f98a-4684-8b22-f4f456f912e8">

- Automatically opens the first collapsed request header and goes to the first tab with errors. One known issue with this implementation is that @grafana/ui does not forward the ref to the Select in a react-hook-form Controller, so it doesn't automatically focus some fields. I'll put another PR up tomorrow to address this as I know another workaround that is a little bit involved.

https://github.com/grafana/synthetic-monitoring-app/assets/6906380/3abe4097-955d-4651-a7f1-40b51dd79ebd

