### PR TITLE
fix: update doc links

### DIFF
--- a/src/components/DocsLink/DocsLink.tsx
+++ b/src/components/DocsLink/DocsLink.tsx
@@ -4,7 +4,7 @@ import { Icon, useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
 
 const docs = {
-  probes: `https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/#probes`,
+  probes: `https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/public-probes/`,
   publicProbes: `https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/public-probes/`,
   privateProbes: `https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/`,
   addPrivateProbe: `https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/#add-a-new-probe-in-your-grafana-instance`,

--- a/src/components/DocsLink/DocsLink.tsx
+++ b/src/components/DocsLink/DocsLink.tsx
@@ -4,10 +4,10 @@ import { Icon, useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
 
 const docs = {
-  probes: `https://grafana.com/docs/grafana-cloud/monitor-public-endpoints/#probes`,
-  publicProbes: `https://grafana.com/docs/grafana-cloud/monitor-public-endpoints/probes/`,
-  privateProbes: `https://grafana.com/docs/grafana-cloud/monitor-public-endpoints/private-probes/`,
-  addPrivateProbe: `https://grafana.com/docs/grafana-cloud/monitor-public-endpoints/private-probes/#add-a-new-probe-in-your-grafana-instance`,
+  probes: `https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/#probes`,
+  publicProbes: `https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/public-probes/`,
+  privateProbes: `https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/`,
+  addPrivateProbe: `https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/#add-a-new-probe-in-your-grafana-instance`,
 };
 
 type DocsLinkProps = {

--- a/src/page/AlertingPage.tsx
+++ b/src/page/AlertingPage.tsx
@@ -89,7 +89,7 @@ const Alerting = () => {
       <p>
         View and edit default alerts for Synthetic Monitoring here. To tie one of these alerts to a check, you must
         select the alert sensitivity from the Alerting section of the check form when creating a check.{' '}
-        <a href="https://grafana.com/docs/grafana-cloud/monitor-public-endpoints/configure-alerts/synthetic-monitoring-alerting/" className={styles.link}>
+        <a href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/synthetic-monitoring-alerting/" className={styles.link}>
           Learn more about alerting for Synthetic Monitoring.
         </a>
       </p>

--- a/src/page/AlertingPage.tsx
+++ b/src/page/AlertingPage.tsx
@@ -89,23 +89,8 @@ const Alerting = () => {
       <p>
         View and edit default alerts for Synthetic Monitoring here. To tie one of these alerts to a check, you must
         select the alert sensitivity from the Alerting section of the check form when creating a check.{' '}
-        <a href="https://grafana.com/docs/grafana-cloud/synthetic-monitoring/#alerting" className={styles.link}>
+        <a href="https://grafana.com/docs/grafana-cloud/monitor-public-endpoints/configure-alerts/synthetic-monitoring-alerting/" className={styles.link}>
           Learn more about alerting for Synthetic Monitoring.
-        </a>
-      </p>
-      <p>
-        Routes and receivers must be configured in{' '}
-        <a href={'/alerting/list'} className={styles.link} target="blank" rel="noopener noreferer">
-          Grafana Alerting
-        </a>{' '}
-        in order to be notified when an alert fires.{' '}
-        <a
-          href="https://grafana.com/blog/2020/02/25/step-by-step-guide-to-setting-up-prometheus-alertmanager-with-slack-pagerduty-and-gmail/"
-          target="blank"
-          rel="noopener noreferer"
-          className={styles.link}
-        >
-          Learn more about configuring Alertmanager
         </a>
       </p>
       {!alertRules && <Spinner />}

--- a/src/scenes/SCRIPTED/AssertionsTable/AssertionsTable.tsx
+++ b/src/scenes/SCRIPTED/AssertionsTable/AssertionsTable.tsx
@@ -216,7 +216,7 @@ function AssertionsTable({ model }: SceneComponentProps<AssertionsTableSceneObje
           href={
             checkType === CheckType.Scripted
               ? 'https://grafana.com/docs/k6/latest/using-k6/checks/'
-              : 'https://grafana.com/docs/grafana-cloud/monitor-public-endpoints/checks/multihttp/#assertions'
+              : 'https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/checks/multihttp/#assertions'
           }
           target="_blank"
           rel="noopener noreferrer"


### PR DESCRIPTION

1 - https://github.com/grafana/website/pull/19543 will update the SM Alerting documentation covering most of the info users need to understand how it works. 

In this PR, https://github.com/grafana/synthetic-monitoring-app/commit/ad5650fa244c24813e9e7244751dfa1bcdf9a1ed removes the reference to the outdated old post. 

If we want to include additional instructions, suggest adding to the documentation.

2 - Took the opportunity to update doc links due to doc reorganization. These links were working becuase redirects are in place, but thought it was a good idea to update them.

