### PR TITLE
Update usage details to use consistent naming "test executions"

### DIFF
--- a/src/components/CheckUsage.tsx
+++ b/src/components/CheckUsage.tsx
@@ -66,7 +66,7 @@ export const CheckUsage = ({ checkType }: { checkType: CheckType }) => {
       <div className={styles.calcList}>
         <div className={styles.section}>
           <Icon className={styles.icon} name="calendar-alt" />
-          Checks per month: <strong className={styles.value}>{usage.checksPerMonth.toLocaleString()}</strong>
+          Test executions per month: <strong className={styles.value}>{usage.checksPerMonth.toLocaleString()}</strong>
         </div>
         {!hideTelemetry && (
           <>


### PR DESCRIPTION

Our usage docs refer to "test executions per month", for example: https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/synthetic-monitoring-costs/

The check creation flow & editing use the term "checks per month", which can cause some confusion.  This PR updates uses the term "test executions per month" to be consistent.

Somewhat related to https://github.com/grafana/synthetic-monitoring-app/issues/805

Before:
<img width="1234" alt="image" src="https://github.com/grafana/synthetic-monitoring-app/assets/7903188/d32f261c-2387-4fc4-bc73-95676afa12b1">

After:
<img width="985" alt="image" src="https://github.com/grafana/synthetic-monitoring-app/assets/7903188/28c1e280-d2a0-4062-bac1-faef14c14050">

