### PR TITLE
fix: submission errors off screen and usage layout

### DIFF
--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -1,9 +1,7 @@
 import React, { BaseSyntheticEvent, useMemo, useRef, useState } from 'react';
 import { FormProvider, SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
-import { GrafanaTheme2 } from '@grafana/data';
-import { Alert, Button, ConfirmModal, LinkButton, useStyles2 } from '@grafana/ui';
-import { css } from '@emotion/css';
+import { Button, ConfirmModal, LinkButton } from '@grafana/ui';
 
 import { Check, CheckFormValues, CheckPageParams, CheckType, ROUTES } from 'types';
 import { isOverCheckLimit, isOverScriptedLimit } from 'utils';
@@ -61,7 +59,6 @@ type CheckFormContentProps = {
 
 const CheckFormContent = ({ check, checkType, overCheckLimit, overScriptedLimit }: CheckFormContentProps) => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const styles = useStyles2(getStyles);
   const { adhocTestData, closeModal, isPending, openTestCheckModal, testCheck, testCheckError } =
     useAdhocTest(checkType);
 
@@ -169,16 +166,14 @@ const CheckFormContent = ({ check, checkType, overCheckLimit, overScriptedLimit 
               buttonText="Go to checks"
             />
           )}
-          <CheckSelector checkType={checkType} formActions={actions} onSubmit={handleSubmit} />
+          <CheckSelector
+            checkType={checkType}
+            formActions={actions}
+            onSubmit={handleSubmit}
+            errorMessage={(submissionError && submissionError.message) ?? 'Something went wrong'}
+          />
         </FormProvider>
       </>
-      {submissionError && (
-        <div className={styles.submissionError}>
-          <Alert title="Save failed" severity="error">
-            {submissionError.message ?? 'Something went wrong'}
-          </Alert>
-        </div>
-      )}
       <CheckTestResultsModal isOpen={openTestCheckModal} onDismiss={closeModal} testResponse={adhocTestData} />
       <ConfirmModal
         isOpen={showDeleteModal}
@@ -200,6 +195,7 @@ const CheckSelector = ({
   formActions: React.JSX.Element[];
   onSubmit: SubmitHandler<CheckFormValues>;
   onSubmitError?: SubmitErrorHandler<CheckFormValues>;
+  errorMessage?: string;
 }) => {
   if (checkType === CheckType.HTTP) {
     return <CheckHTTPLayout {...rest} />;
@@ -243,14 +239,3 @@ function isValidCheckType(checkType?: CheckType): checkType is CheckType {
 
   return false;
 }
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  stack: css({
-    marginTop: theme.spacing(4),
-    display: `flex`,
-    gap: theme.spacing(1),
-  }),
-  submissionError: css({
-    marginTop: theme.spacing(2),
-  }),
-});

--- a/src/components/CheckForm/FormLayout/FormLayout.tsx
+++ b/src/components/CheckForm/FormLayout/FormLayout.tsx
@@ -109,14 +109,15 @@ export const FormLayout = ({
           })}
         >
           <div>{sections}</div>
-          {errorMessage && (
-            <div className={styles.submissionError}>
-              <Alert title="Save failed" severity="error">
-                {errorMessage}
-              </Alert>
-            </div>
-          )}
+
           <div>
+            {errorMessage && (
+              <div className={styles.submissionError}>
+                <Alert title="Save failed" severity="error">
+                  {errorMessage}
+                </Alert>
+              </div>
+            )}{' '}
             <hr />
             <div className={cx(styles.actionsBar, styles.sectionContent)}>
               <div className={styles.buttonGroup}>

--- a/src/components/CheckForm/FormLayout/FormLayout.tsx
+++ b/src/components/CheckForm/FormLayout/FormLayout.tsx
@@ -1,7 +1,7 @@
 import React, { Children, isValidElement, ReactNode, useState } from 'react';
 import { FieldError, FieldErrors, FieldPath, FormState, useFormContext, UseFormGetFieldState } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, useStyles2 } from '@grafana/ui';
+import { Alert, Button, useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
 import { flatten } from 'flat';
 
@@ -13,6 +13,7 @@ import { FormSidebar, FormSidebarSection } from './FormSidebar';
 
 type FormLayoutProps = {
   children: ReactNode;
+  errorMessage?: string;
 };
 
 export const FormLayout = ({
@@ -20,6 +21,7 @@ export const FormLayout = ({
   formActions,
   onSubmit,
   onSubmitError,
+  errorMessage,
 }: FormLayoutProps & CheckFormTypeLayoutProps) => {
   let index = -1;
   const [activeIndex, setActiveIndex] = useState(0);
@@ -107,6 +109,13 @@ export const FormLayout = ({
           })}
         >
           <div>{sections}</div>
+          {errorMessage && (
+            <div className={styles.submissionError}>
+              <Alert title="Save failed" severity="error">
+                {errorMessage}
+              </Alert>
+            </div>
+          )}
           <div>
             <hr />
             <div className={cx(styles.actionsBar, styles.sectionContent)}>
@@ -211,6 +220,9 @@ const getStyles = (theme: GrafanaTheme2) => {
         gridTemplateColumns: `240px 1fr`,
         height: '100%',
       },
+    }),
+    submissionError: css({
+      marginTop: theme.spacing(2),
     }),
     section: css({
       containerName,

--- a/src/components/CheckForm/FormLayouts/CheckDNSLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckDNSLayout.tsx
@@ -18,9 +18,9 @@ import { CheckFormAlert } from 'components/CheckFormAlert';
 import { CheckUsage } from 'components/CheckUsage';
 import { LabelField } from 'components/LabelField';
 
-export const CheckDNSLayout = ({ formActions, onSubmit, onSubmitError }: CheckFormTypeLayoutProps) => {
+export const CheckDNSLayout = ({ formActions, onSubmit, onSubmitError, errorMessage }: CheckFormTypeLayoutProps) => {
   return (
-    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError}>
+    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError} errorMessage={errorMessage}>
       <FormLayout.Section label="Define check" fields={[`enabled`, `job`, `target`]} required>
         <CheckEnabled />
         <CheckJobName />

--- a/src/components/CheckForm/FormLayouts/CheckHttpLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckHttpLayout.tsx
@@ -26,9 +26,9 @@ import { CheckUsage } from 'components/CheckUsage';
 import { LabelField } from 'components/LabelField';
 import { TLSConfig } from 'components/TLSConfig';
 
-export const CheckHTTPLayout = ({ formActions, onSubmit, onSubmitError }: CheckFormTypeLayoutProps) => {
+export const CheckHTTPLayout = ({ formActions, onSubmit, onSubmitError, errorMessage }: CheckFormTypeLayoutProps) => {
   return (
-    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError}>
+    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError} errorMessage={errorMessage}>
       <FormLayout.Section label="Define check" fields={[`enabled`, `job`, `target`]} required>
         <CheckJobName />
         <CheckTarget checkType={CheckType.HTTP} />

--- a/src/components/CheckForm/FormLayouts/CheckPingLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckPingLayout.tsx
@@ -13,9 +13,9 @@ import { CheckFormAlert } from 'components/CheckFormAlert';
 import { CheckUsage } from 'components/CheckUsage';
 import { LabelField } from 'components/LabelField';
 
-export const CheckPingLayout = ({ formActions, onSubmit, onSubmitError }: CheckFormTypeLayoutProps) => {
+export const CheckPingLayout = ({ formActions, onSubmit, onSubmitError, errorMessage }: CheckFormTypeLayoutProps) => {
   return (
-    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError}>
+    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError} errorMessage={errorMessage}>
       <FormLayout.Section label="Define check" fields={[`enabled`, `job`, `target`]} required>
         <CheckEnabled />
         <CheckJobName />

--- a/src/components/CheckForm/FormLayouts/CheckScriptedLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckScriptedLayout.tsx
@@ -14,11 +14,16 @@ import { CheckFormAlert } from 'components/CheckFormAlert';
 import { CheckUsage } from 'components/CheckUsage';
 import { LabelField } from 'components/LabelField';
 
-export const CheckScriptedLayout = ({ formActions, onSubmit, onSubmitError }: CheckFormTypeLayoutProps) => {
+export const CheckScriptedLayout = ({
+  formActions,
+  onSubmit,
+  onSubmitError,
+  errorMessage,
+}: CheckFormTypeLayoutProps) => {
   const styles = useStyles2(getStyles);
 
   return (
-    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError}>
+    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError} errorMessage={errorMessage}>
       <FormLayout.Section label="Define check" fields={[`enabled`, `job`, `target`]} required>
         <CheckEnabled />
         <CheckJobName />

--- a/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
@@ -15,9 +15,9 @@ import { CheckUsage } from 'components/CheckUsage';
 import { LabelField } from 'components/LabelField';
 import { TLSConfig } from 'components/TLSConfig';
 
-export const CheckTCPLayout = ({ formActions, onSubmit, onSubmitError }: CheckFormTypeLayoutProps) => {
+export const CheckTCPLayout = ({ formActions, onSubmit, onSubmitError, errorMessage }: CheckFormTypeLayoutProps) => {
   return (
-    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError}>
+    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError} errorMessage={errorMessage}>
       <FormLayout.Section label="Define check" fields={[`enabled`, `job`, `target`]} required>
         <CheckEnabled />
         <CheckJobName />

--- a/src/components/CheckForm/FormLayouts/CheckTracerouteLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckTracerouteLayout.tsx
@@ -14,9 +14,14 @@ import { CheckFormAlert } from 'components/CheckFormAlert';
 import { CheckUsage } from 'components/CheckUsage';
 import { LabelField } from 'components/LabelField';
 
-export const CheckTracerouteLayout = ({ formActions, onSubmit, onSubmitError }: CheckFormTypeLayoutProps) => {
+export const CheckTracerouteLayout = ({
+  formActions,
+  onSubmit,
+  onSubmitError,
+  errorMessage,
+}: CheckFormTypeLayoutProps) => {
   return (
-    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError}>
+    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError} errorMessage={errorMessage}>
       <FormLayout.Section label="Define check" fields={[`enabled`, `job`, `target`]} required>
         <CheckEnabled />
         <CheckJobName />

--- a/src/components/CheckUsage.tsx
+++ b/src/components/CheckUsage.tsx
@@ -13,8 +13,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginBottom: theme.spacing(6),
   }),
   calcList: css({
-    display: 'flex',
-    flexWrap: 'wrap',
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
     gap: theme.spacing(1),
   }),
   icon: css({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { SubmitErrorHandler, SubmitHandler } from 'react-hook-form';
 import { DataSourceSettings, OrgRole, SelectableValue } from '@grafana/data';
 import { EmbeddedScene, SceneRouteMatch } from '@grafana/scenes';
@@ -778,4 +779,5 @@ export interface CheckFormTypeLayoutProps {
   formActions: React.JSX.Element[];
   onSubmit: SubmitHandler<CheckFormValues>;
   onSubmitError?: SubmitErrorHandler<CheckFormValues>;
+  errorMessage?: string;
 }


### PR DESCRIPTION
<img width="875" alt="Screenshot 2024-04-25 at 13 41 35" src="https://github.com/grafana/synthetic-monitoring-app/assets/8377044/0cc38606-951a-4317-bcf7-3055a2939941">
Puts  usage on two lines so it doesn't wrap annoyingly

Also makes submission errors visible:
<img width="1062" alt="Screenshot 2024-04-25 at 13 42 33" src="https://github.com/grafana/synthetic-monitoring-app/assets/8377044/77285e32-56a1-4535-b21f-834863807af0">
