### PR TITLE
feat: add toggle to prevent scripted checks from running on probes

### DIFF
--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -3,7 +3,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import { OrgRole } from '@grafana/data';
 import { Field, Input } from '@grafana/ui';
 
-import { CheckFormValues, CheckType } from 'types';
+import { CheckFormValues, CheckType, Probe } from 'types';
 import { hasRole } from 'utils';
 import { validateFrequency, validateProbes, validateTimeout } from 'validation';
 import { useProbes } from 'data/useProbes';
@@ -55,6 +55,13 @@ function getTimeoutBounds(checkType: CheckType) {
   };
 }
 
+function getAvailableProbes(probes: Probe[], checkType: CheckType) {
+  if (checkType === CheckType.Scripted) {
+    return probes.filter((probe) => probe.capabilities.disableScriptedChecks === false);
+  }
+  return probes;
+}
+
 export const ProbeOptions = ({ checkType }: Props) => {
   const { data: probes = [] } = useProbes();
   const {
@@ -78,7 +85,7 @@ export const ProbeOptions = ({ checkType }: Props) => {
           <CheckProbes
             {...field}
             probes={field.value}
-            availableProbes={probes}
+            availableProbes={getAvailableProbes(probes, checkType)}
             isEditor={isEditor}
             invalid={Boolean(errors.probes)}
             error={errors.probes?.message}

--- a/src/components/ProbeEditor/ProbeEditor.tsx
+++ b/src/components/ProbeEditor/ProbeEditor.tsx
@@ -6,6 +6,7 @@ import { css } from '@emotion/css';
 
 import { Probe, ROUTES } from 'types';
 import { canEditProbes } from 'utils';
+import { HorizontalCheckboxField } from 'components/HorizonalCheckboxField';
 import { LabelField } from 'components/LabelField';
 import { ProbeRegionsSelect } from 'components/ProbeRegionsSelect';
 import { getRoute } from 'components/Routing';
@@ -162,6 +163,16 @@ export const ProbeEditor = ({
                   </Field>
                 </div>
                 {canEdit && <LabelField<Probe> labelDestination={'probe'} />}
+                <div className={styles.marginBottom}>
+                  <Legend>Capabilities</Legend>
+                  <HorizontalCheckboxField
+                    {...form.register('capabilities.disableScriptedChecks')}
+                    label="Disable scripted checks"
+                    description="Prevent probe from running k6 based scripted checks."
+                    disabled={!canEdit}
+                    id="capabilities.disableScriptedChecks"
+                  />
+                </div>
                 <div className={styles.buttonWrapper}>
                   {canEdit && (
                     <>

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -183,4 +183,5 @@ export const probeToTF = (probe: Probe): TFProbe => ({
   region: probe.region,
   public: false,
   labels: labelsToTFLabels(probe.labels),
+  capabilities: probe.capabilities,
 });

--- a/src/page/NewProbe/NewProbe.tsx
+++ b/src/page/NewProbe/NewProbe.tsx
@@ -23,6 +23,9 @@ export const TEMPLATE_PROBE: Probe = {
   onlineChange: 0,
   version: 'unknown',
   deprecated: false,
+  capabilities: {
+    disableScriptedChecks: false,
+  },
 };
 
 export const NewProbe = () => {

--- a/src/test/fixtures/probes.ts
+++ b/src/test/fixtures/probes.ts
@@ -17,6 +17,9 @@ export const PRIVATE_PROBE: Probe = {
   deprecated: false,
   modified: 1700000000.0,
   created: 1694212496.731247,
+  capabilities: {
+    disableScriptedChecks: false,
+  },
 } as const satisfies Probe;
 
 export const PUBLIC_PROBE: Probe = {
@@ -33,6 +36,9 @@ export const PUBLIC_PROBE: Probe = {
   deprecated: false,
   modified: 1700000000.0,
   created: 1694212496.731247,
+  capabilities: {
+    disableScriptedChecks: false,
+  },
 } as const satisfies Probe;
 
 export const ONLINE_PROBE: Probe = {
@@ -44,6 +50,13 @@ export const OFFLINE_PROBE: Probe = {
   ...PRIVATE_PROBE,
   online: false,
 } as const satisfies Probe;
+
+export const SCRIPTED_DISABLED_PROBE: Probe = {
+  ...PRIVATE_PROBE,
+  capabilities: {
+    disableScriptedChecks: true,
+  },
+};
 
 export const UNSELECTED_PRIVATE_PROBE: Probe = {
   name: 'enchiladas',
@@ -59,6 +72,9 @@ export const UNSELECTED_PRIVATE_PROBE: Probe = {
   deprecated: false,
   modified: 1700000000.0,
   created: 1694212496.731247,
+  capabilities: {
+    disableScriptedChecks: false,
+  },
 } as const satisfies Probe;
 
 export const DEFAULT_PROBES = [PRIVATE_PROBE, PUBLIC_PROBE, UNSELECTED_PRIVATE_PROBE];

--- a/src/test/fixtures/terraform.ts
+++ b/src/test/fixtures/terraform.ts
@@ -14,6 +14,7 @@ export const TERRAFORM_PRIVATE_PROBES = {
     name: PRIVATE_PROBE.name,
     public: PRIVATE_PROBE.public,
     region: PRIVATE_PROBE.region,
+    capabilities: PRIVATE_PROBE.capabilities,
   },
   [UNSELECTED_PRIVATE_PROBE.name]: {
     labels: {
@@ -24,6 +25,7 @@ export const TERRAFORM_PRIVATE_PROBES = {
     name: UNSELECTED_PRIVATE_PROBE.name,
     public: UNSELECTED_PRIVATE_PROBE.public,
     region: UNSELECTED_PRIVATE_PROBE.region,
+    capabilities: UNSELECTED_PRIVATE_PROBE.capabilities,
   },
 };
 

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -5,12 +5,15 @@ import { UserEvent } from '@testing-library/user-event';
 
 import { type Probe } from 'types';
 
-export const UPDATED_VALUES: Pick<Probe, 'name' | 'latitude' | 'longitude' | 'region' | 'labels'> = {
+export const UPDATED_VALUES: Pick<Probe, 'name' | 'latitude' | 'longitude' | 'region' | 'labels' | 'capabilities'> = {
   latitude: 19.05758,
   longitude: 72.89654,
   name: 'Shiny excellent probe',
   region: 'APAC',
   labels: [{ name: 'UPDATED', value: 'PROBE' }],
+  capabilities: {
+    disableScriptedChecks: true,
+  },
 };
 
 export async function fillProbeForm(user: UserEvent) {
@@ -47,6 +50,9 @@ export async function fillProbeForm(user: UserEvent) {
     const labelValueInput = await screen.findByLabelText(`Label ${humanIndex} value`, { exact: false });
     await user.type(labelValueInput, label.value);
   }
+
+  const disableScriptedChecks = await screen.findByLabelText('Disable scripted checks', { exact: false });
+  await user.click(disableScriptedChecks);
 }
 
 export function runTestAsViewer() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,11 @@ export interface Probe extends BaseObject {
   labels: Label[];
   version: string;
   deprecated: boolean;
+  capabilities: ProbeCapabilities;
+}
+
+interface ProbeCapabilities {
+  disableScriptedChecks: boolean;
 }
 
 export enum ResponseMatchType {


### PR DESCRIPTION
Probes now have a `capabilities` key that allows them to communicate their preferences to the frontend. The only one that exists so far is whether to disable scripted checks or not, that allows us to prevent users from added scripted checks to non-AWS probes, and allows users to decide whether to run scripted checks on private probes