### PR TITLE
fix: fix tcp ip version and add associated test

### DIFF
--- a/src/components/CheckEditor/FormComponents/CheckIpVersion.tsx
+++ b/src/components/CheckEditor/FormComponents/CheckIpVersion.tsx
@@ -21,17 +21,19 @@ const requestMap = {
 
 export const CheckIpVersion = ({ checkType, name }: CheckIpVersionProps) => {
   const isEditor = hasRole(OrgRole.Editor);
+  const id = `${checkType}-ip-version`;
 
   return (
     <Field
       label="IP version"
       description={`The IP protocol of the ${requestMap[checkType]} request`}
       disabled={!isEditor}
+      htmlFor={id}
     >
       <Controller
         render={({ field }) => {
           const { ref, ...rest } = field;
-          return <Select {...rest} options={IP_OPTIONS} />;
+          return <Select {...rest} options={IP_OPTIONS} inputId={id} />;
         }}
         name={name}
       />

--- a/src/components/CheckEditor/TCPCheck.test.tsx
+++ b/src/components/CheckEditor/TCPCheck.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { PRIVATE_PROBE } from 'test/fixtures/probes';
+import { apiRoute, getServerRequests } from 'test/handlers';
+import { render } from 'test/render';
+import { server } from 'test/server';
+
+import { AlertSensitivity, CheckType, IpVersion, Label, ROUTES } from 'types';
+import { CheckForm } from 'components/CheckForm/CheckForm';
+import { PLUGIN_URL_PATH } from 'components/constants';
+
+import { fillBasicCheckFields, selectOption, submitForm } from './testHelpers';
+
+const JOB_NAME = `TCP job`;
+const TARGET = `tcpcheck.com:80`;
+const LABELS: Label[] = [];
+
+describe(`Edits the sections of a TCP check correctly`, () => {
+  it(`edits the IP version of a TCP check`, async () => {
+    const IP_VERSION = IpVersion.V6;
+
+    const { record, read } = getServerRequests();
+    server.use(apiRoute(`addCheck`, {}, record));
+
+    const { user } = render(<CheckForm />, {
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.TCP}`,
+    });
+
+    await fillBasicCheckFields(JOB_NAME, TARGET, user, LABELS);
+    await user.click(await screen.getByText('Advanced options'));
+    await selectOption(user, { label: 'IP version', option: IP_VERSION });
+    await submitForm(user);
+
+    const { body } = await read();
+
+    expect(body).toEqual({
+      alertSensitivity: AlertSensitivity.None,
+      basicMetricsOnly: true,
+      enabled: true,
+      frequency: 60000,
+      job: JOB_NAME,
+      labels: LABELS,
+      probes: [PRIVATE_PROBE.id],
+      settings: {
+        tcp: {
+          ipVersion: IP_VERSION,
+          queryResponse: [],
+          tls: false,
+          tlsConfig: { caCert: '', clientCert: '', clientKey: '', insecureSkipVerify: false, serverName: '' },
+        },
+      },
+      target: TARGET,
+      timeout: 3000,
+    });
+  });
+});

--- a/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
@@ -38,9 +38,9 @@ export const CheckTCPLayout = () => {
       <FormLayout.Section label="TLS config" fields={[`settings.tcp.tlsConfig`]}>
         <TLSConfig checkType={CheckType.TCP} />
       </FormLayout.Section>
-      <FormLayout.Section label="Advanced options" fields={[`labels`, `settings.dns.ipVersion`]}>
+      <FormLayout.Section label="Advanced options" fields={[`labels`, `settings.tcp.ipVersion`]}>
         <LabelField<CheckFormValuesPing> />
-        <CheckIpVersion checkType={CheckType.DNS} name="settings.dns.ipVersion" />
+        <CheckIpVersion checkType={CheckType.TCP} name="settings.tcp.ipVersion" />
       </FormLayout.Section>
       <FormLayout.Section label="Alerting" fields={[`alertSensitivity`]}>
         <CheckFormAlert />


### PR DESCRIPTION
Noticed a copy and paste mistake when working on the alerting story this morning.

Added a regression test to pick up on it, with the goal that we can slowly add tests to every input in every check type as time goes on. At the moment our tests are pretty large and test multiple things at once but we should think about doing smaller more targeted integration testing like the one I've added for increased confidence.