### PR TITLE
fix: bulk edit reset correctly

### DIFF
--- a/src/components/CheckList/BulkActions.tsx
+++ b/src/components/CheckList/BulkActions.tsx
@@ -23,7 +23,13 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
   const [bulkEditAction, setBulkEditAction] = useState<BulkAction | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { mutate: bulkUpdateChecks } = useBulkUpdateChecks({ onSuccess: onResolved });
-  const { mutate: bulkDeleteChecks } = useBulkDeleteChecks({ onSuccess: onResolved });
+
+  const handleDeleteResolved = () => {
+    setShowDeleteModal(false);
+    onResolved();
+  };
+
+  const { mutate: bulkDeleteChecks } = useBulkDeleteChecks({ onSuccess: handleDeleteResolved });
 
   const handleDisableSelectedChecks = () => {
     bulkUpdateChecks(checks.filter((check) => check.enabled).map((check) => ({ ...check, enabled: false })));

--- a/src/components/CheckList/CheckList.tsx
+++ b/src/components/CheckList/CheckList.tsx
@@ -135,8 +135,7 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
 
   const handleSelectAll = () => {
     if (isAllSelected) {
-      setSelectedChecksIds(new Set());
-      return;
+      handleUnselectAll();
     }
 
     const allCheckIds = sortedChecks.map((check) => check.id!);
@@ -146,6 +145,10 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
   const handleChangeViewType = (value: CheckListViewType) => {
     onChangeViewType(value);
     setCurrentPage(1);
+  };
+
+  const handleUnselectAll = () => {
+    setSelectedChecksIds(new Set());
   };
 
   if (checks.length === 0) {
@@ -165,7 +168,8 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
           onFilterChange={setCheckFilters}
           onSelectAll={handleSelectAll}
           onSort={updateSortMethod}
-          onReset={handleResetFilters}
+          onResetFilters={handleResetFilters}
+          onDelete={handleUnselectAll}
           selectedCheckIds={selectedCheckIds}
           sortType={sortType}
         />

--- a/src/components/CheckList/CheckListHeader.tsx
+++ b/src/components/CheckList/CheckListHeader.tsx
@@ -20,9 +20,10 @@ type CheckListHeaderProps = {
   checkFilters: CheckFiltersType;
   currentPageChecks: Check[];
   onChangeView: (viewType: CheckListViewType) => void;
+  onDelete: () => void;
   onFilterChange: (filters: CheckFiltersType) => void;
   onSort: (sort: SelectableValue<CheckSort>) => void;
-  onReset: () => void;
+  onResetFilters: () => void;
   onSelectAll: (e: React.ChangeEvent<HTMLInputElement>) => void;
   selectedCheckIds: Set<number>;
   sortType: CheckSort;
@@ -33,9 +34,10 @@ export const CheckListHeader = ({
   checks,
   currentPageChecks,
   onChangeView,
+  onDelete,
   onFilterChange,
   onSort,
-  onReset,
+  onResetFilters,
   onSelectAll,
   selectedCheckIds,
   sortType,
@@ -63,7 +65,12 @@ export const CheckListHeader = ({
             ))}
         </div>
         <div className={styles.stack}>
-          <CheckFilters onReset={onReset} checks={checks} checkFilters={checkFilters} onChange={onFilterChange} />
+          <CheckFilters
+            onReset={onResetFilters}
+            checks={checks}
+            checkFilters={checkFilters}
+            onChange={onFilterChange}
+          />
           {hasRole(OrgRole.Editor) && (
             <>
               <Button variant="secondary" fill="outline" onClick={() => setShowThresholdModal((v) => !v)}>
@@ -86,7 +93,7 @@ export const CheckListHeader = ({
             />
           </Tooltip>
           {selectedCheckIds.size > 0 ? (
-            <BulkActions checks={selectedChecks} onResolved={onReset} />
+            <BulkActions checks={selectedChecks} onResolved={onDelete} />
           ) : (
             <CheckListViewSwitcher onChange={onChangeView} viewType={viewType} />
           )}


### PR DESCRIPTION
When doing one of the larger refactors I added in a confirm modal for bulk deleting checks. I noticed that it doesn't reset correctly so this is to fix that.