### PR TITLE
Synthetic monitoring card component

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,108 @@
+import React, { createContext, HTMLAttributes, ReactNode, useContext } from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Link, styleMixins, useStyles2 } from '@grafana/ui';
+import { css, cx } from '@emotion/css';
+
+type ContextProps = {
+  href?: string;
+};
+
+type CardProps = ContextProps & {
+  children: ReactNode;
+  className?: string;
+};
+
+const CardContext = createContext<ContextProps>({ href: '' });
+
+export const Card = ({ children, className, href }: CardProps) => {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <CardContext.Provider value={{ href }}>
+      <div className={cx(styles.card, className)}>{children}</div>
+    </CardContext.Provider>
+  );
+};
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    card: css({
+      padding: theme.spacing(2),
+      background: theme.colors.background.secondary,
+      borderRadius: theme.shape.radius.default,
+      position: `relative`,
+
+      '&:hover': {
+        background: theme.colors.emphasize(theme.colors.background.secondary, 0.03),
+        cursor: 'pointer',
+        zIndex: 1,
+      },
+    }),
+  };
+}
+
+type HeadingCommonProps = {
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'div' | 'span';
+  children: ReactNode;
+  className?: string;
+  variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+};
+
+type HeadingProps = HTMLAttributes<HTMLElement> & HeadingCommonProps;
+
+const Heading = ({ as = 'h2', children, className, variant = 'h2', ...rest }: HeadingProps) => {
+  const Tag = as;
+  const styles = useStyles2((theme) => getHeadingStyles(theme, variant));
+  const { href } = useContext(CardContext);
+
+  if (href) {
+    return (
+      <Link className={cx(styles.link, className)} href={href} {...rest}>
+        <Tag className={styles.heading}>{children}</Tag>
+      </Link>
+    );
+  }
+
+  return (
+    <Tag className={cx(styles.heading, className)} {...rest}>
+      {children}
+    </Tag>
+  );
+};
+
+const getHeadingStyles = (theme: GrafanaTheme2, variant: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6') => ({
+  heading: css({
+    fontFamily: theme.typography[variant].fontFamily,
+    fontSize: theme.typography[variant].fontSize,
+    fontWeight: theme.typography[variant].fontWeight,
+    letterSpacing: theme.typography[variant].letterSpacing,
+    lineHeight: theme.typography[variant].lineHeight,
+  }),
+  link: css({
+    display: `block`,
+    all: 'unset',
+
+    '&::after': {
+      position: 'absolute',
+      content: '""',
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      borderRadius: theme.shape.radius.default,
+    },
+
+    '&:focus-visible': {
+      outline: 'none',
+      outlineOffset: 0,
+      boxShadow: 'none',
+
+      '&::after': {
+        ...styleMixins.getFocusStyles(theme),
+        zIndex: 1,
+      },
+    },
+  }),
+});
+
+Card.Heading = Heading;

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,0 +1,1 @@
+export { Card } from './Card';

--- a/src/components/ChooseCheckType.tsx
+++ b/src/components/ChooseCheckType.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
-import { Badge, Card, useStyles2 } from '@grafana/ui';
+import { Badge, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { CheckType, FeatureName, ROUTES } from 'types';
 import { useFeatureFlag } from 'hooks/useFeatureFlag';
-import { useNavigation } from 'hooks/useNavigation';
+import { Card } from 'components/Card';
 import { CHECK_TYPE_OPTIONS } from 'components/constants';
 import { PluginPage } from 'components/PluginPage';
+import { getRoute } from 'components/Routing';
 
 export function ChooseCheckType() {
   const styles = useStyles2(getStyles);
   const { isEnabled: multiHttpEnabled } = useFeatureFlag(FeatureName.MultiHttp);
   const { isEnabled: scriptedEnabled } = useFeatureFlag(FeatureName.ScriptedChecks);
   // If we're editing, grab the appropriate check from the list
-  const navigate = useNavigation();
 
   const options = CHECK_TYPE_OPTIONS.filter(({ value }) => {
     if (!multiHttpEnabled && value === CheckType.MULTI_HTTP) {
@@ -31,14 +31,8 @@ export function ChooseCheckType() {
       <div className={styles.container}>
         {options?.map((check) => {
           return (
-            <Card
-              key={check?.label || ''}
-              className={styles.cards}
-              onClick={() => {
-                navigate(`${ROUTES.NewCheck}/${check.value}`);
-              }}
-            >
-              <Card.Heading className={styles.cardsHeader}>
+            <Card key={check?.label || ''} className={styles.card} href={`${getRoute(ROUTES.NewCheck)}/${check.value}`}>
+              <Card.Heading className={styles.heading} variant="h6">
                 {check.label}
                 {check.value === CheckType.MULTI_HTTP && (
                   <Badge text="Public preview" color="blue" className={styles.experimentalBadge} />
@@ -47,7 +41,7 @@ export function ChooseCheckType() {
                   <Badge text="Experimental" color="orange" className={styles.experimentalBadge} />
                 )}
               </Card.Heading>
-              <Card.Description>{check.description}</Card.Description>
+              <div className={styles.desc}>{check.description}</div>
             </Card>
           );
         })}
@@ -57,23 +51,29 @@ export function ChooseCheckType() {
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  container: css`
-    width: 100%;
-    margin: ${theme.spacing(2)} 0;
-    padding: ${theme.spacing(2)};
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 400px));
-    gap: ${theme.spacing(2)};
-  `,
-  cards: css`
-    max-width: 400px;
-  `,
-  cardsHeader: css`
-    text-align: center;
-    justify-content: center;
-    align-items: flex-start;
-  `,
-  experimentalBadge: css`
-    margin-left: ${theme.spacing(1)};
-  `,
+  container: css({
+    width: `100%`,
+    margin: theme.spacing(2, 0),
+    padding: theme.spacing(2),
+    display: `grid`,
+    gridTemplateColumns: `repeat(auto-fit, minmax(200px, 400px))`,
+    gap: theme.spacing(2),
+  }),
+  card: css({
+    ':hover': {
+      cursor: 'pointer',
+      background: theme.colors.emphasize(theme.colors.background.secondary, 0.03),
+    },
+  }),
+  heading: css({
+    textAlign: `center`,
+    justifyContent: `center`,
+    alignItems: `flex-start`,
+  }),
+  desc: css({
+    color: theme.colors.text.secondary,
+  }),
+  experimentalBadge: css({
+    marginLeft: theme.spacing(1),
+  }),
 });

--- a/src/components/ProbeCard/ProbeCard.tsx
+++ b/src/components/ProbeCard/ProbeCard.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Badge, Button, styleMixins, useStyles2 } from '@grafana/ui';
+import { Badge, Button, useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
 
 import { type Label, type Probe, ROUTES } from 'types';
 import { canEditProbes } from 'utils';
+import { Card } from 'components/Card';
 import { SuccessRateGaugeProbe } from 'components/Gauges';
 import { getRoute } from 'components/Routing';
 
@@ -22,12 +22,12 @@ export const ProbeCard = ({ probe }: { probe: Probe }) => {
   const canEdit = canEditProbes(probe);
 
   return (
-    <div className={styles.cardWrapper}>
-      <div className={styles.card}>
+    <Card className={styles.card} href={href}>
+      <div className={styles.cardContent}>
         <div>
-          <Link className={styles.link} to={href} onFocus={() => setIsFocused(true)} onBlur={() => setIsFocused(false)}>
-            <h3 className="h5">{probe.name}</h3>
-          </Link>
+          <Card.Heading as="h3" variant="h5" onFocus={() => setIsFocused(true)} onBlur={() => setIsFocused(false)}>
+            {probe.name}
+          </Card.Heading>
           <div className={styles.info}>
             <div className={styles.badges}>
               <Badge color={color} icon={onlineIcon} text={onlineTxt} />
@@ -49,7 +49,7 @@ export const ProbeCard = ({ probe }: { probe: Probe }) => {
           </Button>
         </div>
       </div>
-    </div>
+    </Card>
   );
 };
 
@@ -60,19 +60,19 @@ const getStyles = (theme: GrafanaTheme2) => {
   const mediaQuery = `@supports not (container-type: inline-size) @media (max-width: ${breakpoint}px)`;
 
   return {
-    cardWrapper: css({
+    card: css({
       containerName,
       containerType: `inline-size`,
+      marginBottom: theme.spacing(1),
+
+      '&:hover button': {
+        opacity: 1,
+      },
     }),
-    card: css({
+    cardContent: css({
       display: `grid`,
       gridTemplateColumns: `auto 1fr auto`,
       gridTemplateAreas: `"info gauge action"`,
-      padding: theme.spacing(2),
-      background: theme.colors.background.secondary,
-      borderRadius: theme.shape.radius.default,
-      position: `relative`,
-      marginBottom: theme.spacing(1),
 
       [containerQuery]: {
         gridTemplateAreas: `
@@ -88,16 +88,6 @@ const getStyles = (theme: GrafanaTheme2) => {
         "gauge action"
         `,
         gridTemplateColumns: `1fr auto`,
-      },
-
-      '&:hover button': {
-        opacity: 1,
-      },
-
-      '&:hover': {
-        background: theme.colors.emphasize(theme.colors.background.secondary, 0.03),
-        cursor: 'pointer',
-        zIndex: 1,
       },
     }),
     info: css({
@@ -133,29 +123,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     link: css({
       marginBottom: theme.spacing(1),
-      display: `block`,
-
-      all: 'unset',
-      '&::after': {
-        position: 'absolute',
-        content: '""',
-        top: 0,
-        bottom: 0,
-        left: 0,
-        right: 0,
-        borderRadius: theme.shape.radius.default,
-      },
-
-      '&:focus-visible': {
-        outline: 'none',
-        outlineOffset: 0,
-        boxShadow: 'none',
-
-        '&::after': {
-          ...styleMixins.getFocusStyles(theme),
-          zIndex: 1,
-        },
-      },
     }),
     buttonWrapper: css({
       alignItems: 'center',

--- a/src/page/ChecksPage.test.tsx
+++ b/src/page/ChecksPage.test.tsx
@@ -32,11 +32,11 @@ test('renders checks', async () => {
 test('renders check selection page with multi-http feature flag is ON', async () => {
   const { user } = await renderChecksPage();
   await user.click(screen.getByRole('button', { name: 'Add new check' }));
-  expect(await screen.findByRole('button', { name: 'HTTP' })).toBeInTheDocument();
-  expect(await screen.findByRole('button', { name: /MULTIHTTP/ })).toBeInTheDocument();
-  expect(await screen.findByRole('button', { name: 'Traceroute' })).toBeInTheDocument();
-  expect(await screen.findByRole('button', { name: 'PING' })).toBeInTheDocument();
-  expect(await screen.findByRole('button', { name: 'DNS' })).toBeInTheDocument();
+  expect(await screen.findByRole('link', { name: 'HTTP' })).toBeInTheDocument();
+  expect(await screen.findByRole('link', { name: /MULTIHTTP/ })).toBeInTheDocument();
+  expect(await screen.findByRole('link', { name: 'Traceroute' })).toBeInTheDocument();
+  expect(await screen.findByRole('link', { name: 'PING' })).toBeInTheDocument();
+  expect(await screen.findByRole('link', { name: 'DNS' })).toBeInTheDocument();
 });
 
 test('renders check selection page without multi-http feature flag is OFF', async () => {
@@ -51,11 +51,11 @@ test('renders check selection page without multi-http feature flag is OFF', asyn
   const { user } = await renderChecksPage();
   await waitFor(() => screen.getByRole('button', { name: 'Add new check' }));
   await user.click(screen.getByRole('button', { name: 'Add new check' }));
-  expect(await screen.queryByRole('button', { name: 'HTTP' })).toBeInTheDocument();
-  expect(await screen.queryByRole('button', { name: 'Traceroute' })).toBeInTheDocument();
-  expect(await screen.queryByRole('button', { name: 'PING' })).toBeInTheDocument();
-  expect(await screen.queryByRole('button', { name: 'DNS' })).toBeInTheDocument();
-  expect(await screen.queryByRole('button', { name: /MULTIHTTP/ })).not.toBeInTheDocument();
+  expect(await screen.queryByRole('link', { name: 'HTTP' })).toBeInTheDocument();
+  expect(await screen.queryByRole('link', { name: 'Traceroute' })).toBeInTheDocument();
+  expect(await screen.queryByRole('link', { name: 'PING' })).toBeInTheDocument();
+  expect(await screen.queryByRole('link', { name: 'DNS' })).toBeInTheDocument();
+  expect(await screen.queryByRole('link', { name: /MULTIHTTP/ })).not.toBeInTheDocument();
 });
 
 test('renders check editor existing check', async () => {


### PR DESCRIPTION
## Problem

The `@grafana/ui` `<Card />` component is _far_ too opinionated (committing us to a grid structure, using h2s for titles, etc). for what it should be providing (a simple card UI...) but is a common design pattern that we want to utilise throughout the application.

The original problem that prompted me to go down this route of refactoring is I wanted to open up all the Checks from 'choose-a-check' side-by-side by using the browser's `cmd + click` to open each in a new window but couldn't do that because the current implementation is based on navigation via a button rather than a link (which has accessibility issues, too).

https://github.com/grafana/synthetic-monitoring-app/assets/6906380/717f192b-75fe-4e30-8a2d-d2a588a6baf4

## Solution

Created a re-usable and less opinionated `Card` component which we can re-use throughout the application. I have refactored the Probe Cards and Choose a Check Cards to utilise it. By default it uses links if provided to the card, which create a much more accessible experience.

https://github.com/grafana/synthetic-monitoring-app/assets/6906380/9643cdcc-a5b2-4177-8017-1e4237a63ccf

