### PR TITLE
chore: add check specific dashboard route

### DIFF
--- a/dev/custom.ini
+++ b/dev/custom.ini
@@ -800,6 +800,8 @@ topnav=true
 multi-http=true
 synthetics-scenes=true
 scripted-checks=true
+synthetics-per-check-dashboards=true
+dockedMegaMenu=true
 
 [navigation.app_standalone_pages]
 # WORKS

--- a/dev/custom.ini
+++ b/dev/custom.ini
@@ -807,6 +807,7 @@ dockedMegaMenu=true
 # WORKS
 # /a/grafana-synthetic-monitoring-app/scene = 'connections-your-connections'
 # "/a/grafana-synthetic-monitoring-app/redirect?dashboard=summary" = "nonexistent"
+"/a/grafana-synthetic-monitoring-app/scene" = "nonexistent"
 
 
 # DOESN'T WORK

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     build:
       context: ./.config
       args:
-        grafana_version: ${GRAFANA_VERSION:-main}
+        grafana_version: ${GRAFANA_VERSION:-10.3.1}
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
     ports:
       - 3000:3000/tcp

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@grafana/faro-web-sdk": "1.3.6",
     "@grafana/k6-test-builder": "^0.8.6",
     "@grafana/runtime": "10.1.4",
-    "@grafana/scenes": "1.21.0",
+    "@grafana/scenes": "2.2.3",
     "@grafana/schema": "10.1.4",
     "@grafana/ui": "10.1.4",
     "@popperjs/core": "^2.9.2",

--- a/src/components/CheckListItem/CheckItemActionButtons.tsx
+++ b/src/components/CheckListItem/CheckItemActionButtons.tsx
@@ -41,7 +41,7 @@ export const CheckItemActionButtons = ({ check, viewDashboardAsIcon, onRemoveChe
       return;
     }
     if (scenesEnabled) {
-      const url = `${PLUGIN_URL_PATH}/${checkType}`;
+      const url = `${PLUGIN_URL_PATH}${ROUTES.Scene}/${checkType}`;
       navigate(
         url,
         {

--- a/src/components/CheckListItem/CheckItemActionButtons.tsx
+++ b/src/components/CheckListItem/CheckItemActionButtons.tsx
@@ -32,10 +32,16 @@ export const CheckItemActionButtons = ({ check, viewDashboardAsIcon, onRemoveChe
   const { instance } = useContext(InstanceContext);
   const navigate = useNavigation();
   const { isEnabled: scenesEnabled } = useFeatureFlag(FeatureName.Scenes);
+  const { isEnabled: perCheckDashboardsEnabled } = useFeatureFlag(FeatureName.PerCheckDashboards);
 
   const showDashboard = () => {
+    if (perCheckDashboardsEnabled) {
+      const url = `${PLUGIN_URL_PATH}${ROUTES.Checks}/${check.id}/dashboard`;
+      navigate(url, {}, true);
+      return;
+    }
     if (scenesEnabled) {
-      const url = `${PLUGIN_URL_PATH}scene/${checkType}`;
+      const url = `${PLUGIN_URL_PATH}/${checkType}`;
       navigate(
         url,
         {

--- a/src/page/CheckRouter.tsx
+++ b/src/page/CheckRouter.tsx
@@ -1,9 +1,10 @@
 import React, { useContext } from 'react';
 import { Route, Switch, useRouteMatch } from 'react-router-dom';
 
-import { CheckType, ROUTES } from 'types';
+import { CheckType, FeatureName, ROUTES } from 'types';
 import { ChecksContext } from 'contexts/ChecksContext';
 import { InstanceContext } from 'contexts/InstanceContext';
+import { useFeatureFlag } from 'hooks/useFeatureFlag';
 import { useNavigation } from 'hooks/useNavigation';
 import { CheckEditor } from 'components/CheckEditor';
 import { CheckList } from 'components/CheckList';
@@ -18,6 +19,7 @@ import { DashboardPage } from './DashboardPage';
 export function CheckRouter() {
   const { instance } = useContext(InstanceContext);
   const { refetchChecks, checks, loading } = useContext(ChecksContext);
+  const { isEnabled: perCheckDashboardsEnabled } = useFeatureFlag(FeatureName.PerCheckDashboards);
 
   const navigate = useNavigation();
   const { path } = useRouteMatch();
@@ -39,9 +41,11 @@ export function CheckRouter() {
         <Route path={path} exact>
           <CheckList instance={instance} onCheckUpdate={returnToList} />
         </Route>
-        <Route path={`${path}/:id/dashboard`} exact>
-          <DashboardPage />
-        </Route>
+        {perCheckDashboardsEnabled && (
+          <Route path={`${path}/:id/dashboard`} exact>
+            <DashboardPage />
+          </Route>
+        )}
         <Route path={`${path}/new/:checkType?`}>
           {({ match }) => {
             switch (match?.params.checkType) {

--- a/src/page/CheckRouter.tsx
+++ b/src/page/CheckRouter.tsx
@@ -13,6 +13,8 @@ import { MultiHttpSettingsForm } from 'components/MultiHttp/MultiHttpSettingsFor
 import { PluginPage } from 'components/PluginPage';
 import { SuccessRateContextProvider } from 'components/SuccessRateContextProvider';
 
+import { DashboardPage } from './DashboardPage';
+
 export function CheckRouter() {
   const { instance } = useContext(InstanceContext);
   const { refetchChecks, checks, loading } = useContext(ChecksContext);
@@ -36,6 +38,9 @@ export function CheckRouter() {
       <Switch>
         <Route path={path} exact>
           <CheckList instance={instance} onCheckUpdate={returnToList} />
+        </Route>
+        <Route path={`${path}/:id/dashboard`} exact>
+          <DashboardPage />
         </Route>
         <Route path={`${path}/new/:checkType?`}>
           {({ match }) => {

--- a/src/page/HomePage.tsx
+++ b/src/page/HomePage.tsx
@@ -201,7 +201,7 @@ export const HomePage = () => {
           title: 'Home',
           url: `${PLUGIN_URL_PATH}${ROUTES.Home}`,
           hideFromBreadcrumbs: true,
-          getScene: getSummaryScene(config, checks),
+          getScene: getSummaryScene(config, checks, perCheckDashboardsEnabled),
         }),
       ],
     });

--- a/src/scenes/Common/variables.ts
+++ b/src/scenes/Common/variables.ts
@@ -1,9 +1,9 @@
-import { QueryVariable } from '@grafana/scenes';
-import { DataSourceRef, VariableRefresh } from '@grafana/schema';
+import { CustomVariable, QueryVariable } from '@grafana/scenes';
+import { DataSourceRef, VariableHide, VariableRefresh } from '@grafana/schema';
 
 import { Check, CheckType } from 'types';
 
-export function getVariables(checkType: CheckType, metrics: DataSourceRef, checks: Check[]) {
+export function getVariables(checkType: CheckType, metrics: DataSourceRef, checks: Check[], singleCheckMode?: boolean) {
   const probe = new QueryVariable({
     includeAll: true,
     allValue: '.*',
@@ -15,12 +15,25 @@ export function getVariables(checkType: CheckType, metrics: DataSourceRef, check
     datasource: metrics,
   });
 
+  if (singleCheckMode) {
+    const job = new CustomVariable({
+      name: 'job',
+      value: checks[0].job,
+      hide: VariableHide.hideVariable,
+    });
+    const instance = new CustomVariable({
+      name: 'instance',
+      value: checks[0].target,
+      hide: VariableHide.hideVariable,
+    });
+    return { probe, job, instance };
+  }
+
   const job = new QueryVariable({
     name: 'job',
     label: 'Job',
     refresh: VariableRefresh.onDashboardLoad,
     query: `label_values(sm_check_info{check_name="${checkType}", probe=~"$probe"},job)`,
-
     datasource: metrics,
   });
 

--- a/src/scenes/DNS/dnsScene.ts
+++ b/src/scenes/DNS/dnsScene.ts
@@ -28,7 +28,7 @@ import { getErrorRateTimeseries } from 'scenes/HTTP/errorRateTimeseries';
 import { getAnswerRecordsStat } from './answerRecords';
 import { getResourcesRecordsPanel } from './resourceRecords';
 
-export function getDNSScene({ metrics, logs }: DashboardSceneAppConfig, checks: Check[]) {
+export function getDNSScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[]) {
   return () => {
     if (checks.length === 0) {
       return getEmptyScene(CheckType.DNS);
@@ -39,7 +39,7 @@ export function getDNSScene({ metrics, logs }: DashboardSceneAppConfig, checks: 
       to: 'now',
     });
 
-    const { probe, job, instance } = getVariables(CheckType.DNS, metrics, checks);
+    const { probe, job, instance } = getVariables(CheckType.DNS, metrics, checks, singleCheckMode);
 
     const variables = new SceneVariableSet({ variables: [probe, job, instance] });
     const errorMap = getErrorRateMapPanel(metrics);

--- a/src/scenes/HTTP/httpScene.ts
+++ b/src/scenes/HTTP/httpScene.ts
@@ -28,7 +28,7 @@ import {
 import { getErrorRateTimeseries } from './errorRateTimeseries';
 import { getLatencyByPhasePanel } from './latencyByPhase';
 
-export function getHTTPScene({ metrics, logs }: DashboardSceneAppConfig, checks: Check[]) {
+export function getHTTPScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[]) {
   return () => {
     const timeRange = new SceneTimeRange({
       from: 'now-6h',
@@ -38,7 +38,7 @@ export function getHTTPScene({ metrics, logs }: DashboardSceneAppConfig, checks:
       return getEmptyScene(CheckType.HTTP);
     }
 
-    const { probe, job, instance } = getVariables(CheckType.HTTP, metrics, checks);
+    const { probe, job, instance } = getVariables(CheckType.HTTP, metrics, checks, singleCheckMode);
     const variableSet = new SceneVariableSet({ variables: [probe, job, instance] });
 
     const mapPanel = getErrorRateMapPanel(metrics);

--- a/src/scenes/PING/pingScene.ts
+++ b/src/scenes/PING/pingScene.ts
@@ -27,7 +27,7 @@ import { getErrorRateTimeseries } from 'scenes/HTTP/errorRateTimeseries';
 
 import { getLatencyByPhasePanel } from './latencyByPhase';
 
-export function getPingScene({ metrics, logs }: DashboardSceneAppConfig, checks: Check[]) {
+export function getPingScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[]) {
   return () => {
     if (checks.length === 0) {
       return getEmptyScene(CheckType.PING);
@@ -38,7 +38,7 @@ export function getPingScene({ metrics, logs }: DashboardSceneAppConfig, checks:
       to: 'now',
     });
 
-    const { job, instance, probe } = getVariables(CheckType.PING, metrics, checks);
+    const { job, instance, probe } = getVariables(CheckType.PING, metrics, checks, singleCheckMode);
 
     const variables = new SceneVariableSet({ variables: [probe, job, instance] });
     const errorMap = getErrorRateMapPanel(metrics);

--- a/src/scenes/SCRIPTED/scriptedScene.ts
+++ b/src/scenes/SCRIPTED/scriptedScene.ts
@@ -25,7 +25,7 @@ import { getDistinctTargets } from './distinctTargets';
 import { getProbeDuration } from './probeDuration';
 
 export function getScriptedScene(
-  { metrics, logs }: DashboardSceneAppConfig,
+  { metrics, logs, singleCheckMode }: DashboardSceneAppConfig,
   checks: Check[] = [],
   checkType: CheckType
 ) {
@@ -37,7 +37,7 @@ export function getScriptedScene(
       from: 'now-6h',
       to: 'now',
     });
-    const { probe, job, instance } = getVariables(checkType, metrics, checks);
+    const { probe, job, instance } = getVariables(checkType, metrics, checks, singleCheckMode);
     const variables = new SceneVariableSet({
       variables: [probe, job, instance],
     });

--- a/src/scenes/Summary/summaryScene.ts
+++ b/src/scenes/Summary/summaryScene.ts
@@ -19,8 +19,10 @@ import { getErrorPctgTimeseriesPanel } from './errorPctTimeseries';
 import { getErrorRateMapPanel } from './errorRateMap';
 import { getLatencyTimeseriesPanel } from './latencyTimeseries';
 import { getSummaryTable } from './summaryTable';
+import { getSummaryTable as getSummaryTable_DEPRECATED } from './summaryTable_DEPRECATED';
 
-export function getSummaryScene({ metrics }: DashboardSceneAppConfig, checks: Check[]) {
+export function getSummaryScene({ metrics, sm }: DashboardSceneAppConfig, checks: Check[], singleCheckNav: boolean) {
+  const summaryTable = singleCheckNav ? getSummaryTable(metrics, sm) : getSummaryTable_DEPRECATED(metrics);
   return () => {
     if (checks.length === 0) {
       return getEmptyScene();
@@ -66,7 +68,7 @@ export function getSummaryScene({ metrics }: DashboardSceneAppConfig, checks: Ch
       },
     });
 
-    const tablePanel = new SceneFlexItem({ height: 400, body: getSummaryTable(metrics) });
+    const tablePanel = new SceneFlexItem({ height: 400, body: summaryTable });
 
     const tableRow = new SceneFlexLayout({
       direction: 'row',

--- a/src/scenes/Summary/summaryTable.ts
+++ b/src/scenes/Summary/summaryTable.ts
@@ -8,15 +8,6 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
     datasource: { type: 'datasource', uid: '-- Mixed --' },
     queries: [
       {
-        datasource: sm,
-        hide: false,
-        instance: '',
-        job: '',
-        probe: '',
-        queryType: 'checks',
-        refId: 'checks',
-      },
-      {
         datasource: metrics,
         editorMode: 'code',
         exemplar: false,
@@ -120,6 +111,15 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
         legendFormat: '',
         refId: 'uptime',
       },
+      {
+        datasource: sm,
+        hide: false,
+        instance: '',
+        job: '',
+        probe: '',
+        queryType: 'checks',
+        refId: 'checks',
+      },
     ],
   });
 
@@ -127,22 +127,44 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
     $data: queryRunner,
     transformations: [
       {
-        id: 'merge',
-        options: {},
+        id: 'joinByField',
+        options: {
+          byField: 'job',
+          mode: 'inner',
+        },
+      },
+
+      {
+        id: 'organize',
+        options: {
+          renameByName: {
+            check_name: 'check type',
+          },
+        },
+      },
+      {
+        id: 'joinByField',
+        options: {
+          byField: 'instance',
+          mode: 'inner',
+        },
       },
       {
         id: 'organize',
         options: {
           excludeByName: {
             Time: true,
-            check_name: false,
             Value: false,
             alertSensitivity: true,
             basicMetricsOnly: true,
+            check_name: false,
+            'check_name 2': true,
+            'check_name 3': true,
             created: true,
             enabled: true,
             frequency: true,
             id: false,
+            instance: true,
             labels: true,
             modified: true,
             offset: true,
@@ -150,7 +172,6 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
             settings: true,
             tenantId: true,
             timeout: true,
-            target: true,
           },
           indexByName: {
             Time: 0,
@@ -158,12 +179,12 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
             'Value #reachability': 6,
             'Value #state': 4,
             'Value #uptime': 5,
-            check_name: 3,
-            instance: 1,
+            'check type': 3,
+            target: 1,
             job: 2,
           },
           renameByName: {
-            check_name: 'check type',
+            target: 'instance',
           },
         },
       },

--- a/src/scenes/Summary/summaryTable_DEPRECATED.ts
+++ b/src/scenes/Summary/summaryTable_DEPRECATED.ts
@@ -3,21 +3,11 @@ import { DataSourceRef, ThresholdsMode } from '@grafana/schema';
 
 import { ExplorablePanel } from 'scenes/ExplorablePanel';
 
-function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
+function getSummaryTableQueryRunner(metrics: DataSourceRef) {
   const queryRunner = new SceneQueryRunner({
-    datasource: { type: 'datasource', uid: '-- Mixed --' },
+    datasource: metrics,
     queries: [
       {
-        datasource: sm,
-        hide: false,
-        instance: '',
-        job: '',
-        probe: '',
-        queryType: 'checks',
-        refId: 'checks',
-      },
-      {
-        datasource: metrics,
         editorMode: 'code',
         exemplar: false,
         expr: `
@@ -41,7 +31,6 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
         refId: 'reachability',
       },
       {
-        datasource: metrics,
         editorMode: 'code',
         exemplar: false,
         expr: `
@@ -65,7 +54,6 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
         refId: 'latency',
       },
       {
-        datasource: metrics,
         editorMode: 'code',
         exemplar: false,
         expr: `
@@ -93,7 +81,6 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
         refId: 'state',
       },
       {
-        datasource: metrics,
         editorMode: 'code',
         exemplar: false,
         expr: `
@@ -136,21 +123,6 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
           excludeByName: {
             Time: true,
             check_name: false,
-            Value: false,
-            alertSensitivity: true,
-            basicMetricsOnly: true,
-            created: true,
-            enabled: true,
-            frequency: true,
-            id: false,
-            labels: true,
-            modified: true,
-            offset: true,
-            probes: true,
-            settings: true,
-            tenantId: true,
-            timeout: true,
-            target: true,
           },
           indexByName: {
             Time: 0,
@@ -334,7 +306,7 @@ function getFieldOverrides() {
           value: [
             {
               title: 'Show details...',
-              url: '/a/grafana-synthetic-monitoring-app/checks/${__data.fields.id}/dashboard',
+              url: '/a/grafana-synthetic-monitoring-app/scene/${__data.fields.check_name}?var-probe=All&var-instance=${__data.fields.instance}&var-job=${__data.fields.job}&from=${__from}&to=${__to}',
             },
           ],
         },
@@ -351,31 +323,19 @@ function getFieldOverrides() {
           value: [
             {
               title: 'Show details...',
-              url: '/a/grafana-synthetic-monitoring-app/checks/${__data.fields.id}/dashboard',
+              url: '/a/grafana-synthetic-monitoring-app/scene/${__data.fields.check_name}?var-probe=All&var-instance=${__data.fields.instance}&var-job=${__data.fields.job}&from=${__from}&to=${__to}',
             },
           ],
-        },
-      ],
-    },
-    {
-      matcher: {
-        id: 'byName',
-        options: 'id',
-      },
-      properties: [
-        {
-          id: 'custom.hidden',
-          value: true,
         },
       ],
     },
   ];
 }
 
-export function getSummaryTable(metrics: DataSourceRef, sm: DataSourceRef) {
+export function getSummaryTable(metrics: DataSourceRef) {
   const tablePanel = new ExplorablePanel({
     pluginId: 'table',
-    $data: getSummaryTableQueryRunner(metrics, sm),
+    $data: getSummaryTableQueryRunner(metrics),
     title: `$check_type checks`,
     description:
       '* instance: the instance that corresponds to this check.\n* **job**: the job that corresponds to this check.\n* **reachability**: the percentage of all the checks that have succeeded during the whole time period.\n* **latency**: the average time to receive an answer across all the checks during the whole time period.\n* **state**: whether the target was up or down the last time it was checked.\n* **uptime**: the fraction of time the target was up  during the whole period.',

--- a/src/scenes/TCP/getTcpScene.ts
+++ b/src/scenes/TCP/getTcpScene.ts
@@ -26,7 +26,7 @@ import { getEditButton } from 'scenes/Common/editButton';
 import { getEmptyScene } from 'scenes/Common/emptyScene';
 import { getErrorRateTimeseries } from 'scenes/HTTP/errorRateTimeseries';
 
-export function getTcpScene({ metrics, logs }: DashboardSceneAppConfig, checks: Check[]) {
+export function getTcpScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[]) {
   return () => {
     if (checks.length === 0) {
       return getEmptyScene(CheckType.TCP);
@@ -37,7 +37,7 @@ export function getTcpScene({ metrics, logs }: DashboardSceneAppConfig, checks: 
       to: 'now',
     });
 
-    const { job, instance, probe } = getVariables(CheckType.TCP, metrics, checks);
+    const { job, instance, probe } = getVariables(CheckType.TCP, metrics, checks, singleCheckMode);
 
     const variables = new SceneVariableSet({ variables: [probe, job, instance] });
     const errorMap = getErrorRateMapPanel(metrics);

--- a/src/scenes/Traceroute/getTracerouteScene.ts
+++ b/src/scenes/Traceroute/getTracerouteScene.ts
@@ -23,7 +23,7 @@ import { getPacketLossPanel } from './packetLoss';
 import { getRouteHashPanel } from './routeHash';
 import { getTraceTimePanel } from './traceTime';
 
-export function getTracerouteScene({ metrics, logs, sm }: DashboardSceneAppConfig, checks: Check[]) {
+export function getTracerouteScene({ metrics, logs, sm, singleCheckMode }: DashboardSceneAppConfig, checks: Check[]) {
   return () => {
     if (checks.length === 0) {
       return getEmptyScene(CheckType.Traceroute);
@@ -33,7 +33,7 @@ export function getTracerouteScene({ metrics, logs, sm }: DashboardSceneAppConfi
       to: 'now',
     });
 
-    const { probe, job, instance } = getVariables(CheckType.Traceroute, metrics, checks);
+    const { probe, job, instance } = getVariables(CheckType.Traceroute, metrics, checks, singleCheckMode);
     const variables = new SceneVariableSet({ variables: [probe, job, instance] });
 
     const nodeGraph = new SceneFlexItem({ height: 500, body: getNodeGraphPanel(sm) });

--- a/src/scenes/dashboardSceneApp.ts
+++ b/src/scenes/dashboardSceneApp.ts
@@ -40,7 +40,7 @@ export function getDashboardSceneApp(
     new SceneAppPage({
       title: 'Summary',
       url: `${PLUGIN_URL_PATH}${ROUTES.Scene}`,
-      getScene: getSummaryScene(config, checks),
+      getScene: getSummaryScene(config, checks, false),
     }),
     new SceneAppPage({
       title: 'HTTP',
@@ -94,7 +94,7 @@ export function getDashboardSceneApp(
         title: 'Dashboards',
         url: `${PLUGIN_URL_PATH}${ROUTES.Scene}`,
         hideFromBreadcrumbs: true,
-        getScene: getSummaryScene(config, checks),
+        getScene: getSummaryScene(config, checks, false),
         tabs,
       }),
     ],

--- a/src/types.ts
+++ b/src/types.ts
@@ -534,6 +534,7 @@ export enum FeatureName {
   MultiHttp = 'multi-http',
   Scenes = 'synthetics-scenes',
   ScriptedChecks = 'scripted-checks',
+  PerCheckDashboards = 'synthetics-per-check-dashboards',
 }
 
 export interface UsageValues {
@@ -583,6 +584,7 @@ export interface DashboardSceneAppConfig {
   metrics: DataSourceRef;
   logs: DataSourceRef;
   sm: DataSourceRef;
+  singleCheckMode?: boolean;
 }
 
 export interface VizViewSceneAppConfig extends DashboardSceneAppConfig {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,10 +1599,10 @@
     systemjs "0.20.19"
     tslib "2.6.0"
 
-"@grafana/scenes@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@grafana/scenes/-/scenes-1.21.0.tgz#151142c896f39577b188404c4987663a84d121ab"
-  integrity sha512-pDmWznJ49ILlQB/Dct84oWy9fTP6HThxHfnRfSfW6Jq6ZaDJcRAXZI9SioOEib1K/9ebNSwuRS4RQsZ3YcNQ1Q==
+"@grafana/scenes@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@grafana/scenes/-/scenes-2.2.3.tgz#7f90b888cb49071d80df3c0b265cd222fcd5c532"
+  integrity sha512-0+CSblniySXGdR6rqh5KTbMs4GA1vB7D8BR8eUYSqxopwqLpu1T5uogq9aECrM3jvkWSsZAr7hMdviwaJfsJhQ==
   dependencies:
     "@grafana/e2e-selectors" "10.0.2"
     react-grid-layout "1.3.4"


### PR DESCRIPTION
The next step here will be to rework the summary dashboard and use it as the home page. I want to tackle that in a separate PR, though. 

This changes should be completely sealed behind the `synthetics-per-check-dashboards` feature toggle