### PR TITLE
feat: add UI for gRPC checks

### DIFF
--- a/.config/jest/utils.js
+++ b/.config/jest/utils.js
@@ -25,5 +25,5 @@ const grafanaESModules = [
 
 module.exports = {
   nodeModulesToTransform,
-  grafanaESModules
-}
+  grafanaESModules,
+};

--- a/src/components/CheckEditor/FormComponents/CheckIpVersion.tsx
+++ b/src/components/CheckEditor/FormComponents/CheckIpVersion.tsx
@@ -8,7 +8,7 @@ import { hasRole } from 'utils';
 import { IP_OPTIONS } from 'components/constants';
 
 type CheckIpVersionProps = {
-  checkType: CheckType.HTTP | CheckType.PING | CheckType.DNS | CheckType.TCP;
+  checkType: CheckType.HTTP | CheckType.PING | CheckType.DNS | CheckType.TCP | CheckType.GRPC;
   name: FieldPath<CheckFormValues>;
 };
 
@@ -17,6 +17,7 @@ const requestMap = {
   [CheckType.PING]: `ICMP`,
   [CheckType.DNS]: `ICMP`,
   [CheckType.TCP]: `TCP`,
+  [CheckType.GRPC]: `GRPC`,
 };
 
 export const CheckIpVersion = ({ checkType, name }: CheckIpVersionProps) => {

--- a/src/components/CheckEditor/FormComponents/CheckUseTLS.tsx
+++ b/src/components/CheckEditor/FormComponents/CheckUseTLS.tsx
@@ -3,13 +3,13 @@ import { useFormContext } from 'react-hook-form';
 import { OrgRole } from '@grafana/data';
 import { Field, Switch } from '@grafana/ui';
 
-import { CheckFormValuesTcp } from 'types';
+import {TLSCheckTypes, TLSFormValues} from 'types';
 import { hasRole } from 'utils';
 
-export const TCPCheckUseTLS = () => {
+export const CheckUseTLS = ({checkType}: {checkType: TLSCheckTypes}) => {
   const isEditor = hasRole(OrgRole.Editor);
-  const { register } = useFormContext<CheckFormValuesTcp>();
-  const id = 'tcp-settings-use-tls';
+  const { register } = useFormContext<TLSFormValues>();
+  const id = `${checkType}-settings-use-tls`;
 
   return (
     <Field
@@ -19,7 +19,7 @@ export const TCPCheckUseTLS = () => {
       htmlFor={id}
     >
       <Switch
-        {...register('settings.tcp.tls')}
+        {...register(`settings.${checkType}.tls`)}
         title="Use TLS"
         disabled={!isEditor}
         id={id}

--- a/src/components/CheckEditor/FormComponents/GRPCCheckService.tsx
+++ b/src/components/CheckEditor/FormComponents/GRPCCheckService.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+import { OrgRole } from '@grafana/data';
+import { Field, Input } from '@grafana/ui';
+
+import { CheckFormValuesGRPC } from 'types';
+import { hasRole } from 'utils';
+
+export const GRPCCheckService = () => {
+  const isEditor = hasRole(OrgRole.Editor);
+  const { formState, register } = useFormContext<CheckFormValuesGRPC>();
+
+  return (
+    <Field
+      label="Service"
+      description={'Service to perform health check against'}
+      disabled={!isEditor}
+      invalid={Boolean(formState.errors?.settings?.grpc?.service)}
+      error={formState.errors?.settings?.grpc?.message}
+    >
+      <Input
+        id="check-editor-grpc-service-input"
+        {...register('settings.grpc.service')}
+        type="text"
+        placeholder="service"
+        data-fs-element="gRPC service name input"
+      />
+    </Field>
+  );
+};

--- a/src/components/CheckEditor/FormComponents/RequestTargetInput.tsx
+++ b/src/components/CheckEditor/FormComponents/RequestTargetInput.tsx
@@ -144,10 +144,11 @@ const getTargetHelpText = (typeOfCheck: CheckType | undefined): TargetHelpInfo =
       };
       break;
     }
+
     case CheckType.GRPC: {
       resp = {
-        text: '',
-        example: '',
+        text: 'Host:port to connect to',
+        example: 'grafana.com:50051',
       };
       break;
     }

--- a/src/components/CheckEditor/transformations/toFormValues.grpc.ts
+++ b/src/components/CheckEditor/transformations/toFormValues.grpc.ts
@@ -14,5 +14,10 @@ export function getGRPCCheckFormValues(check: GRPCCheck): CheckFormValuesGRPC {
 }
 
 const getGRPCSettingsFormValues = (settings: GRPCCheck['settings']): GRPCSettingsFormValues => {
-  return {};
+  return {
+    ipVersion: settings.grpc?.ipVersion,
+    service: settings.grpc?.service,
+    tls: settings.grpc?.tls,
+    tlsConfig: settings.grpc?.tlsConfig,
+  };
 };

--- a/src/components/CheckEditor/transformations/toPayload.grpc.ts
+++ b/src/components/CheckEditor/transformations/toPayload.grpc.ts
@@ -1,5 +1,9 @@
-import { CheckFormValuesGRPC, GRPCCheck } from 'types';
-import { getBasePayloadValuesFromForm } from 'components/CheckEditor/transformations/toPayload.utils';
+import { CheckFormValuesGRPC, GRPCCheck, GRPCSettings, GRPCSettingsFormValues } from 'types';
+import {
+  getBasePayloadValuesFromForm,
+  getTlsConfigFromFormValues,
+} from 'components/CheckEditor/transformations/toPayload.utils';
+import { FALLBACK_CHECK_GRPC } from 'components/constants';
 
 export function getGRPCPayload(formValues: CheckFormValuesGRPC): GRPCCheck {
   const base = getBasePayloadValuesFromForm(formValues);
@@ -7,7 +11,20 @@ export function getGRPCPayload(formValues: CheckFormValuesGRPC): GRPCCheck {
   return {
     ...base,
     settings: {
-      grpc: undefined,
+      grpc: getGRPCSettings(formValues.settings.grpc),
     },
+  };
+}
+
+function getGRPCSettings(settings: Partial<GRPCSettingsFormValues> | undefined = {}): GRPCSettings {
+  const fallbackValues = FALLBACK_CHECK_GRPC.settings.grpc;
+  const tlsConfig = getTlsConfigFromFormValues(settings.tlsConfig);
+
+  return {
+    ...fallbackValues,
+    ipVersion: settings.ipVersion ?? fallbackValues.ipVersion,
+    service: settings.service ?? fallbackValues.service,
+    tls: settings.tls ?? fallbackValues.tls,
+    ...tlsConfig,
   };
 }

--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -16,6 +16,7 @@ import { PluginPage } from 'components/PluginPage';
 import { getRoute } from 'components/Routing';
 
 import { CheckDNSLayout } from './FormLayouts/CheckDNSLayout';
+import { CheckGrpcLayout } from './FormLayouts/CheckGrpcLayout';
 import { CheckHTTPLayout } from './FormLayouts/CheckHttpLayout';
 import { CheckMultiHTTPLayout } from './FormLayouts/CheckMultiHttpLayout';
 import { CheckPingLayout } from './FormLayouts/CheckPingLayout';
@@ -80,7 +81,7 @@ const CheckFormContent = ({ check, checkType, overCheckLimit, overScriptedLimit 
     // react-hook-form doesn't let us provide SubmitEvent to BaseSyntheticEvent
     const submitter = (event?.nativeEvent as SubmitEvent).submitter;
     const toSubmit = toPayload(checkValues);
-
+    console.log('toSubmit', toSubmit);
     if (submitter === testRef.current) {
       return testCheck(toSubmit);
     }
@@ -225,6 +226,10 @@ const CheckSelector = ({
     return <CheckTracerouteLayout {...rest} />;
   }
 
+  if (checkType === CheckType.GRPC) {
+    return <CheckGrpcLayout />;
+  }
+
   throw new Error(`Invalid check type: ${checkType}`);
 };
 
@@ -233,9 +238,5 @@ function isValidCheckType(checkType?: CheckType): checkType is CheckType {
     return false;
   }
 
-  if (Object.values(CheckType).includes(checkType)) {
-    return true;
-  }
-
-  return false;
+  return Object.values(CheckType).includes(checkType);
 }

--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -81,7 +81,7 @@ const CheckFormContent = ({ check, checkType, overCheckLimit, overScriptedLimit 
     // react-hook-form doesn't let us provide SubmitEvent to BaseSyntheticEvent
     const submitter = (event?.nativeEvent as SubmitEvent).submitter;
     const toSubmit = toPayload(checkValues);
-    console.log('toSubmit', toSubmit);
+
     if (submitter === testRef.current) {
       return testCheck(toSubmit);
     }
@@ -227,7 +227,7 @@ const CheckSelector = ({
   }
 
   if (checkType === CheckType.GRPC) {
-    return <CheckGrpcLayout />;
+    return <CheckGrpcLayout {...rest} />;
   }
 
   throw new Error(`Invalid check type: ${checkType}`);

--- a/src/components/CheckForm/FormLayouts/CheckGrpcLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckGrpcLayout.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import {CheckFormValuesGRPC, CheckType} from 'types';
+import { CheckEnabled } from 'components/CheckEditor/FormComponents/CheckEnabled';
+import { CheckIpVersion } from 'components/CheckEditor/FormComponents/CheckIpVersion';
+import { CheckJobName } from 'components/CheckEditor/FormComponents/CheckJobName';
+import { CheckPublishedAdvanceMetrics } from 'components/CheckEditor/FormComponents/CheckPublishedAdvanceMetrics';
+import { CheckTarget } from 'components/CheckEditor/FormComponents/CheckTarget';
+import { CheckUseTLS } from 'components/CheckEditor/FormComponents/CheckUseTLS';
+import { GRPCCheckService } from 'components/CheckEditor/FormComponents/GRPCCheckService';
+import { ProbeOptions } from 'components/CheckEditor/ProbeOptions';
+import { FormLayout } from 'components/CheckForm/FormLayout/FormLayout';
+import { CheckFormAlert } from 'components/CheckFormAlert';
+import { CheckUsage } from 'components/CheckUsage';
+import { LabelField } from 'components/LabelField';
+import { TLSConfig } from 'components/TLSConfig';
+
+export const CheckGrpcLayout = () => {
+  return (
+    <FormLayout>
+      <FormLayout.Section
+        label="General settings"
+        fields={['enabled', 'job', 'target', 'probes', 'frequency', 'timeout']}
+      >
+        <CheckEnabled />
+        <CheckJobName />
+        <CheckTarget checkType={CheckType.GRPC} />
+        <ProbeOptions checkType={CheckType.GRPC} />
+        <CheckPublishedAdvanceMetrics />
+        <CheckUsage />
+      </FormLayout.Section>
+
+      <FormLayout.Section label="gRPC settings" fields={['settings.grpc.service', 'settings.grpc.tls']}>
+        <CheckUseTLS checkType={CheckType.GRPC} />
+        <GRPCCheckService />
+      </FormLayout.Section>
+
+      <FormLayout.Section label="TLS config" fields={[`settings.grpc.tlsConfig`]}>
+        <TLSConfig checkType={CheckType.GRPC} />
+      </FormLayout.Section>
+
+      <FormLayout.Section
+        label="Advanced options"
+        fields={['labels', 'settings.grpc.ipVersion']}
+      >
+        <LabelField<CheckFormValuesGRPC> />
+        <CheckIpVersion checkType={CheckType.GRPC} name="settings.grpc.ipVersion" />
+      </FormLayout.Section>
+      <FormLayout.Section label="Alerting" fields={[`alertSensitivity`]}>
+        <CheckFormAlert />
+      </FormLayout.Section>
+    </FormLayout>
+  );
+};

--- a/src/components/CheckForm/FormLayouts/CheckGrpcLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckGrpcLayout.tsx
@@ -21,21 +21,25 @@ export const CheckGrpcLayout = ({ formActions, onSubmit, onSubmitError, errorMes
       <FormLayout.Section
         label="General settings"
         fields={['enabled', 'job', 'target', 'probes', 'frequency', 'timeout']}
+        required
       >
         <CheckEnabled />
         <CheckJobName />
         <CheckTarget checkType={CheckType.GRPC} />
-        <ProbeOptions checkType={CheckType.GRPC} />
-        <CheckPublishedAdvanceMetrics />
-        <CheckUsage checkType={CheckType.GRPC} />
       </FormLayout.Section>
 
-      <FormLayout.Section label="gRPC settings" fields={['settings.grpc.service', 'settings.grpc.tls']}>
-        <CheckUseTLS checkType={CheckType.GRPC} />
+      <FormLayout.Section label="Probes" fields={[`probes`, `frequency`, `timeout`, `publishAdvancedMetrics`]} required>
+        <CheckUsage checkType={CheckType.GRPC} />
+        <CheckPublishedAdvanceMetrics />
+        <ProbeOptions checkType={CheckType.GRPC} />
+      </FormLayout.Section>
+
+      <FormLayout.Section label="gRPC settings" fields={['settings.grpc.service']}>
         <GRPCCheckService />
       </FormLayout.Section>
 
-      <FormLayout.Section label="TLS config" fields={[`settings.grpc.tlsConfig`]}>
+      <FormLayout.Section label="TLS config" fields={['settings.grpc.tls', 'settings.grpc.tlsConfig']}>
+        <CheckUseTLS checkType={CheckType.GRPC} />
         <TLSConfig checkType={CheckType.GRPC} />
       </FormLayout.Section>
 

--- a/src/components/CheckForm/FormLayouts/CheckGrpcLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckGrpcLayout.tsx
@@ -18,11 +18,7 @@ import { TLSConfig } from 'components/TLSConfig';
 export const CheckGrpcLayout = ({ formActions, onSubmit, onSubmitError, errorMessage }: CheckFormTypeLayoutProps) => {
   return (
     <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError} errorMessage={errorMessage}>
-      <FormLayout.Section
-        label="General settings"
-        fields={['enabled', 'job', 'target', 'probes', 'frequency', 'timeout']}
-        required
-      >
+      <FormLayout.Section label="General settings" fields={['enabled', 'job', 'target']} required>
         <CheckEnabled />
         <CheckJobName />
         <CheckTarget checkType={CheckType.GRPC} />

--- a/src/components/CheckForm/FormLayouts/CheckGrpcLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckGrpcLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {CheckFormValuesGRPC, CheckType} from 'types';
+import { CheckFormTypeLayoutProps, CheckFormValuesGRPC, CheckType } from 'types';
 import { CheckEnabled } from 'components/CheckEditor/FormComponents/CheckEnabled';
 import { CheckIpVersion } from 'components/CheckEditor/FormComponents/CheckIpVersion';
 import { CheckJobName } from 'components/CheckEditor/FormComponents/CheckJobName';
@@ -15,9 +15,9 @@ import { CheckUsage } from 'components/CheckUsage';
 import { LabelField } from 'components/LabelField';
 import { TLSConfig } from 'components/TLSConfig';
 
-export const CheckGrpcLayout = () => {
+export const CheckGrpcLayout = ({ formActions, onSubmit, onSubmitError, errorMessage }: CheckFormTypeLayoutProps) => {
   return (
-    <FormLayout>
+    <FormLayout formActions={formActions} onSubmit={onSubmit} onSubmitError={onSubmitError} errorMessage={errorMessage}>
       <FormLayout.Section
         label="General settings"
         fields={['enabled', 'job', 'target', 'probes', 'frequency', 'timeout']}
@@ -27,7 +27,7 @@ export const CheckGrpcLayout = () => {
         <CheckTarget checkType={CheckType.GRPC} />
         <ProbeOptions checkType={CheckType.GRPC} />
         <CheckPublishedAdvanceMetrics />
-        <CheckUsage />
+        <CheckUsage checkType={CheckType.GRPC} />
       </FormLayout.Section>
 
       <FormLayout.Section label="gRPC settings" fields={['settings.grpc.service', 'settings.grpc.tls']}>
@@ -39,11 +39,8 @@ export const CheckGrpcLayout = () => {
         <TLSConfig checkType={CheckType.GRPC} />
       </FormLayout.Section>
 
-      <FormLayout.Section
-        label="Advanced options"
-        fields={['labels', 'settings.grpc.ipVersion']}
-      >
-        <LabelField<CheckFormValuesGRPC> />
+      <FormLayout.Section label="Advanced options" fields={['labels', 'settings.grpc.ipVersion']}>
+        <LabelField<CheckFormValuesGRPC> labelDestination="check" />
         <CheckIpVersion checkType={CheckType.GRPC} name="settings.grpc.ipVersion" />
       </FormLayout.Section>
       <FormLayout.Section label="Alerting" fields={[`alertSensitivity`]}>

--- a/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
@@ -6,8 +6,8 @@ import { CheckIpVersion } from 'components/CheckEditor/FormComponents/CheckIpVer
 import { CheckJobName } from 'components/CheckEditor/FormComponents/CheckJobName';
 import { CheckPublishedAdvanceMetrics } from 'components/CheckEditor/FormComponents/CheckPublishedAdvanceMetrics';
 import { CheckTarget } from 'components/CheckEditor/FormComponents/CheckTarget';
+import { CheckUseTLS } from 'components/CheckEditor/FormComponents/CheckUseTLS';
 import { TCPCheckQueryAndResponse } from 'components/CheckEditor/FormComponents/TCPCheckQueryAndResponse';
-import { TCPCheckUseTLS } from 'components/CheckEditor/FormComponents/TCPCheckUseTLS';
 import { ProbeOptions } from 'components/CheckEditor/ProbeOptions';
 import { FormLayout } from 'components/CheckForm/FormLayout/FormLayout';
 import { CheckFormAlert } from 'components/CheckFormAlert';
@@ -29,7 +29,7 @@ export const CheckTCPLayout = ({ formActions, onSubmit, onSubmitError, errorMess
         <ProbeOptions checkType={CheckType.TCP} />
       </FormLayout.Section>
       <FormLayout.Section label="TCP settings" fields={[`settings.tcp.tls`]}>
-        <TCPCheckUseTLS />
+        <CheckUseTLS checkType={CheckType.TCP} />
       </FormLayout.Section>
       <FormLayout.Section label="Query/Response" fields={[`settings.tcp.queryResponse`]}>
         <TCPCheckQueryAndResponse />

--- a/src/components/CheckList/CheckList.test.tsx
+++ b/src/components/CheckList/CheckList.test.tsx
@@ -371,6 +371,35 @@ test(`Scripted checks appear in the filters when the feature flag is enabled`, a
   expect(within(listBox).getByText(`Scripted`)).toBeInTheDocument();
 });
 
+test(`gRPC checks do not appear in the filters by default`, async () => {
+  const { user } = await renderCheckList();
+  const additionalFilters = await screen.findByText(/Additional filters/i);
+  await user.click(additionalFilters);
+
+  const select = await getSelect({ label: `Filter by type` });
+  await user.click(select[0]);
+  const listBox = screen.getByLabelText(`Select options menu`);
+
+  expect(within(listBox).queryByText(`gRPC`)).not.toBeInTheDocument();
+});
+
+test(`gRPC checks appear in the filters when the feature flag is enabled`, async () => {
+  jest.replaceProperty(config, 'featureToggles', {
+    // @ts-expect-error
+    [FeatureName.GRPCChecks]: true,
+  });
+
+  const { user } = await renderCheckList();
+  const additionalFilters = await screen.findByText(/Additional filters/i);
+  await user.click(additionalFilters);
+
+  const select = await getSelect({ label: `Filter by type` });
+  await user.click(select[0]);
+  const listBox = screen.getByLabelText(`Select options menu`);
+
+  expect(within(listBox).getByText(`gRPC`)).toBeInTheDocument();
+});
+
 describe(`bulk select behaviour`, () => {
   test('select all performs disable action on all visible checks', async () => {
     const { read, record } = getServerRequests();

--- a/src/components/TLSConfig.tsx
+++ b/src/components/TLSConfig.tsx
@@ -1,24 +1,24 @@
 import React from 'react';
-import { DeepMap, FieldError, useFormContext } from 'react-hook-form';
+import { FieldErrors, useFormContext } from 'react-hook-form';
 import { OrgRole } from '@grafana/data';
 import { Container, Field, Input, TextArea } from '@grafana/ui';
 
-import { CheckFormValuesHttp, CheckFormValuesTcp, CheckType } from 'types';
+import { CheckFormValuesGRPC, CheckFormValuesHttp, CheckFormValuesTcp, TLSCheckTypes, TLSFormValues } from 'types';
 import { hasRole } from 'utils';
 import { validateTLSCACert, validateTLSClientCert, validateTLSClientKey, validateTLSServerName } from 'validation';
 import { HorizontalCheckboxField } from 'components/HorizonalCheckboxField';
 
 interface Props {
-  checkType: CheckType.HTTP | CheckType.TCP;
+  checkType: TLSCheckTypes;
 }
 
 export const TLSConfig = ({ checkType }: Props) => {
   const {
     register,
     formState: { errors },
-  } = useFormContext<CheckFormValuesHttp | CheckFormValuesTcp>();
+  } = useFormContext<CheckFormValuesHttp | CheckFormValuesTcp | CheckFormValuesGRPC>();
   const isEditor = hasRole(OrgRole.Editor);
-  const errs = isErrorsHttp(errors) ? errors.settings?.http : isErrorsTcp(errors) ? errors.settings?.tcp : undefined;
+  const errs = getCheckTypeErrors(errors, checkType);
 
   return (
     <>
@@ -116,18 +116,6 @@ export const TLSConfig = ({ checkType }: Props) => {
   );
 };
 
-function isErrorsHttp(errors: any): errors is DeepMap<CheckFormValuesHttp, FieldError> {
-  if (Object.hasOwnProperty.call(errors?.settings || {}, 'http')) {
-    return true;
-  }
-
-  return false;
-}
-
-function isErrorsTcp(errors: any): errors is DeepMap<CheckFormValuesTcp, FieldError> {
-  if (Object.hasOwnProperty.call(errors?.settings || {}, 'tcp')) {
-    return true;
-  }
-
-  return false;
+function getCheckTypeErrors(errors: FieldErrors<TLSFormValues>, checkType: Props['checkType']) {
+  return errors?.settings?.[checkType];
 }

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -1,6 +1,7 @@
 import { Check, Label, MultiHttpSettings, Probe, TLSConfig } from 'types';
 import {
   isDNSCheck,
+  isGRPCCheck,
   isHttpCheck,
   isMultiHttpCheck,
   isPingCheck,
@@ -148,6 +149,19 @@ const settingsToTF = (check: Check): TFCheckSettings => {
     };
   }
 
+  // TODO: This need to be verified
+  if (isGRPCCheck(check)) {
+    return {
+      grpc: {
+        tls: check.settings.grpc.tls,
+        service: check.settings.grpc.service,
+        ip_version: check.settings.grpc.ipVersion,
+        tls_config: tlsConfigToTF(check.settings.grpc.tlsConfig),
+      },
+    };
+  }
+
+  // @ts-expect-error - This should never happen
   const settingsKey = Object.keys(check.settings)[0];
   throw new Error(`Unknown check type: ${settingsKey}`);
 };

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -1,4 +1,13 @@
-import { BasicAuth, DnsSettings, HeaderMatch, HttpSettings, Probe, TCPQueryResponse, TcpSettings } from 'types';
+import {
+  BasicAuth,
+  DnsSettings,
+  GRPCSettings,
+  HeaderMatch,
+  HttpSettings,
+  Probe,
+  TCPQueryResponse,
+  TcpSettings,
+} from 'types';
 import { MultiHttpEntry, QueryParams, RequestProps } from 'components/MultiHttp/MultiHttpTypes';
 
 export interface TFOutput {
@@ -59,6 +68,10 @@ type KeyedTFScriptedSettings = {
   scripted: {};
 };
 
+type KeyedGRPCCheckSettings = {
+  grpc: TFGRPCSettings;
+};
+
 export type TFCheckSettings =
   | KeyedTFHttpSettings
   | KeyedTFPingSettings
@@ -66,7 +79,8 @@ export type TFCheckSettings =
   | KeyedTFDnsSettings
   | KeyedTFTracerouteSettings
   | KeyedTFMultiHTTPSettings
-  | KeyedTFScriptedSettings;
+  | KeyedTFScriptedSettings
+  | KeyedGRPCCheckSettings;
 
 interface TFFailIfMatchesNotMatches {
   fail_if_matches_regexp?: string[];
@@ -86,6 +100,11 @@ interface TFDnsSettings
   validate_additional_rrs: TFFailIfMatchesNotMatches;
 }
 
+interface TFGRPCSettings extends Omit<GRPCSettings, 'ipVersion' | 'tlsConfig'> {
+  ip_version?: string;
+  tls_config?: TFTlsConfig;
+}
+
 interface TFHttpSettings
   extends Omit<
     HttpSettings,
@@ -99,7 +118,6 @@ interface TFHttpSettings
     | 'basicAuth'
     | 'failIfSSL'
     | 'failIfNotSSL'
-    | 'validStatusCodes'
     | 'validHTTPVersions'
     | 'failIfBodyMatchesRegexp'
     | 'failIfBodyNotMatchesRegexp'

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -154,6 +154,8 @@ export const CHECK_TYPE_OPTIONS = [
     label: 'gRPC',
     value: CheckType.GRPC,
     description: 'Use the gRPC Health Checking Protocol to ensure a gRPC service is healthy',
+    status: CheckStatus.EXPERIMENTAL,
+    featureToggle: FeatureName.GRPCChecks,
   },
 ];
 

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -150,6 +150,11 @@ export const CHECK_TYPE_OPTIONS = [
     status: CheckStatus.PUBLIC_PREVIEW,
     featureToggle: FeatureName.ScriptedChecks,
   },
+  {
+    label: 'gRPC',
+    value: CheckType.GRPC,
+    description: 'Use the gRPC Health Checking Protocol to ensure a gRPC service is healthy',
+  },
 ];
 
 export const HTTP_SSL_OPTIONS = [
@@ -221,7 +226,10 @@ export const FALLBACK_CHECK_DNS: DNSCheck = {
 export const FALLBACK_CHECK_GRPC: GRPCCheck = {
   ...FALLBACK_CHECK_BASE,
   settings: {
-    grpc: undefined,
+    grpc: {
+      ipVersion: IpVersion.V4,
+      tls: false,
+    },
   },
 };
 

--- a/src/page/DashboardPage.tsx
+++ b/src/page/DashboardPage.tsx
@@ -14,6 +14,7 @@ import { getPingScene } from 'scenes/PING/pingScene';
 import { getScriptedScene } from 'scenes/SCRIPTED';
 import { getTcpScene } from 'scenes/TCP/getTcpScene';
 import { getTracerouteScene } from 'scenes/Traceroute/getTracerouteScene';
+import { getGRPCScene } from 'scenes/GRPC/getGRPCScene';
 
 function DashboardPageContent() {
   const { instance } = useContext(InstanceContext);
@@ -113,8 +114,17 @@ function DashboardPageContent() {
           ],
         });
       }
+
       case CheckType.GRPC: {
-        return null;
+        return new SceneApp({
+          pages: [
+            new SceneAppPage({
+              title: checkToView.job,
+              url,
+              getScene: getGRPCScene(config, [checkToView]),
+            }),
+          ],
+        });
       }
     }
   }, [instance.api, instance.logs, instance.metrics, checkToView]);

--- a/src/page/DashboardPage.tsx
+++ b/src/page/DashboardPage.tsx
@@ -9,12 +9,12 @@ import { InstanceContext } from 'contexts/InstanceContext';
 import { useChecks } from 'data/useChecks';
 import { PLUGIN_URL_PATH } from 'components/constants';
 import { getDNSScene } from 'scenes/DNS';
+import { getGRPCScene } from 'scenes/GRPC/getGRPCScene';
 import { getHTTPScene } from 'scenes/HTTP';
 import { getPingScene } from 'scenes/PING/pingScene';
 import { getScriptedScene } from 'scenes/SCRIPTED';
 import { getTcpScene } from 'scenes/TCP/getTcpScene';
 import { getTracerouteScene } from 'scenes/Traceroute/getTracerouteScene';
-import { getGRPCScene } from 'scenes/GRPC/getGRPCScene';
 
 function DashboardPageContent() {
   const { instance } = useContext(InstanceContext);

--- a/src/scenes/GRPC/getGRPCScene.ts
+++ b/src/scenes/GRPC/getGRPCScene.ts
@@ -1,0 +1,108 @@
+import {
+  EmbeddedScene,
+  SceneControlsSpacer,
+  SceneDataLayerControls,
+  SceneFlexItem,
+  SceneFlexLayout,
+  SceneRefreshPicker,
+  SceneTimePicker,
+  SceneTimeRange,
+  SceneVariableSet,
+  VariableValueSelectors,
+} from '@grafana/scenes';
+
+import { Check, CheckType, DashboardSceneAppConfig } from '../../types';
+import { getEmptyScene } from 'scenes/Common/emptyScene';
+
+import {
+  getAvgLatencyStat,
+  getErrorLogs,
+  getErrorRateMapPanel,
+  getFrequencyStat,
+  getLatencyByProbePanel,
+  getReachabilityStat,
+  getUptimeStat,
+  getVariables,
+} from '../Common';
+import { getAlertAnnotations } from '../Common/alertAnnotations';
+import { getEditButton } from '../Common/editButton';
+import { getErrorRateTimeseries } from '../HTTP/errorRateTimeseries';
+import { getMinStepFromFrequency } from '../utils';
+
+// This is a placeholder scene for GRPC checks (basically a copy of the TCP scene)
+// TODO: Implement the actual GRPC scene
+export function getGRPCScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[]) {
+  return () => {
+    if (checks.length === 0) {
+      return getEmptyScene(CheckType.GRPC);
+    }
+
+    const timeRange = new SceneTimeRange({
+      from: 'now-6h',
+      to: 'now',
+    });
+
+    const { job, instance, probe } = getVariables(CheckType.GRPC, metrics, checks, singleCheckMode);
+    const variables = new SceneVariableSet({ variables: [probe, job, instance] });
+    const minStep = getMinStepFromFrequency(checks?.[0]?.frequency);
+    const errorMap = getErrorRateMapPanel(metrics, minStep);
+    const uptime = getUptimeStat(metrics, minStep);
+    const reachability = getReachabilityStat(metrics, minStep);
+    const avgLatency = getAvgLatencyStat(metrics, minStep);
+    const frequency = getFrequencyStat(metrics);
+
+    const statRow = new SceneFlexLayout({
+      direction: 'row',
+      children: [uptime, reachability, avgLatency, frequency].map((panel) => {
+        return new SceneFlexItem({ height: 90, body: panel });
+      }),
+    });
+
+    const errorRateTimeseries = getErrorRateTimeseries(metrics, minStep);
+    const topRight = new SceneFlexLayout({
+      direction: 'column',
+      children: [new SceneFlexItem({ height: 90, body: statRow }), new SceneFlexItem({ body: errorRateTimeseries })],
+    });
+
+    const topRow = new SceneFlexLayout({
+      direction: 'row',
+      children: [new SceneFlexItem({ height: 500, width: 500, body: errorMap }), new SceneFlexItem({ body: topRight })],
+    });
+
+    const latencyByProbe = getLatencyByProbePanel(metrics);
+
+    const latencyRow = new SceneFlexLayout({
+      direction: 'row',
+      children: [new SceneFlexItem({ body: latencyByProbe, height: 300 })],
+    });
+
+    const logsRow = new SceneFlexLayout({
+      direction: 'row',
+      children: [new SceneFlexItem({ height: 500, body: getErrorLogs(logs) })],
+    });
+
+    const editButton = getEditButton({ job, instance });
+
+    const annotations = getAlertAnnotations(metrics);
+    return new EmbeddedScene({
+      $timeRange: timeRange,
+      $variables: variables,
+      $data: annotations,
+      controls: [
+        new VariableValueSelectors({}),
+        new SceneDataLayerControls(),
+        new SceneControlsSpacer(),
+        editButton,
+        new SceneTimePicker({ isOnCanvas: true }),
+        new SceneRefreshPicker({
+          intervals: ['5s', '1m', '1h'],
+          isOnCanvas: true,
+        }),
+      ],
+      body: new SceneFlexLayout({
+        direction: 'column',
+        children: [topRow, latencyRow, logsRow].map((panel) => new SceneFlexItem({ body: panel })),
+      }),
+    });
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,8 +153,6 @@ export interface DnsSettingsFormValues
   validations: DnsValidationFormValue[];
 }
 
-export interface GRPCSettingsFormValues {}
-
 export interface ScriptedSettings {
   script: string;
 }
@@ -231,9 +229,11 @@ export interface HttpSettingsFormValues
   compression: HTTPCompressionAlgo;
   proxyURL?: string;
 }
+
 export interface MultiHttpSettings {
   entries: MultiHttpEntry[];
 }
+
 export interface MultiHttpSettingsFormValues {
   entries: MultiHttpEntryFormValues[];
 }
@@ -274,6 +274,15 @@ export interface PingSettings {
 }
 
 export interface PingSettingsFormValues extends PingSettings {}
+
+export interface GRPCSettings {
+  ipVersion: IpVersion;
+  service?: string;
+  tls?: boolean;
+  tlsConfig?: TLSConfig;
+}
+
+export interface GRPCSettingsFormValues extends GRPCSettings {}
 
 export interface AlertFormValues {
   name: string;
@@ -402,7 +411,7 @@ export type DNSCheck = CheckBase & {
 
 export type GRPCCheck = CheckBase & {
   settings: {
-    grpc: undefined;
+    grpc: GRPCSettings;
   };
 };
 
@@ -704,6 +713,7 @@ export type RouteMatch<T extends { [K in keyof T]?: string | undefined } = any> 
 
 export interface CheckFiltersType {
   [key: string]: any;
+
   search: string;
   labels: string[];
   type: CheckTypeFilter;
@@ -780,4 +790,16 @@ export interface CheckFormTypeLayoutProps {
   onSubmit: SubmitHandler<CheckFormValues>;
   onSubmitError?: SubmitErrorHandler<CheckFormValues>;
   errorMessage?: string;
+}
+
+export type TLSCheckTypes = CheckType.HTTP | CheckType.TCP | CheckType.GRPC;
+
+export interface TLSFormValues extends CheckFormValuesBase {
+  checkType: TLSCheckTypes;
+  settings: {
+    [key in TLSCheckTypes]: {
+      tls?: boolean;
+      tlsConfig?: TLSConfig;
+    };
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -642,6 +642,7 @@ export enum HTTPCompressionAlgo {
 export enum FeatureName {
   UnifiedAlerting = 'ngalert',
   ScriptedChecks = 'scripted-checks',
+  GRPCChecks = 'grpc-checks',
 }
 
 export interface UsageValues {

--- a/src/utils.types.ts
+++ b/src/utils.types.ts
@@ -26,11 +26,7 @@ export function isDNSCheck(check: Partial<Check>): check is DNSCheck {
 }
 
 export function isGRPCCheck(check: Partial<Check>): check is GRPCCheck {
-  if (Object.hasOwnProperty.call(check.settings, 'grpc')) {
-    return true;
-  }
-
-  return false;
+  return 'grpc' in (check.settings ?? {});
 }
 
 export function isHttpCheck(check: Partial<Check>): check is HTTPCheck {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -52,6 +52,9 @@ export function validateTarget(typeOfCheck: CheckType, target: string): string |
       }
       return undefined;
     }
+    case CheckType.GRPC: {
+      return validateHostPort(target);
+    }
     default: {
       // we want to make sure that we are validating the target for all
       // check types; if someone adds a check type but forgets to update


### PR DESCRIPTION

![image](https://github.com/grafana/synthetic-monitoring-app/assets/1382208/f080cdfb-187b-4e10-a589-7383811af3cf)
![image](https://github.com/grafana/synthetic-monitoring-app/assets/1382208/754c4700-f111-4d18-aaf9-dbb91ddd200f)

**What this PR does / why we need it**:
This PR enables creating of gRPC health checks.
gRPC checks must be enabled with `[feature_toggles]` in `config.ini` (`grpc-checks=true`).

Note: gRPC dashboard is only a placeholder dashboard. A new PR will be created to add a gRPC specific dashboard.

Note: Terraform is not yet setup for gRPC checks (in [terraform-provider-grafana](https://github.com/grafana/terraform-provider-grafana/))

**Which issue(s) this PR fixes**:
Partly https://github.com/grafana/synthetic-monitoring/issues/47

**Special notes for your reviewer**:
To test this feature you may have to setup a local gRPC service that support health checks.
I've been using https://github.com/Sho2010/grpc-health-check as a local gRPC service, alongside a private probe running in docker.

Example docker-compose service
```
services:
  probster:
    container_name: local-probe
    image: grafana/synthetic-monitoring-agent:latest
    command: --api-server-address=${API_SERVER} --api-token=${API_TOKEN} --verbose=true
    extra_hosts:
      - "host.docker.internal:host-gateway"
```
`API_SERVER` and `API_TOKEN` is stored in a `.env` file.

This would allow for running gRPC health checks with target `host.docker.internal:50051`
If you're using [this gRPC service](https://github.com/Sho2010/grpc-health-check), you may try to set `service` to `mygrpc` or `health-check-test` (as well as just leaving `service` empty)