### PR TITLE
feat: add custom labels link to docs

### DIFF
--- a/src/components/LabelField/LabelField.tsx
+++ b/src/components/LabelField/LabelField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { OrgRole } from '@grafana/data';
-import { Alert, Button, Field, LoadingPlaceholder, Spinner, useTheme2 } from '@grafana/ui';
+import { Alert, Button, Field, LoadingPlaceholder, Spinner, TextLink, useTheme2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { Label } from 'types';
@@ -32,12 +32,27 @@ function getLimit(labelDestination: LabelFieldProps['labelDestination'], limits?
   return 10;
 }
 
+const customLabelsDocs = (
+  <TextLink
+    href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/analyze-results/custom-labels/#custom-labels"
+    external={true}
+    variant="bodySmall"
+  >
+    Read more
+  </TextLink>
+);
+
 function getDescription(labelDestination: LabelFieldProps['labelDestination'], limit: number, logLabelLimit: number) {
+  let descriptionText = `Custom labels to be included with collected metrics and logs. You can add up to ${limit}. If you add more than ${logLabelLimit} labels, they will potentially not be used to index logs, and rather added as part of the log message.`;
   if (labelDestination === 'probe') {
-    return `Custom labels to be included with collected metrics and logs. You can add up to ${limit}.`;
+    descriptionText = `Custom labels to be included with collected metrics and logs. You can add up to ${limit}.`;
   }
 
-  return `Custom labels to be included with collected metrics and logs. You can add up to ${limit}. If you add more than ${logLabelLimit} labels, they will potentially not be used to index logs, and rather added as part of the log message.`;
+  return (
+    <>
+      {descriptionText} {customLabelsDocs}
+    </>
+  );
 }
 
 export const LabelField = <T extends FormWithLabels>({ labelDestination }: LabelFieldProps) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a link to the documentation in the section where users can add custom labels to their checks.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/synthetic-monitoring-app/issues/746

<img width="637" alt="image" src="https://github.com/grafana/synthetic-monitoring-app/assets/6271380/d1878887-f0d8-42ee-86e0-657c3fab615b">

The "Read more" link takes you to https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/analyze-results/custom-labels/#custom-labels

