### PR TITLE
chore: enforce tenant limits on the frontend

### DIFF
--- a/src/components/CheckEditor/CheckEditorNew.test.tsx
+++ b/src/components/CheckEditor/CheckEditorNew.test.tsx
@@ -257,4 +257,50 @@ describe('new checks', () => {
       },
     });
   });
+
+  describe(`over limits`, () => {
+    it(`shows error alert when check limit is reached`, async () => {
+      server.use(
+        apiRoute('getTenantLimits', {
+          result: () => ({
+            json: {
+              MaxChecks: 1,
+              MaxScriptedChecks: 10,
+            },
+          }),
+        })
+      );
+      render(<CheckForm />, {
+        route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+        path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/http`,
+      });
+
+      const errorAlert = await screen.findByText(/Maximum number of checks reached/, { exact: false });
+      expect(errorAlert).toBeInTheDocument();
+      const submitButton = await screen.findByRole('button', { name: 'Save' });
+      expect(submitButton).toBeDisabled();
+    });
+
+    it(`shows error alert when scripted check limit is reached`, async () => {
+      server.use(
+        apiRoute('getTenantLimits', {
+          result: () => ({
+            json: {
+              MaxChecks: 10,
+              MaxScriptedChecks: 1,
+            },
+          }),
+        })
+      );
+      render(<CheckForm />, {
+        route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+        path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/scripted`,
+      });
+
+      const errorAlert = await screen.findByText(/Maximum number of scripted checks reached/, { exact: false });
+      expect(errorAlert).toBeInTheDocument();
+      const submitButton = await screen.findByRole('button', { name: 'Save' });
+      expect(submitButton).toBeDisabled();
+    });
+  });
 });

--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -40,8 +40,8 @@ export const CheckForm = () => {
   const check = checks?.find((c) => c.id === Number(id)) ?? fallbackCheckMap[checkType];
 
   // We don't want to gate submission for editing pre-existing checks, just prevent creating new ones
-  const overCheckLimit = !check && isOverCheckLimit({ checks, limits });
-  const overScriptedLimit = !check && isOverScriptedLimit({ checks, limits });
+  const overCheckLimit = !check.id && isOverCheckLimit({ checks, limits });
+  const overScriptedLimit = !check.id && isOverScriptedLimit({ checks, limits });
 
   return (
     <CheckFormContent

--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -39,8 +39,9 @@ export const CheckForm = () => {
 
   const check = checks?.find((c) => c.id === Number(id)) ?? fallbackCheckMap[checkType];
 
-  const overCheckLimit = isOverCheckLimit({ checks, limits });
-  const overScriptedLimit = isOverScriptedLimit({ checks, limits });
+  // We don't want to gate submission for editing pre-existing checks, just prevent creating new ones
+  const overCheckLimit = !check && isOverCheckLimit({ checks, limits });
+  const overScriptedLimit = !check && isOverScriptedLimit({ checks, limits });
 
   return (
     <CheckFormContent

--- a/src/components/CheckForm/FormLayouts/CheckDNSLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckDNSLayout.tsx
@@ -46,7 +46,7 @@ export const CheckDNSLayout = () => {
         <DNSCheckResponseMatches />
       </FormLayout.Section>
       <FormLayout.Section label="Advanced options" fields={[`labels`, `settings.dns.ipVersion`]}>
-        <LabelField<CheckFormValuesPing> />
+        <LabelField<CheckFormValuesPing> labelDestination="check" />
         <CheckIpVersion checkType={CheckType.DNS} name="settings.dns.ipVersion" />
       </FormLayout.Section>
       <FormLayout.Section label="Alerting" fields={[`alertSensitivity`]}>

--- a/src/components/CheckForm/FormLayouts/CheckHttpLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckHttpLayout.tsx
@@ -102,7 +102,7 @@ export const CheckHTTPLayout = () => {
           `settings.http.cacheBustingQueryParamName`,
         ]}
       >
-        <LabelField<CheckFormValuesHttp> />
+        <LabelField<CheckFormValuesHttp> labelDestination="check" />
         <CheckIpVersion checkType={CheckType.HTTP} name="settings.http.ipVersion" />
         <HttpCheckFollowRedirects />
         <HttpCheckCacheBuster />

--- a/src/components/CheckForm/FormLayouts/CheckMultiHttpLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckMultiHttpLayout.tsx
@@ -23,7 +23,7 @@ export const CheckMultiHTTPLayout = () => {
         <CheckEnabled />
         <CheckJobName />
         <ProbeOptions checkType={CheckType.MULTI_HTTP} />
-        <LabelField<CheckFormValuesMultiHttp> />
+        <LabelField<CheckFormValuesMultiHttp> labelDestination="check" />
       </FormLayout.Section>
       <FormLayout.Section
         contentClassName={styles.requestsContainer}

--- a/src/components/CheckForm/FormLayouts/CheckPingLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckPingLayout.tsx
@@ -31,7 +31,7 @@ export const CheckPingLayout = () => {
         label="Advanced options"
         fields={[`labels`, `settings.ping.ipVersion`, `settings.ping.dontFragment`]}
       >
-        <LabelField<CheckFormValuesPing> />
+        <LabelField<CheckFormValuesPing> labelDestination="check" />
         <CheckIpVersion checkType={CheckType.PING} name="settings.ping.ipVersion" />
         <PingCheckFragment />
       </FormLayout.Section>

--- a/src/components/CheckForm/FormLayouts/CheckScriptedLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckScriptedLayout.tsx
@@ -26,7 +26,7 @@ export const CheckScriptedLayout = () => {
         <CheckJobName />
         <ScriptedCheckInstance />
         <ProbeOptions checkType={CheckType.Scripted} />
-        <LabelField<CheckFormValuesScripted> />
+        <LabelField<CheckFormValuesScripted> labelDestination="check" />
       </FormLayout.Section>
       <FormLayout.Section
         contentClassName={styles.scriptContainer}

--- a/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
@@ -39,7 +39,7 @@ export const CheckTCPLayout = () => {
         <TLSConfig checkType={CheckType.TCP} />
       </FormLayout.Section>
       <FormLayout.Section label="Advanced options" fields={[`labels`, `settings.tcp.ipVersion`]}>
-        <LabelField<CheckFormValuesPing> labelDestination="probe" />
+        <LabelField<CheckFormValuesPing> labelDestination="check" />
         <CheckIpVersion checkType={CheckType.TCP} name="settings.tcp.ipVersion" />
       </FormLayout.Section>
       <FormLayout.Section label="Alerting" fields={[`alertSensitivity`]}>

--- a/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
@@ -39,7 +39,7 @@ export const CheckTCPLayout = () => {
         <TLSConfig checkType={CheckType.TCP} />
       </FormLayout.Section>
       <FormLayout.Section label="Advanced options" fields={[`labels`, `settings.tcp.ipVersion`]}>
-        <LabelField<CheckFormValuesPing> />
+        <LabelField<CheckFormValuesPing> labelDestination="probe" />
         <CheckIpVersion checkType={CheckType.TCP} name="settings.tcp.ipVersion" />
       </FormLayout.Section>
       <FormLayout.Section label="Alerting" fields={[`alertSensitivity`]}>

--- a/src/components/CheckForm/FormLayouts/CheckTracerouteLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckTracerouteLayout.tsx
@@ -37,7 +37,7 @@ export const CheckTracerouteLayout = () => {
           `settings.traceroute.ptrLookup`,
         ]}
       >
-        <LabelField<CheckFormValuesTraceroute> />
+        <LabelField<CheckFormValuesTraceroute> labelDestination="check" />
         <TracerouteMaxHops />
         <TracerouteMaxUnknownHops />
         <TraceroutePTRLookup />

--- a/src/components/ChooseCheckType.test.tsx
+++ b/src/components/ChooseCheckType.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { config } from '@grafana/runtime';
+import { screen } from '@testing-library/react';
+import { apiRoute } from 'test/handlers';
+import { render } from 'test/render';
+import { server } from 'test/server';
+
+import { FeatureName } from 'types';
+
+import { ChooseCheckType } from './ChooseCheckType';
+
+function renderChooseCheckType(checkLimit = 10, scriptedLimit = 10) {
+  server.use(
+    apiRoute('getTenantLimits', {
+      result: () => ({
+        json: {
+          MaxChecks: checkLimit,
+          MaxScriptedChecks: scriptedLimit,
+          MaxMetricLabels: 16,
+          MaxLogLabels: 13,
+          maxAllowedMetricLabels: 10,
+          maxAllowedLogLabels: 5,
+        },
+      }),
+    })
+  );
+  return render(<ChooseCheckType />);
+}
+it('shows check type options with scripted feature off', async () => {
+  renderChooseCheckType();
+  const checkTypes = ['HTTP', 'TCP', 'DNS', 'PING', 'MULTIHTTP', 'Traceroute'];
+  const cards = await Promise.all(
+    checkTypes.map((checkType) => {
+      return screen.findByText(checkType);
+    })
+  );
+  cards.forEach((card) => {
+    expect(card).toBeInTheDocument();
+  });
+});
+
+it('shows check type options with scripted feature on', async () => {
+  // @ts-ignore
+  config.featureToggles[FeatureName.ScriptedChecks] = true;
+
+  renderChooseCheckType();
+  const checkTypes = ['HTTP', 'TCP', 'DNS', 'PING', 'MULTIHTTP', 'Traceroute', 'Scripted'];
+  const cards = await Promise.all(
+    checkTypes.map((checkType) => {
+      return screen.findByText(checkType);
+    })
+  );
+  cards.forEach((card) => {
+    expect(card).toBeInTheDocument();
+  });
+});
+
+it('shows error alert when check limit is reached', async () => {
+  renderChooseCheckType(1);
+  const errorAlert = await screen.findByText('Check limit reached');
+  expect(errorAlert).toBeInTheDocument();
+  const checkTypes = ['HTTP', 'TCP', 'DNS', 'PING', 'MULTIHTTP', 'Traceroute', 'Scripted'];
+  const cards = await Promise.all(
+    checkTypes.map((checkType) => {
+      return screen.queryByText(checkType);
+    })
+  );
+  cards.forEach((card) => {
+    expect(card).not.toBeInTheDocument();
+  });
+});
+
+it('shows error alert when scripted check limit is reached', async () => {
+  // @ts-ignore
+  config.featureToggles[FeatureName.ScriptedChecks] = true;
+
+  renderChooseCheckType(10, 1);
+  const errorAlert = await screen.findByText('Scripted check limit reached');
+  expect(errorAlert).toBeInTheDocument();
+  const checkTypes = ['HTTP', 'TCP', 'DNS', 'PING', 'Traceroute'];
+  const cards = await Promise.all(
+    checkTypes.map((checkType) => {
+      return screen.findByText(checkType);
+    })
+  );
+  cards.forEach((card) => {
+    expect(card).toBeInTheDocument();
+  });
+  expect(screen.queryByText('MULTIHTTP')).not.toBeInTheDocument();
+  expect(screen.queryByText('Scripted')).not.toBeInTheDocument();
+});

--- a/src/components/ChooseCheckType.test.tsx
+++ b/src/components/ChooseCheckType.test.tsx
@@ -73,8 +73,9 @@ it('shows error alert when check limit is reached', async () => {
 });
 
 it('shows error alert when scripted check limit is reached', async () => {
-  // @ts-ignore
-  config.featureToggles[FeatureName.ScriptedChecks] = true;
+  // When a user is at the scripted limit, the scripted option should not be shown. Turning on the scripted feature flag
+  // here so that we're isolating that it's the limit that's causing the scripted option to not show, and not the feature flag.
+  // This override should be deleted once the scripted feature is generally released
   jest.replaceProperty(config, 'featureToggles', {
     // @ts-expect-error
     [FeatureName.ScriptedChecks]: true,

--- a/src/components/ChooseCheckType.test.tsx
+++ b/src/components/ChooseCheckType.test.tsx
@@ -9,7 +9,7 @@ import { FeatureName } from 'types';
 
 import { ChooseCheckType } from './ChooseCheckType';
 
-function renderChooseCheckType(checkLimit = 10, scriptedLimit = 10) {
+function renderChooseCheckType({ checkLimit = 10, scriptedLimit = 10 }) {
   server.use(
     apiRoute('getTenantLimits', {
       result: () => ({
@@ -27,7 +27,7 @@ function renderChooseCheckType(checkLimit = 10, scriptedLimit = 10) {
   return render(<ChooseCheckType />);
 }
 it('shows check type options with scripted feature off', async () => {
-  renderChooseCheckType();
+  renderChooseCheckType({});
   const checkTypes = ['HTTP', 'TCP', 'DNS', 'PING', 'MULTIHTTP', 'Traceroute'];
   const cards = await Promise.all(
     checkTypes.map((checkType) => {
@@ -40,10 +40,12 @@ it('shows check type options with scripted feature off', async () => {
 });
 
 it('shows check type options with scripted feature on', async () => {
-  // @ts-ignore
-  config.featureToggles[FeatureName.ScriptedChecks] = true;
+  jest.replaceProperty(config, 'featureToggles', {
+    // @ts-expect-error
+    [FeatureName.ScriptedChecks]: true,
+  });
 
-  renderChooseCheckType();
+  renderChooseCheckType({});
   const checkTypes = ['HTTP', 'TCP', 'DNS', 'PING', 'MULTIHTTP', 'Traceroute', 'Scripted'];
   const cards = await Promise.all(
     checkTypes.map((checkType) => {
@@ -56,7 +58,7 @@ it('shows check type options with scripted feature on', async () => {
 });
 
 it('shows error alert when check limit is reached', async () => {
-  renderChooseCheckType(1);
+  renderChooseCheckType({ checkLimit: 1 });
   const errorAlert = await screen.findByText('Check limit reached');
   expect(errorAlert).toBeInTheDocument();
   const checkTypes = ['HTTP', 'TCP', 'DNS', 'PING', 'MULTIHTTP', 'Traceroute', 'Scripted'];
@@ -73,8 +75,12 @@ it('shows error alert when check limit is reached', async () => {
 it('shows error alert when scripted check limit is reached', async () => {
   // @ts-ignore
   config.featureToggles[FeatureName.ScriptedChecks] = true;
+  jest.replaceProperty(config, 'featureToggles', {
+    // @ts-expect-error
+    [FeatureName.ScriptedChecks]: true,
+  });
 
-  renderChooseCheckType(10, 1);
+  renderChooseCheckType({ checkLimit: 10, scriptedLimit: 1 });
   const errorAlert = await screen.findByText('Scripted check limit reached');
   expect(errorAlert).toBeInTheDocument();
   const checkTypes = ['HTTP', 'TCP', 'DNS', 'PING', 'Traceroute'];

--- a/src/components/ChooseCheckType.tsx
+++ b/src/components/ChooseCheckType.tsx
@@ -4,7 +4,7 @@ import { Badge, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { CheckType, FeatureName, ROUTES } from 'types';
-import { checkType } from 'utils';
+import { isOverCheckLimit, isOverScriptedLimit } from 'utils';
 import { useChecks } from 'data/useChecks';
 import { useTenantLimits } from 'data/useTenantLimits';
 import { useFeatureFlag } from 'hooks/useFeatureFlag';
@@ -27,10 +27,8 @@ export function ChooseCheckType() {
     return <LoadingPlaceholder text="Loading..." />;
   }
 
-  const overScriptedLimit =
-    limits &&
-    checks &&
-    checks.filter((c) => checkType(c.settings) === CheckType.Scripted).length >= limits.MaxScriptedChecks;
+  const overScriptedLimit = isOverScriptedLimit({ checks, limits });
+  const overTotalLimit = isOverCheckLimit({ checks, limits });
 
   const options = CHECK_TYPE_OPTIONS.filter(({ value }) => {
     if (overScriptedLimit && (value === CheckType.MULTI_HTTP || value === CheckType.Scripted)) {
@@ -42,7 +40,6 @@ export function ChooseCheckType() {
     return true;
   });
 
-  const overTotalLimit = limits && checks && checks.length >= limits.MaxChecks;
   if (overTotalLimit) {
     return (
       <PluginPage layout={PageLayoutType?.Standard} pageNav={{ text: 'Choose a check type' }}>

--- a/src/components/ChooseCheckType.tsx
+++ b/src/components/ChooseCheckType.tsx
@@ -1,29 +1,74 @@
 import React from 'react';
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
-import { Badge, useStyles2 } from '@grafana/ui';
+import { Badge, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { CheckType, FeatureName, ROUTES } from 'types';
+import { checkType } from 'utils';
+import { useChecks } from 'data/useChecks';
+import { useTenantLimits } from 'data/useTenantLimits';
 import { useFeatureFlag } from 'hooks/useFeatureFlag';
-import { Card } from 'components/Card';
+import { useNavigation } from 'hooks/useNavigation';
 import { CHECK_TYPE_OPTIONS } from 'components/constants';
 import { PluginPage } from 'components/PluginPage';
 import { getRoute } from 'components/Routing';
 
+import { Card } from './Card';
+import { ErrorAlert } from './ErrorAlert';
+
 export function ChooseCheckType() {
   const styles = useStyles2(getStyles);
+  const { data: checks, isLoading: checksLoading } = useChecks();
+  const { data: limits, isLoading: limitsLoading } = useTenantLimits();
+  const nav = useNavigation();
   const { isEnabled: scriptedEnabled } = useFeatureFlag(FeatureName.ScriptedChecks);
-  // If we're editing, grab the appropriate check from the list
+
+  if (checksLoading || limitsLoading) {
+    return <LoadingPlaceholder text="Loading..." />;
+  }
+
+  const overScriptedLimit =
+    limits &&
+    checks &&
+    checks.filter((c) => checkType(c.settings) === CheckType.Scripted).length >= limits.MaxScriptedChecks;
 
   const options = CHECK_TYPE_OPTIONS.filter(({ value }) => {
+    if (overScriptedLimit && (value === CheckType.MULTI_HTTP || value === CheckType.Scripted)) {
+      return false;
+    }
     if (!scriptedEnabled && value === CheckType.Scripted) {
       return false;
     }
     return true;
   });
 
+  const overTotalLimit = limits && checks && checks.length >= limits.MaxChecks;
+  if (overTotalLimit) {
+    return (
+      <PluginPage layout={PageLayoutType?.Standard} pageNav={{ text: 'Choose a check type' }}>
+        <ErrorAlert
+          title="Check limit reached"
+          content={`You have reached the limit of checks you can create. Your current limit is ${limits?.MaxChecks}. You can delete existing checks or upgrade your plan to create more. Please contact support if you've reached this limit in error.`}
+          buttonText={'Back to checks'}
+          onClick={() => {
+            nav(ROUTES.Checks);
+          }}
+        />
+      </PluginPage>
+    );
+  }
   return (
     <PluginPage layout={PageLayoutType?.Standard} pageNav={{ text: 'Choose a check type' }}>
+      {overScriptedLimit && (
+        <ErrorAlert
+          title="Scripted check limit reached"
+          content={`You have reached the limit of scripted and multiHTTP checks you can create. Your current limit is ${limits?.MaxScriptedChecks}. You can delete existing scripted checks or upgrade your plan to create more. Please contact support if you've reached this limit in error.`}
+          buttonText={'Back to checks'}
+          onClick={() => {
+            nav(ROUTES.Checks);
+          }}
+        />
+      )}
       <div className={styles.container}>
         {options?.map((check) => {
           return (

--- a/src/components/LabelField/LabelField.test.tsx
+++ b/src/components/LabelField/LabelField.test.tsx
@@ -21,28 +21,19 @@ function renderLabelField(props: LabelFieldProps) {
   );
 }
 
-it(`Should not render the limit text when limit is not provided`, async () => {
-  renderLabelField({});
+it(`Should render the probe limit text when probe is the destination`, async () => {
+  renderLabelField({ labelDestination: 'probe' });
   await screen.findByText('Labels');
   const limitText = await getLimitText();
-  expect(limitText).not.toBeInTheDocument();
-});
-
-it(`Should render the limit text when limit is provided`, async () => {
-  const limit = 5;
-  renderLabelField({ limit });
-  await screen.findByText('Labels');
-  const limitText = await getLimitText();
-  expect(limitText!.textContent?.includes(limit.toString()));
+  expect(limitText!.textContent?.includes('3'));
   expect(limitText).toBeInTheDocument();
 });
 
-it(`Should render the limit text when limit is provided`, async () => {
-  const limit = 5;
-  renderLabelField({ limit });
+it(`Should render the check limit text when check is the destination`, async () => {
+  renderLabelField({ labelDestination: 'check' });
   await screen.findByText('Labels');
   const limitText = await getLimitText();
-  expect(limitText!.textContent?.includes(limit.toString()));
+  expect(limitText!.textContent?.includes('10'));
   expect(limitText).toBeInTheDocument();
 });
 

--- a/src/components/LabelField/LabelField.test.tsx
+++ b/src/components/LabelField/LabelField.test.tsx
@@ -1,7 +1,10 @@
 import React, { ReactNode } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { screen, waitFor } from '@testing-library/react';
+import { apiRoute } from 'test/handlers';
+import { getTenantLimits } from 'test/handlers/tenants';
 import { render } from 'test/render';
+import { server } from 'test/server';
 
 import { LabelField, type LabelFieldProps } from './LabelField';
 
@@ -35,6 +38,21 @@ it(`Should render the check limit text when check is the destination`, async () 
   const limitText = await getLimitText();
   expect(limitText!.textContent?.includes('10'));
   expect(limitText).toBeInTheDocument();
+});
+
+it(`Should show a warning and a retry when the limits fetch fails`, async () => {
+  // set the limits endpoint to fail
+  server.use(apiRoute('getTenantLimits', { result: () => ({ status: 500, body: 'Error message' }) }));
+  const { user } = await renderLabelField({ labelDestination: 'check' });
+  await screen.findByText('Labels');
+  const warningBanner = await screen.findByText("Couldn't fetch label limits");
+  expect(warningBanner).toBeInTheDocument();
+
+  // reset limits endpoint to succeed
+  server.use(apiRoute('getTenantLimits', getTenantLimits));
+  const retry = await screen.findByText('Retry');
+  await user.click(retry);
+  waitFor(() => expect(screen.queryByText("Couldn't fetch label limits")).not.toBeInTheDocument());
 });
 
 // extract these so we can be sure the negative assertion works

--- a/src/components/LabelField/LabelField.tsx
+++ b/src/components/LabelField/LabelField.tsx
@@ -22,15 +22,19 @@ export const LabelField = <T extends FormWithLabels>({ limit }: LabelFieldProps)
   const { watch } = useFormContext<FormWithLabels>();
   const labels = watch('labels');
   const isEditor = hasRole(OrgRole.Editor);
-  const description = `Custom labels to be included with collected metrics and logs. You can add up to ${
-    limits?.maxAllowedMetricLabels ?? 10
-  }.
-  If you add more than ${
-    limits?.maxAllowedLogLabels ?? 5
-  } labels, they will potentially not be used to index logs, and rather added as part of the log message.`;
+  let description = '';
+  if (limit) {
+    description = `Custom labels to be included with collected metrics and logs. You can add up to ${limit}.`;
+  } else {
+    description = `Custom labels to be included with collected metrics and logs. You can add up to ${
+      limits?.maxAllowedMetricLabels ?? 10
+    }. If you add more than ${
+      limits?.maxAllowedLogLabels ?? 5
+    } labels, they will potentially not be used to index logs, and rather added as part of the log message.`;
+  }
 
   return (
-    <Field label="Labels" description={description} disabled={!isEditor}>
+    <Field label="Labels" description={limit || limits ? description : ''} disabled={!isEditor}>
       <NameValueInput
         name="labels"
         disabled={!isEditor}

--- a/src/components/LabelField/LabelField.tsx
+++ b/src/components/LabelField/LabelField.tsx
@@ -10,36 +10,39 @@ import { useTenantLimits } from 'data/useTenantLimits';
 import { NameValueInput } from 'components/NameValueInput';
 
 export interface LabelFieldProps {
-  limit?: number;
+  labelDestination: 'check' | 'probe';
 }
 
 type FormWithLabels = {
   labels: Label[];
 };
 
-export const LabelField = <T extends FormWithLabels>({ limit }: LabelFieldProps) => {
+export const LabelField = <T extends FormWithLabels>({ labelDestination }: LabelFieldProps) => {
   const { data: limits } = useTenantLimits();
   const { watch } = useFormContext<FormWithLabels>();
   const labels = watch('labels');
   const isEditor = hasRole(OrgRole.Editor);
   let description = '';
-  if (limit) {
-    description = `Custom labels to be included with collected metrics and logs. You can add up to ${limit}.`;
+  let limit = 10;
+  if (labelDestination === 'check') {
+    description = `Custom labels to be included with collected metrics and logs. You can add up to 3.`;
+    limit = 3;
   } else {
     description = `Custom labels to be included with collected metrics and logs. You can add up to ${
       limits?.maxAllowedMetricLabels ?? 10
     }. If you add more than ${
       limits?.maxAllowedLogLabels ?? 5
     } labels, they will potentially not be used to index logs, and rather added as part of the log message.`;
+    limit = limits?.maxAllowedMetricLabels ?? 10;
   }
 
   return (
-    <Field label="Labels" description={limit || limits ? description : ''} disabled={!isEditor}>
+    <Field label="Labels" description={description} disabled={!isEditor}>
       <NameValueInput
         name="labels"
         disabled={!isEditor}
         label="label"
-        limit={limits?.maxAllowedMetricLabels ?? 10}
+        limit={limit}
         validateName={(labelName) => validateLabelName(labelName, labels)}
         validateValue={validateLabelValue}
       />

--- a/src/components/LabelField/LabelField.tsx
+++ b/src/components/LabelField/LabelField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { OrgRole } from '@grafana/data';
-import { Alert, Button, Field, LoadingPlaceholder, useTheme2 } from '@grafana/ui';
+import { Alert, Button, Field, LoadingPlaceholder, Spinner, useTheme2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { Label } from 'types';
@@ -41,7 +41,7 @@ function getDescription(labelDestination: LabelFieldProps['labelDestination'], l
 }
 
 export const LabelField = <T extends FormWithLabels>({ labelDestination }: LabelFieldProps) => {
-  const { data: limits, isLoading, error, refetch } = useTenantLimits();
+  const { data: limits, isLoading, error, isRefetching, refetch } = useTenantLimits();
   const { watch } = useFormContext<FormWithLabels>();
   const labels = watch('labels');
   const isEditor = hasRole(OrgRole.Editor);
@@ -54,7 +54,7 @@ export const LabelField = <T extends FormWithLabels>({ labelDestination }: Label
         <LoadingPlaceholder text="Loading label limits" />
       ) : (
         <>
-          {error ? <LimitsFetchWarning refetch={refetch} error={error} /> : null}
+          {error ? <LimitsFetchWarning refetch={refetch} isRefetching={isRefetching} error={error} /> : null}
           <NameValueInput
             name="labels"
             disabled={!isEditor}
@@ -69,7 +69,15 @@ export const LabelField = <T extends FormWithLabels>({ labelDestination }: Label
   );
 };
 
-function LimitsFetchWarning({ refetch, error }: { refetch: () => void; error: Error }) {
+function LimitsFetchWarning({
+  refetch,
+  isRefetching,
+  error,
+}: {
+  refetch: () => void;
+  isRefetching: boolean;
+  error: Error;
+}) {
   const theme = useTheme2();
   return (
     <Alert severity="warning" title="Couldn't fetch label limits">
@@ -83,8 +91,9 @@ function LimitsFetchWarning({ refetch, error }: { refetch: () => void; error: Er
             refetch();
           }}
           variant="secondary"
+          disabled={isRefetching}
         >
-          Retry
+          {isRefetching ? <Spinner /> : 'Retry'}
         </Button>
       </div>
     </Alert>

--- a/src/components/LabelField/LabelField.tsx
+++ b/src/components/LabelField/LabelField.tsx
@@ -6,6 +6,7 @@ import { Field } from '@grafana/ui';
 import { Label } from 'types';
 import { hasRole } from 'utils';
 import { validateLabelName, validateLabelValue } from 'validation';
+import { useTenantLimits } from 'data/useTenantLimits';
 import { NameValueInput } from 'components/NameValueInput';
 
 export interface LabelFieldProps {
@@ -17,15 +18,16 @@ type FormWithLabels = {
 };
 
 export const LabelField = <T extends FormWithLabels>({ limit }: LabelFieldProps) => {
+  const { data: limits } = useTenantLimits();
   const { watch } = useFormContext<FormWithLabels>();
   const labels = watch('labels');
   const isEditor = hasRole(OrgRole.Editor);
-
-  let description = `Custom labels to be included with collected metrics and logs.`;
-
-  if (limit) {
-    description += ` You can add up to ${limit}.`;
-  }
+  const description = `Custom labels to be included with collected metrics and logs. You can add up to ${
+    limits?.maxAllowedMetricLabels ?? 10
+  }.
+  If you add more than ${
+    limits?.maxAllowedLogLabels ?? 5
+  } labels, they will potentially not be used to index logs, and rather added as part of the log message.`;
 
   return (
     <Field label="Labels" description={description} disabled={!isEditor}>
@@ -33,7 +35,7 @@ export const LabelField = <T extends FormWithLabels>({ limit }: LabelFieldProps)
         name="labels"
         disabled={!isEditor}
         label="label"
-        limit={limit ?? 10}
+        limit={limits?.maxAllowedMetricLabels ?? 10}
         validateName={(labelName) => validateLabelName(labelName, labels)}
         validateValue={validateLabelValue}
       />

--- a/src/components/LabelField/LabelField.tsx
+++ b/src/components/LabelField/LabelField.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { OrgRole } from '@grafana/data';
-import { Field } from '@grafana/ui';
+import { Alert, Button, Field, LoadingPlaceholder, useTheme2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 
 import { Label } from 'types';
+import { FaroEvent, reportEvent } from 'faro';
 import { hasRole } from 'utils';
 import { validateLabelName, validateLabelValue } from 'validation';
+import { ListTenantLimitsResponse } from 'datasource/responses.types';
 import { useTenantLimits } from 'data/useTenantLimits';
 import { NameValueInput } from 'components/NameValueInput';
 
@@ -17,35 +20,73 @@ type FormWithLabels = {
   labels: Label[];
 };
 
+function getLimit(labelDestination: LabelFieldProps['labelDestination'], limits?: ListTenantLimitsResponse) {
+  if (labelDestination === 'probe') {
+    return 3;
+  }
+
+  if (limits?.maxAllowedMetricLabels) {
+    return limits.maxAllowedMetricLabels;
+  }
+
+  return 10;
+}
+
+function getDescription(labelDestination: LabelFieldProps['labelDestination'], limit: number, logLabelLimit: number) {
+  if (labelDestination === 'probe') {
+    return `Custom labels to be included with collected metrics and logs. You can add up to ${limit}.`;
+  }
+
+  return `Custom labels to be included with collected metrics and logs. You can add up to ${limit}. If you add more than ${logLabelLimit} labels, they will potentially not be used to index logs, and rather added as part of the log message.`;
+}
+
 export const LabelField = <T extends FormWithLabels>({ labelDestination }: LabelFieldProps) => {
-  const { data: limits } = useTenantLimits();
+  const { data: limits, isLoading, error, refetch } = useTenantLimits();
   const { watch } = useFormContext<FormWithLabels>();
   const labels = watch('labels');
   const isEditor = hasRole(OrgRole.Editor);
-  let description = '';
-  let limit = 10;
-  if (labelDestination === 'check') {
-    description = `Custom labels to be included with collected metrics and logs. You can add up to 3.`;
-    limit = 3;
-  } else {
-    description = `Custom labels to be included with collected metrics and logs. You can add up to ${
-      limits?.maxAllowedMetricLabels ?? 10
-    }. If you add more than ${
-      limits?.maxAllowedLogLabels ?? 5
-    } labels, they will potentially not be used to index logs, and rather added as part of the log message.`;
-    limit = limits?.maxAllowedMetricLabels ?? 10;
-  }
+  const limit = getLimit(labelDestination, limits);
+  const description = getDescription(labelDestination, limit, limits?.maxAllowedLogLabels ?? 5);
 
   return (
     <Field label="Labels" description={description} disabled={!isEditor}>
-      <NameValueInput
-        name="labels"
-        disabled={!isEditor}
-        label="label"
-        limit={limit}
-        validateName={(labelName) => validateLabelName(labelName, labels)}
-        validateValue={validateLabelValue}
-      />
+      {isLoading ? (
+        <LoadingPlaceholder text="Loading label limits" />
+      ) : (
+        <>
+          {error ? <LimitsFetchWarning refetch={refetch} error={error} /> : null}
+          <NameValueInput
+            name="labels"
+            disabled={!isEditor}
+            label="label"
+            limit={limit}
+            validateName={(labelName) => validateLabelName(labelName, labels)}
+            validateValue={validateLabelValue}
+          />
+        </>
+      )}
     </Field>
   );
 };
+
+function LimitsFetchWarning({ refetch, error }: { refetch: () => void; error: Error }) {
+  const theme = useTheme2();
+  return (
+    <Alert severity="warning" title="Couldn't fetch label limits">
+      <div className={css({ display: 'flex', gap: theme.spacing(2), alignItems: 'center' })}>
+        <span>
+          There was an error fetching the label limits for your account. The default minimum limits will be used.
+        </span>
+        <Button
+          onClick={() => {
+            reportEvent(FaroEvent.REFETCH_TENANT_LIMITS, { error: error.message });
+            refetch();
+          }}
+          variant="secondary"
+        >
+          Retry
+        </Button>
+      </div>
+    </Alert>
+  );
+}

--- a/src/components/ProbeEditor/ProbeEditor.tsx
+++ b/src/components/ProbeEditor/ProbeEditor.tsx
@@ -161,7 +161,7 @@ export const ProbeEditor = ({
                     />
                   </Field>
                 </div>
-                {canEdit && <LabelField<Probe> limit={3} />}
+                {canEdit && <LabelField<Probe> labelDestination={'probe'} />}
                 <div className={styles.buttonWrapper}>
                   {canEdit && (
                     <>

--- a/src/data/useTenantLimits.ts
+++ b/src/data/useTenantLimits.ts
@@ -1,0 +1,20 @@
+import { useContext } from 'react';
+import { QueryKey } from '@tanstack/query-core';
+import { useQuery } from '@tanstack/react-query';
+
+import { SMDataSource } from 'datasource/DataSource';
+import { InstanceContext } from 'contexts/InstanceContext';
+
+export const queryKeys: Record<'list', QueryKey> = {
+  list: ['tenantLimits'],
+};
+
+export function useTenantLimits() {
+  const { instance } = useContext(InstanceContext);
+  const api = instance.api as SMDataSource;
+
+  return useQuery({
+    queryKey: queryKeys.list,
+    queryFn: () => api.getTenantLimits(),
+  });
+}

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -353,10 +353,13 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       });
   }
 
-  async getTenantLimits(): Promise<ListTenantLimitsResponse> {
+  async getTenantLimits() {
     return firstValueFrom(
-      getBackendSrv().fetch({ method: 'GET', url: `${this.instanceSettings.url}/sm/tenant/limits` })
-    ).then((res: any) => {
+      getBackendSrv().fetch<ListTenantLimitsResponse>({
+        method: 'GET',
+        url: `${this.instanceSettings.url}/sm/tenant/limits`,
+      })
+    ).then((res) => {
       return res.data;
     });
   }

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -22,6 +22,7 @@ import {
   DeleteProbeResult,
   ListCheckResult,
   ListProbeResult,
+  ListTenantLimitsResponse,
   ListTenantSettingsResult,
   ResetProbeTokenResult,
   UpdateCheckResult,
@@ -350,6 +351,14 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       .then((res: any) => {
         return res.data;
       });
+  }
+
+  async getTenantLimits(): Promise<ListTenantLimitsResponse> {
+    return firstValueFrom(
+      getBackendSrv().fetch({ method: 'GET', url: `${this.instanceSettings.url}/sm/tenant/limits` })
+    ).then((res: any) => {
+      return res.data;
+    });
   }
 
   async getTenantSettings() {

--- a/src/datasource/responses.types.ts
+++ b/src/datasource/responses.types.ts
@@ -79,6 +79,15 @@ export type TenantResponse = {
   status: number;
 };
 
+export type ListTenantLimitsResponse = {
+  MaxChecks: number;
+  MaxScriptedChecks: number;
+  MaxMetricLabels: number;
+  MaxLogLabels: number;
+  maxAllowedMetricLabels: number;
+  maxAllowedLogLabels: number;
+};
+
 export type ListTenantSettingsResult = {
   remote_validation_disabled: boolean;
   thresholds: ThresholdSettings;

--- a/src/faro.ts
+++ b/src/faro.ts
@@ -17,6 +17,7 @@ export enum FaroEvent {
   CREATE_ACCESS_TOKEN = 'create_access_token',
   SAVE_THRESHOLDS = 'save_thresholds',
   SHOW_TERRAFORM_CONFIG = 'show_terraform_config',
+  REFETCH_TENANT_LIMITS = 'refetch_tenant_limits',
 }
 
 enum FARO_ENV {

--- a/src/test/fixtures/tenants.ts
+++ b/src/test/fixtures/tenants.ts
@@ -1,4 +1,9 @@
-import { ListTenantSettingsResult, TenantResponse, UpdateTenantSettingsResult } from 'datasource/responses.types';
+import {
+  ListTenantLimitsResponse,
+  ListTenantSettingsResult,
+  TenantResponse,
+  UpdateTenantSettingsResult,
+} from 'datasource/responses.types';
 
 export const TENANT: TenantResponse = {
   id: 76,
@@ -42,3 +47,11 @@ export const TENANT_SETTINGS: ListTenantSettingsResult = {
 };
 
 export const UPDATE_TENANT_SETTINGS: UpdateTenantSettingsResult = { msg: 'Settings updated' };
+export const TENANT_LIMITS: ListTenantLimitsResponse = {
+  MaxChecks: 100,
+  MaxScriptedChecks: 10,
+  MaxMetricLabels: 20,
+  MaxLogLabels: 15,
+  maxAllowedMetricLabels: 10,
+  maxAllowedLogLabels: 5,
+};

--- a/src/test/handlers/index.ts
+++ b/src/test/handlers/index.ts
@@ -4,7 +4,7 @@ import { addCheck, bulkUpdateChecks, checkInfo, listChecks, updateCheck } from '
 import { getDashboard } from 'test/handlers/dashboards';
 import { getMetrics } from 'test/handlers/metrics';
 import { addProbe, listProbes, updateProbe } from 'test/handlers/probes';
-import { getTenant, getTenantSettings, updateTenantSettings } from 'test/handlers/tenants';
+import { getTenant, getTenantLimits, getTenantSettings, updateTenantSettings } from 'test/handlers/tenants';
 
 import { ApiEntry, RequestRes } from 'test/handlers/types';
 
@@ -19,6 +19,7 @@ const apiRoutes = {
   getMetrics,
   getTenant,
   getTenantSettings,
+  getTenantLimits,
   listChecks,
   listProbes,
   updateCheck,

--- a/src/test/handlers/tenants.ts
+++ b/src/test/handlers/tenants.ts
@@ -1,7 +1,12 @@
-import { TENANT, TENANT_SETTINGS, UPDATE_TENANT_SETTINGS } from 'test/fixtures/tenants';
+import { TENANT, TENANT_LIMITS, TENANT_SETTINGS, UPDATE_TENANT_SETTINGS } from 'test/fixtures/tenants';
 
 import { ApiEntry } from 'test/handlers/types';
-import { ListTenantSettingsResult, TenantResponse, UpdateTenantSettingsResult } from 'datasource/responses.types';
+import {
+  ListTenantLimitsResponse,
+  ListTenantSettingsResult,
+  TenantResponse,
+  UpdateTenantSettingsResult,
+} from 'datasource/responses.types';
 
 export const getTenant: ApiEntry<TenantResponse> = {
   route: `/sm/tenant`,
@@ -29,6 +34,16 @@ export const updateTenantSettings: ApiEntry<UpdateTenantSettingsResult> = {
   result: () => {
     return {
       json: UPDATE_TENANT_SETTINGS,
+    };
+  },
+};
+
+export const getTenantLimits: ApiEntry<ListTenantLimitsResponse> = {
+  route: `/sm/tenant/limits`,
+  method: `get`,
+  result: () => {
+    return {
+      json: TENANT_LIMITS,
     };
   },
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,7 @@ import {
   isTCPSettings,
 } from 'utils.types';
 import { SMDataSource } from 'datasource/DataSource';
-import { Metric } from 'datasource/responses.types';
+import { ListCheckResult, ListTenantLimitsResponse, Metric } from 'datasource/responses.types';
 
 /**
  * Find all synthetic-monitoring datasources
@@ -420,4 +420,32 @@ function doesTLSConfigHaveValues(tlsConfig?: TLSConfig) {
   }
 
   return Object.values(tlsConfig).some((value) => value);
+}
+
+export function isOverScriptedLimit({
+  checks,
+  limits,
+}: {
+  checks?: Check[] | ListCheckResult;
+  limits?: ListTenantLimitsResponse;
+}): boolean {
+  if (!limits || !checks) {
+    return false;
+  }
+  return (
+    checks && checks.filter((c) => checkType(c.settings) === CheckType.Scripted).length >= limits.MaxScriptedChecks
+  );
+}
+
+export function isOverCheckLimit({
+  checks,
+  limits,
+}: {
+  checks?: Check[] | ListCheckResult;
+  limits?: ListTenantLimitsResponse;
+}): boolean {
+  if (!limits || !checks) {
+    return false;
+  }
+  return checks.length >= limits.MaxChecks;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -432,9 +432,8 @@ export function isOverScriptedLimit({
   if (!limits || !checks) {
     return false;
   }
-  return (
-    checks && checks.filter((c) => checkType(c.settings) === CheckType.Scripted).length >= limits.MaxScriptedChecks
-  );
+  const scriptedChecksCount = checks.filter((c) => checkType(c.settings) === CheckType.Scripted).length;
+  return scriptedChecksCount >= limits.MaxScriptedChecks;
 }
 
 export function isOverCheckLimit({


### PR DESCRIPTION
I'm a little unsure where the best place to gate access based on limits is. I definitely don't want it to be how it currently is (when you submit a form after filling it out), but there are other options than what I've done. Opinions welcome.

Fixes https://github.com/grafana/synthetic-monitoring/issues/49

No limits reached:
![Screenshot 2024-04-03 at 14 07 38](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/5f3600f2-7968-4475-9fa2-97aa1654ffb2)

Overall limit reached:
![Screenshot 2024-04-03 at 13 13 38](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/8a4d5ae0-2dc3-4333-97a6-aa0bc9d1db0c)

Scripted limit reached:
![Screenshot 2024-04-03 at 13 12 39](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/ac2cd80d-7d61-4508-9fbf-c2d55ab5d1e9)
