### PR TITLE
fix: change password type to input on http auth config

### DIFF
--- a/src/components/CheckEditor/FormComponents/HttpCheckBasicAuthorization.tsx
+++ b/src/components/CheckEditor/FormComponents/HttpCheckBasicAuthorization.tsx
@@ -48,7 +48,7 @@ export const HttpCheckBasicAuthorization = () => {
             required: { value: true, message: 'Password is required' },
           })}
           id={passwordId}
-          type="text"
+          type="password"
           disabled={!isEditor}
           data-fs-element="Basic auth password input"
         />

--- a/src/components/CheckEditor/FormComponents/HttpCheckBasicAuthorization.tsx
+++ b/src/components/CheckEditor/FormComponents/HttpCheckBasicAuthorization.tsx
@@ -27,9 +27,7 @@ export const HttpCheckBasicAuthorization = () => {
         required
       >
         <Input
-          {...register('settings.http.basicAuth.username', {
-            required: { value: true, message: 'Username is required' },
-          })}
+          {...register('settings.http.basicAuth.username')}
           id={userNameId}
           type="text"
           disabled={!isEditor}
@@ -38,9 +36,7 @@ export const HttpCheckBasicAuthorization = () => {
       </Field>
 
       <PasswordField
-        {...register('settings.http.basicAuth.password', {
-          required: { value: true, message: 'Password is required' },
-        })}
+        {...register('settings.http.basicAuth.password')}
         label="Password"
         disabled={!isEditor}
         invalid={Boolean(formState.errors.settings?.http?.basicAuth?.password)}

--- a/src/components/CheckEditor/FormComponents/HttpCheckBasicAuthorization.tsx
+++ b/src/components/CheckEditor/FormComponents/HttpCheckBasicAuthorization.tsx
@@ -6,6 +6,7 @@ import { css } from '@emotion/css';
 
 import { CheckFormValuesHttp } from 'types';
 import { hasRole } from 'utils';
+import { PasswordField } from 'components/PasswordField/PasswordField';
 
 export const HttpCheckBasicAuthorization = () => {
   const isEditor = hasRole(OrgRole.Editor);
@@ -35,24 +36,19 @@ export const HttpCheckBasicAuthorization = () => {
           data-fs-element="Basic auth username input"
         />
       </Field>
-      <Field
-        htmlFor={passwordId}
-        disabled={!isEditor}
+
+      <PasswordField
+        {...register('settings.http.basicAuth.password', {
+          required: { value: true, message: 'Password is required' },
+        })}
         label="Password"
+        disabled={!isEditor}
         invalid={Boolean(formState.errors.settings?.http?.basicAuth?.password)}
         error={formState.errors.settings?.http?.basicAuth?.password?.message}
-        required
-      >
-        <Input
-          {...register('settings.http.basicAuth.password', {
-            required: { value: true, message: 'Password is required' },
-          })}
-          id={passwordId}
-          type="password"
-          disabled={!isEditor}
-          data-fs-element="Basic auth password input"
-        />
-      </Field>
+        id={passwordId}
+        required={true}
+        data-fs-element="Basic auth password input"
+      />
     </div>
   );
 };

--- a/src/components/CheckEditor/FormComponents/HttpCheckBearerToken.tsx
+++ b/src/components/CheckEditor/FormComponents/HttpCheckBearerToken.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { OrgRole } from '@grafana/data';
-import { Field, Input } from '@grafana/ui';
 
 import { CheckFormValuesHttp } from 'types';
 import { hasRole } from 'utils';
+import { PasswordField } from 'components/PasswordField/PasswordField';
 
 export const HttpCheckBearerToken = () => {
   const isEditor = hasRole(OrgRole.Editor);
@@ -12,24 +12,17 @@ export const HttpCheckBearerToken = () => {
   const id = 'bearerToken';
 
   return (
-    <Field
-      htmlFor={id}
-      disabled={!isEditor}
+    <PasswordField
+      {...register('settings.http.bearerToken', {
+        required: { value: true, message: 'Bearer Token is required' },
+      })}
       label="Include bearer authorization header in request"
+      disabled={!isEditor}
       invalid={Boolean(formState.errors.settings?.http?.bearerToken)}
       error={formState.errors.settings?.http?.bearerToken?.message}
-      required
-    >
-      <Input
-        {...register('settings.http.bearerToken', {
-          required: { value: true, message: 'Bearer Token is required' },
-        })}
-        id={id}
-        type="password"
-        placeholder="Bearer token"
-        disabled={!isEditor}
-        data-fs-element="Bearer token input"
-      />
-    </Field>
+      id={id}
+      required={true}
+      data-fs-element="Bearer token input"
+    />
   );
 };

--- a/src/components/CheckEditor/FormComponents/HttpCheckBearerToken.tsx
+++ b/src/components/CheckEditor/FormComponents/HttpCheckBearerToken.tsx
@@ -13,14 +13,12 @@ export const HttpCheckBearerToken = () => {
 
   return (
     <PasswordField
-      {...register('settings.http.bearerToken', {
-        required: { value: true, message: 'Bearer Token is required' },
-      })}
+      {...register('settings.http.bearerToken')}
       label="Include bearer authorization header in request"
       disabled={!isEditor}
       invalid={Boolean(formState.errors.settings?.http?.bearerToken)}
       error={formState.errors.settings?.http?.bearerToken?.message}
-      placeholder='Bearer token'
+      placeholder="Bearer token"
       id={id}
       required={true}
       data-fs-element="Bearer token input"

--- a/src/components/CheckEditor/FormComponents/HttpCheckBearerToken.tsx
+++ b/src/components/CheckEditor/FormComponents/HttpCheckBearerToken.tsx
@@ -20,6 +20,7 @@ export const HttpCheckBearerToken = () => {
       disabled={!isEditor}
       invalid={Boolean(formState.errors.settings?.http?.bearerToken)}
       error={formState.errors.settings?.http?.bearerToken?.message}
+      placeholder='Bearer token'
       id={id}
       required={true}
       data-fs-element="Bearer token input"

--- a/src/components/PasswordField/PasswordField.test.tsx
+++ b/src/components/PasswordField/PasswordField.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { Field } from '@grafana/ui';
+
+import { PasswordField } from './PasswordField';
+import { render } from 'test/render';
+
+describe('PasswordField', () => {
+  test('should render correctly', async () => {
+    const { findByLabelText, getByRole } = render(
+      <Field label="Password">
+        <PasswordField id="password" />
+      </Field>
+    );
+
+    expect(await findByLabelText('Password')).toBeInTheDocument();
+    expect(await getByRole('switch', { name: 'Show password' })).toBeInTheDocument();
+  });
+
+  test('should able to show password value if clicked on password-reveal icon', async () => {
+    const { user, findByLabelText, getByRole } = render(
+      <Field label="Password">
+        <PasswordField id="password" />
+      </Field>
+    );
+
+    const passwordInput = await findByLabelText('Password');
+    expect(passwordInput).toHaveProperty('type', 'password');
+    await user.click(getByRole('switch', { name: 'Show password' }));
+    expect(passwordInput).toHaveProperty('type', 'text');
+  });
+});

--- a/src/components/PasswordField/PasswordField.test.tsx
+++ b/src/components/PasswordField/PasswordField.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-
 import { Field } from '@grafana/ui';
+import { render } from 'test/render';
 
 import { PasswordField } from './PasswordField';
-import { render } from 'test/render';
 
 describe('PasswordField', () => {
   test('should render correctly', async () => {

--- a/src/components/PasswordField/PasswordField.tsx
+++ b/src/components/PasswordField/PasswordField.tsx
@@ -1,0 +1,49 @@
+import React, { forwardRef, HTMLProps, useState } from 'react';
+import { Field, IconButton, Input } from '@grafana/ui';
+
+interface PasswordFieldProps extends Omit<HTMLProps<HTMLInputElement>, 'width'> {
+  description?: string;
+  invalid?: boolean;
+  error?: string;
+}
+
+export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
+  ({ id, label, description, placeholder, disabled, invalid, error, required, className, ...props }, ref) => {
+    const [showPassword, setShowPassword] = useState(false);
+
+    return (
+      <Field
+        htmlFor={id}
+        disabled={Boolean(disabled)}
+        invalid={Boolean(invalid)}
+        label={label}
+        description={description}
+        error={error}
+        required={required}
+      >
+        <Input
+          {...props}
+          ref={ref}
+          id={id}
+          type={showPassword ? 'text' : 'password'}
+          placeholder={placeholder}
+          disabled={disabled}
+          suffix={
+            <IconButton
+              name={showPassword ? 'eye-slash' : 'eye'}
+              aria-controls={id}
+              role="switch"
+              aria-checked={showPassword}
+              onClick={() => {
+                setShowPassword(!showPassword);
+              }}
+              tooltip={showPassword ? 'Hide password' : 'Show password'}
+            />
+          }
+        />
+      </Field>
+    );
+  }
+);
+
+PasswordField.displayName = 'PasswordField';

--- a/src/schemas/forms/HttpCheckSchema.ts
+++ b/src/schemas/forms/HttpCheckSchema.ts
@@ -57,7 +57,26 @@ const HttpSettingsSchema: ZodType<HttpSettingsFormValues> = z.object({
       username: z.string(),
       password: z.string(),
     })
-    .optional(),
+    .optional()
+    .superRefine((data, ctx) => {
+      if (!data) {
+        return;
+      }
+      if (!data.username && data.password) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Username is required',
+          path: ['username'],
+        });
+      }
+      if (data.username && !data.password) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Password is required',
+          path: ['password'],
+        });
+      }
+    }),
   tlsConfig: TLSConfigSchema,
   cacheBustingQueryParamName: z.string().optional(),
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

The Authentication step for HTTP checks allows to configure a username and password. This password field was displaying the value entered by the user in clear text, posing a security concern.

This PR adds a `PasswordField` component that allows to mask/show the value in the input and uses it in Auth/bearer and password fields.

**Which issue(s) this PR fixes**:

**Before**
![image](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/33736d95-4a95-4f77-b86a-9713449a01e4)

**After**
![image](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/a2354ca4-c173-416a-a07d-0569e0f2b852)

![image](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/adc835d4-4cb2-4ee2-86e1-d7d3fbfa4c15)


Fixes https://github.com/grafana/synthetic-monitoring-app/issues/795


