### PR TITLE
fix: query logs by probe success instead of error level

### DIFF
--- a/src/scenes/Common/allLogs.tsx
+++ b/src/scenes/Common/allLogs.tsx
@@ -10,7 +10,7 @@ function getQueryRunner(logs: DataSourceRef) {
     datasource: logs,
     queries: [
       {
-        expr: '{probe=~"$probe", instance="$instance", job="$job"} | logfmt | __error__ = "" | level =~ "$errorLevel"',
+        expr: '{probe=~"$probe", instance="$instance", job="$job", probe_success=~"$probeSuccess"} | logfmt | __error__ = ""',
         refId: 'A',
       },
     ],
@@ -18,27 +18,27 @@ function getQueryRunner(logs: DataSourceRef) {
 }
 
 export function getAllLogs(logs: DataSourceRef) {
-  const errorLevel = new CustomVariable({
+  const unsuccessfulOnly = new CustomVariable({
     value: '.*',
-    name: 'errorLevel',
+    query: '.*',
+    name: 'probeSuccess',
     hide: VariableHide.hideVariable,
   });
   const variables = new SceneVariableSet({
-    variables: [errorLevel],
+    variables: [unsuccessfulOnly],
   });
 
   const levelSwitch = new SceneReactObject({
     reactNode: (
       <InlineSwitch
-        label="Errors only"
+        label="Unsuccessful runs only"
         transparent
         showLabel
         onChange={(e) => {
           if (e.currentTarget.checked) {
-            errorLevel.changeValueTo('error');
-            // switchState.setState({ value: true });
+            unsuccessfulOnly.changeValueTo('0');
           } else {
-            errorLevel.changeValueTo('.*');
+            unsuccessfulOnly.changeValueTo('.*');
           }
         }}
       />

--- a/src/scenes/SCRIPTED/scriptedScene.ts
+++ b/src/scenes/SCRIPTED/scriptedScene.ts
@@ -96,7 +96,7 @@ export function getScriptedScene(
           }),
           new SceneFlexLayout({
             direction: 'row',
-            minHeight: 300,
+            minHeight: 900,
             children: [getAllLogs(logs)],
           }),
         ],


### PR DESCRIPTION
Untoggled:

![Screenshot 2024-04-19 at 11 23 32](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/09fe1386-3255-4f39-ae83-749187cd4eb7)

Now toggled:

![Screenshot 2024-04-19 at 11 23 37](https://github.com/grafana/synthetic-monitoring-app/assets/8377044/68ac8fcd-6b23-44ea-ab97-3a2e6dab5fad)

Hopefully this makes it easier to see _why_ a check failed. The one in this screenshot timed out. Before this change the logs were getting filtered by error level, and all the lines that preceded the actual error got filtered out.