### PR TITLE
fix: traceroute check default timeout

### DIFF
--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -302,6 +302,7 @@ export const FALLBACK_CHECK_TCP: TCPCheck = {
 
 export const FALLBACK_CHECK_TRACEROUTE: TracerouteCheck = {
   ...FALLBACK_CHECK_BASE,
+  timeout: 30000,
   settings: {
     traceroute: {
       maxHops: 64,


### PR DESCRIPTION
**What this PR does / why we need it**:

Traceroute checkk only accepts 30s as timeout. Since this was not specified in its default definition, it was falling back to the base check timeout, which specifies a TO of 3s.