### PR TITLE
fix: fix onChange for ssl select and add tests

### DIFF
--- a/src/components/CheckEditor/CheckEditorExisting.test.tsx
+++ b/src/components/CheckEditor/CheckEditorExisting.test.tsx
@@ -106,7 +106,7 @@ describe('editing checks', () => {
     expect(await within(validation).findByText(validStatusCodes![0])).toBeInTheDocument();
     expect(await within(validation).findByText(validHTTPVersions![0])).toBeInTheDocument();
     // failIfNotSSL
-    expect(await within(validation).findByText('Probe fails if SSL is not present.')).toBeInTheDocument();
+    expect(await within(validation).findByText('Probe fails if SSL is not present')).toBeInTheDocument();
     const [header1, header2] = await within(validation).findAllByPlaceholderText('Header name');
     expect(header1).toHaveValue(failIfHeaderMatchesRegexp![0].header);
     expect(header2).toHaveValue(failIfHeaderNotMatchesRegexp![0]?.header);

--- a/src/components/CheckEditor/FormComponents/HttpCheckSSLOptions.tsx
+++ b/src/components/CheckEditor/FormComponents/HttpCheckSSLOptions.tsx
@@ -24,8 +24,16 @@ export const HttpCheckSSLOptions = () => {
         name="settings.http.sslOptions"
         control={control}
         render={({ field }) => {
-          const { ref, ...rest } = field;
-          return <Select {...rest} inputId={id} options={HTTP_SSL_OPTIONS} disabled={!isEditor} />;
+          const { ref, onChange, ...rest } = field;
+          return (
+            <Select
+              {...rest}
+              inputId={id}
+              options={HTTP_SSL_OPTIONS}
+              disabled={!isEditor}
+              onChange={(e) => onChange(e.value)}
+            />
+          );
         }}
       />
     </Field>

--- a/src/components/CheckEditor/HttpCheck.test.tsx
+++ b/src/components/CheckEditor/HttpCheck.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
+import { merge } from 'lodash';
 import { PRIVATE_PROBE } from 'test/fixtures/probes';
 import { apiRoute, getServerRequests } from 'test/handlers';
 import { render } from 'test/render';
@@ -9,11 +10,51 @@ import { AlertSensitivity, CheckType, Label, ROUTES } from 'types';
 import { CheckForm } from 'components/CheckForm/CheckForm';
 import { PLUGIN_URL_PATH } from 'components/constants';
 
-import { fillBasicCheckFields, submitForm } from './testHelpers';
+import { fillBasicCheckFields, selectOption, submitForm } from './testHelpers';
 
 const JOB_NAME = `Http job`;
 const TARGET = `https://grafana.com`;
 const LABELS: Label[] = [];
+
+const EXPECTED_PAYLOAD = {
+  alertSensitivity: AlertSensitivity.None,
+  basicMetricsOnly: true,
+  enabled: true,
+  frequency: 60000,
+  job: JOB_NAME,
+  labels: LABELS,
+  probes: [PRIVATE_PROBE.id],
+  settings: {
+    http: {
+      body: '',
+      cacheBustingQueryParamName: '',
+      compression: '',
+      failIfBodyMatchesRegexp: [],
+      failIfBodyNotMatchesRegexp: [],
+      failIfHeaderMatchesRegexp: [],
+      failIfHeaderNotMatchesRegexp: [],
+      failIfNotSSL: false,
+      failIfSSL: false,
+      headers: [],
+      ipVersion: 'V4',
+      method: 'GET',
+      noFollowRedirects: false,
+      proxyConnectHeaders: [],
+      proxyURL: '',
+      tlsConfig: {
+        caCert: '',
+        clientCert: '',
+        clientKey: '',
+        insecureSkipVerify: false,
+        serverName: '',
+      },
+      validHTTPVersions: [],
+      validStatusCodes: [],
+    },
+  },
+  target: TARGET,
+  timeout: 3000,
+};
 
 describe(`Edits the sections of a HTTP check correctly`, () => {
   it(`Adds basic auth if added`, async () => {
@@ -39,46 +80,7 @@ describe(`Edits the sections of a HTTP check correctly`, () => {
 
     const { body } = await read();
 
-    expect(body).toEqual({
-      alertSensitivity: AlertSensitivity.None,
-      basicMetricsOnly: true,
-      enabled: true,
-      frequency: 60000,
-      job: JOB_NAME,
-      labels: LABELS,
-      probes: [PRIVATE_PROBE.id],
-      settings: {
-        http: {
-          basicAuth,
-          body: '',
-          cacheBustingQueryParamName: '',
-          compression: '',
-          failIfBodyMatchesRegexp: [],
-          failIfBodyNotMatchesRegexp: [],
-          failIfHeaderMatchesRegexp: [],
-          failIfHeaderNotMatchesRegexp: [],
-          failIfNotSSL: false,
-          failIfSSL: false,
-          headers: [],
-          ipVersion: 'V4',
-          method: 'GET',
-          noFollowRedirects: false,
-          proxyConnectHeaders: [],
-          proxyURL: '',
-          tlsConfig: {
-            caCert: '',
-            clientCert: '',
-            clientKey: '',
-            insecureSkipVerify: false,
-            serverName: '',
-          },
-          validHTTPVersions: [],
-          validStatusCodes: [],
-        },
-      },
-      target: TARGET,
-      timeout: 3000,
-    });
+    expect(body).toStrictEqual(merge({}, EXPECTED_PAYLOAD, { settings: { http: { basicAuth } } }));
   });
 
   it(`Does not add basic auth if not added`, async () => {
@@ -97,45 +99,64 @@ describe(`Edits the sections of a HTTP check correctly`, () => {
     const { body } = await read();
 
     expect(body.settings.http.basicAuth).toBeUndefined();
+    expect(body).toStrictEqual(EXPECTED_PAYLOAD);
+  });
 
-    expect(body).toStrictEqual({
-      alertSensitivity: AlertSensitivity.None,
-      basicMetricsOnly: true,
-      enabled: true,
-      frequency: 60000,
-      job: JOB_NAME,
-      labels: LABELS,
-      probes: [PRIVATE_PROBE.id],
-      settings: {
-        http: {
-          body: '',
-          cacheBustingQueryParamName: '',
-          compression: '',
-          failIfBodyMatchesRegexp: [],
-          failIfBodyNotMatchesRegexp: [],
-          failIfHeaderMatchesRegexp: [],
-          failIfHeaderNotMatchesRegexp: [],
-          failIfNotSSL: false,
-          failIfSSL: false,
-          headers: [],
-          ipVersion: 'V4',
-          method: 'GET',
-          noFollowRedirects: false,
-          proxyConnectHeaders: [],
-          proxyURL: '',
-          tlsConfig: {
-            caCert: '',
-            clientCert: '',
-            clientKey: '',
-            insecureSkipVerify: false,
-            serverName: '',
-          },
-          validHTTPVersions: [],
-          validStatusCodes: [],
-        },
-      },
-      target: TARGET,
-      timeout: 3000,
+  it(`Adds probe fails if SSL is present to payload`, async () => {
+    const { record, read } = getServerRequests();
+    server.use(apiRoute(`addCheck`, {}, record));
+
+    const { user } = render(<CheckForm />, {
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.HTTP}`,
     });
+
+    await fillBasicCheckFields(JOB_NAME, TARGET, user, LABELS);
+    await user.click(await screen.getByText('Validation', { selector: `span` }));
+    await selectOption(user, { label: 'SSL options', option: 'Probe fails if SSL is present' });
+
+    await submitForm(user);
+
+    const { body } = await read();
+
+    expect(body).toStrictEqual(
+      merge({}, EXPECTED_PAYLOAD, {
+        settings: {
+          http: {
+            failIfNotSSL: false,
+            failIfSSL: true,
+          },
+        },
+      })
+    );
+  });
+
+  it(`Adds probe fails if SSL is present to payload`, async () => {
+    const { record, read } = getServerRequests();
+    server.use(apiRoute(`addCheck`, {}, record));
+
+    const { user } = render(<CheckForm />, {
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/:checkType`,
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckType.HTTP}`,
+    });
+
+    await fillBasicCheckFields(JOB_NAME, TARGET, user, LABELS);
+    await user.click(await screen.getByText('Validation', { selector: `span` }));
+    await selectOption(user, { label: 'SSL options', option: 'Probe fails if SSL is not present' });
+
+    await submitForm(user);
+
+    const { body } = await read();
+
+    expect(body).toStrictEqual(
+      merge({}, EXPECTED_PAYLOAD, {
+        settings: {
+          http: {
+            failIfNotSSL: true,
+            failIfSSL: false,
+          },
+        },
+      })
+    );
   });
 });

--- a/src/components/CheckEditor/transformations/toPayload.http.ts
+++ b/src/components/CheckEditor/transformations/toPayload.http.ts
@@ -29,7 +29,7 @@ function getHttpSettingsPayload(settings: Partial<HttpSettingsFormValues> | unde
   const formattedHeaders = headers?.map((header) => `${header.name}:${header.value}`) ?? [];
   const proxyHeaders = settings.proxyConnectHeaders ?? [];
   const formattedProxyHeaders = proxyHeaders?.map((header) => `${header.name}:${header.value}`) ?? [];
-  const sslConfig = getHttpSslOptionsFromFormValue(settings.sslOptions ?? HttpSslOption.Ignore);
+  const sslConfig = getHttpSslOptionsFromFormValue(settings.sslOptions);
   const compression = settings.compression;
   const validationRegexes = getHttpRegexValidationsFromFormValue(settings.regexValidations ?? []);
 
@@ -53,7 +53,16 @@ function getHttpSettingsPayload(settings: Partial<HttpSettingsFormValues> | unde
   });
 }
 
-const getHttpSslOptionsFromFormValue = (sslOption: HttpSslOption): Pick<HttpSettings, 'failIfSSL' | 'failIfNotSSL'> => {
+const getHttpSslOptionsFromFormValue = (
+  sslOption?: HttpSslOption
+): Pick<HttpSettings, 'failIfSSL' | 'failIfNotSSL'> => {
+  if (sslOption === undefined) {
+    return {
+      failIfNotSSL: false,
+      failIfSSL: false,
+    };
+  }
+
   switch (sslOption) {
     case HttpSslOption.Ignore: {
       return {

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -165,11 +165,11 @@ export const HTTP_SSL_OPTIONS = [
     value: HttpSslOption.Ignore,
   },
   {
-    label: 'Probe fails if SSL is present.',
+    label: 'Probe fails if SSL is present',
     value: HttpSslOption.FailIfPresent,
   },
   {
-    label: 'Probe fails if SSL is not present.',
+    label: 'Probe fails if SSL is not present',
     value: HttpSslOption.FailIfNotPresent,
   },
 ];


### PR DESCRIPTION
Closes: https://github.com/grafana/synthetic-monitoring-app/issues/788

There was a regression when updating the payloads recently where we missed updating the onChange handler for the select in `<HttpCheckSSLOptions />`.

This fixes the regression and adds tests to ensure it doesn't break again in the future.