### PR TITLE
Fix bulk unselect state

### DIFF
--- a/src/components/CheckList/CheckList.tsx
+++ b/src/components/CheckList/CheckList.tsx
@@ -135,7 +135,7 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
 
   const handleSelectAll = () => {
     if (isAllSelected) {
-      handleUnselectAll();
+      return handleUnselectAll();
     }
 
     const allCheckIds = sortedChecks.map((check) => check.id!);


### PR DESCRIPTION
Forgot to return from the `handleSelectAll` function when bulk deselecting so it wasn't working. Added comprehensive testing, too, so it doesn't slip through as a regression in the future.