### PR TITLE
Fix a few query errors

### DIFF
--- a/src/scenes/SCRIPTED/AssertionsTable/AssertionsTable.tsx
+++ b/src/scenes/SCRIPTED/AssertionsTable/AssertionsTable.tsx
@@ -135,8 +135,8 @@ function AssertionsTable({ model }: SceneComponentProps<AssertionsTableSceneObje
         name: 'Success',
         selector: (row) => {
           let successRate;
-          if (isNaN(row.successRate)) {
-            successRate = 'N/A';
+          if (isNaN(row.successRate) || row.successRate === 0) {
+            successRate = '0%';
           } else {
             successRate = row.successRate.toFixed(2) + '%';
           }

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/ResultsByTargetTableRow.tsx
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/ResultsByTargetTableRow.tsx
@@ -10,9 +10,9 @@ import { CheckType } from 'types';
 
 import { getExpectedResponse } from '../expectedResponse';
 import { getDurationByTargetProbe } from './durationByTargetProbe';
+import { getErrorRateByTargetProbe } from './errorRateByTargetProbe';
 import { getLatencyByPhaseTarget } from './latencyByPhaseTarget';
 import { DataRow, ResultsByTargetTableSceneObject } from './ResultByTargetTable';
-import { getSuccessRateByTargetProbe } from './successRateByTargetProbe';
 
 function getResultsByTargetRowScene(metrics: DataSourceRef, labelValue: string, method: string, checkType: CheckType) {
   const labelName = checkType === CheckType.MULTI_HTTP ? 'url' : 'name';
@@ -23,7 +23,7 @@ function getResultsByTargetRowScene(metrics: DataSourceRef, labelValue: string, 
         width: '100%',
         height: 250,
         children: [
-          getSuccessRateByTargetProbe(metrics, labelName, labelValue, method),
+          getErrorRateByTargetProbe(metrics, labelName, labelValue, method),
           getExpectedResponse(metrics, labelName, labelValue, method),
         ],
       }),

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/errorRateByTargetProbe.ts
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/errorRateByTargetProbe.ts
@@ -7,11 +7,11 @@ function getQueryRunner(metrics: DataSourceRef, labelName: string, labelValue: s
   const queries = [
     {
       exemplar: true,
-      expr: `sum by (probe) (
-        probe_http_requests_total{instance="$instance", job="$job", probe=~".*", ${labelName}="${labelValue}", method="${method}"}
+      expr: `sum by (probe, method) (
+        probe_http_requests_failed_total{instance="$instance", job="$job", probe=~".*", ${labelName}="${labelValue}", method="${method}"}
       )
       /
-      sum by (probe) (
+      sum by (probe, method) (
         probe_http_requests_total{instance="$instance", job="$job", probe=~".*", ${labelName}="${labelValue}", method="${method}"}
       )`,
       hide: false,
@@ -27,7 +27,7 @@ function getQueryRunner(metrics: DataSourceRef, labelName: string, labelValue: s
   });
 }
 
-export function getSuccessRateByTargetProbe(
+export function getErrorRateByTargetProbe(
   metrics: DataSourceRef,
   labelName: string,
   labelValue: string,
@@ -36,7 +36,7 @@ export function getSuccessRateByTargetProbe(
   return new SceneFlexItem({
     body: new ExplorablePanel({
       pluginId: 'timeseries',
-      title: `Success rate by probe for ${labelValue} ${method}`,
+      title: `Error rate by probe for ${labelValue} ${method}`,
       $data: getQueryRunner(metrics, labelName, labelValue, method),
       fieldConfig: {
         overrides: [],

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/latencyByPhaseTarget.ts
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/latencyByPhaseTarget.ts
@@ -9,11 +9,7 @@ function getQueryRunner(metrics: DataSourceRef, labelName: string, labelValue: s
     queries: [
       {
         refId: 'A',
-        expr: `
-        sum by (phase) (probe_http_duration_seconds{job="$job", instance="$instance", ${labelName}="${labelValue}", probe=~"$probe", method="${method}"})
-        /
-        count by (phase) (probe_http_duration_seconds{job="$job", instance="$instance", ${labelName}="${labelValue}", probe=~"$probe", method="${method}"})
-        `,
+        expr: `sum by (phase) (probe_http_duration_seconds{job="$job", instance="$instance", ${labelName}="${labelValue}", probe=~"$probe", method="${method}"})`,
         legendFormat: '__auto',
         range: true,
       },


### PR DESCRIPTION
I realized some of the queries in the MultiHTTP/Scripted dashboard were misleading/slight incorrect. Hopefully this rectifies all those issues. 

Specifically success rate by URL, latency by URL/phase, and success rate by URL/probe were all aggregating incorrectly.