### PR TITLE
fix: add queryClientProvider to ConfigPageWrapper

### DIFF
--- a/src/components/ConfigPageWrapper.tsx
+++ b/src/components/ConfigPageWrapper.tsx
@@ -1,24 +1,24 @@
-import React, { PureComponent } from 'react';
-import { AppPluginMeta,PluginConfigPageProps } from '@grafana/data';
+import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { AppPluginMeta, PluginConfigPageProps } from '@grafana/data';
 
 import { GlobalSettings } from 'types';
+import { queryClient } from 'data/queryClient';
 import { InstanceProvider } from 'components/InstanceProvider';
 import { ConfigPage } from 'page/ConfigPage';
 
 interface Props extends PluginConfigPageProps<AppPluginMeta<GlobalSettings>> {}
 
-export class ConfigPageWrapper extends PureComponent<Props> {
-  render() {
-    const { plugin } = this.props;
-
-    return (
-      <InstanceProvider
-        metricInstanceName={plugin.meta.jsonData?.metrics?.grafanaName}
-        logsInstanceName={plugin.meta.jsonData?.logs?.grafanaName}
-        meta={plugin.meta}
-      >
+export const ConfigPageWrapper = ({ plugin }: Props) => {
+  return (
+    <InstanceProvider
+      metricInstanceName={plugin.meta.jsonData?.metrics?.grafanaName}
+      logsInstanceName={plugin.meta.jsonData?.logs?.grafanaName}
+      meta={plugin.meta}
+    >
+      <QueryClientProvider client={queryClient}>
         <ConfigPage />
-      </InstanceProvider>
-    );
-  }
-}
+      </QueryClientProvider>
+    </InstanceProvider>
+  );
+};


### PR DESCRIPTION
Closes: https://github.com/grafana/synthetic-monitoring-app/issues/777

When adding `react-query` a while back I forgot that the plugin config page exists and that is utilising components that have queries.

Converted to a function component whilst I was there as we have moved away from using Classes for React components.