### PR TITLE
fix: remove basicAuth if not explicitely added

### DIFF
--- a/src/components/CheckEditor/CheckEditorNew.test.tsx
+++ b/src/components/CheckEditor/CheckEditorNew.test.tsx
@@ -103,7 +103,6 @@ describe('new checks', () => {
       basicMetricsOnly: true,
       settings: {
         http: {
-          basicAuth: {},
           method: HttpMethod.GET,
           ipVersion: IpVersion.V4,
           noFollowRedirects: false,

--- a/src/components/CheckEditor/HttpCheck.test.tsx
+++ b/src/components/CheckEditor/HttpCheck.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { PRIVATE_PROBE } from 'test/fixtures/probes';
+import { apiRoute, getServerRequests } from 'test/handlers';
+import { render } from 'test/render';
+import { server } from 'test/server';
+
+import { AlertSensitivity, CheckType, Label, ROUTES } from 'types';
+import { CheckForm } from 'components/CheckForm/CheckForm';
+import { PLUGIN_URL_PATH } from 'components/constants';
+
+import { fillBasicCheckFields, submitForm } from './testHelpers';
+
+const JOB_NAME = `Http job`;
+const TARGET = `https://grafana.com`;
+const LABELS: Label[] = [];
+
+describe(`Edits the sections of a HTTP check correctly`, () => {
+  it(`Adds basic auth if added`, async () => {
+    const basicAuth = {
+      username: 'admin',
+      password: 'hunter2',
+    };
+
+    const { record, read } = getServerRequests();
+    server.use(apiRoute(`addCheck`, {}, record));
+
+    const { user } = render(<CheckForm />, {
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.HTTP}`,
+    });
+
+    await fillBasicCheckFields(JOB_NAME, TARGET, user, LABELS);
+    await user.click(await screen.getByText('Authentication'));
+    await user.click(await screen.findByLabelText('Include basic authorization header in request'));
+    await user.type(await screen.findByLabelText('Username'), basicAuth.username);
+    await user.type(await screen.findByLabelText('Password'), basicAuth.password);
+    await submitForm(user);
+
+    const { body } = await read();
+
+    expect(body).toEqual({
+      alertSensitivity: AlertSensitivity.None,
+      basicMetricsOnly: true,
+      enabled: true,
+      frequency: 60000,
+      job: JOB_NAME,
+      labels: LABELS,
+      probes: [PRIVATE_PROBE.id],
+      settings: {
+        http: {
+          basicAuth,
+          body: '',
+          cacheBustingQueryParamName: '',
+          compression: '',
+          failIfBodyMatchesRegexp: [],
+          failIfBodyNotMatchesRegexp: [],
+          failIfHeaderMatchesRegexp: [],
+          failIfHeaderNotMatchesRegexp: [],
+          failIfNotSSL: false,
+          failIfSSL: false,
+          headers: [],
+          ipVersion: 'V4',
+          method: 'GET',
+          noFollowRedirects: false,
+          proxyConnectHeaders: [],
+          proxyURL: '',
+          tlsConfig: {
+            caCert: '',
+            clientCert: '',
+            clientKey: '',
+            insecureSkipVerify: false,
+            serverName: '',
+          },
+          validHTTPVersions: [],
+          validStatusCodes: [],
+        },
+      },
+      target: TARGET,
+      timeout: 3000,
+    });
+  });
+
+  it(`Does not add basic auth if not added`, async () => {
+    const { record, read } = getServerRequests();
+    server.use(apiRoute(`addCheck`, {}, record));
+
+    const { user } = render(<CheckForm />, {
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.HTTP}`,
+    });
+
+    await fillBasicCheckFields(JOB_NAME, TARGET, user, LABELS);
+    await user.click(await screen.getByText('Authentication'));
+    await submitForm(user);
+
+    const { body } = await read();
+
+    expect(body.settings.http.basicAuth).toBeUndefined();
+
+    expect(body).toStrictEqual({
+      alertSensitivity: AlertSensitivity.None,
+      basicMetricsOnly: true,
+      enabled: true,
+      frequency: 60000,
+      job: JOB_NAME,
+      labels: LABELS,
+      probes: [PRIVATE_PROBE.id],
+      settings: {
+        http: {
+          body: '',
+          cacheBustingQueryParamName: '',
+          compression: '',
+          failIfBodyMatchesRegexp: [],
+          failIfBodyNotMatchesRegexp: [],
+          failIfHeaderMatchesRegexp: [],
+          failIfHeaderNotMatchesRegexp: [],
+          failIfNotSSL: false,
+          failIfSSL: false,
+          headers: [],
+          ipVersion: 'V4',
+          method: 'GET',
+          noFollowRedirects: false,
+          proxyConnectHeaders: [],
+          proxyURL: '',
+          tlsConfig: {
+            caCert: '',
+            clientCert: '',
+            clientKey: '',
+            insecureSkipVerify: false,
+            serverName: '',
+          },
+          validHTTPVersions: [],
+          validStatusCodes: [],
+        },
+      },
+      target: TARGET,
+      timeout: 3000,
+    });
+  });
+});

--- a/src/components/CheckEditor/checkFormTransformations.ts
+++ b/src/components/CheckEditor/checkFormTransformations.ts
@@ -537,7 +537,7 @@ const getHttpSettings = (settings: Partial<HttpSettingsFormValues> | undefined =
   const validationRegexes = getHttpRegexValidationsFromFormValue(settings.regexValidations ?? []);
 
   // We need to pick the sslOptions key out of the settings, since the API doesn't expect this key
-  const { sslOptions, regexValidations, followRedirects, tlsConfig, ...restToKeep } = settings;
+  const { basicAuth, sslOptions, regexValidations, followRedirects, tlsConfig, ...restToKeep } = settings;
 
   const transformedTlsConfig = getTlsConfigFromFormValues(tlsConfig);
 
@@ -546,6 +546,7 @@ const getHttpSettings = (settings: Partial<HttpSettingsFormValues> | undefined =
     ...sslConfig,
     ...validationRegexes,
     ...transformedTlsConfig,
+    basicAuth: isBasicAuthEmpty(basicAuth) ? undefined : basicAuth,
     noFollowRedirects: !followRedirects,
     method,
     headers: formattedHeaders,
@@ -864,3 +865,7 @@ export const getCheckFromFormValues = (formValues: CheckFormValues): Check => {
 
   throw new Error(`Unknown check type: ${formValues.checkType}`);
 };
+
+function isBasicAuthEmpty(basicAuth: HttpSettingsFormValues['basicAuth']) {
+  return !basicAuth?.username && !basicAuth?.password;
+}


### PR DESCRIPTION
In a recent refactor and to appease React form / React ref errors in the console (such as controlling uncontrolled fields...) I set some fields with empty strings, this had an unexpected consequence of being included in the payload which can mess up authentication to many services.

This problem was included in [this internal Slack thread](https://raintank-corp.slack.com/archives/C0162C1K9E1/p1712732546959319).

Going to make a ticket to check through if any other fields which are considered empty should also be omitted, as well as improving the UI so that if the include checkbox is not ticked it won't include the payload either.