### PR TITLE
fix 'create checks programmatically' link

### DIFF
--- a/src/page/HomePage.tsx
+++ b/src/page/HomePage.tsx
@@ -221,7 +221,7 @@ export const HomePage = () => {
               <p>Create, configure, and manage checks programmatically via Grizzly or Terraform.</p>
               <a
                 className={styles.link}
-                href="https://grafana.com/docs/grafana-cloud/synthetic-monitoring/?manage-checks-with-the-api--config-as-code#manage-checks-with-the-api--config-as-code"
+                href="https://grafana.com/docs/grafana-cloud/synthetic-monitoring/?manage-checks-with-the-api--config-as-code#config-as-code"
                 target="_blank"
                 rel="noopenner noreferrer"
               >


### PR DESCRIPTION

**What this PR does / why we need it**:

- The "Learn more about creating checks programmatically" link isn't quite working right.  It takes you to the top of the docs page.  This fix will take people to the expected heading
- <img width="529" alt="image" src="https://github.com/grafana/synthetic-monitoring-app/assets/7903188/6664a632-df37-4ad0-9e9b-40442aaee233">


Video clip
https://github.com/grafana/synthetic-monitoring-app/assets/7903188/5ec9fab2-144b-4583-84a8-edb1dcdbede2

  

