### PR TITLE
Feat: Display test execution rate in check's list

### DIFF
--- a/src/checkUsageCalc.ts
+++ b/src/checkUsageCalc.ts
@@ -14,7 +14,7 @@ const getChecksPerMonth = (frequencySeconds: number) => {
   return Math.round(checksPerMonth);
 };
 
-const getTotalChecksPerMonth = (probeCount: number, frequencySeconds: number) => {
+export const getTotalChecksPerMonth = (probeCount: number, frequencySeconds: number) => {
   const checksPerMonth = getChecksPerMonth(frequencySeconds);
   return checksPerMonth * probeCount;
 };

--- a/src/components/CheckList/CheckList.tsx
+++ b/src/components/CheckList/CheckList.tsx
@@ -269,14 +269,14 @@ function sortChecks(checks: Check[], sortType: CheckSort, reachabilitySuccessRat
   if (sortType === CheckSort.ExecutionsAsc) {
     return checks.sort((a, b) => {
       const [sortA, sortB] = getNumberOfExecutions(a, b);
-      return sortB - sortA;
+      return sortA - sortB;
     });
   }
 
   if (sortType === CheckSort.ExecutionsDesc) {
     return checks.sort((a, b) => {
       const [sortA, sortB] = getNumberOfExecutions(a, b);
-      return sortA - sortB;
+      return sortB - sortA;
     });
   }
 

--- a/src/components/CheckList/CheckList.tsx
+++ b/src/components/CheckList/CheckList.tsx
@@ -3,6 +3,7 @@ import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Pagination, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { getTotalChecksPerMonth } from 'checkUsageCalc';
 
 import { Check, CheckEnabledStatus, CheckFiltersType, CheckListViewType, CheckSort, CheckType, Label } from 'types';
 import { MetricCheckSuccess, Time } from 'datasource/responses.types';
@@ -265,6 +266,20 @@ function sortChecks(checks: Check[], sortType: CheckSort, reachabilitySuccessRat
     });
   }
 
+  if (sortType === CheckSort.ExecutionsAsc) {
+    return checks.sort((a, b) => {
+      const [sortA, sortB] = getNumberOfExecutions(a, b);
+      return sortB - sortA;
+    });
+  }
+
+  if (sortType === CheckSort.ExecutionsDesc) {
+    return checks.sort((a, b) => {
+      const [sortA, sortB] = getNumberOfExecutions(a, b);
+      return sortA - sortB;
+    });
+  }
+
   return checks;
 }
 
@@ -275,6 +290,12 @@ function getMetricValues(checkA: Check, checkB: Check, metrics: MetricCheckSucce
   const sortA = metricA?.value[1] || 101;
   const sortB = metricB?.value[1] || 101;
 
+  return [sortA, sortB];
+}
+
+function getNumberOfExecutions(checkA: Check, checkB: Check) {
+  const sortA = getTotalChecksPerMonth(checkA.probes.length, checkA.frequency / 1000) || 101;
+  const sortB = getTotalChecksPerMonth(checkB.probes.length, checkB.frequency / 1000) || 101;
   return [sortA, sortB];
 }
 

--- a/src/components/CheckListItem/CheckListItemCard.tsx
+++ b/src/components/CheckListItem/CheckListItemCard.tsx
@@ -59,6 +59,7 @@ export const CheckListItemCard = ({
                   frequency={check.frequency}
                   activeSeries={usage?.activeSeries}
                   probeLocations={check.probes.length}
+                  executionsRate={usage?.checksPerMonth}
                 />
               </div>
             </div>

--- a/src/components/CheckListItem/CheckListItemDetails.tsx
+++ b/src/components/CheckListItem/CheckListItemDetails.tsx
@@ -13,7 +13,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     white-space: nowrap;
     display: flex;
     align-items: center;
-    width: 400px;
+    width: 600px;
   `,
   labelWidth: css`
     max-width: 350px;
@@ -24,6 +24,7 @@ interface Props {
   frequency: number;
   activeSeries?: number;
   probeLocations: number;
+  executionsRate?: number;
   className?: string;
   labelCount?: number;
   labels?: Label[];
@@ -34,6 +35,7 @@ export const CheckListItemDetails = ({
   frequency,
   activeSeries,
   probeLocations,
+  executionsRate,
   className,
   labels,
   onLabelClick,
@@ -41,10 +43,12 @@ export const CheckListItemDetails = ({
   const styles = useStyles2(getStyles);
   const activeSeriesMessage = activeSeries !== undefined ? `${activeSeries} active series` : null;
   const probeLocationsMessage = probeLocations === 1 ? `${probeLocations} location` : `${probeLocations} locations`;
+  const executionRateMessage = executionsRate ? `${executionsRate} executions / month` : null;
   return (
     <div className={cx(styles.checkDetails, className)}>
       {frequency / 1000}s frequency &nbsp;&nbsp;<strong>|</strong>&nbsp;&nbsp; {activeSeriesMessage}
-      &nbsp;&nbsp;<strong>|</strong>&nbsp;&nbsp; {probeLocationsMessage}
+      &nbsp;&nbsp;<strong>|</strong>&nbsp;&nbsp; {probeLocationsMessage}&nbsp;&nbsp;
+      <strong>|</strong>&nbsp;&nbsp; {executionRateMessage}
       {labels && onLabelClick && (
         <>
           &nbsp;&nbsp;<strong>|</strong>

--- a/src/components/CheckListItem/CheckListItemRow.tsx
+++ b/src/components/CheckListItem/CheckListItemRow.tsx
@@ -58,6 +58,7 @@ export const CheckListItemRow = ({
           labelCount={check.labels.length}
           labels={check.labels}
           onLabelClick={onLabelSelect}
+          executionsRate={usage?.checksPerMonth}
         />
         <CheckItemActionButtons check={check} viewDashboardAsIcon />
       </div>

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -421,6 +421,14 @@ export const CHECK_LIST_SORT_OPTIONS = [
     label: 'Desc. Reachability ',
     value: CheckSort.ReachabilityDesc,
   },
+  {
+    label: 'Asc. Executions ',
+    value: CheckSort.ExecutionsAsc,
+  },
+  {
+    label: 'Desc. Executions ',
+    value: CheckSort.ExecutionsDesc,
+  },
 ];
 
 export const CHECK_LIST_STATUS_OPTIONS: Array<SelectableValue<CheckEnabledStatus>> = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -610,6 +610,8 @@ export enum CheckSort {
   ZToA = 'ztoa',
   ReachabilityDesc = 'reachabilityDesc',
   ReachabilityAsc = 'reachabilityAsc',
+  ExecutionsDesc = 'executionsDesc',
+  ExecutionsAsc = 'executionsAsc',
 }
 
 export enum CheckEnabledStatus {


### PR DESCRIPTION
This PR adds a new indicator for each check card: the **number of test executions per month**.
Besides indicating the number of executions, it's also possible to sort by that value either in ascending or descending order. 

Why is it needed?
When trying to understand and manage costs, it would be helpful to sort the list by rate.

![image](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/f11a4112-b4e8-43aa-959b-98805d0c5942)

![2024-06-06 18 17 11](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/cab0bbee-54f9-4ee0-b117-be6951382019)

Note that it is the same number that we display in the "Probes" section when creating/editing a check. This provides consistency and makes it easy to translate that into a monthly cost.

![image](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/8f25981b-2a00-4fd3-85fa-3b1c1766cac2)





Closes https://github.com/grafana/synthetic-monitoring-app/issues/805