### PR TITLE
fix: indent expandable rows in the scripted scene

### DIFF
--- a/src/scenes/SCRIPTED/AssertionsTable/AssertionsTableRow.tsx
+++ b/src/scenes/SCRIPTED/AssertionsTable/AssertionsTableRow.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect } from 'react';
 import { ExpanderComponentProps } from 'react-data-table-component';
+import { GrafanaTheme2 } from '@grafana/data';
 import { SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
+import { useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 
 import { AssertionsTableSceneObject, DataRow } from './AssertionsTable';
 import { getSuccessOverTimeByProbe } from './successOverTimeByProbe';
@@ -26,9 +29,19 @@ interface Props extends ExpanderComponentProps<DataRow> {
   logs?: DataSourceRef;
 }
 
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    container: css({
+      padding: theme.spacing(2),
+      background: theme.colors.background.canvas,
+    }),
+  };
+}
+
 export function AssertionTableRow({ data, tableViz, logs }: Props) {
   const { expandedRows } = tableViz?.useState() ?? {};
   const [rowKey, setRowKey] = React.useState<string | undefined>(undefined);
+  const styles = useStyles2(getStyles);
   const rowScene = expandedRows?.find((scene) => scene.state.key === rowKey);
 
   useEffect(() => {
@@ -40,5 +53,5 @@ export function AssertionTableRow({ data, tableViz, logs }: Props) {
     }
   }, [data.name, tableViz, rowScene, logs]);
 
-  return <div>{rowScene ? <rowScene.Component model={rowScene} /> : null}</div>;
+  return <div className={styles.container}>{rowScene ? <rowScene.Component model={rowScene} /> : null}</div>;
 }

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/ResultsByTargetTableRow.tsx
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/ResultsByTargetTableRow.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect } from 'react';
 import { ExpanderComponentProps } from 'react-data-table-component';
+import { GrafanaTheme2 } from '@grafana/data';
 import { SceneFlexLayout } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
+import { useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 
 import { getExpectedResponse } from '../expectedResponse';
 import { getDurationByTargetProbe } from './durationByTargetProbe';
@@ -33,9 +36,19 @@ interface Props extends ExpanderComponentProps<DataRow> {
   metrics?: DataSourceRef;
 }
 
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    container: css({
+      padding: theme.spacing(2),
+      background: theme.colors.background.canvas,
+    }),
+  };
+}
+
 export function ResultsByTargetTableRow({ data, tableViz, metrics }: Props) {
   const { expandedRows } = tableViz?.useState() ?? {};
   const [rowKey, setRowKey] = React.useState<string | undefined>(undefined);
+  const styles = useStyles2(getStyles);
   const rowScene = expandedRows?.find((scene) => scene.state.key === rowKey);
 
   useEffect(() => {
@@ -46,5 +59,5 @@ export function ResultsByTargetTableRow({ data, tableViz, metrics }: Props) {
     }
   }, [data.name, tableViz, rowScene, metrics]);
 
-  return <div>{rowScene ? <rowScene.Component model={rowScene} /> : null}</div>;
+  return <div className={styles.container}>{rowScene ? <rowScene.Component model={rowScene} /> : null}</div>;
 }


### PR DESCRIPTION
With no indentation the scene can be really hard to parse:

![screencapture-smdev-grafana-dev-net-a-grafana-synthetic-monitoring-app-scene-k6-2024-01-03-11_47_47](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/6d76f6e5-bb6e-412f-925e-b9bb22bad219)

Adding a bit of space with a different background color helps
![Screenshot 2024-01-03 at 09 50 02](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/2c438704-e4de-4d9c-a012-8de111461c01)
