### PR TITLE
fix: allow min step to be 1 minute in dashboard queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# [1.13.3](https://github.com/grafana/synthetic-monitoring-app/compare/v1.13.2...v1.13.3) (2024-4-11)
+
+- Fix a bug where the min step in dashboard queries was defaulting to 5 minutes unnecessarily
+
 # [1.13.2](https://github.com/grafana/synthetic-monitoring-app/compare/v1.13.1...v1.13.2) (2024-4-10)
 
 - Fix a bug where basic auth was always being submitted even when empty

--- a/src/scenes/Common/uptimeStat.ts
+++ b/src/scenes/Common/uptimeStat.ts
@@ -4,7 +4,18 @@ import { DataSourceRef, ThresholdsMode } from '@grafana/schema';
 import { UPTIME_DESCRIPTION } from 'components/constants';
 import { ExplorablePanel } from 'scenes/ExplorablePanel';
 
+function getMinStep(minStep: string) {
+  try {
+    const minStepParsed = parseInt(minStep[0], 10);
+    return `${Math.max(minStepParsed, 5)}m`;
+  } catch (e) {
+    return minStep;
+  }
+}
+
 function getQueryRunner(metrics: DataSourceRef, minStep: string) {
+  // The min step for most queries is a minimum of 1 minute. For uptime, however, we want to make sure we have steps of at least 5 minutes in order for the math to work out.
+  const uptimeMinStep = getMinStep(minStep);
   const runner = new SceneQueryRunner({
     datasource: metrics,
     queries: [
@@ -22,7 +33,7 @@ function getQueryRunner(metrics: DataSourceRef, minStep: string) {
         )`,
         hide: false,
         instant: false,
-        interval: minStep,
+        interval: uptimeMinStep,
         legendFormat: '',
         range: true,
         refId: 'B',

--- a/src/scenes/utils.ts
+++ b/src/scenes/utils.ts
@@ -1,5 +1,5 @@
 export function getMinStepFromFrequency(ms?: number): string {
   const frequencyVal = (ms ?? 600000) / 1000 / 60; // turn ms to minutes
-  const minStep = `${Math.max(Math.floor(frequencyVal), 5)}m`;
+  const minStep = `${Math.max(Math.floor(frequencyVal), 1)}m`;
   return minStep;
 }


### PR DESCRIPTION
I had thought the min step had to be increased in order to support long range queries and checks with larger frequencies, but it appears I was mistaken.