### PR TITLE
fix: set fixed overflow widgets on monaco editor

### DIFF
--- a/src/components/CheckForm/FormLayout/FormLayout.tsx
+++ b/src/components/CheckForm/FormLayout/FormLayout.tsx
@@ -198,36 +198,34 @@ function checkForErrors({
 
 const getStyles = (theme: GrafanaTheme2) => {
   const containerName = `checkForm`;
-  // const breakpoint = theme.breakpoints.values.xs;
-  // const query = `(min-width: ${breakpoint + 1}px)`;
-  // const containerQuery = `@container ${containerName} ${query}`;
-  // const mediaQuery = `@supports not (container-type: inline-size) @media ${query}`;
+  const breakpoint = theme.breakpoints.values.md;
+  const query = `(min-width: ${breakpoint + 1}px)`;
+  const containerQuery = `@container ${containerName} ${query}`;
+  const mediaQuery = `@supports not (container-type: inline-size) @media ${query}`;
 
   return {
     wrapper: css({
-      // containerName,
-      // containerType: `inline-size`,
+      containerName,
+      containerType: `inline-size`,
       height: '100%',
     }),
     container: css({
       display: 'grid',
       gap: theme.spacing(4),
-
-      gridTemplateColumns: `240px 1fr`,
-      height: '100%',
-      // [containerQuery]: {
-      // },
-      // [mediaQuery]: {
-      //   gridTemplateColumns: `240px 1fr`,
-      //   height: '100%',
-      // },
+      [containerQuery]: {
+        gridTemplateColumns: `240px 1fr`,
+        height: '100%',
+      },
+      [mediaQuery]: {
+        gridTemplateColumns: `240px 1fr`,
+        height: '100%',
+      },
     }),
     submissionError: css({
       marginTop: theme.spacing(2),
     }),
     section: css({
       containerName,
-      flex: 1,
     }),
     sectionContent: css({
       maxWidth: `800px`,

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -154,6 +154,7 @@ export const CodeEditor = forwardRef(function CodeEditor(
         showLineNumbers={true}
         showMiniMap={false}
         monacoOptions={{
+          fixedOverflowWidgets: false,
           scrollBeyondLastLine: false,
           scrollbar: {
             alwaysConsumeMouseWheel: false,


### PR DESCRIPTION
This fixes the autosuggest window wandering away from the cursor for the check editor. The actual fix is adding `          fixedOverflowWidgets: false,`, the rest is just reverting back the responsive layout. 

I'm not sure _why_. It has something to do with how Monaco handles overflows, and how `container` is sizing things, but I'm unsure what's going on there

