### PR TITLE
feat: add copy panel json

### DIFF
--- a/src/scenes/ExplorablePanel.ts
+++ b/src/scenes/ExplorablePanel.ts
@@ -1,5 +1,7 @@
+import { AppEvents, PanelModel } from '@grafana/data';
 import { sceneGraph, VizPanel, VizPanelMenu, VizPanelState } from '@grafana/scenes';
 import { DataQuery } from '@grafana/schema';
+import appEvents from 'grafana/app/core/app_events';
 
 interface DataQueryExtended extends DataQuery {
   expr: string;
@@ -18,19 +20,14 @@ export class ExplorablePanel extends VizPanel {
     this.initHeaderActionsSync();
   }
 
-  // // use upgraded encoding function that custom escapes "/"
-  // interpolate: InterpolateFunction = (value, scopedVars, format) => {
-  //   if (value.includes(':path')) {
-  //     return sceneGraph.interpolate(
-  //       this,
-  //       value.replace(':path', ''),
-  //       scopedVars,
-  //       encodeParameter as VariableCustomFormatterFn
-  //     );
-  //   }
-
-  //   return sceneGraph.interpolate(this, value, scopedVars, format as VariableCustomFormatterFn);
-  // };
+  private getBasicJsonDefinition(): Partial<PanelModel> {
+    return {
+      fieldConfig: this.state.fieldConfig,
+      description: this.state.description,
+      options: this.state.options,
+      type: this.state.pluginId,
+    };
+  }
 
   private initHeaderActionsSync() {
     this.addActivationHandler(() => {
@@ -59,6 +56,9 @@ export class ExplorablePanel extends VizPanel {
             })
           );
 
+          const panelJson = this.getBasicJsonDefinition();
+          panelJson.datasource = { uid: datasource };
+          panelJson.targets = queries;
           this.setState({
             menu: new VizPanelMenu({
               items: [
@@ -67,6 +67,20 @@ export class ExplorablePanel extends VizPanel {
                   iconClassName: 'compass',
                   text: 'Explore',
                   href: `/explore?left=${left}`,
+                },
+                {
+                  type: 'submenu',
+                  iconClassName: 'copy',
+                  text: 'Copy JSON',
+                  onClick: () => {
+                    try {
+                      navigator.clipboard.writeText(JSON.stringify(panelJson));
+                      appEvents.emit(AppEvents.alertSuccess, ['Panel JSON copied to clipboard']);
+                    } catch (e: any) {
+                      reportError(e);
+                      appEvents.emit(AppEvents.alertError, ['Failed to copy JSON: ' + e?.message]);
+                    }
+                  },
                 },
               ],
             }),


### PR DESCRIPTION
Adds the ability to copy panel json to the clipboard from scenes so folks can add those panels to their own dashboards

![Screenshot 2023-12-29 at 10 26 28](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/bf59ce44-b94f-4060-b0be-d8000b5903b3)

![Screenshot 2023-12-29 at 10 26 31](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/a7c16156-4c16-4a50-b08e-e7f56b036000)
