### PR TITLE
fix: custom probe longitude validation

### DIFF
--- a/src/schemas/forms/ProbeSchema.ts
+++ b/src/schemas/forms/ProbeSchema.ts
@@ -37,8 +37,8 @@ export const ProbeSchema: ZodType<Probe> = z.object({
       required_error: `Longitude is required`,
       invalid_type_error: `Latitude must be a number`,
     })
-    .min(LATITUDE_MIN, `Longitude must be greater than ${LONGITUDE_MIN}`)
-    .max(LATITUDE_MAX, `Longitude must be less than ${LONGITUDE_MAX}`),
+    .min(LONGITUDE_MIN, `Longitude must be greater than ${LONGITUDE_MIN}`)
+    .max(LONGITUDE_MAX, `Longitude must be less than ${LONGITUDE_MAX}`),
   region: z.string({
     required_error: `Region is required`,
     invalid_type_error: `Region is required`,


### PR DESCRIPTION
There was a bug in the validation of the custom probes longitude field which marked invalid values that were ok. This PR fixes that.

Fixes https://github.com/grafana/support-escalations/issues/11171

![2024-06-25 12 46 43](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/47244d6c-d3e9-45fa-b453-00f287a1bf6f)
