### PR TITLE
feat: add scenes debugTransform function

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "react-hook-form": "7.50.1",
     "react-popper": "^2.2.5",
     "react-router-dom": "^5.2.0",
+    "rxjs": "7.8.1",
     "sortablejs": "^1.15.0",
     "valid-url": "^1.0.9",
     "yaml": "^2.2.2",

--- a/src/scenes/debugTransform.ts
+++ b/src/scenes/debugTransform.ts
@@ -1,0 +1,17 @@
+import { DataFrame } from '@grafana/data';
+import { CustomTransformOperator } from '@grafana/scenes';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+// Scenes data is very opaque and hard to debug.
+// Insert this function in the transformation pipeline at any / multiple points
+// in the transformation chain to view what is happening to the data.
+
+export const debugTransform: CustomTransformOperator = () => (source: Observable<DataFrame[]>) => {
+  return source.pipe(
+    map((data: DataFrame[]) => {
+      console.log(data);
+      return data;
+    })
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -13113,7 +13113,7 @@ rxjs@7.8.0:
   dependencies:
     tslib "^2.1.0"
 
-rxjs@^7.2.0, rxjs@^7.5.1, rxjs@^7.5.5:
+rxjs@7.8.1, rxjs@^7.2.0, rxjs@^7.5.1, rxjs@^7.5.5:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
   integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==


### PR DESCRIPTION
# Problem

We've had some problems with the Scenes dashboards [1](https://github.com/grafana/synthetic-monitoring-app/pull/801), [2](https://github.com/grafana/synthetic-monitoring-app/pull/811) recently and the debugging process is very difficult due to the [extensive transforms](https://github.com/search?q=repo%3Agrafana%2Fsynthetic-monitoring-app%20SceneDataTransformer&type=code) that get added throughout the panels.

![Slack message from Peter Schretlen saying 'I can see why people struggle with scenes.. this is really hard to debug.'](https://github.com/grafana/synthetic-monitoring-app/assets/6906380/5cf9b464-e5e6-4fe2-b1ae-837c8f43c3dd)

# Solution

I've added a simple utility function called `debugTransform` in the scenes folder which you can inject at any point during the transformation process to view what the DataFrames appear like at that point in the transform.

![](https://github.com/grafana/synthetic-monitoring-app/assets/6906380/a57412f2-6384-4285-bc0a-9f0ddd1cecdd)
The above is an example of where I've added `debugTransform` three times in separate locations during the summaryTable transformation.
