### PR TITLE
fix: account for multihttp having different label names

### DIFF
--- a/src/scenes/SCRIPTED/ResultsByTargetTable/ResultByTargetTable.tsx
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/ResultByTargetTable.tsx
@@ -109,7 +109,7 @@ export class ResultsByTargetTableSceneObject extends SceneObjectBase<ResultsByTa
       if (!successRateSeries || !expectedResponseSeries || !latencySeries) {
         return [];
       }
-      const namesIndex = successRateSeries.fields?.findIndex((field) => field.name === 'name');
+      const namesIndex = successRateSeries.fields?.findIndex((field) => field.name === 'name' || field.name === 'url');
       const successRateNamesField = successRateSeries?.fields?.[namesIndex];
       const methodIndex = successRateSeries.fields?.findIndex((field) => field.name === 'method');
       const successRateMethodField = successRateSeries.fields?.[methodIndex];

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/utils.ts
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/utils.ts
@@ -19,7 +19,7 @@ export function findValueByName(
   fieldName: string,
   fields: Array<Field<any, any[]>>
 ): any {
-  const nameFieldIndex = fields.findIndex((field) => field.name === 'name');
+  const nameFieldIndex = fields.findIndex((field) => field.name === 'name' || field.name === 'url');
   if (nameFieldIndex === -1) {
     return;
   }


### PR DESCRIPTION
I didn't account for the fact multihttp and scripted checks have different label names in my previous fixes 🤦 