### PR TITLE
scripted check latency: use avg of http requests duration

### DIFF
--- a/src/data/useLatency.ts
+++ b/src/data/useLatency.ts
@@ -33,6 +33,8 @@ export function useLatency({ job, target, settings }: Check) {
 }
 
 function getQuery(job: Check['job'], target: Check['target'], type: CheckType) {
+  // TODO: find a way to dynamically check what metrics are available in the scripted check so can more accurately report latency
+  // making assumption that all scripted checks are utilizing http protocol currently so this will report incorrectly for scripted checks using other protocols
   if (type === CheckType.MULTI_HTTP || type === CheckType.Scripted) {
     return `sum by (job, instance) (sum_over_time(probe_http_total_duration_seconds{job="${job}", instance="${target}"}[6h])) / sum by (job, instance) (count_over_time(probe_http_total_duration_seconds{job="${job}", instance="${target}"}[6h])) `;
   }

--- a/src/data/useLatency.ts
+++ b/src/data/useLatency.ts
@@ -33,7 +33,7 @@ export function useLatency({ job, target, settings }: Check) {
 }
 
 function getQuery(job: Check['job'], target: Check['target'], type: CheckType) {
-  if (type === CheckType.MULTI_HTTP) {
+  if (type === CheckType.MULTI_HTTP || type === CheckType.Scripted) {
     return `sum by (job, instance) (sum_over_time(probe_http_total_duration_seconds{job="${job}", instance="${target}"}[6h])) / sum by (job, instance) (count_over_time(probe_http_total_duration_seconds{job="${job}", instance="${target}"}[6h])) `;
   }
 


### PR DESCRIPTION

The latency column for scripted check isn't really latency right now - it's the average run duration of the k6 script, which can include lots of non-request overhead such as k6 startup time. 

For multihttp we take the average the http requests rather than the average execution duration of the test. 
This PR applies the same to scripted checks.  

The only downside is that scripted checks can include other protocols like websockets or grpc,  so we will not accurately capture average latency when those are used.   But in the interim, using http request duration average is better than the alternative of average execution duration. 