### PR TITLE
fix: min steps with two digits having incorrect uptime

### DIFF
--- a/src/scenes/Common/uptimeStat.ts
+++ b/src/scenes/Common/uptimeStat.ts
@@ -6,7 +6,7 @@ import { ExplorablePanel } from 'scenes/ExplorablePanel';
 
 function getMinStep(minStep: string) {
   try {
-    const minStepParsed = parseInt(minStep[0], 10);
+    const minStepParsed = parseInt(minStep.slice(0, -1), 10);
     return `${Math.max(minStepParsed, 5)}m`;
   } catch (e) {
     return minStep;


### PR DESCRIPTION
Uptime was calculating incorrectly for checks with frequencies of an hour because of some bad string parsing