### PR TITLE
chore: clean up test output

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
       '<rootDir>/src/test/fileMock.js',
     '^!raw-loader!*': '<rootDir>/src/test/rawLoaderMock.js',
   },
-  // testTimeout: 30000,
+  testTimeout: 30000,
   // Inform jest to only transform specific node_module packages.
   transform: {
     ...config.transform,

--- a/src/components/CheckForm/MultiHttpExisting.test.tsx
+++ b/src/components/CheckForm/MultiHttpExisting.test.tsx
@@ -17,12 +17,11 @@ jest.setTimeout(60000);
 beforeEach(() => jest.resetAllMocks());
 
 async function renderForm(route: string) {
-  const res = waitFor(() =>
-    render(<CheckForm />, {
-      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/edit/:checkType/:id`,
-      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}${route}`,
-    })
-  );
+  const res = render(<CheckForm />, {
+    route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/edit/:checkType/:id`,
+    path: `${PLUGIN_URL_PATH}${ROUTES.Checks}${route}`,
+  });
+
   await waitFor(() => expect(screen.getByText('Probe options')).toBeInTheDocument());
   return res;
 }

--- a/src/page/ChecksPage.test.tsx
+++ b/src/page/ChecksPage.test.tsx
@@ -12,12 +12,10 @@ import { CheckRouter } from './CheckRouter';
 jest.setTimeout(20000);
 
 const renderChecksPage = () => {
-  return waitFor(() =>
-    render(<CheckRouter />, {
-      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
-      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
-    })
-  );
+  return render(<CheckRouter />, {
+    path: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
+    route: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
+  });
 };
 
 test('renders checks', async () => {


### PR DESCRIPTION
The MultiHTTP tests were spewing lots of act errors. I think the `waitFor` was originally put in there when render behaved differently?

I was also getting tests timing out a lot, so I turned the global timeout back on