### PR TITLE
fix: hide the add new check button if a user doesnt have permissions

### DIFF
--- a/src/scenes/Summary/summaryScene.ts
+++ b/src/scenes/Summary/summaryScene.ts
@@ -1,3 +1,4 @@
+import { OrgRole } from '@grafana/data';
 import {
   AdHocFiltersVariable,
   EmbeddedScene,
@@ -16,6 +17,7 @@ import {
 import { VariableRefresh } from '@grafana/schema';
 
 import { Check, DashboardSceneAppConfig } from 'types';
+import { hasRole } from 'utils';
 import { AddNewCheckButton } from 'components/CheckList/AddNewCheckButton';
 import { getSummaryAlertAnnotations } from 'scenes/Common/alertAnnotations';
 import { getEmptyScene } from 'scenes/Common/emptyScene';
@@ -120,7 +122,8 @@ export function getSummaryScene({ metrics, sm }: DashboardSceneAppConfig, checks
         new SceneDataLayerControls(),
         new SceneControlsSpacer(),
         new SceneReactObject({
-          component: AddNewCheckButton,
+          //@ts-ignore null is a valid value for a React component
+          component: hasRole(OrgRole.Editor) ? AddNewCheckButton : null,
         }),
         new SceneTimePicker({ isOnCanvas: true }),
         new SceneRefreshPicker({

--- a/src/scenes/behaviors/HiddenLayoutItemBehavior.ts
+++ b/src/scenes/behaviors/HiddenLayoutItemBehavior.ts
@@ -1,0 +1,46 @@
+import { SceneFlexItem, SceneFlexLayout, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+
+/**
+ * Just a proof of concept example of a behavior
+ */
+export class HiddenLayoutItemBehavior<
+  TState extends SceneObjectState = SceneObjectState
+> extends SceneObjectBase<TState> {
+  public constructor(state: TState) {
+    super(state);
+  }
+
+  protected setHidden() {
+    const parentLayoutItem = getClosestLayoutItem(this);
+    if (!parentLayoutItem) {
+      return;
+    }
+
+    if (!parentLayoutItem.state.isHidden) {
+      parentLayoutItem.setState({ isHidden: true });
+    }
+  }
+
+  protected setVisible() {
+    const parentLayoutItem = getClosestLayoutItem(this);
+    if (!parentLayoutItem) {
+      return;
+    }
+
+    if (parentLayoutItem.state.isHidden) {
+      parentLayoutItem.setState({ isHidden: false });
+    }
+  }
+}
+
+function getClosestLayoutItem(obj: SceneObject): SceneFlexItem | SceneFlexLayout | undefined {
+  if (obj instanceof SceneFlexItem || obj instanceof SceneFlexLayout) {
+    return obj;
+  }
+
+  if (!obj.parent) {
+    return;
+  }
+
+  return getClosestLayoutItem(obj.parent);
+}

--- a/src/scenes/behaviors/HideableObject.ts
+++ b/src/scenes/behaviors/HideableObject.ts
@@ -1,0 +1,46 @@
+import { sceneGraph, SceneObject, SceneObjectState } from '@grafana/scenes';
+
+import { HiddenLayoutItemBehavior } from './HiddenLayoutItemBehavior';
+
+export interface ShowBasedOnConditionBehaviorState extends SceneObjectState {
+  references: string[];
+  condition: (...args: any[]) => boolean;
+}
+
+export interface SceneShowHide {
+  references: SceneObject[];
+  condition: () => boolean;
+}
+
+export class HideableObject extends HiddenLayoutItemBehavior<ShowBasedOnConditionBehaviorState> {
+  private _resolvedRefs: SceneObject[] = [];
+
+  public constructor(state: ShowBasedOnConditionBehaviorState) {
+    super(state);
+
+    this.addActivationHandler(() => this._onActivate());
+  }
+
+  private _onActivate() {
+    // Subscribe to references
+    for (const objectKey of this.state.references) {
+      const solvedRef = sceneGraph.findObject(this, (obj) => obj.state.key === objectKey);
+      if (!solvedRef) {
+        throw new Error(`SceneObject with key ${objectKey} not found in scene graph`);
+      }
+
+      this._resolvedRefs.push(solvedRef);
+      this._subs.add(solvedRef.subscribeToState(() => this._onReferenceChanged()));
+    }
+
+    this._onReferenceChanged();
+  }
+
+  private _onReferenceChanged() {
+    if (this.state.condition(...this._resolvedRefs)) {
+      this.setVisible();
+    } else {
+      this.setHidden();
+    }
+  }
+}


### PR DESCRIPTION
Viewers:
![Screenshot 2024-03-11 at 08 41 14](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/42602e7e-b03b-4a31-a052-3f52226ca00a)

Editors/Admins:
![Screenshot 2024-03-11 at 08 41 10](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/550db7bd-0b8f-4c68-8206-b2999ff0adf5)

I also added a behavior that allows showing/hiding based on a condition (copied from the scenes repo). I ended up not being able to use it because this particular element is part of the scene controls, not part of the layout tree, but figure it will be useful down the line