### PR TITLE
chore: upgrade scenes to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@grafana/faro-web-sdk": "1.3.6",
     "@grafana/k6-test-builder": "^0.8.6",
     "@grafana/runtime": "11.0.0",
-    "@grafana/scenes": "3.5.0",
+    "@grafana/scenes": "5.1.0",
     "@grafana/schema": "11.0.0",
     "@grafana/ui": "11.0.0",
     "@hookform/resolvers": "3.3.4",

--- a/src/scenes/Common/alertAnnotations.ts
+++ b/src/scenes/Common/alertAnnotations.ts
@@ -1,8 +1,8 @@
-import { dataLayers, SceneDataLayers } from '@grafana/scenes';
+import { dataLayers, SceneDataLayerSet } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
 export function getAlertAnnotations(metrics: DataSourceRef) {
-  return new SceneDataLayers({
+  return new SceneDataLayerSet({
     layers: [
       new dataLayers.AnnotationsDataLayer({
         name: 'Alerts firing',
@@ -39,7 +39,7 @@ export function getAlertAnnotations(metrics: DataSourceRef) {
 }
 
 export function getSummaryAlertAnnotations(metrics: DataSourceRef) {
-  return new SceneDataLayers({
+  return new SceneDataLayerSet({
     layers: [
       new dataLayers.AnnotationsDataLayer({
         name: 'Alerts firing',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1501,16 +1501,7 @@
     uplot "1.6.30"
     xss "^1.0.14"
 
-"@grafana/e2e-selectors@10.0.2":
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-10.0.2.tgz#98cd7fa01ca21b416db8827980508195554fb5a4"
-  integrity sha512-3dc+2hL/AJLkOMXiN2UmWU3kOHO4Eqv10AJVOTkpDwecQvWoSS5vtflyPCEWshDqDSE/6k2gB9N2rlZk9O/R5g==
-  dependencies:
-    "@grafana/tsconfig" "^1.2.0-rc1"
-    tslib "2.5.0"
-    typescript "4.8.4"
-
-"@grafana/e2e-selectors@11.0.0":
+"@grafana/e2e-selectors@11.0.0", "@grafana/e2e-selectors@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-11.0.0.tgz#07f433120617985b1251caa9b905b67a3297d7f0"
   integrity sha512-qrShgu7zmpua4vbhgyAMHHX30FQ1oeHMp3wOGxkutKu550H+QPEOIrYnu5UyKITkenhLkz1nQNNGH7ZKG7yaRg==
@@ -1631,15 +1622,16 @@
     rxjs "7.8.1"
     tslib "2.6.2"
 
-"@grafana/scenes@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@grafana/scenes/-/scenes-3.5.0.tgz#d3f53b6b629444d0a57e938b4c7645ca1f3e4b34"
-  integrity sha512-eNUkXv7N5UX6mhrMpIt2QHywLhKAiZr7VuYQLoTn5tadQPuCqDvfwdbm4r1s3OHGfaQOWdsjvpfqtnEgOxlHxQ==
+"@grafana/scenes@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@grafana/scenes/-/scenes-5.1.0.tgz#6878555302d8ef44d25619963dbd508f41de6ef0"
+  integrity sha512-v2lBWeJ9Yp47qVNRfzA80eq0UjpQrmO74lh1Nsw3W0yGxF/AxF26AiGngxxAyHffLP6vmKC/XMugta+aHtCgtQ==
   dependencies:
-    "@grafana/e2e-selectors" "10.0.2"
+    "@grafana/e2e-selectors" "^11.0.0"
+    "@leeoniya/ufuzzy" "^1.0.14"
     react-grid-layout "1.3.4"
-    react-use "17.4.0"
-    react-virtualized-auto-sizer "1.0.7"
+    react-use "17.5.0"
+    react-virtualized-auto-sizer "1.0.24"
     uuid "^9.0.0"
 
 "@grafana/schema@11.0.0":
@@ -2085,7 +2077,7 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@leeoniya/ufuzzy@1.0.14":
+"@leeoniya/ufuzzy@1.0.14", "@leeoniya/ufuzzy@^1.0.14":
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/@leeoniya/ufuzzy/-/ufuzzy-1.0.14.tgz#01572c0de9cfa1420cf6ecac76dd59db5ebd1337"
   integrity sha512-/xF4baYuCQMo+L/fMSUrZnibcu0BquEGnbxfVPiZhs/NbJeKj4c/UmFpQzW9Us0w45ui/yYW3vyaqawhNYsTzA==
@@ -11034,7 +11026,7 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nano-css@^5.3.1, nano-css@^5.6.1:
+nano-css@^5.6.1:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/nano-css/-/nano-css-5.6.1.tgz#964120cb1af6cccaa6d0717a473ccd876b34c197"
   integrity sha512-T2Mhc//CepkTa3X4pUhKgbEheJHYAxD0VptuqFhDbGMUWVV2m+lkNiW/Ieuj35wrfC8Zm0l7HvssQh7zcEttSw==
@@ -12715,26 +12707,6 @@ react-universal-interface@^0.6.2:
   resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
   integrity sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==
 
-react-use@17.4.0:
-  version "17.4.0"
-  resolved "https://registry.yarnpkg.com/react-use/-/react-use-17.4.0.tgz#cefef258b0a6c534a5c8021c2528ac6e1a4cdc6d"
-  integrity sha512-TgbNTCA33Wl7xzIJegn1HndB4qTS9u03QUwyNycUnXaweZkE4Kq2SB+Yoxx8qbshkZGYBDvUXbXWRUmQDcZZ/Q==
-  dependencies:
-    "@types/js-cookie" "^2.2.6"
-    "@xobotyi/scrollbar-width" "^1.9.5"
-    copy-to-clipboard "^3.3.1"
-    fast-deep-equal "^3.1.3"
-    fast-shallow-equal "^1.0.0"
-    js-cookie "^2.2.1"
-    nano-css "^5.3.1"
-    react-universal-interface "^0.6.2"
-    resize-observer-polyfill "^1.5.1"
-    screenfull "^5.1.0"
-    set-harmonic-interval "^1.0.1"
-    throttle-debounce "^3.0.1"
-    ts-easing "^0.2.0"
-    tslib "^2.1.0"
-
 react-use@17.5.0:
   version "17.5.0"
   resolved "https://registry.yarnpkg.com/react-use/-/react-use-17.5.0.tgz#1fae45638828a338291efa0f0c61862db7ee6442"
@@ -12755,10 +12727,10 @@ react-use@17.5.0:
     ts-easing "^0.2.0"
     tslib "^2.1.0"
 
-react-virtualized-auto-sizer@1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz#bfb8414698ad1597912473de3e2e5f82180c1195"
-  integrity sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA==
+react-virtualized-auto-sizer@1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.24.tgz#3ebdc92f4b05ad65693b3cc8e7d8dd54924c0227"
+  integrity sha512-3kCn7N9NEb3FlvJrSHWGQ4iVl+ydQObq2fHMn12i5wbtm74zHOPhz/i64OL3c1S1vi9i2GXtZqNqUJTQ+BnNfg==
 
 react-window@1.8.10:
   version "1.8.10"
@@ -14555,11 +14527,6 @@ tslib@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
-
-tslib@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tslib@2.5.3:
   version "2.5.3"


### PR DESCRIPTION
Upgrades scenes to the latest version (`5.1.0`)

Fixes https://github.com/grafana/synthetic-monitoring-app/issues/825

Note: there was a breaking change where `SceneDataLayers` was renamed to `SceneDataLayerSet` (https://github.com/grafana/scenes/pull/640)

