### PR TITLE
Fix: only show query params for `CheckType.HTTP`

### DIFF
--- a/src/components/CheckEditor/FormComponents/CheckTarget.tsx
+++ b/src/components/CheckEditor/FormComponents/CheckTarget.tsx
@@ -8,14 +8,6 @@ interface Props {
   checkType: CheckType;
 }
 
-export const CheckTarget = ({ checkType }: Props) => {
-  return (
-    <RequestTargetInput
-      checkType={checkType}
-      data-testid="check-editor-target"
-      id="check-target"
-      name="target"
-      showQueryParams
-    />
-  );
-};
+export const CheckTarget = ({ checkType }: Props) => (
+  <RequestTargetInput checkType={checkType} data-testid="check-editor-target" id="check-target" name="target" />
+);

--- a/src/components/CheckEditor/FormComponents/RequestTargetInput.tsx
+++ b/src/components/CheckEditor/FormComponents/RequestTargetInput.tsx
@@ -142,12 +142,14 @@ const getTargetHelpText = (typeOfCheck: CheckType | undefined): TargetHelpInfo =
         text: 'The URL that best describes the target of the check',
         example: `https://grafana.com/`,
       };
+      break;
     }
     case CheckType.GRPC: {
       resp = {
         text: '',
         example: '',
       };
+      break;
     }
   }
   return resp;

--- a/src/components/CheckEditor/FormComponents/RequestTargetInput.tsx
+++ b/src/components/CheckEditor/FormComponents/RequestTargetInput.tsx
@@ -16,7 +16,6 @@ type RequestMethodInputProps = {
   checkType: CheckType;
   id: string;
   name: FieldPath<CheckFormValues>;
-  showQueryParams?: boolean;
 };
 
 export const RequestTargetInput = ({
@@ -25,13 +24,13 @@ export const RequestTargetInput = ({
   id,
   name,
   'data-testid': dataTestId,
-  showQueryParams,
 }: RequestMethodInputProps) => {
   const { control, formState, watch } = useFormContext<CheckFormValues>();
   const error = get(formState.errors, name);
   const styles = useStyles2(getStyles);
   const targetHelp = getTargetHelpText(checkType);
   const parsedURL = parseUrl(watch('target'));
+  const showQueryParams = checkType === CheckType.HTTP;
 
   return (
     <Controller


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:
Every check that was using `CheckTarget` component could have the "Query Params" inputs rendered based on the `target` value. AFAIK, only `CheckType.HTTP` is using the "Query Params" part of `RequestTargetInput`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/synthetic-monitoring-app/issues/766

**Special notes for your reviewer**:
![image](https://github.com/grafana/synthetic-monitoring-app/assets/1382208/eee2725c-fc4d-493c-a8ba-db48f30fa336)
![image](https://github.com/grafana/synthetic-monitoring-app/assets/1382208/908e8ce6-c145-4f1f-a137-658c98ab8907)
![image](https://github.com/grafana/synthetic-monitoring-app/assets/1382208/91c44d45-8581-4d65-8cc5-7c32c9134177)
![image](https://github.com/grafana/synthetic-monitoring-app/assets/1382208/58dafc66-55be-4234-934e-6d4b2183e5f4)

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
