### PR TITLE
fix: remove byRole selectors in tests and add some a11y to inputs

### DIFF
--- a/src/components/CheckEditor/CheckEditorExisting.test.tsx
+++ b/src/components/CheckEditor/CheckEditorExisting.test.tsx
@@ -184,7 +184,7 @@ describe('editing checks', () => {
     requestBodyInput.focus();
     await user.clear(requestBodyInput);
     await user.paste(BODY);
-    await user.click(await screen.findByRole('button', { name: 'Add request header' }));
+    await user.click(await screen.findByText('Add request header'));
 
     await user.type(await screen.findByLabelText('Request header 2 name'), NEW_HEADER.name);
     await user.type(await screen.findByLabelText('Request header 2 value'), NEW_HEADER.value);
@@ -256,7 +256,9 @@ describe('editing checks', () => {
     await user.clear(regexFields[1]);
     await user.type(regexFields[1], BODY_REGEX);
 
-    const [allowMissing, invertMatch] = await within(validationSection).findAllByRole('checkbox');
+    const invertMatch = await within(validationSection).findByLabelText(/Invert match for regex 1/);
+    const allowMissing = await within(validationSection).findByLabelText(/Allow missing header for regex 1/);
+
     await user.click(allowMissing);
     await user.click(invertMatch);
 
@@ -318,8 +320,8 @@ describe('editing checks', () => {
     await user.clear(expressionInputs[1]);
     await user.type(expressionInputs[0], NOT_INVERTED_VALIDATION);
     await user.type(expressionInputs[1], INVERTED_VALIDATION);
-    const invertedCheckboxes = await screen.findAllByRole('checkbox');
-    await user.click(invertedCheckboxes[2]);
+    const invert = await screen.findByLabelText('Invert match for regex 1');
+    await user.click(invert);
     await submitForm(user);
 
     const { body } = await read();

--- a/src/components/CheckEditor/FormComponents/DNSCheckResponseMatches.tsx
+++ b/src/components/CheckEditor/FormComponents/DNSCheckResponseMatches.tsx
@@ -23,42 +23,43 @@ export const DNSCheckResponseMatches = () => {
           <Label>Expression</Label>
           <Label>Invert Match</Label>
           <div />
-          {fields.map((field, index) => (
-            <Fragment key={field.id}>
-              <Controller
-                name={`settings.dns.validations.${index}.responseMatch` as const}
-                rules={{ required: true }}
-                render={({ field }) => {
-                  const { ref, ...rest } = field;
-                  return (
-                    <Select
-                      {...rest}
-                      value={field.value}
-                      aria-label={`DNS Response Match ${index + 1}`}
-                      options={DNS_RESPONSE_MATCH_OPTIONS}
-                      invalid={Boolean(formState.errors.settings?.dns?.validations?.[index]?.responseMatch)}
-                    />
-                  );
-                }}
-              />
-              <Input
-                {...register(`settings.dns.validations.${index}.expression` as const)}
-                placeholder="Type expression"
-              />
-              <div
-                className={css`
-                  position: relative;
-                  justify-self: center;
-                `}
-              >
-                <Checkbox
-                  {...register(`settings.dns.validations.${index}.inverted` as const)}
-                  aria-label="dns-validation-inverted"
+          {fields.map((field, index) => {
+            const userIndex = index + 1;
+
+            return (
+              <Fragment key={field.id}>
+                <Controller
+                  name={`settings.dns.validations.${index}.responseMatch`}
+                  rules={{ required: true }}
+                  render={({ field }) => {
+                    const { ref, ...rest } = field;
+                    return (
+                      <Select
+                        {...rest}
+                        value={field.value}
+                        aria-label={`DNS Response Match ${userIndex}`}
+                        options={DNS_RESPONSE_MATCH_OPTIONS}
+                        invalid={Boolean(formState.errors.settings?.dns?.validations?.[index]?.responseMatch)}
+                      />
+                    );
+                  }}
                 />
-              </div>
-              <IconButton name="minus-circle" onClick={() => remove(index)} tooltip="Delete" />
-            </Fragment>
-          ))}
+                <Input {...register(`settings.dns.validations.${index}.expression`)} placeholder="Type expression" />
+                <div
+                  className={css`
+                    position: relative;
+                    justify-self: center;
+                  `}
+                >
+                  <Checkbox
+                    {...register(`settings.dns.validations.${index}.inverted`)}
+                    aria-label={`Invert match for regex ${userIndex}`}
+                  />
+                </div>
+                <IconButton name="minus-circle" onClick={() => remove(index)} tooltip="Delete" />
+              </Fragment>
+            );
+          })}
         </div>
       )}
       <div>

--- a/src/components/CheckEditor/FormComponents/HttpCheckRegExValidation.tsx
+++ b/src/components/CheckEditor/FormComponents/HttpCheckRegExValidation.tsx
@@ -36,6 +36,7 @@ export const HttpCheckRegExValidation = () => {
             const isHeaderMatch =
               watch(`${REGEX_FIELD_NAME}.${index}.matchType`)?.value === HttpRegexValidationType.Header;
             const disallowBodyMatching = watch('settings.http.method').value === HttpMethod.HEAD;
+            const userIndex = index + 1;
 
             return (
               <Fragment key={field.id}>
@@ -45,7 +46,7 @@ export const HttpCheckRegExValidation = () => {
                     return (
                       <Select
                         {...rest}
-                        aria-label={`Validation Field Name ${index + 1}`}
+                        aria-label={`Validation Field Name ${userIndex}`}
                         placeholder="Field name"
                         options={HTTP_REGEX_VALIDATION_OPTIONS}
                         invalid={
@@ -65,22 +66,28 @@ export const HttpCheckRegExValidation = () => {
                       return;
                     },
                   }}
-                  name={`${REGEX_FIELD_NAME}.${index}.matchType` as const}
+                  name={`${REGEX_FIELD_NAME}.${index}.matchType`}
                 />
                 <div className={styles.validationExpressions}>
                   {isHeaderMatch && (
                     <div className={styles.validationHeaderName}>
-                      <Input {...register(`${REGEX_FIELD_NAME}.${index}.header` as const)} placeholder="Header name" />
+                      <Input {...register(`${REGEX_FIELD_NAME}.${index}.header`)} placeholder="Header name" />
                     </div>
                   )}
-                  <Input {...register(`${REGEX_FIELD_NAME}.${index}.expression` as const)} placeholder="Regex" />
+                  <Input {...register(`${REGEX_FIELD_NAME}.${index}.expression`)} placeholder="Regex" />
                 </div>
                 <div className={styles.validationInverted}>
-                  <Checkbox {...register(`${REGEX_FIELD_NAME}.${index}.inverted` as const)} />
+                  <Checkbox
+                    {...register(`${REGEX_FIELD_NAME}.${index}.inverted`)}
+                    aria-label={`Invert match for regex ${userIndex}`}
+                  />
                 </div>
                 {isHeaderMatch ? (
                   <div className={styles.validationAllowMissing}>
-                    <Switch {...register(`${REGEX_FIELD_NAME}.${index}.allowMissing` as const)} />
+                    <Switch
+                      {...register(`${REGEX_FIELD_NAME}.${index}.allowMissing`)}
+                      aria-label={`Allow missing header for regex ${userIndex}`}
+                    />
                   </div>
                 ) : (
                   <div />

--- a/src/components/CheckEditor/FormComponents/MultiHttpCheckRequests.tsx
+++ b/src/components/CheckEditor/FormComponents/MultiHttpCheckRequests.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { FieldErrors, useFieldArray, useFormContext } from 'react-hook-form';
 import { Button, HorizontalGroup, useStyles2, VerticalGroup } from '@grafana/ui';
 
-import { CheckFormValues, CheckFormValuesMultiHttp, CheckType } from 'types';
+import { CheckFormValues, CheckFormValuesMultiHttp, CheckType, HttpMethod } from 'types';
 import { RequestMethodSelect } from 'components/CheckEditor/FormComponents/RequestMethodSelect';
 import { RequestTargetInput } from 'components/CheckEditor/FormComponents/RequestTargetInput';
 import { CHECK_FORM_ERROR_EVENT } from 'components/constants';
@@ -73,6 +73,7 @@ export const MultiHttpCheckRequests = () => {
             label={urlForIndex}
             key={field.id}
             className={styles.collapseTarget}
+            data-testid={`multihttp-request-${index}`}
             invalid={Boolean(errors?.settings?.multihttp?.entries?.[index])}
             isOpen={collapseState[index].open}
             onToggle={() => dispatchCollapse({ type: 'toggle', index })}
@@ -127,7 +128,9 @@ export const MultiHttpCheckRequests = () => {
         tooltip={requests?.length > 9 ? 'Maximum of 10 requests per check' : undefined}
         tooltipPlacement="bottom-start"
         onClick={() => {
-          append({});
+          append({
+            request: { url: ``, method: HttpMethod.GET },
+          });
           dispatchCollapse({ type: 'addNewRequest' });
         }}
         className={styles.addRequestButton}

--- a/src/components/CheckEditor/testHelpers.ts
+++ b/src/components/CheckEditor/testHelpers.ts
@@ -12,15 +12,16 @@ export const toggleSection = async (sectionName: string, user: UserEvent): Promi
 };
 
 export const submitForm = async (user: UserEvent) => {
-  const saveButton = await screen.findByRole('button', { name: 'Save' });
+  const saveButton = await screen.findByText('Save');
   expect(saveButton).not.toBeDisabled();
   await user.click(saveButton);
 };
 
 export const getSlider = async (formName: string) => {
   const container = await screen.findByTestId(formName);
-  const inputs = await within(container).findAllByRole('textbox');
-  return inputs;
+  const minutes = await within(container).findByLabelText('minutes');
+  const seconds = await within(container).findByLabelText('seconds');
+  return [minutes, seconds];
 };
 
 export const fillBasicCheckFields = async (jobName: string, target: string, user: UserEvent, labels: Label[]) => {
@@ -40,7 +41,7 @@ export const fillBasicCheckFields = async (jobName: string, target: string, user
   await toggleSection('Advanced options', user);
 
   for (const label of labels) {
-    const addLabel = await screen.findByRole('button', { name: 'Add label' });
+    const addLabel = await screen.findByText('Add label');
     await user.click(addLabel);
     const labelNameInput = await screen.findByPlaceholderText('name');
     await user.type(labelNameInput, label.name);
@@ -65,13 +66,13 @@ export const fillDnsValidationFields = async (user: UserEvent) => {
   const expressionInputs = await screen.findAllByPlaceholderText('Type expression');
   await user.type(expressionInputs[0], 'not inverted validation');
   await user.type(expressionInputs[1], 'inverted validation');
-  const invertedCheckboxes = await screen.findAllByRole('checkbox');
-  await user.click(invertedCheckboxes[2]);
+  const invertedCheckbox = await screen.findByLabelText('Invert match for regex 1');
+  await user.click(invertedCheckbox);
 };
 
 export const fillTCPQueryResponseFields = async (user: UserEvent) => {
   const container = await toggleSection('Query/Response', user);
-  const addQueryResp = await screen.findByRole('button', { name: 'Add query/response' });
+  const addQueryResp = await screen.findByText('Add query/response');
   await user.click(addQueryResp);
   const responseInput = await within(container).findByPlaceholderText('Response to expect');
   await user.type(responseInput, 'STARTTLS');

--- a/src/components/CheckForm/CheckEditor.test.tsx
+++ b/src/components/CheckForm/CheckEditor.test.tsx
@@ -28,7 +28,7 @@ describe(`<CheckForm />`, () => {
           path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${type}`,
         });
 
-        const testButton = await screen.findByRole('button', { name: 'Save' });
+        const testButton = await screen.findByText('Save');
         await waitFor(() => expect(testButton).toBeInTheDocument());
         await user.click(testButton);
         expect(screen.getByText(`Job name is required`)).toBeInTheDocument();
@@ -46,7 +46,7 @@ describe(`<CheckForm />`, () => {
           path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${type}`,
         });
 
-        const testButton = await screen.findByRole('button', { name: 'Test' });
+        const testButton = await screen.findByText('Test');
         await waitFor(() => expect(testButton).toBeInTheDocument());
         await user.click(testButton);
         expect(screen.getByText(`Job name is required`)).toBeInTheDocument();
@@ -62,7 +62,7 @@ describe(`<CheckForm />`, () => {
           path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${type}`,
         });
 
-        const testButton = screen.queryByRole('button', { name: 'Test' });
+        const testButton = screen.queryByText('Test');
         expect(testButton).not.toBeInTheDocument();
       });
     });

--- a/src/components/CheckForm/MultiHttpExisting.test.tsx
+++ b/src/components/CheckForm/MultiHttpExisting.test.tsx
@@ -97,7 +97,7 @@ describe('editing multihttp check', () => {
     await user.click(variablesTabs[0]);
     await user.click(variablesTabs[1]);
 
-    const submitButton = await screen.findByRole('button', { name: 'Save' });
+    const submitButton = await screen.findByText('Save');
     await user.click(submitButton);
 
     const { body } = await read();
@@ -176,7 +176,7 @@ describe('editing multihttp check', () => {
     await user.click(subjects[0]);
     await user.click(screen.getByText('Headers', { selector: `span` }));
 
-    const submitButton = await screen.findByRole('button', { name: 'Save' });
+    const submitButton = await screen.findByText('Save');
     await user.click(submitButton);
 
     const { body } = await read();

--- a/src/components/CheckForm/MultiHttpNew.test.tsx
+++ b/src/components/CheckForm/MultiHttpNew.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import { PUBLIC_PROBE } from 'test/fixtures/probes';
 import { apiRoute, getServerRequests } from 'test/handlers';
 import { render } from 'test/render';
@@ -63,10 +63,10 @@ describe('new checks', () => {
     await selectOption(user, { label: 'Probe locations', option: PUBLIC_PROBE.name });
 
     // Open requests section
-    await user.click(screen.getByRole('button', { name: /Requests/ }));
+    await user.click(screen.getByText(/Requests/));
 
     // Add a custom label
-    const addCustomLabelButton = await screen.findByRole('button', { name: /Add label/ });
+    const addCustomLabelButton = await screen.findByText(/Add label/);
     await user.click(addCustomLabelButton);
     const labelNameInput = await screen.findByTestId('label-name-0');
     await user.type(labelNameInput, LABELS[0].name);
@@ -86,7 +86,8 @@ describe('new checks', () => {
     await user.click(requestContainer);
     const assertionsTabs = await screen.findAllByLabelText('Tab Assertions');
     await user.click(assertionsTabs[0]);
-    const addAssertion = await screen.findByRole('button', { name: 'Add assertions' });
+    const request = screen.getByTestId('multihttp-request-0');
+    const addAssertion = await within(request).findByText('Add assertions');
     await user.click(addAssertion);
 
     await selectOption(user, { label: 'Assertion type', option: `JSON path value` });

--- a/src/components/CheckList/CheckList.test.tsx
+++ b/src/components/CheckList/CheckList.test.tsx
@@ -138,17 +138,18 @@ test('clicking label value adds to label filter', async () => {
   const constructedLabel = `${label.name}: ${label.value}`;
   const labelValue = await screen.findAllByText(constructedLabel);
   await user.click(labelValue[0]);
-  const additionalFilters = await screen.findByRole('button', { name: /Additional filters/i });
+  const additionalFilters = await screen.findByText(/Additional filters/i);
   await user.click(additionalFilters);
 
-  expect(within(screen.getByRole(`dialog`)).getByText(constructedLabel)).toBeInTheDocument();
+  const dialog = getModalContainer();
+  expect(within(dialog).getByText(constructedLabel)).toBeInTheDocument();
   const checks = await screen.findAllByTestId('check-card');
   expect(checks.length).toBe(1);
 });
 
 test('filters by check type', async () => {
   const { user } = await renderCheckList([BASIC_DNS_CHECK, BASIC_HTTP_CHECK]);
-  const additionalFilters = await screen.findByRole('button', { name: 'Additional filters' });
+  const additionalFilters = await screen.findByText(/Additional filters/i);
   await user.click(additionalFilters);
 
   await selectOption(user, { label: 'Filter by type', option: 'HTTP' });
@@ -163,7 +164,7 @@ test('filters by probe', async () => {
   };
 
   const { user } = await renderCheckList([DNS_CHECK_WITH_REMOVED_PROBE, BASIC_HTTP_CHECK]);
-  const additionalFilters = await screen.findByRole('button', { name: 'Additional filters' });
+  const additionalFilters = await screen.findByText(/Additional filters/i);
   await user.click(additionalFilters);
   const probeFilter = await screen.findByLabelText('Filter by probe');
   await user.click(probeFilter);
@@ -209,10 +210,11 @@ test('loads status filter from localStorage', async () => {
   };
 
   const { user } = await renderCheckList([DNS_CHECK_DISABLED, BASIC_HTTP_CHECK]);
-  const additionalFilters = await screen.findByRole('button', { name: /Additional filters \(1 active\)/i });
+  const additionalFilters = await screen.findByText(/Additional filters/i);
   await user.click(additionalFilters);
 
-  const statusFilter = await within(screen.getByRole('dialog')).findByText(filters.status.label);
+  const dialog = getModalContainer();
+  const statusFilter = await within(dialog).findByText(filters.status.label);
   expect(statusFilter).toBeInTheDocument();
   const checks = await screen.findAllByTestId('check-card');
   expect(checks.length).toBe(1);
@@ -229,10 +231,11 @@ test('loads type filter from localStorage', async () => {
 
   localStorage.setItem('checkFilters', JSON.stringify(filters));
   const { user } = await renderCheckList([BASIC_DNS_CHECK, BASIC_HTTP_CHECK]);
-  const additionalFilters = await screen.findByRole('button', { name: /Additional filters \(1 active\)/i });
+  const additionalFilters = await screen.findByText(/Additional filters \(1 active\)/i);
   await user.click(additionalFilters);
 
-  const typeFilter = await within(screen.getByRole('dialog')).findByText(filters.type, { exact: false });
+  const dialog = getModalContainer();
+  const typeFilter = await within(dialog).findByText(filters.type, { exact: false });
   expect(typeFilter).toBeInTheDocument();
 
   const checks = await screen.findAllByTestId('check-card');
@@ -253,10 +256,11 @@ test('loads labels from localStorage', async () => {
 
   localStorage.setItem('checkFilters', JSON.stringify(filters));
   const { user } = await renderCheckList([BASIC_DNS_CHECK, BASIC_HTTP_CHECK]);
-  const additionalFilters = await screen.findByRole('button', { name: /Additional filters \(1 active\)/i });
+  const additionalFilters = await screen.findByText(/Additional filters \(1 active\)/i);
   await user.click(additionalFilters);
 
-  const typeFilter = await within(screen.getByRole('dialog')).findByText(constructedLabel, { exact: false });
+  const dialog = getModalContainer();
+  const typeFilter = await within(dialog).findByText(constructedLabel, { exact: false });
   expect(typeFilter).toBeInTheDocument();
 
   const checks = await screen.findAllByTestId('check-card');
@@ -267,11 +271,12 @@ test('clicking type chiclet adds it to filter', async () => {
   const { user } = await renderCheckList([BASIC_DNS_CHECK, BASIC_HTTP_CHECK]);
   const httpTypeChiclet = await screen.findAllByText('HTTP');
   await user.click(httpTypeChiclet[0]);
-  const additionalFilters = await screen.findByRole('button', { name: /Additional filters/i });
+  const additionalFilters = await screen.findByText(/Additional filters/i);
   await user.click(additionalFilters);
   const checks = await screen.findAllByTestId('check-card');
 
-  const typeFilter = await within(screen.getByRole('dialog')).findByText(`HTTP`);
+  const dialog = getModalContainer();
+  const typeFilter = await within(dialog).findByText(`HTTP`);
   expect(typeFilter).toBeInTheDocument();
 
   expect(checks.length).toBe(1);
@@ -286,10 +291,11 @@ test('clicking status chiclet adds it to filter', async () => {
   const { user } = await renderCheckList([DNS_CHECK_DISABLED, BASIC_HTTP_CHECK]);
   const disabledChiclet = await screen.findAllByText('Disabled');
   await user.click(disabledChiclet[0]);
-  const additionalFilters = await screen.findByRole('button', { name: /Additional filters/i });
+  const additionalFilters = await screen.findByText(/Additional filters/i);
   await user.click(additionalFilters);
 
-  const statusFilter = await within(screen.getByRole('dialog')).findByText(`Disabled`);
+  const dialog = getModalContainer();
+  const statusFilter = await within(dialog).findByText(`Disabled`);
   expect(statusFilter).toBeInTheDocument();
 
   const checks = await screen.findAllByTestId('check-card');
@@ -300,26 +306,27 @@ test('clicking add new is handled', async () => {
   const navigate = jest.fn();
   useNavigationHook.useNavigation = jest.fn(() => navigate); // TODO: COME BACK TO
   const { user } = await renderCheckList();
-  const addNewButton = await screen.findByRole('button', { name: 'Add new check' });
+  const addNewButton = await screen.findByText('Add new check');
   await user.click(addNewButton);
   expect(navigate).toHaveBeenCalledWith(ROUTES.ChooseCheckType);
 });
 
 test('cascader adds labels to label filter', async () => {
   const { user } = await renderCheckList([BASIC_DNS_CHECK, BASIC_HTTP_CHECK]);
-  const additionalFilters = await screen.findByRole('button', { name: 'Additional filters' });
+  const additionalFilters = await screen.findByText(/Additional filters/i);
   await user.click(additionalFilters);
-  const cascader = await screen.findByRole('button', { name: 'Labels' });
+  const cascader = await screen.findByText('Labels');
   await user.click(cascader);
-  const labelMenuItems = await screen.findAllByRole('menuitemcheckbox');
+  const labelMenuItems = await screen.findAllByLabelText('Select check');
   expect(labelMenuItems.length).toBe(2);
-  const labelName = await screen.findByRole('menuitemcheckbox', { name: BASIC_DNS_CHECK.labels[0].name });
+  const labelName = await screen.findByText(BASIC_DNS_CHECK.labels[0].name);
   await user.click(labelName);
-  const labelValue = await screen.findByRole('menuitemcheckbox', { name: BASIC_DNS_CHECK.labels[0].value });
+  const labelValue = await screen.findByText(BASIC_DNS_CHECK.labels[0].value);
   await user.click(labelValue);
 
   const constructedLabel = `${BASIC_DNS_CHECK.labels[0].name}: ${BASIC_DNS_CHECK.labels[0].value}`;
-  const labelFilterInput = await within(screen.getByRole('dialog')).findByText(constructedLabel);
+  const dialog = getModalContainer();
+  const labelFilterInput = await within(dialog).findByText(constructedLabel);
 
   expect(labelFilterInput).toBeInTheDocument();
 });
@@ -345,7 +352,7 @@ describe(`bulk select behaviour`, () => {
     await user.click(selectAll);
     const selectedText = await screen.findByText(`${checkList.length} checks are selected.`);
     expect(selectedText).toBeInTheDocument();
-    const disableButton = await screen.findByRole('button', { name: 'Disable' });
+    const disableButton = await screen.findByText('Disable');
 
     await user.click(disableButton);
 
@@ -372,7 +379,7 @@ describe(`bulk select behaviour`, () => {
     await user.click(selectAll);
     const selectedText = await screen.findByText(`${checkList.length} checks are selected.`);
     expect(selectedText).toBeInTheDocument();
-    const enableButton = await screen.findByRole('button', { name: 'Enable' });
+    const enableButton = await screen.findByText('Enable');
     await user.click(enableButton);
 
     const { body } = await read();
@@ -385,7 +392,7 @@ describe(`bulk select behaviour`, () => {
     const selectAll = await screen.findByLabelText('Select all');
     await user.click(selectAll);
 
-    const checkedCheckBoxes = await screen.findAllByRole('checkbox', { name: 'Select check' });
+    const checkedCheckBoxes = await screen.findAllByLabelText('Select check');
     checkedCheckBoxes.forEach((checkbox) => {
       expect(checkbox).toBeChecked();
     });
@@ -395,7 +402,7 @@ describe(`bulk select behaviour`, () => {
 
     const deselectAll = await screen.findByLabelText('Select all');
     await user.click(deselectAll);
-    const unCheckedCheckBoxes = await screen.queryAllByRole('checkbox', { name: 'Select check' });
+    const unCheckedCheckBoxes = await screen.findAllByLabelText('Select check');
 
     unCheckedCheckBoxes.forEach((checkbox) => {
       expect(checkbox).not.toBeChecked();
@@ -407,7 +414,7 @@ describe(`bulk select behaviour`, () => {
     const selectAll = await screen.findByLabelText('Select all');
     await user.click(selectAll);
 
-    const checkedCheckBoxes = await screen.findAllByRole('checkbox', { name: 'Select check' });
+    const checkedCheckBoxes = await screen.findAllByLabelText('Select check');
     await user.click(checkedCheckBoxes[0]);
 
     const indeterminateState = await screen.findByLabelText('Select all');
@@ -420,3 +427,7 @@ describe(`bulk select behaviour`, () => {
     });
   });
 });
+
+function getModalContainer() {
+  return document.body.querySelector(`[role="dialog"]`) as HTMLElement;
+}

--- a/src/components/ConfigActions.test.tsx
+++ b/src/components/ConfigActions.test.tsx
@@ -8,7 +8,7 @@ import { ConfigActions } from 'components/ConfigActions';
 it('shows disable option when activated', async () => {
   render(<ConfigActions enabled={true} pluginId="steve" />);
 
-  const disableButton = await screen.findByRole('button', { name: 'Disable synthetic monitoring' });
+  const disableButton = await screen.findByText('Disable synthetic monitoring');
   expect(disableButton).toBeInTheDocument();
 });
 
@@ -22,7 +22,7 @@ it('shows enable action when disabled', async () => {
 
   render(<ConfigActions enabled={false} pluginId="steve" />);
 
-  const enableButton = await screen.findByRole('button', { name: 'Enable plugin' });
+  const enableButton = await screen.findByText('Enable plugin');
   expect(enableButton).toBeInTheDocument();
 });
 
@@ -35,6 +35,6 @@ it('shows setup action when not intialized', async () => {
   });
 
   render(<ConfigActions enabled={true} pluginId="steve" />);
-  const setupButton = await screen.findByRole('button', { name: 'Setup' });
+  const setupButton = await screen.findByText('Setup');
   expect(setupButton).toBeInTheDocument();
 });

--- a/src/components/MultiHttp/MultiHttpCollapse.tsx
+++ b/src/components/MultiHttp/MultiHttpCollapse.tsx
@@ -4,6 +4,7 @@ import { Icon, useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
 
 interface Props {
+  'data-testid'?: string;
   label: string;
   invalid?: boolean;
   className?: string | string[];
@@ -12,7 +13,7 @@ interface Props {
 }
 
 export const MultiHttpCollapse = forwardRef<HTMLButtonElement, PropsWithChildren<Props>>(function MultiHttpCollapse(
-  { label, children, invalid, className, isOpen, onToggle },
+  { 'data-testid': dataTestId, label, children, invalid, className, isOpen, onToggle },
   ref
 ) {
   const styles = useStyles2(getStyles);
@@ -32,7 +33,9 @@ export const MultiHttpCollapse = forwardRef<HTMLButtonElement, PropsWithChildren
         <div className={styles.label}>{label}</div>
         {!isOpen && invalid && <Icon name="exclamation-triangle" className={styles.errorIcon} />}
       </button>
-      <div className={cx(styles.body, { [styles.hidden]: !isOpen })}>{children}</div>
+      <div className={cx(styles.body, { [styles.hidden]: !isOpen })} data-testid={dataTestId}>
+        {children}
+      </div>
     </div>
   );
 });

--- a/src/components/ProbeEditor/ProbeEditor.test.tsx
+++ b/src/components/ProbeEditor/ProbeEditor.test.tsx
@@ -57,7 +57,7 @@ describe('validation', () => {
 
 it('returns on back button', async () => {
   const { history, user } = await renderProbeEditor();
-  const backButton = await screen.findByRole('link', { name: 'Back' });
+  const backButton = await screen.findByText('Back');
   await user.click(backButton);
   await waitFor(() => {}, { timeout: 1000 });
   expect(history.location.pathname).toBe(getRoute(ROUTES.Probes));
@@ -127,7 +127,7 @@ async function assertUneditable() {
 }
 
 async function assertNoActions() {
-  const addLabelButton = await screen.findByRole('button', { name: /Add label/ });
+  const addLabelButton = await screen.findByText(/Add label/);
   expect(addLabelButton).not.toBeInTheDocument();
 
   const saveButton = await getSaveButton();
@@ -136,5 +136,5 @@ async function assertNoActions() {
 
 // extract this so we can be sure our assertions for them not being there are correct
 function getSaveButton() {
-  return screen.queryByRole('button', { name: submitText });
+  return screen.queryByText(submitText)?.parentNode as HTMLButtonElement | null;
 }

--- a/src/components/QueryParamInput.tsx
+++ b/src/components/QueryParamInput.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent } from 'react';
-import { IconButton,Input } from '@grafana/ui';
+import { IconButton, Input } from '@grafana/ui';
 
 export interface QueryParam {
   name: string;
@@ -7,6 +7,7 @@ export interface QueryParam {
 }
 
 interface Props {
+  index: number;
   queryParam: {
     name: string;
     value: string;
@@ -16,9 +17,10 @@ interface Props {
   onBlur?: () => void;
 }
 
-const QueryParamInput = ({ queryParam, onChange, onDelete, onBlur }: Props) => (
+const QueryParamInput = ({ index, queryParam, onChange, onDelete, onBlur }: Props) => (
   <>
     <Input
+      aria-label={`Query param key ${index + 1}`}
       label="Key"
       onBlur={onBlur}
       type="text"
@@ -32,6 +34,7 @@ const QueryParamInput = ({ queryParam, onChange, onDelete, onBlur }: Props) => (
       }
     />
     <Input
+      aria-label={`Query param value ${index + 1}`}
       label="Value"
       onBlur={onBlur}
       type="text"
@@ -44,7 +47,13 @@ const QueryParamInput = ({ queryParam, onChange, onDelete, onBlur }: Props) => (
         })
       }
     />
-    <IconButton name="minus-circle" onClick={onDelete} type="button" tooltip="Delete" />
+    <IconButton
+      aria-label={`Delete param ${index + 1}`}
+      name="minus-circle"
+      onClick={onDelete}
+      type="button"
+      tooltip="Delete"
+    />
   </>
 );
 

--- a/src/components/QueryParams.test.tsx
+++ b/src/components/QueryParams.test.tsx
@@ -22,7 +22,7 @@ test('Shows empty inputs if no query params', async () => {
 test('Should handle initial value', async () => {
   const target = new URL('http://example.com?test=1&another=tacos');
   render(<QueryParams target={target} onChange={onChange} />);
-  const inputs = (await screen.findAllByRole('textbox')) as HTMLInputElement[];
+  const inputs = (await screen.findAllByLabelText(/Query param/)) as HTMLInputElement[];
   expect(inputs.length).toBe(4);
   const expectedValues = ['test', '1', 'another', 'tacos'];
   inputs.forEach((input) => {
@@ -46,7 +46,7 @@ test('Returns a query string onChange', async () => {
 test('Delete button deletes a query param', async () => {
   const target = new URL('https://example.com?robert=bob&stephen=steve&jim=james');
   const { user } = render(<QueryParams target={target} onChange={onChange} />);
-  const buttons = await screen.findAllByRole('button');
+  const buttons = await screen.findAllByLabelText('Delete');
   await user.click(buttons[1]);
   await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
   expect(onChange).toHaveBeenCalledWith('https://example.com/?robert=bob&jim=james');

--- a/src/components/QueryParams.tsx
+++ b/src/components/QueryParams.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useReducer, useState } from 'react';
-import { Button,Field, Label } from '@grafana/ui';
+import { Button, Field, Label } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import QueryParamInput, { QueryParam } from './QueryParamInput';
@@ -102,6 +102,7 @@ const QueryParams = ({ target, onChange, className, onBlur }: Props) => {
           <div />
           {formattedParams.map((queryParam, index) => (
             <QueryParamInput
+              index={index}
               queryParam={queryParam}
               onBlur={onBlur}
               key={index}

--- a/src/components/ScriptedCheckCodeEditor.test.tsx
+++ b/src/components/ScriptedCheckCodeEditor.test.tsx
@@ -27,6 +27,8 @@ jest.mock('components/CodeEditor', () => {
   };
 });
 
+const { findByLabelText, findByPlaceholderText, findByTestId, findByText, getByText } = screen;
+
 describe('new scripted check', () => {
   it('renders the new scripted check form', async () => {
     const { findByText } = render(<CheckForm />, {
@@ -39,13 +41,10 @@ describe('new scripted check', () => {
   it('creates a new k6 check', async () => {
     const { record, read } = getServerRequests();
     server.use(apiRoute(`addCheck`, {}, record));
-    const { user, findByLabelText, getByText, findByTestId, findByRole, findByPlaceholderText } = render(
-      <CheckForm />,
-      {
-        route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
-        path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.Scripted}`,
-      }
-    );
+    const { user } = render(<CheckForm />, {
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.Scripted}`,
+    });
 
     const JOB_NAME = 'New k6 check';
     const TARGET = 'https://www.k6.com';
@@ -67,7 +66,7 @@ describe('new scripted check', () => {
     await user.click(probeSelectMenu);
     await user.click(screen.getByText(PRIVATE_PROBE.name));
 
-    const addLabel = await findByRole('button', { name: 'Add label' });
+    const addLabel = await findByText('Add label');
     await user.click(addLabel);
     const labelNameInput = await findByPlaceholderText('name');
     await user.type(labelNameInput, LABEL.name);

--- a/src/components/SliderInput.tsx
+++ b/src/components/SliderInput.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, FieldPath, useFormContext } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+
+import { CheckFormValues } from 'types';
 
 import { TimeSlider } from './TimeSlider/TimeSlider';
 
 export interface SliderInputProps {
   min: number;
   max: number;
-  name: string;
+  name: FieldPath<CheckFormValues>;
   id?: string;
   validate?: (value: number) => string | undefined;
   step?: number;

--- a/src/components/TerraformConfig/TerraformConfig.test.tsx
+++ b/src/components/TerraformConfig/TerraformConfig.test.tsx
@@ -24,9 +24,9 @@ const renderTerraformConfig = async () => {
 
 const openConfig = async () => {
   const { user } = await renderTerraformConfig();
-  const launchButton = await screen.findByRole('button', { name: 'Generate config' });
+  const launchButton = await screen.findByText('Generate config');
   await user.click(launchButton);
-  const modalHeader = await screen.findByRole('heading', { name: 'Terraform config' });
+  const modalHeader = await screen.findByText('Terraform config');
   expect(modalHeader).toBeInTheDocument();
 };
 

--- a/src/components/TimeSlider/TimeSlider.tsx
+++ b/src/components/TimeSlider/TimeSlider.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FocusEvent, useCallback, useState } from 'react';
+import React, { ChangeEvent, FocusEvent, useCallback, useId, useState } from 'react';
 import { Input, useStyles2 } from '@grafana/ui';
 import { cx } from '@emotion/css';
 import SliderComponent from 'rc-slider';
@@ -30,6 +30,8 @@ export function TimeSlider({
   ariaLabelForHandle,
   included,
 }: SliderProps) {
+  const minutesId = useId();
+  const secondsId = useId();
   const initialSeconds = (value ?? min) % 60;
   const initialMinutes = Math.floor((value ?? min) / 60);
   const styles = useStyles2(getStyles);
@@ -136,8 +138,9 @@ export function TimeSlider({
           value={minutes}
           onChange={onMinutesInputChange}
           onBlur={onMinutesInputBlur}
+          id={minutesId}
         />
-        <span>minutes</span>
+        <label htmlFor={minutesId}>minutes</label>
 
         <Input
           type="text"
@@ -145,9 +148,9 @@ export function TimeSlider({
           value={seconds}
           onChange={onSecondsInputChange}
           onBlur={onSecondsInputBlur}
+          id={secondsId}
         />
-
-        <span>seconds</span>
+        <label htmlFor={secondsId}>seconds</label>
       </div>
     </div>
   );

--- a/src/page/AlertingPage.test.tsx
+++ b/src/page/AlertingPage.test.tsx
@@ -47,14 +47,14 @@ const toggleSection = async (sectionName: string, user: UserEvent): Promise<HTML
 
 it('adds default alerts and edits alerts', async () => {
   const { user } = renderAlerting();
-  const defaultAlertButton = await screen.findByRole('button', { name: 'Populate default alerts' });
+  const defaultAlertButton = await screen.findByText('Populate default alerts');
   await user.click(defaultAlertButton);
   await waitFor(() => expect(defaultAlertButton).not.toBeDisabled());
   expect(setDefaultRules).toHaveBeenCalledTimes(1);
 
-  const button = await screen.findByRole('button', {
-    name: DEFAULT_ALERT_NAMES_BY_FAMILY_AND_SENSITIVITY[AlertFamily.ProbeSuccess][AlertSensitivity.High],
-  });
+  const button = await screen.findByText(
+    DEFAULT_ALERT_NAMES_BY_FAMILY_AND_SENSITIVITY[AlertFamily.ProbeSuccess][AlertSensitivity.High]
+  );
   await user.click(button);
 
   const alertNameInput = await screen.findByLabelText('Alert name');
@@ -77,7 +77,7 @@ it('adds default alerts and edits alerts', async () => {
   await selectOption(user, { label: 'Time unit', option: 'seconds' });
 
   const labels = await toggleSection('Labels', user);
-  const addLabelButton = await within(labels).findByRole('button', { name: 'Add label' });
+  const addLabelButton = await within(labels).findByText('Add label');
   await user.click(addLabelButton);
   const labelNameInputs = await within(labels).findAllByPlaceholderText('Name');
   await user.type(labelNameInputs[labelNameInputs.length - 1], 'a_label_name');
@@ -85,7 +85,7 @@ it('adds default alerts and edits alerts', async () => {
   await user.type(labelValueInputs[labelValueInputs.length - 1], 'a_label_value');
 
   const annotations = await toggleSection('Annotations', user);
-  const addAnnotationsButton = await within(annotations).findByRole('button', { name: 'Add annotation' });
+  const addAnnotationsButton = await within(annotations).findByText('Add annotation');
   await user.click(addAnnotationsButton);
   const annotationNameInputs = await within(annotations).findAllByPlaceholderText('Name');
   await user.type(annotationNameInputs[annotationNameInputs.length - 1], 'an_annotation_name');
@@ -93,7 +93,7 @@ it('adds default alerts and edits alerts', async () => {
   annotationValueInputs[annotationValueInputs.length - 1].focus();
   await user.paste('an annotation value');
 
-  const submitButton = await screen.findByRole('button', { name: 'Save alert' });
+  const submitButton = await screen.findByText('Save alert');
   await user.click(submitButton);
   await waitFor(() => {
     expect(setRules).toHaveBeenCalledTimes(1);

--- a/src/page/ChecksPage.test.tsx
+++ b/src/page/ChecksPage.test.tsx
@@ -20,7 +20,7 @@ const renderChecksPage = async () => {
     route: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
   });
 
-  await waitFor(() => expect(screen.getByRole('button', { name: 'Add new check' })).toBeInTheDocument());
+  await waitFor(() => expect(screen.getByText('Add new check')).toBeInTheDocument());
   return res;
 };
 
@@ -31,12 +31,12 @@ test('renders checks', async () => {
 
 test('renders check selection page with multi-http feature flag is ON', async () => {
   const { user } = await renderChecksPage();
-  await user.click(screen.getByRole('button', { name: 'Add new check' }));
-  expect(await screen.findByRole('link', { name: 'HTTP' })).toBeInTheDocument();
-  expect(await screen.findByRole('link', { name: /MULTIHTTP/ })).toBeInTheDocument();
-  expect(await screen.findByRole('link', { name: 'Traceroute' })).toBeInTheDocument();
-  expect(await screen.findByRole('link', { name: 'PING' })).toBeInTheDocument();
-  expect(await screen.findByRole('link', { name: 'DNS' })).toBeInTheDocument();
+  await user.click(screen.getByText('Add new check'));
+  expect(screen.queryByText('HTTP', { selector: `h2` })).toBeInTheDocument();
+  expect(screen.queryByText('MULTIHTTP', { selector: `h2` })).toBeInTheDocument();
+  expect(screen.queryByText('Traceroute', { selector: `h2` })).toBeInTheDocument();
+  expect(screen.queryByText('PING', { selector: `h2` })).toBeInTheDocument();
+  expect(screen.queryByText('DNS', { selector: `h2` })).toBeInTheDocument();
 });
 
 test('renders check selection page without multi-http feature flag is OFF', async () => {
@@ -49,13 +49,12 @@ test('renders check selection page without multi-http feature flag is OFF', asyn
   });
 
   const { user } = await renderChecksPage();
-  await waitFor(() => screen.getByRole('button', { name: 'Add new check' }));
-  await user.click(screen.getByRole('button', { name: 'Add new check' }));
-  expect(await screen.queryByRole('link', { name: 'HTTP' })).toBeInTheDocument();
-  expect(await screen.queryByRole('link', { name: 'Traceroute' })).toBeInTheDocument();
-  expect(await screen.queryByRole('link', { name: 'PING' })).toBeInTheDocument();
-  expect(await screen.queryByRole('link', { name: 'DNS' })).toBeInTheDocument();
-  expect(await screen.queryByRole('link', { name: /MULTIHTTP/ })).not.toBeInTheDocument();
+  await user.click(screen.getByText('Add new check'));
+  expect(screen.queryByText('HTTP', { selector: `h2` })).toBeInTheDocument();
+  expect(screen.queryByText('MULTIHTTP', { selector: `h2` })).not.toBeInTheDocument();
+  expect(screen.queryByText('Traceroute', { selector: `h2` })).toBeInTheDocument();
+  expect(screen.queryByText('PING', { selector: `h2` })).toBeInTheDocument();
+  expect(screen.queryByText('DNS', { selector: `h2` })).toBeInTheDocument();
 });
 
 test('renders check editor existing check', async () => {

--- a/src/page/EditProbe/EditProbe.test.tsx
+++ b/src/page/EditProbe/EditProbe.test.tsx
@@ -68,7 +68,7 @@ describe(`Private probes`, () => {
     const resetButton = getResetTokenButton();
     await user.click(resetButton!);
 
-    const confirmButton = await screen.findByRole('button', { name: 'Reset Token' });
+    const confirmButton = await screen.findByText('Reset Token');
     await user.click(confirmButton);
 
     const tokenValue = await screen.findByText(UPDATED_PROBE_TOKEN_RESPONSE);
@@ -79,11 +79,11 @@ describe(`Private probes`, () => {
 // extract these so we can be sure the assertion for them NOT existing is accurate
 // as they work when we are confirming their existence
 function getSaveButton() {
-  return screen.queryByRole('button', { name: 'Update probe' });
+  return screen.queryByText('Update probe');
 }
 
 function getResetTokenButton() {
-  return screen.queryByRole('button', { name: 'Reset Access Token' });
+  return screen.queryByText('Reset Access Token');
 }
 
 function checkInformation(probe: Probe) {

--- a/src/page/NewProbe/NewProbe.test.tsx
+++ b/src/page/NewProbe/NewProbe.test.tsx
@@ -22,10 +22,10 @@ it(`creates a new probe, displays the modal and redirects on close`, async () =>
   const { history, user } = renderNewProbe();
   await fillProbeForm(user);
 
-  const saveButton = await screen.findByRole('button', { name: 'Add new probe' });
+  const saveButton = await screen.findByText('Add new probe');
   await user.click(saveButton);
   await waitFor(() => expect(screen.queryByText(ADD_PROBE_TOKEN_RESPONSE)).toBeInTheDocument());
-  const dismiss = screen.getByRole('button', { name: 'Go back to probes list' });
+  const dismiss = screen.getByText('Go back to probes list');
   await user.click(dismiss);
   await waitFor(() => expect(history.location.pathname).toBe(getRoute(ROUTES.Probes)));
 });

--- a/src/page/Probes/Probes.test.tsx
+++ b/src/page/Probes/Probes.test.tsx
@@ -41,7 +41,7 @@ it(`renders public probes in the correct list`, async () => {
 
 it('handles add new', async () => {
   const { history, user } = renderProbeList();
-  const addNewButton = await screen.findByRole('link', { name: 'Add Private Probe' });
+  const addNewButton = await screen.findByText('Add Private Probe');
   await user.click(addNewButton);
 
   expect(history.location.pathname).toBe(getRoute(ROUTES.NewProbe));

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -32,7 +32,7 @@ export async function fillProbeForm(user: UserEvent) {
   await user.paste(UPDATED_VALUES.region);
   await user.type(regionInput, '{enter}');
 
-  const addLabelButton = await screen.findByRole('button', { name: /Add label/ });
+  const addLabelButton = await screen.findByText(/Add label/);
   const existingLabels = await screen.queryAllByTestId(/label-name-/);
 
   for (let i = 0; i < UPDATED_VALUES.labels.length; i++) {


### PR DESCRIPTION
## Problem

As [per this issue in testing-library](https://github.com/testing-library/dom-testing-library/issues/552), `*byRole` selectors can have a significant performance impact. We have seen some flaky tests locally and it is unclear if this is contributing to them, so this is a precautionary step to try and reduce variables and debug the root cause.

## Solution

Remove all `*ByRole` selectors and put in equivalents. To help convert the selectors I also added some accessibility help to certain inputs, as well as reduce a bit of test noise by correcting the `append` method for adding requests to the multihttp check form.

To be honest, this doesn't speed up the tests as much as I was hoping but I think it is worth doing anyway to see if it helps resolve some of the flakiness. It takes about 10% or so off after a few goes of me trying to bench mark its impact:

**Before**
![Screenshot of a terminal with test results. 221 tests took 33.491 seconds.](https://github.com/grafana/synthetic-monitoring-app/assets/6906380/fdd4ebb1-48c1-4a75-a8a7-cf179f4378fc)

**After**
![Screenshot of a terminal with test results. 221 tests took 29.096 seconds.](https://github.com/grafana/synthetic-monitoring-app/assets/6906380/ebc9bc97-da6d-4589-ae0a-2b7f57adcde4)
