### PR TITLE
fix: new region select disabled and fixed async probe form tests

### DIFF
--- a/src/components/ProbeEditor/ProbeEditor.test.tsx
+++ b/src/components/ProbeEditor/ProbeEditor.test.tsx
@@ -21,7 +21,7 @@ const renderProbeEditor = async ({ probe = TEMPLATE_PROBE } = {}) => {
   };
 
   const res = render(<ProbeEditor {...props} />);
-  await screen.findByText(/This probe is private./);
+  await screen.findByText(/Probe Name */);
   return res;
 };
 
@@ -91,25 +91,25 @@ it('saves new probe', async () => {
 });
 
 it('the form is uneditable when viewing a public probe', async () => {
-  renderProbeEditor({ probe: PUBLIC_PROBE });
-  assertUneditable();
+  await renderProbeEditor({ probe: PUBLIC_PROBE });
+  await assertUneditable();
 });
 
 it('the form is uneditable when logged in as a viewer', async () => {
   runTestAsViewer();
-  renderProbeEditor();
-  assertUneditable();
+  await renderProbeEditor();
+  await assertUneditable();
 });
 
 it('the form actions are unavailable when viewing a public probe', async () => {
-  renderProbeEditor({ probe: PUBLIC_PROBE });
-  assertNoActions();
+  await renderProbeEditor({ probe: PUBLIC_PROBE });
+  await assertNoActions();
 });
 
 it('the form actions are unavailable as a viewer', async () => {
   runTestAsViewer();
-  renderProbeEditor();
-  assertNoActions();
+  await renderProbeEditor();
+  await assertNoActions();
 });
 
 async function assertUneditable() {
@@ -127,11 +127,11 @@ async function assertUneditable() {
 }
 
 async function assertNoActions() {
-  const addLabelButton = await screen.findByText(/Add label/);
+  const addLabelButton = await screen.queryByText(/Add label/);
   expect(addLabelButton).not.toBeInTheDocument();
 
   const saveButton = await getSaveButton();
-  expect(saveButton).not.toBeInTheDocument();
+  expect(saveButton).toBeUndefined();
 }
 
 // extract this so we can be sure our assertions for them not being there are correct

--- a/src/components/ProbeEditor/ProbeEditor.tsx
+++ b/src/components/ProbeEditor/ProbeEditor.tsx
@@ -149,6 +149,7 @@ export const ProbeEditor = ({
                       rules={{ required: 'Region is required' }}
                       render={({ field }) => (
                         <ProbeRegionsSelect
+                          disabled={!canEdit}
                           id="region"
                           invalid={Boolean(errors.region)}
                           onChange={(value) => {

--- a/src/components/ProbeRegionsSelect/ProbeRegionsSelect.tsx
+++ b/src/components/ProbeRegionsSelect/ProbeRegionsSelect.tsx
@@ -6,13 +6,14 @@ import { Probe } from 'types';
 import { useProbes } from 'data/useProbes';
 
 type ProbeRegionsSelectProps = {
+  disabled?: boolean;
   id: string;
   onChange: (value: string | undefined | null) => void;
   invalid?: boolean;
   value?: string | null;
 };
 
-export const ProbeRegionsSelect = ({ id, invalid, onChange, value }: ProbeRegionsSelectProps) => {
+export const ProbeRegionsSelect = ({ disabled, id, invalid, onChange, value }: ProbeRegionsSelectProps) => {
   const { data, isLoading } = useProbes();
   const regions = getRegions(data, value);
   const options = regions.map((region) => ({ label: region, value: region }));
@@ -33,7 +34,7 @@ export const ProbeRegionsSelect = ({ id, invalid, onChange, value }: ProbeRegion
         onChange(value);
       }}
       isLoading={isLoading}
-      disabled={isLoading}
+      disabled={isLoading || disabled}
       placeholder="Add or select a region"
       isClearable
       invalid={invalid}


### PR DESCRIPTION
Small regression with the probe region not being disabled after the [probe region select PR](https://github.com/grafana/synthetic-monitoring-app/pull/710) went in. 

Also noticed that the tests weren't running because we weren't awaiting them to run so that's why the test didn't pick up on it. 🤦 