### PR TITLE
fix: make adhoc timeout relative to check timeout

### DIFF
--- a/src/components/CheckTestResultsModal.tsx
+++ b/src/components/CheckTestResultsModal.tsx
@@ -95,7 +95,7 @@ export function CheckTestResultsModal({ testResponse, isOpen, onDismiss }: Props
           });
           setResultsByProbe({ ...resultsByProbe, ...resultsToUpdate });
         }
-      }, 30000);
+      }, testResponse.timeout + 30000);
     }
     return () => clearTimeout(timeoutId);
   }, [testResponse, probes, resultsByProbe]);


### PR DESCRIPTION
Scripted checks can take a really long time to run, so a hardcoded 30s timeout for adhoc checks doesn't work anymore. I think just adding the 30s on top of the check timeout should get us there