### PR TITLE
fix: tcp queryresponse fix

### DIFF
--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -227,7 +227,7 @@ const getTcpQueryResponseFormValues = (queryResponses: TCPQueryResponse[]) => {
 
 const getTcpSettingsFormValues = (settings: TCPCheck['settings']): TcpSettingsFormValues => {
   const tcpSettings = settings.tcp ?? FALLBACK_CHECK_TCP.settings.tcp;
-  const formattedQueryResponse = getTcpQueryResponseFormValues(tcpSettings.queryResponse);
+  const formattedQueryResponse = getTcpQueryResponseFormValues(tcpSettings.queryResponse || []);
   const tlsConfig = getTlsConfigFormValues(tcpSettings.tlsConfig);
 
   return {
@@ -705,7 +705,7 @@ const getTcpSettings = (settings: TcpSettingsFormValues): TcpSettings => {
   const fallbackValues = FALLBACK_CHECK_TCP.settings.tcp;
 
   const tlsConfig = getTlsConfigFromFormValues(settings.tlsConfig);
-  const queryResponse = getTcpQueryResponseFromFormFields(settings.queryResponse);
+  const queryResponse = getTcpQueryResponseFromFormFields(settings.queryResponse || []);
 
   return {
     ...fallbackValues,

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,7 +170,7 @@ export interface TcpSettings {
   ipVersion: IpVersion;
   tls: boolean;
   tlsConfig?: TLSConfig;
-  queryResponse: TCPQueryResponse[];
+  queryResponse?: TCPQueryResponse[];
 }
 
 export interface TcpSettingsFormValues extends Omit<TcpSettings, 'ipVersion'> {


### PR DESCRIPTION
Small bug when going to a tcp check directly it wasn't rendering correctly. Think this was a regression introduced last week.