### PR TITLE
fix: temporary fix for success gauges

### DIFF
--- a/src/components/SuccessRateContextProvider.tsx
+++ b/src/components/SuccessRateContextProvider.tsx
@@ -16,6 +16,7 @@ import {
 
 interface Props {
   probes?: Probe[];
+  onlyProbes?: boolean;
 }
 
 type SeedRequestMetric = {
@@ -129,9 +130,11 @@ const parseProbeResults = (probes: Probe[] | undefined, data: any) => {
   return resultsPerProbe;
 };
 
-export function SuccessRateContextProvider({ probes, children }: PropsWithChildren<Props>) {
+export function SuccessRateContextProvider({ onlyProbes, probes, children }: PropsWithChildren<Props>) {
   const { instance } = useContext(InstanceContext);
-  const { checks } = useContext(ChecksContext);
+  const { checks: contextChecks } = useContext(ChecksContext);
+  // very temporary solution...
+  const checks = onlyProbes ? undefined : contextChecks;
   const [successRateValues, setSuccessRate] = useState<SuccessRates>(defaultValues);
   const [loading, setLoading] = useState(true);
   const [thresholds, setThresholds] = useState<ThresholdSettings>(defaultThresholds);

--- a/src/page/ProbeRouter.tsx
+++ b/src/page/ProbeRouter.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, { useContext, useEffect,useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Route, Switch, useRouteMatch } from 'react-router-dom';
 
 // Types
@@ -41,7 +41,7 @@ export const ProbeRouter = () => {
   }
 
   return (
-    <SuccessRateContextProvider probes={probes}>
+    <SuccessRateContextProvider onlyProbes probes={probes}>
       <Switch>
         <Route path={path} exact>
           <ProbeList


### PR DESCRIPTION
This is a **very temporary fix** to get the success gauges working again.

The `SuccessRateContextProvider` component is very confusing and is starting to show its age as it very easily broke with what looks like a sensible change from [this PR](https://github.com/grafana/synthetic-monitoring-app/pull/647). I'm going to loop back to refactoring this when I look at adding `react-query` after the Probes PR I am about to put up.

**Before:**
![Screenshot of Synthetic Monitoring plugin with incorrect SuccessGauge values on the probes list page.](https://github.com/grafana/synthetic-monitoring-app/assets/6906380/7889986c-62ab-4db8-8e35-19920488ce71)


**After:**
![Screenshot of Synthetic Monitoring plugin with correct SuccessGauge values on the probes list page.](https://github.com/grafana/synthetic-monitoring-app/assets/6906380/eb9a3c87-6e3d-4fd4-9105-0e57b5843a30)
