### PR TITLE
Fix long range queries

### DIFF
--- a/src/scenes/Common/divideSumByCountTransformation.ts
+++ b/src/scenes/Common/divideSumByCountTransformation.ts
@@ -1,0 +1,53 @@
+import { SceneDataTransformer, SceneQueryRunner } from '@grafana/scenes';
+
+export function divideSumByCountTransformation(runner: SceneQueryRunner) {
+  return new SceneDataTransformer({
+    $data: runner,
+    transformations: [
+      {
+        id: 'reduce',
+        options: {
+          labelsToFields: false,
+          reducers: ['sum'],
+        },
+      },
+      {
+        id: 'rowsToFields',
+        options: {
+          mappings: [
+            {
+              fieldName: 'Total',
+              handlerKey: 'field.value',
+            },
+          ],
+        },
+      },
+      {
+        id: 'calculateField',
+        options: {
+          binary: {
+            left: 'sum',
+            operator: '/',
+            right: 'count',
+          },
+          mode: 'binary',
+          reduce: {
+            reducer: 'sum',
+          },
+        },
+      },
+      {
+        id: 'organize',
+        options: {
+          excludeByName: {
+            count: true,
+            sum: true,
+          },
+          includeByName: {},
+          indexByName: {},
+          renameByName: {},
+        },
+      },
+    ],
+  });
+}

--- a/src/scenes/Common/reachabilityStat.ts
+++ b/src/scenes/Common/reachabilityStat.ts
@@ -1,28 +1,40 @@
+import { SpecialValueMatch } from '@grafana/data';
 import { SceneQueryRunner } from '@grafana/scenes';
-import { DataSourceRef, ThresholdsMode } from '@grafana/schema';
+import { DataSourceRef, MappingType, ThresholdsMode } from '@grafana/schema';
 
 import { REACHABILITY_DESCRIPTION } from 'components/constants';
 import { ExplorablePanel } from 'scenes/ExplorablePanel';
 
+import { divideSumByCountTransformation } from './divideSumByCountTransformation';
+
 function getQueryRunner(metrics: DataSourceRef) {
   const queries = [
     {
-      exemplar: true,
-      expr: 'sum(\n  increase(probe_all_success_sum{instance="$instance", job="$job", probe=~"$probe"}[$__range])\n   )\n/\nsum(\n  increase(probe_all_success_count{instance="$instance", job="$job", probe=~"$probe"}[$__range])\n)',
+      expr: 'sum(rate(probe_all_success_sum{instance="$instance", job="$job", probe=~"$probe"}[$__rate_interval]))',
       hide: false,
-      instant: true,
-      interval: '',
-      legendFormat: '',
-      refId: 'reachabilityStat',
+      instant: false,
+      legendFormat: 'sum',
+      range: true,
+      refId: 'A',
+    },
+    {
+      exemplar: true,
+      expr: 'sum(rate(probe_all_success_count{instance="$instance", job="$job", probe=~"$probe"}[$__rate_interval]))',
+      hide: false,
+      instant: false,
+      legendFormat: 'count',
+      range: true,
+      refId: 'B',
     },
   ];
   const runner = new SceneQueryRunner({
     datasource: metrics,
     queries,
+    minInterval: '2m',
   });
+
   return {
-    queries,
-    runner,
+    runner: divideSumByCountTransformation(runner),
   };
 }
 
@@ -34,18 +46,18 @@ export function getReachabilityStat(metrics: DataSourceRef) {
     description: REACHABILITY_DESCRIPTION,
     $data: runner,
     fieldConfig: {
-      overrides: [],
       defaults: {
-        decimals: 2,
-        // mappings: [
-        //   {
-        //     id: 0,
-        //     op: '=',
-        //     text: 'N/A',
-        //     type: 1,
-        //     value: 'null',
-        //   },
-        // ],
+        mappings: [
+          {
+            options: {
+              match: SpecialValueMatch.Null,
+              result: {
+                text: 'N/A',
+              },
+            },
+            type: MappingType.SpecialValue,
+          },
+        ],
         thresholds: {
           mode: ThresholdsMode.Absolute,
           steps: [
@@ -63,8 +75,12 @@ export function getReachabilityStat(metrics: DataSourceRef) {
             },
           ],
         },
+        decimals: 2,
+        max: 1,
+        min: 0,
         unit: 'percentunit',
       },
+      overrides: [],
     },
   });
 }

--- a/src/scenes/Common/reachabilityStat.ts
+++ b/src/scenes/Common/reachabilityStat.ts
@@ -14,6 +14,7 @@ function getQueryRunner(metrics: DataSourceRef) {
       hide: false,
       instant: false,
       legendFormat: 'sum',
+      interval: '1m',
       range: true,
       refId: 'A',
     },
@@ -22,6 +23,7 @@ function getQueryRunner(metrics: DataSourceRef) {
       expr: 'sum(rate(probe_all_success_count{instance="$instance", job="$job", probe=~"$probe"}[$__rate_interval]))',
       hide: false,
       instant: false,
+      interval: '1m',
       legendFormat: 'count',
       range: true,
       refId: 'B',
@@ -30,7 +32,6 @@ function getQueryRunner(metrics: DataSourceRef) {
   const runner = new SceneQueryRunner({
     datasource: metrics,
     queries,
-    minInterval: '2m',
   });
 
   return {

--- a/src/scenes/Common/uptimeStat.ts
+++ b/src/scenes/Common/uptimeStat.ts
@@ -1,21 +1,43 @@
-import { SceneQueryRunner } from '@grafana/scenes';
+import { SceneDataTransformer, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, ThresholdsMode } from '@grafana/schema';
 
 import { UPTIME_DESCRIPTION } from 'components/constants';
 import { ExplorablePanel } from 'scenes/ExplorablePanel';
 
 function getQueryRunner(metrics: DataSourceRef) {
-  return new SceneQueryRunner({
+  const runner = new SceneQueryRunner({
     datasource: metrics,
     queries: [
       {
-        exemplar: true,
-        expr: '# find the average uptime over the entire time range evaluating \'up\' in 5 minute windows\navg_over_time(\n  (\n    # the inner query is going to produce a non-zero value if there was at least one successful check during the 5 minute window\n    # so make it a 1 if there was at least one success and a 0 otherwise\n    ceil(\n      # the number of successes across all probes\n      sum by (instance, job) (increase(probe_all_success_sum{instance="$instance", job="$job"}[5m]))\n      /\n      # the total number of times we checked across all probes\n      (sum by (instance, job) (increase(probe_all_success_count{instance="$instance", job="$job"}[5m])) + 1) # + 1 because we want to make sure it goes to 1, not 2\n    )\n  )\n  [$__range:5m]\n)',
+        exemplar: false,
+        expr: `# find the average uptime over the entire time range evaluating \'up\' in 5 minute windows
+          # this query is going to produce a non-zero value if there was at least one successful check during the 5 minute window
+          # so make it a 1 if there was at least one success and a 0 otherwise
+        ceil(
+          # the number of successes across all probes
+          sum by (instance, job) (increase(probe_all_success_sum{instance="$instance", job="$job"}[5m]))
+          /
+          # the total number of times we checked across all probes
+          (sum by (instance, job) (increase(probe_all_success_count{instance="$instance", job="$job"}[5m])) + 1) # + 1 because we want to make sure it goes to 1, not 2
+        )`,
         hide: false,
-        instant: true,
+        range: true,
+        instant: false,
         interval: '',
         legendFormat: '',
         refId: 'uptimeStat',
+      },
+    ],
+  });
+
+  return new SceneDataTransformer({
+    $data: runner,
+    transformations: [
+      {
+        id: 'reduce',
+        options: {
+          reducers: ['mean'],
+        },
       },
     ],
   });

--- a/src/scenes/Common/uptimeStat.ts
+++ b/src/scenes/Common/uptimeStat.ts
@@ -10,26 +10,22 @@ function getQueryRunner(metrics: DataSourceRef) {
     queries: [
       {
         editorMode: 'code',
-        exemplar: false,
-        expr: 'sum by (instance, job) (increase(probe_all_success_sum{instance="$instance", job="$job"}[5m]))\n',
+        exemplar: true,
+        expr: `# the inner query is going to produce a non-zero value if there was at least one successful check during the 5 minute window
+        # so make it a 1 if there was at least one success and a 0 otherwise
+        ceil(
+          # the number of successes across all probes
+          sum by (instance, job) (increase(probe_all_success_sum{instance="$instance", job="$job"}[5m]))
+          /
+          # the total number of times we checked across all probes
+          (sum by (instance, job) (increase(probe_all_success_count{instance="$instance", job="$job"}[5m])) + 1) # + 1 because we want to make sure it goes to 1, not 2
+        )`,
         hide: false,
         instant: false,
-        interval: '',
-        legendFormat: 'numerator',
+        interval: '5m',
+        legendFormat: '',
         range: true,
         refId: 'B',
-        format: 'table',
-      },
-      {
-        refId: 'A',
-        expr: '(sum by (instance, job) (increase(probe_all_success_count{instance="$instance", job="$job"}[5m])) + 1) # + 1 because we want to make sure it goes to 1, not 2',
-        range: true,
-        instant: false,
-        hide: false,
-        editorMode: 'code',
-        legendFormat: 'denominator',
-        interval: '',
-        format: 'table',
       },
     ],
   });
@@ -38,74 +34,9 @@ function getQueryRunner(metrics: DataSourceRef) {
     $data: runner,
     transformations: [
       {
-        id: 'joinByField',
+        id: 'reduce',
         options: {
-          reduceOptions: {
-            values: false,
-            calcs: ['mean'],
-            fields: '/^uptime$/',
-            limit: 1,
-          },
-          orientation: 'horizontal',
-          textMode: 'auto',
-          wideLayout: true,
-          colorMode: 'value',
-          graphMode: 'none',
-          justifyMode: 'auto',
-          showPercentChange: false,
-          fieldOptions: {
-            calcs: ['lastNotNull'],
-          },
-          text: {},
-        },
-      },
-      {
-        id: 'groupBy',
-        options: {
-          fields: {
-            'Value #B': {
-              aggregations: ['sum'],
-              operation: 'aggregate',
-            },
-            'Value #A': {
-              aggregations: ['sum'],
-              operation: 'aggregate',
-            },
-            Time: {
-              aggregations: [],
-              operation: 'groupby',
-            },
-          },
-        },
-      },
-      {
-        id: 'calculateField',
-        options: {
-          mode: 'binary',
-          reduce: {
-            reducer: 'sum',
-          },
-          binary: {
-            left: 'Value #B (sum)',
-            operator: '/',
-            right: 'Value #A (sum)',
-          },
-          replaceFields: true,
-        },
-      },
-      {
-        id: 'calculateField',
-        options: {
-          mode: 'unary',
-          reduce: {
-            reducer: 'sum',
-          },
-          unary: {
-            operator: 'ceil',
-            fieldName: 'Value #B (sum) / Value #A (sum)',
-          },
-          replaceFields: true,
-          alias: 'uptime',
+          reducers: ['mean'],
         },
       },
     ],

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/ResultByTargetTable.tsx
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/ResultByTargetTable.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { TableColumn } from 'react-data-table-component';
-import { DataQueryError } from '@grafana/data';
+import { DataQueryError, dateTimeParse } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import {
   SceneComponentProps,
@@ -39,15 +39,32 @@ export interface DataRow {
 export class ResultsByTargetTableSceneObject extends SceneObjectBase<ResultsByTargetTableState> {
   static Component = ({ model }: SceneComponentProps<ResultsByTargetTableSceneObject>) => {
     const { data } = sceneGraph.getData(model).useState();
+    const { value: timeRange } = sceneGraph.getTimeRange(model).useState();
     const [hasLoaded, setHasLoaded] = React.useState(false);
+    const [hasStartedLoading, setHasStartedLoading] = React.useState(false);
+    const [logTimeLimitExceeded, setLogTimeLimitExceeded] = React.useState(false);
     const { metrics, checkType } = model.useState();
     const styles = useStyles2(getTablePanelStyles);
 
     useEffect(() => {
-      if (data?.state === LoadingState.Done && !hasLoaded) {
+      const logQueryLimit = new Date().setDate(new Date().getDate() - 31);
+      const from = dateTimeParse(timeRange.from);
+      if (from.valueOf() < logQueryLimit) {
+        setLogTimeLimitExceeded(true);
+      } else if (logTimeLimitExceeded) {
+        setLogTimeLimitExceeded(false);
+      }
+    }, [timeRange.from, logTimeLimitExceeded]);
+
+    useEffect(() => {
+      // This is a hack because the data Loading state initializes as "Done", then goes to "Loading", and then goes back to "Done"
+      if (data?.state === LoadingState.Loading) {
+        setHasStartedLoading(true);
+      }
+      if (data?.state === LoadingState.Done && hasStartedLoading && !hasLoaded) {
         setHasLoaded(true);
       }
-    }, [data, hasLoaded]);
+    }, [data, hasLoaded, hasStartedLoading]);
 
     const columns = useMemo<Array<TableColumn<DataRow>>>(() => {
       return [
@@ -183,21 +200,30 @@ export class ResultsByTargetTableSceneObject extends SceneObjectBase<ResultsByTa
             Results by URL
           </h6>
         </div>
-        <Table<DataRow>
-          columns={columns}
-          data={tableData}
-          expandableRows
-          dataTableProps={{
-            expandableRowsComponentProps: { tableViz: model, metrics, checkType },
-          }}
-          expandableComponent={ResultsByTargetTableRow}
-          //@ts-ignore - noDataText expects a string, but we want to render a component and it works
-          noDataText={getPlaceholder(data?.state, data?.errors)}
-          pagination={false}
-          id="assertion-table"
-          name="Assertions"
-          config={config}
-        />
+        {logTimeLimitExceeded ? (
+          <div className={styles.noDataContainer}>
+            <Alert severity="warning" title="Time range beyond retention">
+              The query that powers this panel is based on logs and the time range selected is beyond the retention
+              period of logs. In order to see data, select a time range less than 31 days.
+            </Alert>
+          </div>
+        ) : (
+          <Table<DataRow>
+            columns={columns}
+            data={tableData}
+            expandableRows
+            dataTableProps={{
+              expandableRowsComponentProps: { tableViz: model, metrics, checkType },
+            }}
+            expandableComponent={ResultsByTargetTableRow}
+            //@ts-ignore - noDataText expects a string, but we want to render a component and it works
+            noDataText={getPlaceholder(data?.state, data?.errors)}
+            pagination={false}
+            id="assertion-table"
+            name="Assertions"
+            config={config}
+          />
+        )}
       </div>
     );
   };

--- a/src/scenes/Summary/errorPctTimeseries.ts
+++ b/src/scenes/Summary/errorPctTimeseries.ts
@@ -49,7 +49,6 @@ function getErrorPercentageQueryRunner(metrics: DataSourceRef) {
         refId: 'A',
       },
     ],
-    // maxDataPoints: 100,
   });
   return queryRunner;
 }
@@ -60,61 +59,6 @@ export function getErrorPctgTimeseriesPanel(metrics: DataSourceRef) {
     title: `$check_type check error percentage`,
     fieldConfig: {
       defaults: {
-        custom: {
-          //   drawStyle: 'line',
-          lineInterpolation: 'linear',
-        },
-        //   barAlignment: 0,
-        //   lineWidth: 1,
-        //   fillOpacity: 0,
-        //   gradientMode: 'none',
-        //   spanNulls: true,
-        //   insertNulls: false,
-        //   showPoints: 'never',
-        //   pointSize: 5,
-        //   stacking: {
-        //     mode: 'none',
-        //     group: 'A',
-        //   },
-        //   axisPlacement: 'auto',
-        //   axisLabel: '',
-        //   axisColorMode: 'text',
-        //   axisBorderShow: false,
-        //   scaleDistribution: {
-        //     type: 'linear',
-        //   },
-        //   axisCenteredZero: false,
-        //   hideFrom: {
-        //     tooltip: false,
-        //     viz: false,
-        //     legend: false,
-        //   },
-        //   thresholdsStyle: {
-        //     mode: 'off',
-        //   },
-        // },
-        // color: {
-        //   mode: 'palette-classic',
-        // },
-        // mappings: [],
-        // thresholds: {
-        //   mode: ThresholdsMode.Absolute,
-        //   steps: [
-        //     {
-        //       color: 'green',
-        //       value: 0,
-        //     },
-        //     {
-        //       color: '#EAB839',
-        //       value: 0.5,
-        //     },
-        //     {
-        //       color: 'red',
-        //       value: 1,
-        //     },
-        //   ],
-        // },
-        // links: [],
         min: 0,
         max: 1,
         unit: 'percentunit',

--- a/src/scenes/Summary/errorPctTimeseries.ts
+++ b/src/scenes/Summary/errorPctTimeseries.ts
@@ -1,12 +1,11 @@
 import { SceneQueryRunner } from '@grafana/scenes';
-import { DataSourceRef, ThresholdsMode } from '@grafana/schema';
+import { DataSourceRef } from '@grafana/schema';
 
 import { ExplorablePanel } from 'scenes/ExplorablePanel';
 
 function getErrorPercentageQuery() {
   return `1 - sum(
-    rate(
-      probe_all_success_sum{probe=~"$probe"}[$__range]) 
+      rate(probe_all_success_sum{probe=~"$probe"}[$__rate_interval])
       * 
       on (
         instance, job, probe, config_version
@@ -21,7 +20,7 @@ function getErrorPercentageQuery() {
     / 
     sum(
       rate(
-        probe_all_success_count{probe=~"$probe"}[$__range]) 
+        probe_all_success_count{probe=~"$probe"}[$__rate_interval])
         * 
         on (
           instance, job, probe, config_version
@@ -45,6 +44,7 @@ function getErrorPercentageQueryRunner(metrics: DataSourceRef) {
         exemplar: true,
         expr: getErrorPercentageQuery(),
         hide: false,
+        interval: '1m',
         legendFormat: '{{job}}/{{ instance }}',
         refId: 'A',
       },
@@ -61,59 +61,60 @@ export function getErrorPctgTimeseriesPanel(metrics: DataSourceRef) {
     fieldConfig: {
       defaults: {
         custom: {
-          drawStyle: 'line',
+          //   drawStyle: 'line',
           lineInterpolation: 'linear',
-          barAlignment: 0,
-          lineWidth: 1,
-          fillOpacity: 0,
-          gradientMode: 'none',
-          spanNulls: true,
-          insertNulls: false,
-          showPoints: 'never',
-          pointSize: 5,
-          stacking: {
-            mode: 'none',
-            group: 'A',
-          },
-          axisPlacement: 'auto',
-          axisLabel: '',
-          axisColorMode: 'text',
-          axisBorderShow: false,
-          scaleDistribution: {
-            type: 'linear',
-          },
-          axisCenteredZero: false,
-          hideFrom: {
-            tooltip: false,
-            viz: false,
-            legend: false,
-          },
-          thresholdsStyle: {
-            mode: 'off',
-          },
         },
-        color: {
-          mode: 'palette-classic',
-        },
-        mappings: [],
-        thresholds: {
-          mode: ThresholdsMode.Absolute,
-          steps: [
-            {
-              color: 'green',
-              value: 0,
-            },
-            {
-              color: '#EAB839',
-              value: 0.5,
-            },
-            {
-              color: 'red',
-              value: 1,
-            },
-          ],
-        },
-        links: [],
+        //   barAlignment: 0,
+        //   lineWidth: 1,
+        //   fillOpacity: 0,
+        //   gradientMode: 'none',
+        //   spanNulls: true,
+        //   insertNulls: false,
+        //   showPoints: 'never',
+        //   pointSize: 5,
+        //   stacking: {
+        //     mode: 'none',
+        //     group: 'A',
+        //   },
+        //   axisPlacement: 'auto',
+        //   axisLabel: '',
+        //   axisColorMode: 'text',
+        //   axisBorderShow: false,
+        //   scaleDistribution: {
+        //     type: 'linear',
+        //   },
+        //   axisCenteredZero: false,
+        //   hideFrom: {
+        //     tooltip: false,
+        //     viz: false,
+        //     legend: false,
+        //   },
+        //   thresholdsStyle: {
+        //     mode: 'off',
+        //   },
+        // },
+        // color: {
+        //   mode: 'palette-classic',
+        // },
+        // mappings: [],
+        // thresholds: {
+        //   mode: ThresholdsMode.Absolute,
+        //   steps: [
+        //     {
+        //       color: 'green',
+        //       value: 0,
+        //     },
+        //     {
+        //       color: '#EAB839',
+        //       value: 0.5,
+        //     },
+        //     {
+        //       color: 'red',
+        //       value: 1,
+        //     },
+        //   ],
+        // },
+        // links: [],
         min: 0,
         max: 1,
         unit: 'percentunit',

--- a/src/scenes/Summary/errorRateMap.ts
+++ b/src/scenes/Summary/errorRateMap.ts
@@ -1,52 +1,154 @@
-import { SceneQueryRunner } from '@grafana/scenes';
+import { SceneDataTransformer, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, ThresholdsMode } from '@grafana/schema';
 
 import { ExplorablePanel } from 'scenes/ExplorablePanel';
 
-function getErrorMapQuery() {
-  return `
-  100 * (1 - (
-    sum by (probe, geohash)
+function getErrorMapQueries() {
+  return [
+    {
+      expr: `sum by (probe, geohash)
       (
-        rate(probe_all_success_sum{probe=~"$probe"}[$__range])
+        rate(probe_all_success_sum{probe=~"$probe"}[$__rate_interval])
         *
         on (instance, job, probe, config_version)
         group_left(geohash)
-        max
-        by (instance, job, probe, config_version, check_name, geohash)
-        (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters})
-      ) 
-      / 
-      sum by (probe, geohash)
+        max by (instance, job, probe, config_version, geohash)
+        (
+          (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters})  
+        )
+      )`,
+      format: 'table',
+      interval: '1m',
+      instant: false,
+      legendFormat: 'numerator',
+      refId: 'A',
+      range: true,
+    },
+    {
+      refId: 'B',
+      expr: `sum by (probe, geohash)
       (
-        rate(probe_all_success_count{probe=~"$probe"}[$__range])
-        *
+        rate(probe_all_success_count{probe=~"$probe"}[$__rate_interval])
+          *
         on (instance, job, probe, config_version)
         group_left(geohash)
-        max
-        by (instance, job, probe, config_version, check_name, geohash)
+        max by (instance, job, probe, config_version, geohash)
         (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters})
-      )
-    )
-  )`;
+      )`,
+      range: true,
+      interval: '1m',
+      instant: false,
+      hide: false,
+      legendFormat: 'denominator',
+      format: 'table',
+    },
+  ];
 }
 
 function getMapQueryRunner(metrics: DataSourceRef) {
   const queryRunner = new SceneQueryRunner({
     datasource: metrics,
-    queries: [
+    queries: getErrorMapQueries(),
+  });
+
+  return new SceneDataTransformer({
+    $data: queryRunner,
+    transformations: [
       {
-        expr: getErrorMapQuery(),
-        format: 'table',
-        hide: false,
-        instant: true,
-        interval: '',
-        legendFormat: '',
-        refId: 'A',
+        id: 'groupBy',
+        options: {
+          fields: {
+            Value: {
+              aggregations: ['sum'],
+              operation: 'aggregate',
+            },
+            'Value #A': {
+              aggregations: ['sum'],
+              operation: 'aggregate',
+            },
+            'Value #B': {
+              aggregations: ['sum'],
+              operation: 'aggregate',
+            },
+            geohash: {
+              aggregations: [],
+              operation: 'groupby',
+            },
+            probe: {
+              aggregations: [],
+              operation: 'groupby',
+            },
+            'probe 1': {
+              aggregations: [],
+              operation: null,
+            },
+            'probe 2': {
+              aggregations: [],
+              operation: null,
+            },
+          },
+        },
+      },
+      {
+        id: 'joinByField',
+        options: {
+          byField: 'probe',
+          mode: 'outerTabular',
+        },
+      },
+      {
+        id: 'calculateField',
+        options: {
+          alias: 'success rate',
+          binary: {
+            left: 'Value #A (sum)',
+            operator: '/',
+            right: 'Value #B (sum)',
+          },
+          mode: 'binary',
+          reduce: {
+            reducer: 'sum',
+          },
+        },
+      },
+      {
+        id: 'calculateField',
+        options: {
+          alias: 'Error rate',
+          binary: {
+            left: '1.00',
+            operator: '-',
+            right: 'success rate',
+          },
+          mode: 'binary',
+          reduce: {
+            reducer: 'sum',
+          },
+        },
+      },
+      {
+        id: 'organize',
+        options: {
+          excludeByName: {
+            'Value #A (sum)': true,
+            'Value #B (sum)': true,
+            geohash: false,
+            'probe 2': true,
+            'success rate': true,
+            'geohash 2': true,
+          },
+          indexByName: {},
+          renameByName: {
+            'error rate': '',
+            geohash: '',
+            'probe 1': 'Probe',
+            'geohash 1': 'geohash',
+          },
+          includeByName: {},
+        },
       },
     ],
   });
-  return queryRunner;
 }
 
 export function getErrorRateMapPanel(metrics: DataSourceRef) {
@@ -72,7 +174,7 @@ export function getErrorRateMapPanel(metrics: DataSourceRef) {
             showLegend: true,
             style: {
               color: {
-                field: 'Value',
+                field: 'Error rate',
                 fixed: 'dark-green',
               },
               opacity: 0.4,
@@ -83,7 +185,7 @@ export function getErrorRateMapPanel(metrics: DataSourceRef) {
                 mode: 'mod',
               },
               size: {
-                field: 'Value',
+                field: 'Error rate',
                 fixed: 5,
                 max: 10,
                 min: 4,
@@ -105,7 +207,7 @@ export function getErrorRateMapPanel(metrics: DataSourceRef) {
             geohash: 'geohash',
             mode: 'geohash',
           },
-          name: 'Layer 1',
+          name: 'Error rate',
           type: 'markers',
         },
       ],
@@ -123,41 +225,28 @@ export function getErrorRateMapPanel(metrics: DataSourceRef) {
         },
         decimals: 2,
         mappings: [],
-        max: 1,
+        max: 0.1,
         min: 0,
         thresholds: {
           mode: ThresholdsMode.Absolute,
           steps: [
             {
-              color: 'dark-green',
+              color: 'green',
               value: 0,
             },
             {
-              color: 'dark-orange',
-              value: 0.5,
+              color: '#EAB839',
+              value: 0.01,
             },
             {
-              color: 'dark-red',
-              value: 1,
+              color: 'red',
+              value: 0.015,
             },
           ],
         },
-        unit: 'percent',
+        unit: 'percentunit',
       },
-      overrides: [
-        {
-          matcher: {
-            id: 'byName',
-            options: 'Value',
-          },
-          properties: [
-            {
-              id: 'displayName',
-              value: 'Error rate',
-            },
-          ],
-        },
-      ],
+      overrides: [],
     },
   });
   return mapPanel;

--- a/src/scenes/Summary/latencyTimeseries.ts
+++ b/src/scenes/Summary/latencyTimeseries.ts
@@ -11,7 +11,7 @@ function getLatencyQueryRunner(metrics: DataSourceRef) {
         expr: `
         (
           sum(
-            rate(probe_all_duration_seconds_sum{probe=~"$probe"}[$__range])
+            rate(probe_all_duration_seconds_sum{probe=~"$probe"}[$__rate_interval])
             * on (instance, job, probe, config_version) group_left max(sm_check_info{check_name=~"$check_type", region=~"$region", $Filters})
             by (instance, job, probe, config_version)
           )
@@ -20,7 +20,7 @@ function getLatencyQueryRunner(metrics: DataSourceRef) {
         /
         (
           sum(
-            rate(probe_all_duration_seconds_count{probe=~"$probe"}[$__range])
+            rate(probe_all_duration_seconds_count{probe=~"$probe"}[$__rate_interval])
             * on (instance, job, probe, config_version) group_left max(sm_check_info{check_name=~"$check_type", region=~"$region", $Filters})
             by (instance, job, probe, config_version)
           )
@@ -28,7 +28,7 @@ function getLatencyQueryRunner(metrics: DataSourceRef) {
         )
         `,
         hide: false,
-        interval: '',
+        interval: '1m',
         legendFormat: '{{job}}/{{ instance }}',
         refId: 'A',
       },

--- a/src/scenes/Summary/summaryTable.ts
+++ b/src/scenes/Summary/summaryTable.ts
@@ -89,6 +89,7 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
         range: true,
         instant: false,
         hide: false,
+        interval: '5m',
         editorMode: 'code',
         legendFormat: '__auto',
         format: 'table',

--- a/src/scenes/Summary/summaryTable.ts
+++ b/src/scenes/Summary/summaryTable.ts
@@ -293,6 +293,10 @@ function getFieldOverrides() {
       },
       properties: [
         {
+          id: 'unit',
+          value: 'percentunit',
+        },
+        {
           id: 'custom.cellOptions',
           value: {
             mode: 'gradient',
@@ -300,8 +304,24 @@ function getFieldOverrides() {
           },
         },
         {
-          id: 'unit',
-          value: 'percentunit',
+          id: 'thresholds',
+          value: {
+            mode: 'absolute',
+            steps: [
+              {
+                color: 'red',
+                value: null,
+              },
+              {
+                color: 'yellow',
+                value: 0.9,
+              },
+              {
+                color: 'green',
+                value: 0.99,
+              },
+            ],
+          },
         },
       ],
     },

--- a/src/scenes/Summary/summaryTable.ts
+++ b/src/scenes/Summary/summaryTable.ts
@@ -5,120 +5,127 @@ import { ExplorablePanel } from 'scenes/ExplorablePanel';
 
 function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
   const queryRunner = new SceneQueryRunner({
-    datasource: { type: 'datasource', uid: '-- Mixed --' },
+    datasource: {
+      uid: '-- Mixed --',
+      type: 'datasource',
+    },
     queries: [
       {
-        datasource: sm,
+        datasource: metrics,
+        editorMode: 'code',
+        expr: ` sum by (instance, job, check_name)
+          (
+            rate(probe_all_success_sum{probe=~"$probe"}[$__rate_interval])
+            *
+            on (instance, job, probe, config_version) group_left(check_name) max by (instance, job, probe, config_version, check_name) (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters })
+          )`,
+        legendFormat: '__auto',
+        interval: '1m',
+        range: true,
+        refId: 'reach numer',
+        format: 'table',
+      },
+      {
+        datasource: metrics,
+        refId: 'reach denom',
+        expr: `sum by (instance, check_name, job)
+          (
+            rate(probe_all_success_count{probe=~"$probe"}[$__rate_interval])
+            *
+            on (instance, job, probe, config_version) group_left(check_name) max by (instance, job, probe, config_version, check_name) (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters })
+          )`,
+        range: true,
+        instant: false,
         hide: false,
-        instance: '',
-        job: '',
-        probe: '',
-        queryType: 'checks',
-        refId: 'checks',
+        interval: '1m',
+        editorMode: 'code',
+        legendFormat: '__auto',
+        format: 'table',
       },
       {
         datasource: metrics,
-        editorMode: 'code',
-        exemplar: false,
-        expr: `
-          sum by (instance, job, check_name)
+        refId: 'latency numer',
+        expr: `   sum by (instance, job, check_name)
           (
-            rate(probe_all_success_sum{probe=~"$probe"}[$__range])
-            *
-            on (instance, job, probe, config_version) group_left(check_name) max by (instance, job, probe, config_version, check_name) (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters })
-          )
-          /
-          sum by (instance, check_name, job)
-          (
-            rate(probe_all_success_count{probe=~"$probe"}[$__range])
+            rate(probe_all_duration_seconds_sum{probe=~"$probe"}[$__rate_interval])
             *
             on (instance, job, probe, config_version) group_left(check_name) max by (instance, job, probe, config_version, check_name) (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters })
           )`,
+        range: true,
+        instant: false,
+        hide: false,
+        interval: '1m',
+        editorMode: 'code',
+        legendFormat: '__auto',
         format: 'table',
-        instant: true,
-        interval: '',
-        legendFormat: '{{check_name}}-{{instance}}-uptime',
-        refId: 'reachability',
       },
       {
         datasource: metrics,
-        editorMode: 'code',
-        exemplar: false,
-        expr: `
-          sum by (instance, job, check_name)
+        refId: 'latency denom',
+        expr: ` sum by (instance, job, check_name)
           (
-            rate(probe_all_duration_seconds_sum{probe=~"$probe"}[$__range])
+            rate(probe_all_duration_seconds_count{probe=~"$probe"}[$__rate_interval])
             *
-            on (instance, job, probe, config_version) group_left(check_name) max by (instance, job, probe, config_version, check_name) (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters})
-          )
-          /
-          sum by (instance, job, check_name)
-          (
-            rate(probe_all_duration_seconds_count{probe=~"$probe"}[$__range])
-            *
-            on (instance, job, probe, config_version) group_left(check_name) max by (instance, job, probe, config_version, check_name) (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters})
+            on (instance, job, probe, config_version) group_left(check_name) max by (instance, job, probe, config_version, check_name) (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters })
           )`,
+        range: true,
+        instant: false,
+        hide: false,
+        interval: '1m',
+        editorMode: 'code',
+        legendFormat: '__auto',
         format: 'table',
-        instant: true,
-        interval: '',
-        legendFormat: '{{check_name}}-{{instance}}-latency',
-        refId: 'latency',
       },
       {
         datasource: metrics,
+        refId: 'uptime',
+        expr: `    ceil(
+                # the number of successes across all probes
+                sum by (instance, job) (increase(probe_all_success_sum{probe=~"$probe"}[5m]) * on (instance, job, probe, config_version) sm_check_info{check_name=~"$check_type", region=~"$region", $Filters })
+                /
+                # the total number of times we checked across all probes
+                (sum by (instance, job) (increase(probe_all_success_count{probe=~"$probe"}[5m])) + 1) # + 1 because we want to make sure it goes to 1, not 2
+              )`,
+        range: true,
+        instant: false,
+        hide: false,
         editorMode: 'code',
-        exemplar: false,
-        expr: `
-          ceil(
+        legendFormat: '__auto',
+        format: 'table',
+      },
+      {
+        datasource: metrics,
+        refId: 'state',
+        expr: `ceil(
             sum by (instance, job, check_name)
             (
               rate(probe_all_success_sum{probe=~"$probe"}[5m])
               *
-              on (instance, job, probe, config_version) group_left(check_name) max by (instance, job, probe, config_version, check_name) (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters})
+              on (instance, job, probe, config_version) group_left(check_name) max by (instance, job, probe, config_version, check_name) (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters })
             )
             /
             sum by (instance, check_name, job)
             (
               rate(probe_all_success_count{probe=~"$probe"}[5m])
               *
-              on (instance, job, probe, config_version) group_left(check_name) max by (instance, job, probe, config_version, check_name) (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters})
+              on (instance, job, probe, config_version) group_left(check_name) max by (instance, job, probe, config_version, check_name) (sm_check_info{check_name=~"$check_type", region=~"$region", $Filters })
             )
-          )
-        `,
-        format: 'table',
+          )`,
+        range: true,
+        instant: false,
         hide: false,
-        instant: true,
-        interval: '',
-        legendFormat: '{{check_name}}-{{instance}}-uptime',
-        refId: 'state',
+        editorMode: 'code',
+        legendFormat: '__auto',
+        format: 'table',
       },
       {
-        datasource: metrics,
-        editorMode: 'code',
-        exemplar: false,
-        expr: `
-          # find the average uptime over the entire time range evaluating 'up' in 5 minute windows
-          avg_over_time(
-            (
-              # the inner query is going to produce a non-zero value if there was at least one successful check during the 5 minute window
-              # so make it a 1 if there was at least one success and a 0 otherwise
-              ceil(
-                # the number of successes across all probes
-                sum by (instance, job) (increase(probe_all_success_sum{probe=~"$probe"}[5m]) * on (instance, job, probe, config_version) sm_check_info{check_name=~"$check_type", $Filters})
-                /
-                # the total number of times we checked across all probes
-                (sum by (instance, job) (increase(probe_all_success_count{probe=~"$probe"}[5m])) + 1) # + 1 because we want to make sure it goes to 1, not 2
-              )
-            )
-            [$__range:5m]
-          )
-        `,
-        format: 'table',
+        refId: 'A',
         hide: false,
-        instant: true,
-        interval: '',
-        legendFormat: '',
-        refId: 'uptime',
+        datasource: sm,
+        queryType: 'checks',
+        instance: '',
+        job: '',
+        probe: '',
       },
     ],
   });
@@ -130,39 +137,47 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
         id: 'groupBy',
         options: {
           fields: {
-            'Value #latency': {
-              aggregations: ['mean'],
+            'Value #A': {
+              aggregations: ['sum'],
               operation: 'aggregate',
             },
-            'Value #reachability': {
-              aggregations: ['mean'],
+            'Value #latency denom': {
+              aggregations: ['sum'],
+              operation: 'aggregate',
+            },
+            'Value #latency numer': {
+              aggregations: ['sum'],
+              operation: 'aggregate',
+            },
+            'Value #reach denom': {
+              aggregations: ['sum'],
+              operation: 'aggregate',
+            },
+            'Value #reach numer': {
+              aggregations: ['sum'],
               operation: 'aggregate',
             },
             'Value #state': {
-              aggregations: ['mean'],
+              aggregations: ['last'],
               operation: 'aggregate',
             },
             'Value #uptime': {
               aggregations: ['mean'],
               operation: 'aggregate',
             },
-            id: {
-              aggregations: [],
-              operation: 'groupby',
-            },
             check_name: {
-              aggregations: [],
-              operation: 'groupby',
+              aggregations: ['lastNotNull'],
+              operation: 'aggregate',
+            },
+            id: {
+              aggregations: ['lastNotNull'],
+              operation: 'aggregate',
             },
             instance: {
               aggregations: [],
               operation: 'groupby',
             },
             job: {
-              aggregations: [],
-              operation: 'groupby',
-            },
-            target: {
               aggregations: [],
               operation: 'groupby',
             },
@@ -173,88 +188,95 @@ function getSummaryTableQueryRunner(metrics: DataSourceRef, sm: DataSourceRef) {
         id: 'joinByField',
         options: {
           byField: 'job',
-          mode: 'outer',
+          mode: 'inner',
         },
       },
       {
-        id: 'renameByRegex',
+        id: 'calculateField',
         options: {
-          regex: 'check_name 1',
-          renamePattern: 'check type',
+          mode: 'binary',
+          reduce: {
+            reducer: 'sum',
+          },
+          alias: '',
+          binary: {
+            left: 'Value #reach numer (sum)',
+            operator: '/',
+            right: 'Value #reach denom (sum)',
+          },
         },
       },
       {
-        id: 'renameByRegex',
+        id: 'calculateField',
         options: {
-          regex: 'check_name .*',
-          renamePattern: 'hidden',
-        },
-      },
-      {
-        id: 'renameByRegex',
-        options: {
-          regex: 'instance(.*)',
-          renamePattern: 'hidden',
-        },
-      },
-
-      {
-        id: 'renameByRegex',
-        options: {
-          regex: 'Time (.*)',
-          renamePattern: 'hidden',
+          mode: 'binary',
+          reduce: {
+            reducer: 'sum',
+          },
+          alias: '',
+          binary: {
+            left: 'Value #latency numer (sum)',
+            operator: '/',
+            right: 'Value #latency denom (sum)',
+          },
         },
       },
       {
         id: 'organize',
         options: {
-          includeByName: {
-            job: true,
-            // instance: true,
-            'check type': true,
-            target: true,
-            'Value #state (mean)': true,
-            'Value #uptime (mean)': true,
-            'Value #reachability (mean)': true,
-            'Value #latency (mean)': true,
-            id: 9,
+          excludeByName: {
+            'Value #A (sum)': true,
+            'Value #latency denom (sum)': true,
+            'Value #latency numer (sum)': true,
+            'Value #reach denom (sum)': true,
+            'Value #reach numer (sum)': true,
+            'check_name (lastNotNull) 2': true,
+            'check_name (lastNotNull) 3': true,
+            'check_name (lastNotNull) 4': true,
+            'check_name (lastNotNull) 5': true,
+            'id (lastNotNull)': false,
+            'instance 2': true,
+            'instance 3': true,
+            'instance 4': true,
+            'instance 5': true,
+            'instance 6': true,
           },
           indexByName: {
+            'Value #latency denom (sum)': 16,
+            'Value #latency numer (sum)': 13,
+            'Value #reach denom (sum)': 10,
+            'Value #reach numer (sum)': 7,
+            'Value #state (last)': 3,
+            'Value #uptime (mean)': 4,
+            'check_name (lastNotNull)': 2,
+            'check_name (lastNotNull) 1': 2,
+            'check_name (lastNotNull) 2': 9,
+            'check_name (lastNotNull) 3': 12,
+            'check_name (lastNotNull) 4': 15,
+            'check_name (lastNotNull) 5': 19,
+            'id (lastNotNull)': 20,
+            'instance 1': 1,
+            'instance 2': 8,
+            'instance 3': 11,
+            'instance 4': 14,
+            'instance 5': 17,
+            'instance 6': 18,
             job: 0,
-            'check type': 3,
-            target: 2,
-            'Value #state (mean)': 4,
-            'Value #uptime (mean)': 5,
-            'Value #reachability (mean)': 6,
-            'Value #latency (mean)': 7,
-            id: 8,
+            latency: 6,
+            reachability: 5,
+            'Value #reach numer (sum) / Value #reach denom (sum)': 5,
+            'Value #latency numer (sum) / Value #latency denom (sum)': 6,
           },
           renameByName: {
-            'Value #latency': 'latency',
-            'Value #latency (mean)': 'latency',
-            'Value #reachability (mean)': 'reachability',
-            'Value #state': 'up',
-            'Value #state (mean)': 'state',
-            'Value #uptime': 'uptime',
+            'Value #state (last)': 'state',
             'Value #uptime (mean)': 'uptime',
-            target: 'instance',
+            'check_name (lastNotNull)': 'check type',
+            'check_name (lastNotNull) 1': 'check type',
+            'id (lastNotNull)': 'id',
+            'Value #reach numer (sum) / Value #reach denom (sum)': 'reachability',
+            'Value #latency numer (sum) / Value #latency denom (sum)': 'latency',
           },
-        },
-      },
-      {
-        id: 'filterByValue',
-        options: {
-          filters: [
-            {
-              fieldName: 'check type',
-              config: {
-                id: 'isNull',
-                options: {},
-              },
-            },
-          ],
-          type: 'exclude',
-          match: 'any',
+          includeByName: {},
         },
       },
     ],
@@ -338,13 +360,13 @@ function getFieldOverrides() {
           id: 'mappings',
           value: [
             {
-              type: 'value',
               options: {
                 k6: {
-                  text: 'scripted',
                   index: 0,
+                  text: 'scripted',
                 },
               },
+              type: 'value',
             },
           ],
         },
@@ -473,19 +495,22 @@ export function getSummaryTable(metrics: DataSourceRef, sm: DataSourceRef) {
     pluginId: 'table',
     $data: getSummaryTableQueryRunner(metrics, sm),
     title: `$check_type checks`,
-    description:
-      '* instance: the instance that corresponds to this check.\n* **job**: the job that corresponds to this check.\n* **reachability**: the percentage of all the checks that have succeeded during the whole time period.\n* **latency**: the average time to receive an answer across all the checks during the whole time period.\n* **state**: whether the target was up or down the last time it was checked.\n* **uptime**: the fraction of time the target was up  during the whole period.',
+    description: `* instance: the instance that corresponds to this check.
+    * **job**: the job that corresponds to this check.
+    * **reachability**: the percentage of all the checks that have succeeded during the whole time period.
+    * **latency**: the average time to receive an answer across all the checks during the whole time period.
+    * **state**: whether the target was up or down the last time it was checked.
+    * **uptime**: the fraction of time the target was up  during the whole period.`,
+
     fieldConfig: {
       defaults: {
-        color: {
-          mode: 'thresholds',
-        },
         custom: {
+          align: 'auto',
           cellOptions: {
             type: 'auto',
           },
-          filterable: false,
           inspect: false,
+          filterable: false,
         },
         mappings: [],
         thresholds: {
@@ -504,6 +529,9 @@ export function getSummaryTable(metrics: DataSourceRef, sm: DataSourceRef) {
               value: 1,
             },
           ],
+        },
+        color: {
+          mode: 'thresholds',
         },
       },
       overrides: getFieldOverrides(),


### PR DESCRIPTION
Fixes #667 

This change should be entirely transparent to users, it moves most of the calculations in our dashboards from prometheus into Grafana transformations. That, in turn, allows us to query longer time ranges. 