### PR TITLE
fix: remove deprecated arrayVector

### DIFF
--- a/src/components/CheckTestResultsModal.tsx
+++ b/src/components/CheckTestResultsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { ArrayVector, dateTime, FieldType } from '@grafana/data';
+import { dateTime, FieldType } from '@grafana/data';
 import { Modal, Spinner } from '@grafana/ui';
 
 import { AdHocCheckResponse } from 'datasource/responses.types';
@@ -22,7 +22,7 @@ function buildLogsDf(logs: Array<Record<string, any>>) {
       name: 'ts',
       type: FieldType.time,
       config: { displayName: 'Time' },
-      values: new ArrayVector(tsValues),
+      values: tsValues,
     },
   };
   // We need to loop through all the logs and build up a complete list of fields.
@@ -34,7 +34,7 @@ function buildLogsDf(logs: Array<Record<string, any>>) {
         fields[fieldName] = {
           name: fieldName,
           type: FieldType.string,
-          values: new ArrayVector(values),
+          values,
           config: {},
         };
       } else {

--- a/src/datasource/traceroute-utils.ts
+++ b/src/datasource/traceroute-utils.ts
@@ -16,13 +16,6 @@ const getNodeGraphFields = () => {
     config: { displayName: 'Host' },
   };
 
-  // const typeField = {
-  //   name: NodeGraphDataFrameFieldNames.subTitle,
-  //   type: FieldType.string,
-  //   values: new ArrayVector(),
-  //   config: { displayName: 'Type' },
-  // };
-
   const nodeMainStatField = {
     name: NodeGraphDataFrameFieldNames.mainStat,
     type: FieldType.number,
@@ -96,25 +89,6 @@ const getNodeGraphEdgeFields = () => {
     type: FieldType.string,
     values: [] as string[],
   };
-
-  // These are needed for links to work
-  // const edgeSourceNameField = {
-  //   name: 'sourceName',
-  //   type: FieldType.string,
-  //   values: new ArrayVector(),
-  // };
-  // const edgeTargetNameField = {
-  //   name: 'targetName',
-  //   type: FieldType.string,
-  //   values: new ArrayVector(),
-  // };
-
-  // const edgeMainStatField = {
-  //   name: NodeGraphDataFrameFieldNames.mainStat,
-  //   type: FieldType.string,
-  //   values: new ArrayVector(),
-  //   config: { displayName: 'Response percentage' },
-  // };
 
   return {
     edgeIdField,


### PR DESCRIPTION
Grafana 11 is being rolled out in dev and ops and they have fully deprecated and removed `ArrayVector` in this major version bump.

The issue was reported in this [Slack thread](https://raintank-corp.slack.com/archives/C0162C1K9E1/p1709137607374859). According to the notes in the Grafana documentation the fix is just to use a simple array instead.