### PR TITLE
fix: results by URL table wasnt handling out of order updates correctly

### DIFF
--- a/src/scenes/SCRIPTED/AssertionsTable/AssertionsTable.tsx
+++ b/src/scenes/SCRIPTED/AssertionsTable/AssertionsTable.tsx
@@ -137,6 +137,8 @@ function AssertionsTable({ model }: SceneComponentProps<AssertionsTableSceneObje
           let successRate;
           if (isNaN(row.successRate) || row.successRate === 0) {
             successRate = '0%';
+          } else if (row.successRate === 100) {
+            successRate = '100%';
           } else {
             successRate = row.successRate.toFixed(2) + '%';
           }

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/resultsByTargetTableQueries.ts
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/resultsByTargetTableQueries.ts
@@ -1,0 +1,65 @@
+import { SceneQueryRunner } from '@grafana/scenes';
+import { DataSourceRef } from '@grafana/schema';
+
+import { CheckType } from 'types';
+
+import { RESULTS_BY_TARGET_TABLE_REF_ID } from './utils';
+
+export function getQueryRunner(metrics: DataSourceRef, checkType: CheckType) {
+  const label = checkType === CheckType.K6 ? 'name' : 'url';
+  return new SceneQueryRunner({
+    queries: [
+      {
+        datasource: metrics,
+        editorMode: 'code',
+        exemplar: false,
+        expr: `
+          avg_over_time(
+            (
+              sum by (${label}, method) (probe_http_requests_failed_total{job="$job", instance="$instance"})
+              /
+              sum by (${label}, method) (probe_http_requests_total{job="$job", instance="$instance"})
+            )[$__range:]
+          )
+          `,
+        format: 'table',
+        instant: true,
+        legendFormat: '__auto',
+        range: false,
+        refId: RESULTS_BY_TARGET_TABLE_REF_ID.SUCCESS_RATE,
+      },
+      {
+        datasource: metrics,
+        editorMode: 'code',
+        exemplar: false,
+        expr: `
+          avg_over_time(
+            (
+              sum by (${label}, method) (probe_http_got_expected_response{job="$job", instance="$instance"})
+              /
+              count by (${label}, method)(probe_http_got_expected_response{job="$job", instance="$instance"})
+            )[$__range:]
+          )`,
+        format: 'table',
+        instant: true,
+        legendFormat: '__auto',
+        range: false,
+        refId: RESULTS_BY_TARGET_TABLE_REF_ID.EXPECTED_RESPONSE,
+      },
+      {
+        datasource: metrics,
+        editorMode: 'code',
+        exemplar: false,
+        expr: `
+          avg_over_time(
+            (
+              sum by (${label}, method)(probe_http_duration_seconds{job="$job", instance="$instance"})
+            )[$__range:]
+          )`,
+        format: 'table',
+        instant: true,
+        refId: RESULTS_BY_TARGET_TABLE_REF_ID.LATENCY,
+      },
+    ],
+  });
+}

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/utils.ts
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/utils.ts
@@ -1,0 +1,41 @@
+import { Field } from '@grafana/data';
+
+export enum RESULTS_BY_TARGET_TABLE_REF_ID {
+  SUCCESS_RATE = 'successRate',
+  EXPECTED_RESPONSE = 'expectedResponse',
+  LATENCY = 'latency',
+}
+
+export function getValueFieldName(refId: RESULTS_BY_TARGET_TABLE_REF_ID) {
+  return `Value #${refId}`;
+}
+
+// name is the name of the target. By default it is a url, but the end user can override that with a name specified in the k6 script.
+// method is the HTTP method (e.g. GET, POST, etc.)
+// Field name is the name of the field in the query (e.g. 'name' or 'Value #refId')
+export function findValueByName(
+  name: string,
+  method: string,
+  fieldName: string,
+  fields: Array<Field<any, any[]>>
+): any {
+  const nameFieldIndex = fields.findIndex((field) => field.name === 'name');
+  if (nameFieldIndex === -1) {
+    return;
+  }
+  const methodFieldIndex = fields.findIndex((field) => field.name === 'method');
+  if (methodFieldIndex === -1) {
+    return;
+  }
+  const index = fields[nameFieldIndex]?.values?.findIndex((value, index) => {
+    return value === name && fields[methodFieldIndex]?.values?.[index] === method;
+  });
+  if (index === -1) {
+    return;
+  }
+  const valueField = fields.findIndex((field) => field.name === fieldName);
+  if (valueField === -1) {
+    return;
+  }
+  return fields?.[valueField]?.values?.[index] ?? NaN;
+}


### PR DESCRIPTION
Successive refetches of metric data was resulting in the results by URL table getting scrambled and mixing up which results are related to which URL. I had assumed that data frames were consistent across queries sent out by the same runner (i.e. if the index of the value for URL A is 1 in the success rate query, it will also be 1 in the latency query). Turns out that is _not_ the case, so we have to be defensive and sift through the data in order to pluck the results from the correct place every time.