### PR TITLE
Fix/add scripted check to filter

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -55,19 +55,17 @@ const Heading = ({ as = 'h2', children, className, variant = 'h2', ...rest }: He
   const styles = useStyles2((theme) => getHeadingStyles(theme, variant));
   const { href } = useContext(CardContext);
 
+  const content = <Tag className={cx(styles.heading, className)}>{children}</Tag>;
+
   if (href) {
     return (
-      <Link className={cx(styles.link, className)} href={href} {...rest}>
-        <Tag className={styles.heading}>{children}</Tag>
+      <Link className={styles.link} href={href} {...rest}>
+        {content}
       </Link>
     );
   }
 
-  return (
-    <Tag className={cx(styles.heading, className)} {...rest}>
-      {children}
-    </Tag>
-  );
+  return content;
 };
 
 const getHeadingStyles = (theme: GrafanaTheme2, variant: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6') => ({

--- a/src/components/CheckFilters.tsx
+++ b/src/components/CheckFilters.tsx
@@ -3,23 +3,13 @@ import { GrafanaTheme2, SelectableValue, unEscapeStringFromRegex } from '@grafan
 import { Icon, Input, MultiSelect, Select, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
-import { Check, CheckFiltersType } from 'types';
+import { Check, CheckFiltersType, CheckTypeFilter } from 'types';
 import { useProbes } from 'data/useProbes';
+import { useCheckTypeOptions } from 'hooks/useCheckTypeOptions';
 
 import CheckFilterGroup from './CheckList/CheckFilterGroup';
-import { CHECK_FILTER_OPTIONS, CHECK_LIST_STATUS_OPTIONS } from './constants';
+import { CHECK_LIST_STATUS_OPTIONS } from './constants';
 import { LabelFilterInput } from './LabelFilterInput';
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  flexRow: css`
-    display: flex;
-    flex-direction: row;
-  `,
-  verticalSpace: css`
-    margin-top: 10px;
-    margin-bottom: 10px;
-  `,
-});
 
 interface Props {
   onReset: () => void;
@@ -56,6 +46,22 @@ export function CheckFilters({
   checkFilters = defaultFilters,
   includeStatus = true,
 }: Props) {
+  const checkTypeOptions = useCheckTypeOptions();
+  const filterDesc = checkTypeOptions.map((option) => {
+    return {
+      label: option.label,
+      value: option.value,
+    };
+  });
+
+  const options: Array<{ label: string; value: CheckTypeFilter }> = [
+    {
+      label: 'All',
+      value: 'all',
+    },
+    ...filterDesc,
+  ];
+
   const styles = useStyles2(getStyles);
   const [searchValue, setSearchValue] = useState(checkFilters.search);
   const { data: probes = [] } = useProbes();
@@ -112,7 +118,7 @@ export function CheckFilters({
           <Select
             aria-label="Filter by type"
             prefix="Types"
-            options={CHECK_FILTER_OPTIONS}
+            options={options}
             className={styles.verticalSpace}
             width={20}
             onChange={(selected: SelectableValue) => {
@@ -157,3 +163,14 @@ export function CheckFilters({
     </>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  flexRow: css({
+    display: `flex`,
+    flexDirection: `row`,
+  }),
+  verticalSpace: css({
+    marginTop: `10px`,
+    marginTottom: `10px`,
+  }),
+});

--- a/src/components/CheckList/checkFilters.ts
+++ b/src/components/CheckList/checkFilters.ts
@@ -1,9 +1,9 @@
 import { SelectableValue } from '@grafana/data';
 
-import { Check, CheckEnabledStatus, CheckFiltersType } from 'types';
+import { Check, CheckEnabledStatus, CheckFiltersType, CheckTypeFilter } from 'types';
 import { checkType as getCheckType, matchStrings } from 'utils';
 
-const matchesFilterType = (check: Check, typeFilter: string) => {
+const matchesFilterType = (check: Check, typeFilter: CheckTypeFilter) => {
   if (typeFilter === 'all') {
     return true;
   }

--- a/src/components/ChooseCheckType.tsx
+++ b/src/components/ChooseCheckType.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { Badge, BadgeColor, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { DataTestIds } from 'test/dataTestIds';
 
 import { CheckStatus, CheckType, ROUTES } from 'types';
 import { isOverCheckLimit, isOverScriptedLimit } from 'utils';
@@ -63,7 +64,7 @@ export function ChooseCheckType() {
           }}
         />
       )}
-      <div className={styles.container}>
+      <div className={styles.container} data-testid={DataTestIds.CHOOSE_CHECK_TYPE}>
         {options.map((check) => {
           return (
             <Card key={check?.label || ''} className={styles.card} href={`${getRoute(ROUTES.NewCheck)}/${check.value}`}>

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -8,11 +8,13 @@ import {
   CheckEnabledStatus,
   CheckListViewType,
   CheckSort,
+  CheckStatus,
   CheckType,
   DNSCheck,
   DnsProtocol,
   DnsRecordType,
   DnsResponseCodes,
+  FeatureName,
   GRPCCheck,
   HTTPCheck,
   HTTPCompressionAlgo,
@@ -110,37 +112,6 @@ export const IP_OPTIONS = [
   },
 ];
 
-export const CHECK_FILTER_OPTIONS = [
-  {
-    label: 'All',
-    value: 'all',
-  },
-  {
-    label: 'HTTP',
-    value: CheckType.HTTP,
-  },
-  {
-    label: 'MULTIHTTP',
-    value: CheckType.MULTI_HTTP,
-  },
-  {
-    label: 'PING',
-    value: CheckType.PING,
-  },
-  {
-    label: 'DNS',
-    value: CheckType.DNS,
-  },
-  {
-    label: 'TCP',
-    value: CheckType.TCP,
-  },
-  {
-    label: 'Traceroute',
-    value: CheckType.Traceroute,
-  },
-];
-
 export const CHECK_TYPE_OPTIONS = [
   {
     label: 'HTTP',
@@ -151,6 +122,7 @@ export const CHECK_TYPE_OPTIONS = [
     label: 'MULTIHTTP',
     value: CheckType.MULTI_HTTP,
     description: 'Check multiple web endpoints in sequence',
+    status: CheckStatus.PUBLIC_PREVIEW,
   },
   {
     label: 'PING',
@@ -176,6 +148,8 @@ export const CHECK_TYPE_OPTIONS = [
     label: 'Scripted',
     value: CheckType.Scripted,
     description: 'Write a K6 script to run custom checks',
+    status: CheckStatus.EXPERIMENTAL,
+    featureToggle: FeatureName.ScriptedChecks,
   },
 ];
 

--- a/src/hooks/useCheckTypeOptions.ts
+++ b/src/hooks/useCheckTypeOptions.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+
+import { FeatureFlagContext } from 'contexts/FeatureFlagContext';
+import { CHECK_TYPE_OPTIONS } from 'components/constants';
+
+export function useCheckTypeOptions() {
+  const { isFeatureEnabled } = useContext(FeatureFlagContext);
+
+  return CHECK_TYPE_OPTIONS.filter((option) => {
+    if (option.featureToggle) {
+      return isFeatureEnabled(option.featureToggle);
+    }
+
+    return true;
+  });
+}

--- a/src/page/ChecksPage.test.tsx
+++ b/src/page/ChecksPage.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
+import { DataTestIds } from 'test/dataTestIds';
 import { ALERTING_RULES } from 'test/fixtures/alerting';
 import { BASIC_CHECK_LIST, BASIC_HTTP_CHECK, BASIC_PING_CHECK } from 'test/fixtures/checks';
 import { apiRoute } from 'test/handlers';
@@ -31,11 +32,12 @@ test('renders checks', async () => {
 test('renders check selection page with correct check types', async () => {
   const { user } = await renderChecksPage();
   await user.click(screen.getByText('Add new check'));
-  expect(screen.queryByText('HTTP', { selector: `h2` })).toBeInTheDocument();
-  expect(screen.queryByText('MULTIHTTP', { selector: `h2` })).toBeInTheDocument();
-  expect(screen.queryByText('Traceroute', { selector: `h2` })).toBeInTheDocument();
-  expect(screen.queryByText('PING', { selector: `h2` })).toBeInTheDocument();
-  expect(screen.queryByText('DNS', { selector: `h2` })).toBeInTheDocument();
+  const container = screen.getByTestId(DataTestIds.CHOOSE_CHECK_TYPE);
+  expect(within(container).queryByText('HTTP')).toBeInTheDocument();
+  expect(within(container).queryByText('MULTIHTTP')).toBeInTheDocument();
+  expect(within(container).queryByText('Traceroute')).toBeInTheDocument();
+  expect(within(container).queryByText('PING')).toBeInTheDocument();
+  expect(within(container).queryByText('DNS')).toBeInTheDocument();
 });
 
 test('renders check editor existing check', async () => {

--- a/src/test/dataTestIds.ts
+++ b/src/test/dataTestIds.ts
@@ -2,4 +2,5 @@ export enum DataTestIds {
   PRIVATE_PROBES_LIST = 'private-probes-list',
   PUBLIC_PROBES_LIST = 'public-probes-list',
   CHECK_FORM_HTTP_VALIDATION_REGEX = 'check-form-http-validation-regex',
+  CHOOSE_CHECK_TYPE = 'choose-check-type',
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -371,6 +371,8 @@ export type CheckFormValues =
   | CheckFormValuesTcp
   | CheckFormValuesTraceroute;
 
+export type CheckTypeFilter = CheckType | 'all';
+
 export interface FilteredCheck extends Omit<Check, 'id'> {
   id: number;
 }
@@ -697,7 +699,7 @@ export interface CheckFiltersType {
   [key: string]: any;
   search: string;
   labels: string[];
-  type: CheckType | 'all';
+  type: CheckTypeFilter;
   status: SelectableValue<CheckEnabledStatus>;
   probes: SelectableValue[] | [];
 }
@@ -760,3 +762,8 @@ export type PrometheusAlertingRule = {
   state: 'inactive'; // fill in others
   type: `alerting`;
 };
+
+export enum CheckStatus {
+  EXPERIMENTAL = 'experimental',
+  PUBLIC_PREVIEW = 'public-preview',
+}


### PR DESCRIPTION
## Problem

The scripted checks weren't showing as a filter option on the checks list page when the feature toggle was enabled.

## Solution

As there were several places for this data to be read from, I've unified them into a singular `useCheckTypeOptions` hook, so there is a singular source of truth making further maintenance easier. This hook could probably be expanded on further in the future so we also tie in messaging on the check pages to refer to the status or some such here, too.

In particular I am thinking of when we add browser checks but that work can be done closer to the time then.