### PR TITLE
Tests/traceroute tests

### DIFF
--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -96,7 +96,7 @@ export const ProbeOptions = ({ checkType }: Props) => {
       <Field
         label="Frequency"
         description="How frequently the check should run."
-        disabled={!isEditor || isTraceroute} // is this correct?
+        disabled={!isEditor}
         invalid={Boolean(errors.frequency)}
         error={errors.frequency?.message}
       >

--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -67,6 +67,7 @@ export const ProbeOptions = ({ checkType }: Props) => {
   const {
     control,
     formState: { errors },
+    register,
   } = useFormContext<CheckFormValues>();
   const isTraceroute = checkType === CheckType.Traceroute;
   const { minFrequency, maxFrequency } = getFrequencyBounds(checkType);
@@ -95,7 +96,7 @@ export const ProbeOptions = ({ checkType }: Props) => {
       <Field
         label="Frequency"
         description="How frequently the check should run."
-        disabled={!isEditor || isTraceroute}
+        disabled={!isEditor || isTraceroute} // is this correct?
         invalid={Boolean(errors.frequency)}
         error={errors.frequency?.message}
       >
@@ -109,13 +110,19 @@ export const ProbeOptions = ({ checkType }: Props) => {
       <Field
         label="Timeout"
         description="Maximum execution time for a check"
-        disabled={!isEditor || checkType === CheckType.Traceroute}
         invalid={Boolean(errors.timeout)}
         error={errors.timeout?.message}
+        htmlFor={`timeout`}
       >
-        {checkType === CheckType.Traceroute ? (
-          // This is just a placeholder for now, the timeout for traceroute checks is hardcoded in the submit
-          <Input value={30} prefix="Every" suffix="seconds" width={20} />
+        {isTraceroute ? (
+          <Input
+            {...register(`timeout`)}
+            readOnly={!isEditor || isTraceroute}
+            prefix="Every"
+            suffix="seconds"
+            width={18}
+            id={`timeout`}
+          />
         ) : (
           <SliderInput
             name="timeout"

--- a/src/components/CheckEditor/TracerouteCheck.test.tsx
+++ b/src/components/CheckEditor/TracerouteCheck.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { PRIVATE_PROBE } from 'test/fixtures/probes';
+import { apiRoute, getServerRequests } from 'test/handlers';
+import { render } from 'test/render';
+import { server } from 'test/server';
+
+import { AlertSensitivity, CheckType, Label, ROUTES } from 'types';
+import { CheckForm } from 'components/CheckForm/CheckForm';
+import { PLUGIN_URL_PATH } from 'components/constants';
+
+import { fillBasicCheckFields, submitForm, toggleSection } from './testHelpers';
+
+const JOB_NAME = `Traceroute job`;
+const TARGET = `https://grafana.com`;
+const LABELS: Label[] = [];
+
+describe(`Edits the sections of a Traceroute check correctly`, () => {
+  it(`Renders a readonly field for the probe's timeout field with a value of 30 seconds`, async () => {
+    const { user } = render(<CheckForm />, {
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.Traceroute}`,
+    });
+
+    await fillBasicCheckFields(JOB_NAME, TARGET, user, LABELS);
+    await toggleSection(`Probes`, user);
+
+    const timeout = await screen.findByLabelText(/Timeout/);
+    expect(timeout).toHaveValue(`30`);
+  });
+
+  it(`Submits the form with a value of 30000 for the timeout field`, async () => {
+    const { record, read } = getServerRequests();
+    server.use(apiRoute(`addCheck`, {}, record));
+
+    const { user } = render(<CheckForm />, {
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.Traceroute}`,
+    });
+
+    await fillBasicCheckFields(JOB_NAME, TARGET, user, LABELS);
+
+    await submitForm(user);
+
+    const { body } = await read();
+
+    expect(body).toEqual({
+      alertSensitivity: AlertSensitivity.None,
+      basicMetricsOnly: true,
+      enabled: true,
+      frequency: 60000,
+      job: JOB_NAME,
+      labels: LABELS,
+      probes: [PRIVATE_PROBE.id],
+      settings: {
+        traceroute: {
+          hopTimeout: 0,
+          maxHops: 64,
+          maxUnknownHops: 15,
+          ptrLookup: true,
+        },
+      },
+      target: TARGET,
+      timeout: 30000,
+    });
+  });
+});

--- a/src/components/CheckEditor/testHelpers.ts
+++ b/src/components/CheckEditor/testHelpers.ts
@@ -36,7 +36,7 @@ export const fillBasicCheckFields = async (jobName: string, target: string, user
 
   // Set probe options
   await toggleSection(`Probes *`, user);
-  const probeOptions = screen.getByText('Probe options').parentElement;
+  const probeOptions = screen.getByText('Probe options');
   if (!probeOptions) {
     throw new Error('Couldnt find Probe Options');
   }

--- a/src/components/CheckEditor/testHelpers.ts
+++ b/src/components/CheckEditor/testHelpers.ts
@@ -35,6 +35,7 @@ export const fillBasicCheckFields = async (jobName: string, target: string, user
   await user.type(targetInput, target);
 
   // Set probe options
+  await toggleSection(`Probes *`, user);
   const probeOptions = screen.getByText('Probe options').parentElement;
   if (!probeOptions) {
     throw new Error('Couldnt find Probe Options');

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -303,6 +303,7 @@ export const FALLBACK_CHECK_TCP: TCPCheck = {
 export const FALLBACK_CHECK_TRACEROUTE: TracerouteCheck = {
   ...FALLBACK_CHECK_BASE,
   timeout: 30000,
+  frequency: 120000,
   settings: {
     traceroute: {
       maxHops: 64,

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -302,6 +302,7 @@ export const FALLBACK_CHECK_TCP: TCPCheck = {
 
 export const FALLBACK_CHECK_TRACEROUTE: TracerouteCheck = {
   ...FALLBACK_CHECK_BASE,
+  timeout: 30000,
   settings: {
     traceroute: {
       maxHops: 64,


### PR DESCRIPTION
To expand upon https://github.com/grafana/synthetic-monitoring-app/pull/780. I wanted to make sure it doesn't regress and add tests to ensure so. I also wanted to make sure the Traceroute timeout input has a single source of truth rather than being defined within the component.