### PR TITLE
fix: change grafana dependency to 11.0.0

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -69,7 +69,7 @@
     }
   ],
   "dependencies": {
-    "grafanaDependency": ">=10.0.0",
-    "grafanaVersion": "10.0"
+    "grafanaDependency": ">=11.0.0",
+    "grafanaVersion": "11.0"
   }
 }


### PR DESCRIPTION
After upgrading dependencies in https://github.com/grafana/synthetic-monitoring-app/pull/815 there are some incompatibilities with older versions of grafana (for instance, the `Stack` component is only available in `11.0.0`) so we need to update this configuration.

![image](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/197d2d8b-239a-4af5-bf9c-75c22f46b598)
