### PR TITLE
feat: improve non-initialized pages

### DIFF
--- a/src/components/ProgrammaticManagement.tsx
+++ b/src/components/ProgrammaticManagement.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import { AccessToken } from 'components/AccessToken';
 import { TerraformConfig } from 'components/TerraformConfig';
+import { InstanceContext } from 'contexts/InstanceContext';
 
 export const ProgrammaticManagement = () => {
+  const { meta, instance } = useContext(InstanceContext);
+  const initialized = meta?.enabled && instance.api;
+
   return (
     <div>
       <h3>Programmatic management</h3>
-      <AccessToken />
+      {initialized && <AccessToken />}
       <br />
       <TerraformConfig />
     </div>

--- a/src/components/ProgrammaticManagement.tsx
+++ b/src/components/ProgrammaticManagement.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react';
 
+import { InstanceContext } from 'contexts/InstanceContext';
 import { AccessToken } from 'components/AccessToken';
 import { TerraformConfig } from 'components/TerraformConfig';
-import { InstanceContext } from 'contexts/InstanceContext';
 
 export const ProgrammaticManagement = () => {
   const { meta, instance } = useContext(InstanceContext);

--- a/src/components/Routing.test.tsx
+++ b/src/components/Routing.test.tsx
@@ -33,20 +33,73 @@ describe('Only renders the unprovisioned setup page regardless of route when app
   });
 });
 
-describe('Only renders the welcome page regardless of route when app is not initializd', () => {
-  Object.entries(ROUTES).map(([key, route]) => {
-    test(`Route ${key}`, async () => {
-      jest.spyOn(runTime, `getDataSourceSrv`).mockImplementation(() => {
-        return {
-          ...jest.requireActual('@grafana/runtime').getDataSourceSrv(),
-          get: () => Promise.resolve(),
-        };
-      });
-
-      renderRouting({ path: getRoute(route) });
-      const text = await screen.findByText('Up and running in seconds, no instrumentation required');
-      expect(text).toBeInTheDocument();
+describe('Renders specific welcome pages when app is not initializd', () => {
+  test(`Route Home`, async () => {
+    jest.spyOn(runTime, `getDataSourceSrv`).mockImplementation(() => {
+      return {
+        ...jest.requireActual('@grafana/runtime').getDataSourceSrv(),
+        get: () => Promise.resolve(),
+      };
     });
+
+    renderRouting({ path: getRoute(ROUTES.Home) });
+    const text = await screen.findByText('Up and running in seconds, no instrumentation required');
+    expect(text).toBeInTheDocument();
+  });
+  test(`Route Probes`, async () => {
+    jest.spyOn(runTime, `getDataSourceSrv`).mockImplementation(() => {
+      return {
+        ...jest.requireActual('@grafana/runtime').getDataSourceSrv(),
+        get: () => Promise.resolve(),
+      };
+    });
+
+    renderRouting({ path: getRoute(ROUTES.Probes) });
+    const text = await screen.findByText(
+      'Click the See Probes button to initialize the plugin and see a list of public probes',
+      { exact: false }
+    );
+    expect(text).toBeInTheDocument();
+  });
+  test(`Route Alerts`, async () => {
+    jest.spyOn(runTime, `getDataSourceSrv`).mockImplementation(() => {
+      return {
+        ...jest.requireActual('@grafana/runtime').getDataSourceSrv(),
+        get: () => Promise.resolve(),
+      };
+    });
+
+    renderRouting({ path: getRoute(ROUTES.Alerts) });
+    const text = await screen.findByText(
+      'Click the See Alerting button to initialize the plugin and see a list of default alerts',
+      { exact: false }
+    );
+    expect(text).toBeInTheDocument();
+  });
+  test(`Route Checks`, async () => {
+    jest.spyOn(runTime, `getDataSourceSrv`).mockImplementation(() => {
+      return {
+        ...jest.requireActual('@grafana/runtime').getDataSourceSrv(),
+        get: () => Promise.resolve(),
+      };
+    });
+
+    renderRouting({ path: getRoute(ROUTES.Checks) });
+    const text = await screen.findByText('Click the Create a Check button to create checks', { exact: false });
+    expect(text).toBeInTheDocument();
+  });
+
+  test(`Route Config`, async () => {
+    jest.spyOn(runTime, `getDataSourceSrv`).mockImplementation(() => {
+      return {
+        ...jest.requireActual('@grafana/runtime').getDataSourceSrv(),
+        get: () => Promise.resolve(),
+      };
+    });
+
+    renderRouting({ path: getRoute(ROUTES.Config) });
+    const text = await screen.findByText('Programmatic management');
+    expect(text).toBeInTheDocument();
   });
 
   test('Non-existent route (404)', async () => {

--- a/src/components/Routing.test.tsx
+++ b/src/components/Routing.test.tsx
@@ -85,7 +85,7 @@ describe('Renders specific welcome pages when app is not initializd', () => {
     });
 
     renderRouting({ path: getRoute(ROUTES.Checks) });
-    const text = await screen.findByText('Click the Create a Check button to create checks', { exact: false });
+    const text = await screen.findByText('Click the Create a Check button to initialize the plugin and create checks', { exact: false });
     expect(text).toBeInTheDocument();
   });
 

--- a/src/components/Routing.tsx
+++ b/src/components/Routing.tsx
@@ -18,6 +18,9 @@ import { WelcomePage } from 'page/WelcomePage';
 
 import { PLUGIN_URL_PATH } from './constants';
 import { SceneRedirecter } from './SceneRedirecter';
+import { ChecksWelcomePage } from 'page/ChecksWelcomePage';
+import { ProbesWelcomePage } from 'page/ProbesWelcomePage';
+import { AlertingWelcomePage } from 'page/AlertingWelcomePage';
 
 export const Routing = ({ onNavChanged }: Pick<AppRootProps, 'onNavChanged'>) => {
   const queryParams = useQuery();
@@ -48,17 +51,13 @@ export const Routing = ({ onNavChanged }: Pick<AppRootProps, 'onNavChanged'>) =>
   }, [page, navigate, queryParams]);
 
   useLayoutEffect(() => {
-    if (!provisioned || (!initialized && location.pathname !== getRoute(ROUTES.Home))) {
+    if (!provisioned) {
       navigate(ROUTES.Home);
     }
-  }, [provisioned, initialized, location.pathname, navigate]);
+  }, [provisioned, navigate]);
 
   if (!provisioned) {
     return <UnprovisionedSetup />;
-  }
-
-  if (!initialized) {
-    return <WelcomePage />;
   }
 
   return (
@@ -67,19 +66,13 @@ export const Routing = ({ onNavChanged }: Pick<AppRootProps, 'onNavChanged'>) =>
         <SceneRedirecter />
       </Route>
       <Route exact path={getRoute(ROUTES.Home)}>
-        <SceneHomepage />
+        {initialized ? <SceneHomepage /> : <WelcomePage />}
       </Route>
-      <Route path={getRoute(ROUTES.Scene)}>
-        <SceneRedirecter />
-      </Route>
-      <Route path={getRoute(ROUTES.Checks)}>
-        <CheckRouter />
-      </Route>
-      <Route path={getRoute(ROUTES.Probes)}>
-        <ProbeRouter />
-      </Route>
+      <Route path={getRoute(ROUTES.Scene)}>{initialized ? <SceneRedirecter /> : <WelcomePage />}</Route>
+      <Route path={getRoute(ROUTES.Checks)}>{initialized ? <CheckRouter /> : <ChecksWelcomePage />}</Route>
+      <Route path={getRoute(ROUTES.Probes)}>{initialized ? <ProbeRouter /> : <ProbesWelcomePage />}</Route>
       <Route exact path={getRoute(ROUTES.Alerts)}>
-        <AlertingPage />
+        {initialized ? <AlertingPage /> : <AlertingWelcomePage />}
       </Route>
       <Route path={getRoute(ROUTES.Config)}>
         <ConfigPage />

--- a/src/components/Routing.tsx
+++ b/src/components/Routing.tsx
@@ -8,19 +8,19 @@ import { InstanceContext } from 'contexts/InstanceContext';
 import { QueryParamMap, useNavigation } from 'hooks/useNavigation';
 import { useQuery } from 'hooks/useQuery';
 import { AlertingPage } from 'page/AlertingPage';
+import { AlertingWelcomePage } from 'page/AlertingWelcomePage';
 import { CheckRouter } from 'page/CheckRouter';
+import { ChecksWelcomePage } from 'page/ChecksWelcomePage';
 import { ConfigPage } from 'page/ConfigPage';
 import { getNavModel } from 'page/pageDefinitions';
 import { ProbeRouter } from 'page/ProbeRouter';
+import { ProbesWelcomePage } from 'page/ProbesWelcomePage';
 import { SceneHomepage } from 'page/SceneHomepage';
 import { UnprovisionedSetup } from 'page/UnprovisionedSetup';
 import { WelcomePage } from 'page/WelcomePage';
 
 import { PLUGIN_URL_PATH } from './constants';
 import { SceneRedirecter } from './SceneRedirecter';
-import { ChecksWelcomePage } from 'page/ChecksWelcomePage';
-import { ProbesWelcomePage } from 'page/ProbesWelcomePage';
-import { AlertingWelcomePage } from 'page/AlertingWelcomePage';
 
 export const Routing = ({ onNavChanged }: Pick<AppRootProps, 'onNavChanged'>) => {
   const queryParams = useQuery();

--- a/src/components/TerraformConfig/TerraformConfig.tsx
+++ b/src/components/TerraformConfig/TerraformConfig.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, Modal, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -7,6 +7,7 @@ import { FaroEvent, reportEvent } from 'faro';
 import { useTerraformConfig } from 'hooks/useTerraformConfig';
 import { Clipboard } from 'components/Clipboard';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
+import { InstanceContext } from 'contexts/InstanceContext';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   modal: css`
@@ -28,11 +29,20 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
 export const TerraformConfig = () => {
   const styles = useStyles2(getStyles);
-
+  const { meta, instance } = useContext(InstanceContext);
+  const initialized = meta?.enabled && instance.api;
   return (
     <div>
       <h5>Terraform</h5>
-      <div>You can manage synthetic monitoring checks via Terraform. Export your current checks as config</div>
+      <div>
+        You can manage synthetic monitoring checks via Terraform. Export your current checks as config
+        {!initialized && (
+          <p>
+            <strong>Note: </strong>You need to initialize the plugin before importing this configuration.
+          </p>
+        )}
+      </div>
+
       <QueryErrorBoundary
         fallback={
           <Button className={styles.vericalSpace} disabled icon="fa fa-spinner">
@@ -50,6 +60,8 @@ const GenerateButton = () => {
   const { config, checkCommands, probeCommands, error } = useTerraformConfig();
   const [showModal, setShowModal] = useState(false);
   const styles = useStyles2(getStyles);
+  const { meta, instance } = useContext(InstanceContext);
+  const initialized = meta?.enabled && instance.api;
 
   return (
     <>
@@ -68,7 +80,7 @@ const GenerateButton = () => {
         onDismiss={() => setShowModal(false)}
         contentClassName={styles.modal}
       >
-        {error && <Alert title={error.message} />}
+        {initialized && error && <Alert title={error.message} />}
         {config && (checkCommands || probeCommands) && (
           <>
             <Alert title="Terraform and JSON" severity="info">
@@ -78,17 +90,17 @@ const GenerateButton = () => {
               <TextLink href="https://registry.terraform.io/providers/grafana/grafana/latest/docs" external={true}>
                 Terraform provider docs
               </TextLink>{' '}
-              for more details
+              for more details.
             </Alert>
             <h5>tf.json</h5>
             <Clipboard content={JSON.stringify(config, null, 2)} className={styles.clipboard} />
-            {checkCommands && (
+            {initialized && checkCommands && (
               <>
                 <h5>Import existing checks into Terraform</h5>
                 <Clipboard content={checkCommands.join(' && ')} className={styles.clipboard} />
               </>
             )}
-            {probeCommands && (
+            {initialized && probeCommands && (
               <>
                 <h5>Import custom probes into Terraform</h5>
                 <Clipboard content={probeCommands.join(' && ')} className={styles.clipboard} />

--- a/src/components/TerraformConfig/TerraformConfig.tsx
+++ b/src/components/TerraformConfig/TerraformConfig.tsx
@@ -4,10 +4,10 @@ import { Alert, Button, Modal, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { FaroEvent, reportEvent } from 'faro';
+import { InstanceContext } from 'contexts/InstanceContext';
 import { useTerraformConfig } from 'hooks/useTerraformConfig';
 import { Clipboard } from 'components/Clipboard';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
-import { InstanceContext } from 'contexts/InstanceContext';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   modal: css`

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -1,0 +1,211 @@
+import { useContext, useState } from 'react';
+import { DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
+
+import { isNumber } from 'lodash';
+import { config, getBackendSrv } from '@grafana/runtime';
+
+import { ROUTES, SubmissionErrorWrapper } from 'types';
+import { FaroEvent, reportError, reportEvent } from 'faro';
+import { initializeDatasource } from 'utils';
+import { InstanceContext } from 'contexts/InstanceContext';
+import { getRoute } from 'components/Routing';
+import { LEGACY_LOGS_DS_NAME, LEGACY_METRICS_DS_NAME } from 'components/constants';
+
+interface InitializeProps {
+  metricsSettings: DataSourceInstanceSettings<DataSourceJsonData>;
+  metricsHostedId: number;
+  logsSettings: DataSourceInstanceSettings<DataSourceJsonData>;
+  logsHostedId: number;
+}
+
+function getMetricsName(provisionedName?: string) {
+  if (config.datasources[LEGACY_METRICS_DS_NAME]) {
+    return LEGACY_METRICS_DS_NAME;
+  }
+  return provisionedName ?? '';
+}
+
+function getLogsName(provisionedName?: string) {
+  if (config.datasources[LEGACY_LOGS_DS_NAME]) {
+    return LEGACY_LOGS_DS_NAME;
+  }
+  return provisionedName ?? '';
+}
+
+function findDatasourceByNameAndUid(
+  provisionedName: string,
+  type: 'loki' | 'prometheus'
+): {
+  byName: DataSourceInstanceSettings<DataSourceJsonData> | undefined;
+  byUid: DataSourceInstanceSettings<DataSourceJsonData> | undefined;
+} {
+  const byName = config.datasources[provisionedName];
+  const byUid = Object.values(config.datasources).find((ds) => {
+    if (type === 'loki') {
+      return ds.uid === 'grafanacloud-logs';
+    } else {
+      return ds.uid === 'grafanacloud-metrics';
+    }
+  });
+  return {
+    byName,
+    byUid,
+  };
+}
+
+enum DatasourceStatus {
+  NameOnly = 'NameOnly',
+  Match = 'Match',
+  Mismatch = 'Mismatch',
+  UidOnly = 'UidOnly',
+  NotFound = 'NotFound',
+}
+
+function ensureNameAndUidMatch(
+  metricsByName?: DataSourceInstanceSettings<DataSourceJsonData>,
+  metricsByUid?: DataSourceInstanceSettings<DataSourceJsonData>
+): DatasourceStatus {
+  if (!metricsByUid && !metricsByName) {
+    return DatasourceStatus.NotFound;
+  }
+  if (!metricsByUid && metricsByName) {
+    return DatasourceStatus.NameOnly;
+  }
+  if (metricsByUid && !metricsByName) {
+    return DatasourceStatus.UidOnly;
+  }
+  if (metricsByUid && metricsByName) {
+    if (metricsByUid.name === metricsByName.name) {
+      return DatasourceStatus.Match;
+    }
+    return DatasourceStatus.Mismatch;
+  }
+  throw new Error('Invalid provisioning. Could not find datasources');
+}
+
+const useAppInitializer = (redirectTo?: ROUTES) => {
+  const [error, setError] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(false);
+  const [datasourceModalOpen, setDataSouceModalOpen] = useState<boolean>(false);
+  const { meta } = useContext(InstanceContext);
+
+  const metricsName = getMetricsName(meta?.jsonData?.metrics.grafanaName);
+  const { byName: metricsByName, byUid: metricsByUid } = findDatasourceByNameAndUid(metricsName, 'prometheus');
+  const logsName = getLogsName(meta?.jsonData?.logs.grafanaName);
+  const { byName: logsByName, byUid: logsByUid } = findDatasourceByNameAndUid(logsName, 'loki');
+  const stackId = meta?.jsonData?.stackId;
+
+  const handleClick = async () => {
+    try {
+      const metricsStatus = ensureNameAndUidMatch(metricsByName, metricsByUid);
+      const logsStatus = ensureNameAndUidMatch(logsByName, logsByUid);
+
+      if (metricsStatus === DatasourceStatus.NotFound) {
+        throw new Error('Invalid plugin configuration. Could not find a metrics datasource');
+      }
+      if (logsStatus === DatasourceStatus.NotFound) {
+        throw new Error('Invalid plugin configuration. Could not find a logs datasource');
+      }
+      // Either the plugin is running on prem and can find a datasource, or the provisioning matches with the default grafana cloud UIDs. Everything is good to go!
+      if (
+        (metricsStatus === DatasourceStatus.Match || metricsStatus === DatasourceStatus.NameOnly) &&
+        metricsByName &&
+        (logsStatus === DatasourceStatus.Match || logsStatus === DatasourceStatus.NameOnly) &&
+        logsByName
+      ) {
+        const metricsHostedId = meta?.jsonData?.metrics.hostedId;
+        if (!metricsHostedId) {
+          throw new Error('Invalid plugin configuration. Could not find metrics datasource hostedId');
+        }
+
+        const logsHostedId = meta?.jsonData?.logs.hostedId;
+        if (!logsHostedId) {
+          throw new Error('Invalid plugin configuration. Could not find logs datasource hostedId');
+        }
+
+        await initialize({
+          metricsSettings: metricsByName,
+          metricsHostedId,
+          logsSettings: logsByName,
+          logsHostedId: logsHostedId,
+        });
+
+        return;
+      }
+
+      if (metricsStatus === DatasourceStatus.UidOnly || logsStatus === DatasourceStatus.UidOnly) {
+        setDataSouceModalOpen(true);
+      }
+    } catch (e: any) {
+      setError(e?.message ?? 'Invalid plugin configuration. Could not find logs and metrics datasources');
+    }
+  };
+
+  const initialize = async ({ metricsSettings, metricsHostedId, logsSettings, logsHostedId }: InitializeProps) => {
+    reportEvent(FaroEvent.INIT);
+    if (!meta?.jsonData) {
+      reportError('Invalid plugin configuration', FaroEvent.INIT);
+      setError('Invalid plugin configuration');
+      return;
+    }
+    setLoading(true);
+    const body = {
+      stackId: isNumber(stackId) ? stackId : parseInt(stackId ?? '1', 10),
+      metricsInstanceId: metricsHostedId,
+      logsInstanceId: logsHostedId,
+    };
+    try {
+      const { accessToken } = await getBackendSrv().request({
+        url: `api/plugin-proxy/${meta.id}/install`,
+        method: 'POST',
+        data: body,
+      });
+      const datasourcePayload = {
+        apiHost: meta.jsonData.apiHost,
+        accessToken,
+        metrics: {
+          uid: metricsSettings.uid,
+          grafanaName: metricsSettings.name,
+          type: metricsSettings.type,
+          hostedId: meta.jsonData.metrics?.hostedId,
+        },
+        logs: {
+          uid: logsSettings.uid,
+          grafanaName: logsSettings.name,
+          type: logsSettings.type,
+          hostedId: meta.jsonData.logs?.hostedId,
+        },
+      };
+
+      await initializeDatasource(datasourcePayload);
+
+      if (redirectTo) {
+        window.location.href = `${window.location.origin}${getRoute(redirectTo)}`;
+      } else {
+        // force reload so that GrafanaBootConfig is updated.
+        window.location.href = `${window.location.origin}${getRoute(ROUTES.Home)}`;
+      }
+    } catch (e) {
+      const err = e as unknown as SubmissionErrorWrapper;
+      setError(err.data?.msg ?? err.data?.err ?? 'Something went wrong');
+      setLoading(false);
+      reportError(err.data?.msg ?? err.data?.err ?? err, FaroEvent.INIT);
+    }
+  };
+
+  return {
+    error,
+    setError,
+    loading,
+    handleClick,
+    metricsByName,
+    metricsByUid,
+    logsByName,
+    logsByUid,
+    initialize,
+    datasourceModalOpen,
+    setDataSouceModalOpen,
+  };
+};
+
+export default useAppInitializer;

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -1,15 +1,14 @@
 import { useContext, useState } from 'react';
 import { DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
-
-import { isNumber } from 'lodash';
 import { config, getBackendSrv } from '@grafana/runtime';
+import { isNumber } from 'lodash';
 
 import { ROUTES, SubmissionErrorWrapper } from 'types';
 import { FaroEvent, reportError, reportEvent } from 'faro';
 import { initializeDatasource } from 'utils';
 import { InstanceContext } from 'contexts/InstanceContext';
-import { getRoute } from 'components/Routing';
 import { LEGACY_LOGS_DS_NAME, LEGACY_METRICS_DS_NAME } from 'components/constants';
+import { getRoute } from 'components/Routing';
 
 interface InitializeProps {
   metricsSettings: DataSourceInstanceSettings<DataSourceJsonData>;

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -82,7 +82,7 @@ function ensureNameAndUidMatch(
   throw new Error('Invalid provisioning. Could not find datasources');
 }
 
-const useAppInitializer = (redirectTo?: ROUTES) => {
+export const useAppInitializer = (redirectTo?: ROUTES) => {
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
   const [datasourceModalOpen, setDataSouceModalOpen] = useState<boolean>(false);
@@ -206,5 +206,3 @@ const useAppInitializer = (redirectTo?: ROUTES) => {
     setDataSouceModalOpen,
   };
 };
-
-export default useAppInitializer;

--- a/src/page/AlertingWelcomePage.tsx
+++ b/src/page/AlertingWelcomePage.tsx
@@ -1,32 +1,21 @@
 import React from 'react';
-import { OrgRole } from '@grafana/data';
-import { Stack, TextLink } from '@grafana/ui';
+import { TextLink } from '@grafana/ui';
 
 import { ROUTES } from 'types';
-import { hasRole } from 'utils';
-import { Card } from 'components/Card';
-import { PluginPage } from 'components/PluginPage';
 
-import { AppInitializer } from './AppInitializer';
+import { SubsectionWelcomePage } from './SubsectionWelcomePage';
 
 export const AlertingWelcomePage = () => {
-  return (
-    <PluginPage>
-      <Card>
-        <Stack justifyContent={'center'} alignItems={'center'} direction={'column'}>
-          <h2>Get started monitoring your services</h2>
-          <p>
-            Click the {"See Alerting"} button to initialize the plugin and see a list of default alerts or visit the
-            Synthetic Monitoring{' '}
-            <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
-              documentation
-            </TextLink>{' '}
-            for more information
-          </p>
+  const BUTTON_TEXT = 'See Alerting';
 
-          <AppInitializer redirectTo={ROUTES.Alerts} disabled={!hasRole(OrgRole.Editor)} buttonText="See Alerting" />
-        </Stack>
-      </Card>
-    </PluginPage>
+  return (
+    <SubsectionWelcomePage redirectTo={ROUTES.Alerts} buttonText={BUTTON_TEXT}>
+      Click the {BUTTON_TEXT} button to initialize the plugin and see a list of default alerts or visit the Synthetic
+      Monitoring{' '}
+      <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
+        documentation
+      </TextLink>{' '}
+      for more information
+    </SubsectionWelcomePage>
   );
 };

--- a/src/page/AlertingWelcomePage.tsx
+++ b/src/page/AlertingWelcomePage.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
+import { OrgRole } from '@grafana/data';
 import { Stack, TextLink } from '@grafana/ui';
 
-import { PluginPage } from 'components/PluginPage';
-import { Card } from 'components/Card';
 import { ROUTES } from 'types';
-import { AppInitializer } from './AppInitializer';
 import { hasRole } from 'utils';
-import { OrgRole } from '@grafana/data';
+import { Card } from 'components/Card';
+import { PluginPage } from 'components/PluginPage';
+
+import { AppInitializer } from './AppInitializer';
 
 export const AlertingWelcomePage = () => {
   return (
@@ -15,7 +16,7 @@ export const AlertingWelcomePage = () => {
         <Stack justifyContent={'center'} alignItems={'center'} direction={'column'}>
           <h2>Get started monitoring your services</h2>
           <p>
-            Click the "See Alerting" button to initialize the plugin and see a list of default alerts or visit the
+            Click the {"See Alerting"} button to initialize the plugin and see a list of default alerts or visit the
             Synthetic Monitoring{' '}
             <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
               documentation

--- a/src/page/AlertingWelcomePage.tsx
+++ b/src/page/AlertingWelcomePage.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Stack, TextLink } from '@grafana/ui';
+
+import { PluginPage } from 'components/PluginPage';
+import { Card } from 'components/Card';
+import { ROUTES } from 'types';
+import { AppInitializer } from './AppInitializer';
+import { hasRole } from 'utils';
+import { OrgRole } from '@grafana/data';
+
+export const AlertingWelcomePage = () => {
+  return (
+    <PluginPage>
+      <Card>
+        <Stack justifyContent={'center'} alignItems={'center'} direction={'column'}>
+          <h2>Get started monitoring your services</h2>
+          <p>
+            Click the "See Alerting" button to initialize the plugin and see a list of default alerts or visit the
+            Synthetic Monitoring{' '}
+            <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
+              documentation
+            </TextLink>{' '}
+            for more information
+          </p>
+
+          <AppInitializer redirectTo={ROUTES.Alerts} disabled={!hasRole(OrgRole.Editor)} buttonText="See Alerting" />
+        </Stack>
+      </Card>
+    </PluginPage>
+  );
+};

--- a/src/page/AppInitializer.tsx
+++ b/src/page/AppInitializer.tsx
@@ -16,7 +16,6 @@ interface Props {
 }
 
 export const AppInitializer = ({
-  children,
   redirectTo,
   disabled,
   buttonClassname,

--- a/src/page/AppInitializer.tsx
+++ b/src/page/AppInitializer.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/css';
 
 import { ROUTES } from 'types';
 import { InstanceContext } from 'contexts/InstanceContext';
-import useAppInitializer from 'hooks/useAppInitializer';
+import { useAppInitializer } from 'hooks/useAppInitializer';
 import { MismatchedDatasourceModal } from 'components/MismatchedDatasourceModal';
 
 interface Props {
@@ -15,12 +15,7 @@ interface Props {
   buttonText: string;
 }
 
-export const AppInitializer = ({
-  redirectTo,
-  disabled,
-  buttonClassname,
-  buttonText,
-}: PropsWithChildren<Props>) => {
+export const AppInitializer = ({ redirectTo, disabled, buttonClassname, buttonText }: PropsWithChildren<Props>) => {
   const { meta } = useContext(InstanceContext);
 
   const styles = useStyles2(getStyles);

--- a/src/page/AppInitializer.tsx
+++ b/src/page/AppInitializer.tsx
@@ -1,12 +1,12 @@
 import React, { PropsWithChildren, useContext } from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, Spinner, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 
+import { ROUTES } from 'types';
 import { InstanceContext } from 'contexts/InstanceContext';
 import useAppInitializer from 'hooks/useAppInitializer';
-import { ROUTES } from 'types';
 import { MismatchedDatasourceModal } from 'components/MismatchedDatasourceModal';
-import { GrafanaTheme2 } from '@grafana/data';
-import { css } from '@emotion/css';
 
 interface Props {
   redirectTo?: ROUTES;

--- a/src/page/AppInitializer.tsx
+++ b/src/page/AppInitializer.tsx
@@ -1,0 +1,84 @@
+import React, { PropsWithChildren, useContext } from 'react';
+import { Alert, Button, Spinner, useStyles2 } from '@grafana/ui';
+
+import { InstanceContext } from 'contexts/InstanceContext';
+import useAppInitializer from 'hooks/useAppInitializer';
+import { ROUTES } from 'types';
+import { MismatchedDatasourceModal } from 'components/MismatchedDatasourceModal';
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+
+interface Props {
+  redirectTo?: ROUTES;
+  disabled: boolean;
+  buttonClassname?: string;
+  buttonText: string;
+}
+
+export const AppInitializer = ({
+  children,
+  redirectTo,
+  disabled,
+  buttonClassname,
+  buttonText,
+}: PropsWithChildren<Props>) => {
+  const { meta } = useContext(InstanceContext);
+
+  const styles = useStyles2(getStyles);
+
+  const {
+    error,
+    setError,
+    loading,
+    metricsByName,
+    metricsByUid,
+    logsByName,
+    logsByUid,
+    initialize,
+    handleClick,
+    datasourceModalOpen,
+    setDataSouceModalOpen,
+  } = useAppInitializer(redirectTo);
+
+  return (
+    <div>
+      <Button onClick={handleClick} disabled={loading || disabled} size="lg" className={buttonClassname}>
+        {loading ? <Spinner /> : buttonText}
+      </Button>
+
+      {error && (
+        <Alert title="Something went wrong:" className={styles.errorAlert}>
+          {error}
+        </Alert>
+      )}
+
+      <MismatchedDatasourceModal
+        isOpen={datasourceModalOpen}
+        metricsFoundName={metricsByName?.name ?? 'Not found'}
+        metricsExpectedName={metricsByUid?.name ?? 'Not found'}
+        logsFoundName={logsByName?.name ?? 'Not found'}
+        logsExpectedName={logsByUid?.name ?? 'Not found'}
+        onDismiss={() => setDataSouceModalOpen(false)}
+        isSubmitting={loading}
+        onSubmit={() => {
+          if (meta?.jsonData?.metrics?.hostedId && meta?.jsonData?.logs.hostedId) {
+            initialize({
+              metricsSettings: metricsByUid!, // we have already guaranteed that this exists above
+              metricsHostedId: meta.jsonData.metrics.hostedId,
+              logsSettings: logsByUid!, // we have already guaranteed that this exists above
+              logsHostedId: meta.jsonData.logs.hostedId,
+            });
+          } else {
+            setError('Missing datasource hostedId');
+          }
+        }}
+      />
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  errorAlert: css({
+    marginTop: theme.spacing(4),
+  }),
+});

--- a/src/page/ChecksWelcomePage.tsx
+++ b/src/page/ChecksWelcomePage.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Stack, TextLink } from '@grafana/ui';
+
+import { PluginPage } from 'components/PluginPage';
+import { Card } from 'components/Card';
+import { ROUTES } from 'types';
+import { AppInitializer } from './AppInitializer';
+import { hasRole } from 'utils';
+import { OrgRole } from '@grafana/data';
+
+export const ChecksWelcomePage = () => {
+  return (
+    <PluginPage>
+      <p>Monitor your endpoints</p>
+      <Card>
+        <Stack justifyContent={'center'} alignItems={'center'} direction={'column'}>
+          <h2>Get started monitoring your services</h2>
+          <p>
+            Click the "Create a Check" button to create checks or visit the Synthetic Monitoring{' '}
+            <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
+              documentation
+            </TextLink>{' '}
+            for more information
+          </p>
+
+          <AppInitializer
+            redirectTo={ROUTES.ChooseCheckType}
+            disabled={!hasRole(OrgRole.Editor)}
+            buttonText="Create a Check"
+          />
+        </Stack>
+      </Card>
+    </PluginPage>
+  );
+};

--- a/src/page/ChecksWelcomePage.tsx
+++ b/src/page/ChecksWelcomePage.tsx
@@ -10,7 +10,7 @@ export const ChecksWelcomePage = () => {
 
   return (
     <SubsectionWelcomePage redirectTo={ROUTES.ChooseCheckType} buttonText={BUTTON_TEXT}>
-      Click the {BUTTON_TEXT} button to to initialize the plugin and create checks or visit the Synthetic Monitoring{' '}
+      Click the {BUTTON_TEXT} button to initialize the plugin and create checks or visit the Synthetic Monitoring{' '}
       <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
         documentation
       </TextLink>{' '}

--- a/src/page/ChecksWelcomePage.tsx
+++ b/src/page/ChecksWelcomePage.tsx
@@ -1,36 +1,20 @@
 import React from 'react';
-import { OrgRole } from '@grafana/data';
-import { Stack, TextLink } from '@grafana/ui';
+import { TextLink } from '@grafana/ui';
 
 import { ROUTES } from 'types';
-import { hasRole } from 'utils';
-import { Card } from 'components/Card';
-import { PluginPage } from 'components/PluginPage';
 
-import { AppInitializer } from './AppInitializer';
+import { SubsectionWelcomePage } from './SubsectionWelcomePage';
 
 export const ChecksWelcomePage = () => {
-  return (
-    <PluginPage>
-      <p>Monitor your endpoints</p>
-      <Card>
-        <Stack justifyContent={'center'} alignItems={'center'} direction={'column'}>
-          <h2>Get started monitoring your services</h2>
-          <p>
-            Click the {'Create a Check'} button to create checks or visit the Synthetic Monitoring{' '}
-            <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
-              documentation
-            </TextLink>{' '}
-            for more information
-          </p>
+  const BUTTON_TEXT = 'Create a Check';
 
-          <AppInitializer
-            redirectTo={ROUTES.ChooseCheckType}
-            disabled={!hasRole(OrgRole.Editor)}
-            buttonText="Create a Check"
-          />
-        </Stack>
-      </Card>
-    </PluginPage>
+  return (
+    <SubsectionWelcomePage redirectTo={ROUTES.ChooseCheckType} buttonText={BUTTON_TEXT}>
+      Click the {BUTTON_TEXT} button to to initialize the plugin and create checks or visit the Synthetic Monitoring{' '}
+      <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
+        documentation
+      </TextLink>{' '}
+      for more information
+    </SubsectionWelcomePage>
   );
 };

--- a/src/page/ChecksWelcomePage.tsx
+++ b/src/page/ChecksWelcomePage.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
+import { OrgRole } from '@grafana/data';
 import { Stack, TextLink } from '@grafana/ui';
 
-import { PluginPage } from 'components/PluginPage';
-import { Card } from 'components/Card';
 import { ROUTES } from 'types';
-import { AppInitializer } from './AppInitializer';
 import { hasRole } from 'utils';
-import { OrgRole } from '@grafana/data';
+import { Card } from 'components/Card';
+import { PluginPage } from 'components/PluginPage';
+
+import { AppInitializer } from './AppInitializer';
 
 export const ChecksWelcomePage = () => {
   return (
@@ -16,7 +17,7 @@ export const ChecksWelcomePage = () => {
         <Stack justifyContent={'center'} alignItems={'center'} direction={'column'}>
           <h2>Get started monitoring your services</h2>
           <p>
-            Click the "Create a Check" button to create checks or visit the Synthetic Monitoring{' '}
+            Click the {'Create a Check'} button to create checks or visit the Synthetic Monitoring{' '}
             <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
               documentation
             </TextLink>{' '}

--- a/src/page/ConfigPage.tsx
+++ b/src/page/ConfigPage.tsx
@@ -30,7 +30,7 @@ function getStyles(theme: GrafanaTheme2) {
       padding: ${theme.spacing(2)} 0;
     `,
     configActions: css`
-      padding: ${theme.spacing(4)} 0;
+      padding-bottom: ${theme.spacing(2)};
     `,
   };
 }

--- a/src/page/ProbesWelcomePage.tsx
+++ b/src/page/ProbesWelcomePage.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Stack, TextLink } from '@grafana/ui';
+
+import { PluginPage } from 'components/PluginPage';
+import { Card } from 'components/Card';
+import { ROUTES } from 'types';
+import { AppInitializer } from './AppInitializer';
+import { hasRole } from 'utils';
+import { OrgRole } from '@grafana/data';
+
+export const ProbesWelcomePage = () => {
+  return (
+    <PluginPage>
+      <Card>
+        <Stack justifyContent={'center'} alignItems={'center'} direction={'column'}>
+          <h2>Get started monitoring your services</h2>
+          <p>
+            Click the "See Probes" button to initialize the plugin and see a list of public probes or visit the
+            Synthetic Monitoring{' '}
+            <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
+              documentation
+            </TextLink>{' '}
+            for more information
+          </p>
+
+          <AppInitializer redirectTo={ROUTES.Probes} disabled={!hasRole(OrgRole.Editor)} buttonText="See Probes" />
+        </Stack>
+      </Card>
+    </PluginPage>
+  );
+};

--- a/src/page/ProbesWelcomePage.tsx
+++ b/src/page/ProbesWelcomePage.tsx
@@ -1,32 +1,21 @@
 import React from 'react';
-import { OrgRole } from '@grafana/data';
-import { Stack, TextLink } from '@grafana/ui';
+import { TextLink } from '@grafana/ui';
 
 import { ROUTES } from 'types';
-import { hasRole } from 'utils';
-import { Card } from 'components/Card';
-import { PluginPage } from 'components/PluginPage';
 
-import { AppInitializer } from './AppInitializer';
+import { SubsectionWelcomePage } from './SubsectionWelcomePage';
 
 export const ProbesWelcomePage = () => {
-  return (
-    <PluginPage>
-      <Card>
-        <Stack justifyContent={'center'} alignItems={'center'} direction={'column'}>
-          <h2>Get started monitoring your services</h2>
-          <p>
-            Click the {"See Probes"} button to initialize the plugin and see a list of public probes or visit the
-            Synthetic Monitoring{' '}
-            <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
-              documentation
-            </TextLink>{' '}
-            for more information
-          </p>
+  const BUTTON_TEXT = 'See Probes';
 
-          <AppInitializer redirectTo={ROUTES.Probes} disabled={!hasRole(OrgRole.Editor)} buttonText="See Probes" />
-        </Stack>
-      </Card>
-    </PluginPage>
+  return (
+    <SubsectionWelcomePage redirectTo={ROUTES.Probes} buttonText={BUTTON_TEXT}>
+      Click the {BUTTON_TEXT} button to initialize the plugin and see a list of public probes or visit the Synthetic
+      Monitoring{' '}
+      <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
+        documentation
+      </TextLink>{' '}
+      for more information
+    </SubsectionWelcomePage>
   );
 };

--- a/src/page/ProbesWelcomePage.tsx
+++ b/src/page/ProbesWelcomePage.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
+import { OrgRole } from '@grafana/data';
 import { Stack, TextLink } from '@grafana/ui';
 
-import { PluginPage } from 'components/PluginPage';
-import { Card } from 'components/Card';
 import { ROUTES } from 'types';
-import { AppInitializer } from './AppInitializer';
 import { hasRole } from 'utils';
-import { OrgRole } from '@grafana/data';
+import { Card } from 'components/Card';
+import { PluginPage } from 'components/PluginPage';
+
+import { AppInitializer } from './AppInitializer';
 
 export const ProbesWelcomePage = () => {
   return (
@@ -15,7 +16,7 @@ export const ProbesWelcomePage = () => {
         <Stack justifyContent={'center'} alignItems={'center'} direction={'column'}>
           <h2>Get started monitoring your services</h2>
           <p>
-            Click the "See Probes" button to initialize the plugin and see a list of public probes or visit the
+            Click the {"See Probes"} button to initialize the plugin and see a list of public probes or visit the
             Synthetic Monitoring{' '}
             <TextLink href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/" external={true}>
               documentation

--- a/src/page/SubsectionWelcomePage.tsx
+++ b/src/page/SubsectionWelcomePage.tsx
@@ -1,0 +1,44 @@
+import React, { PropsWithChildren } from 'react';
+import { GrafanaTheme2, OrgRole } from '@grafana/data';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { ROUTES } from 'types';
+import { hasRole } from 'utils';
+import { Card } from 'components/Card';
+import { PluginPage } from 'components/PluginPage';
+
+import { AppInitializer } from './AppInitializer';
+
+interface Props {
+  children: React.ReactNode;
+  redirectTo: ROUTES;
+  buttonText: string;
+}
+
+export const SubsectionWelcomePage = ({ children, redirectTo, buttonText }: PropsWithChildren<Props>) => {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <PluginPage>
+      <Stack alignItems={'center'} justifyContent={'center'}>
+        <Card className={styles.welcomeCard}>
+          <Stack justifyContent={'center'} alignItems={'center'} direction={'column'}>
+            <h2>Get started monitoring your services</h2>
+            <p>{children}</p>
+
+            <AppInitializer redirectTo={redirectTo} disabled={!hasRole(OrgRole.Editor)} buttonText={buttonText} />
+          </Stack>
+        </Card>
+      </Stack>
+    </PluginPage>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  welcomeCard: css({
+    'max-width': '1200px',
+    padding: theme.spacing(4),
+    'margin-top': theme.spacing(4),
+  }),
+});

--- a/src/page/WelcomePage.tsx
+++ b/src/page/WelcomePage.tsx
@@ -1,202 +1,19 @@
-import React, { FC, useContext, useState } from 'react';
-import { DataSourceInstanceSettings, DataSourceJsonData, GrafanaTheme2, OrgRole, PageLayoutType } from '@grafana/data';
-import { config, getBackendSrv } from '@grafana/runtime';
-import { Alert, Button, Spinner, useStyles2 } from '@grafana/ui';
+import React, { FC, useContext } from 'react';
+import { GrafanaTheme2, OrgRole, PageLayoutType } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
-import { isNumber } from 'lodash';
 
-import { ROUTES, SubmissionErrorWrapper } from 'types';
-import { FaroEvent, reportError, reportEvent } from 'faro';
-import { hasRole, initializeDatasource } from 'utils';
+import { hasRole } from 'utils';
 import { InstanceContext } from 'contexts/InstanceContext';
-import { LEGACY_LOGS_DS_NAME, LEGACY_METRICS_DS_NAME } from 'components/constants';
-import { MismatchedDatasourceModal } from 'components/MismatchedDatasourceModal';
 import { PluginPage } from 'components/PluginPage';
-import { getRoute } from 'components/Routing';
 import { WelcomeTabs } from 'components/WelcomeTabs/WelcomeTabs';
-
-function getMetricsName(provisionedName?: string) {
-  if (config.datasources[LEGACY_METRICS_DS_NAME]) {
-    return LEGACY_METRICS_DS_NAME;
-  }
-  return provisionedName ?? '';
-}
-
-function getLogsName(provisionedName?: string) {
-  if (config.datasources[LEGACY_LOGS_DS_NAME]) {
-    return LEGACY_LOGS_DS_NAME;
-  }
-  return provisionedName ?? '';
-}
-
-function findDatasourceByNameAndUid(
-  provisionedName: string,
-  type: 'loki' | 'prometheus'
-): {
-  byName: DataSourceInstanceSettings<DataSourceJsonData> | undefined;
-  byUid: DataSourceInstanceSettings<DataSourceJsonData> | undefined;
-} {
-  const byName = config.datasources[provisionedName];
-  const byUid = Object.values(config.datasources).find((ds) => {
-    if (type === 'loki') {
-      return ds.uid === 'grafanacloud-logs';
-    } else {
-      return ds.uid === 'grafanacloud-metrics';
-    }
-  });
-  return {
-    byName,
-    byUid,
-  };
-}
-
-enum DatasourceStatus {
-  NameOnly = 'NameOnly',
-  Match = 'Match',
-  Mismatch = 'Mismatch',
-  UidOnly = 'UidOnly',
-  NotFound = 'NotFound',
-}
-
-function ensureNameAndUidMatch(
-  metricsByName?: DataSourceInstanceSettings<DataSourceJsonData>,
-  metricsByUid?: DataSourceInstanceSettings<DataSourceJsonData>
-): DatasourceStatus {
-  if (!metricsByUid && !metricsByName) {
-    return DatasourceStatus.NotFound;
-  }
-  if (!metricsByUid && metricsByName) {
-    return DatasourceStatus.NameOnly;
-  }
-  if (metricsByUid && !metricsByName) {
-    return DatasourceStatus.UidOnly;
-  }
-  if (metricsByUid && metricsByName) {
-    if (metricsByUid.name === metricsByName.name) {
-      return DatasourceStatus.Match;
-    }
-    return DatasourceStatus.Mismatch;
-  }
-  throw new Error('Invalid provisioning. Could not find datasources');
-}
+import { AppInitializer } from './AppInitializer';
 
 interface Props {}
 
 export const WelcomePage: FC<Props> = () => {
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [datasourceModalOpen, setDataSouceModalOpen] = useState(false);
-  const { meta } = useContext(InstanceContext);
   const styles = useStyles2(getStyles);
-
-  const metricsName = getMetricsName(meta?.jsonData?.metrics.grafanaName);
-  const { byName: metricsByName, byUid: metricsByUid } = findDatasourceByNameAndUid(metricsName, 'prometheus');
-  const logsName = getLogsName(meta?.jsonData?.logs.grafanaName);
-  const { byName: logsByName, byUid: logsByUid } = findDatasourceByNameAndUid(logsName, 'loki');
-  const stackId = meta?.jsonData?.stackId;
-
-  const handleClick = async () => {
-    try {
-      const metricsStatus = ensureNameAndUidMatch(metricsByName, metricsByUid);
-      const logsStatus = ensureNameAndUidMatch(logsByName, logsByUid);
-
-      if (metricsStatus === DatasourceStatus.NotFound) {
-        throw new Error('Invalid plugin configuration. Could not find a metrics datasource');
-      }
-      if (logsStatus === DatasourceStatus.NotFound) {
-        throw new Error('Invalid plugin configuration. Could not find a logs datasource');
-      }
-      // Either the plugin is running on prem and can find a datasource, or the provisioning matches with the default grafana cloud UIDs. Everything is good to go!
-      if (
-        (metricsStatus === DatasourceStatus.Match || metricsStatus === DatasourceStatus.NameOnly) &&
-        metricsByName &&
-        (logsStatus === DatasourceStatus.Match || logsStatus === DatasourceStatus.NameOnly) &&
-        logsByName
-      ) {
-        const metricsHostedId = meta?.jsonData?.metrics.hostedId;
-        if (!metricsHostedId) {
-          throw new Error('Invalid plugin configuration. Could not find metrics datasource hostedId');
-        }
-
-        const logsHostedId = meta?.jsonData?.logs.hostedId;
-        if (!logsHostedId) {
-          throw new Error('Invalid plugin configuration. Could not find logs datasource hostedId');
-        }
-
-        initialize({
-          metricsSettings: metricsByName,
-          metricsHostedId,
-          logsSettings: logsByName,
-          logsHostedId: logsHostedId,
-        });
-        return;
-      }
-
-      if (metricsStatus === DatasourceStatus.UidOnly || logsStatus === DatasourceStatus.UidOnly) {
-        setDataSouceModalOpen(true);
-      }
-    } catch (e: any) {
-      setError(e?.message ?? 'Invalid plugin configuration. Could not find logs and metrics datasources');
-    }
-  };
-
-  const initialize = async ({
-    metricsSettings,
-    metricsHostedId,
-    logsSettings,
-    logsHostedId,
-  }: {
-    metricsSettings: DataSourceInstanceSettings<DataSourceJsonData>;
-    metricsHostedId: number;
-    logsSettings: DataSourceInstanceSettings<DataSourceJsonData>;
-    logsHostedId: number;
-  }) => {
-    reportEvent(FaroEvent.INIT);
-    if (!meta?.jsonData) {
-      reportError('Invalid plugin configuration', FaroEvent.INIT);
-      setError('Invalid plugin configuration');
-      return;
-    }
-    setLoading(true);
-    const body = {
-      stackId: isNumber(stackId) ? stackId : parseInt(stackId ?? '1', 10),
-      metricsInstanceId: metricsHostedId,
-      logsInstanceId: logsHostedId,
-    };
-    try {
-      const { accessToken } = await getBackendSrv().request({
-        url: `api/plugin-proxy/${meta.id}/install`,
-        method: 'POST',
-        data: body,
-      });
-      const datasourcePayload = {
-        apiHost: meta.jsonData.apiHost,
-        accessToken,
-        metrics: {
-          uid: metricsSettings.uid,
-          grafanaName: metricsSettings.name,
-          type: metricsSettings.type,
-          hostedId: meta.jsonData.metrics?.hostedId,
-        },
-        logs: {
-          uid: logsSettings.uid,
-          grafanaName: logsSettings.name,
-          type: logsSettings.type,
-          hostedId: meta.jsonData.logs?.hostedId,
-        },
-      };
-
-      await initializeDatasource(datasourcePayload);
-
-      // force reload so that GrafanaBootConfig is updated.
-      window.location.href = `${window.location.origin}${getRoute(ROUTES.Home)}`;
-    } catch (e) {
-      const err = e as unknown as SubmissionErrorWrapper;
-      setError(err.data?.msg ?? err.data?.err ?? 'Something went wrong');
-      setLoading(false);
-      reportError(err.data?.msg ?? err.data?.err ?? err, FaroEvent.INIT);
-    }
-  };
+  const { meta } = useContext(InstanceContext);
 
   return (
     <PluginPage layout={PageLayoutType.Canvas}>
@@ -212,19 +29,11 @@ export const WelcomePage: FC<Props> = () => {
               simulate user journeys, and get alerted before your users
             </h5>
           </div>
-          <Button
-            onClick={handleClick}
-            disabled={loading || !hasRole(OrgRole.Editor)}
-            size="lg"
-            className={styles.getStartedButton}
-          >
-            {loading ? <Spinner /> : 'Get started'}
-          </Button>
-          {error && (
-            <Alert title="Something went wrong:" className={styles.errorAlert}>
-              {error}
-            </Alert>
-          )}
+          <AppInitializer
+            disabled={!hasRole(OrgRole.Editor)}
+            buttonText="Get started"
+            buttonClassname={styles.getStartedButton}
+          />
         </div>
         <hr className={styles.divider} />
         <div className={styles.valueProp}>
@@ -232,28 +41,6 @@ export const WelcomePage: FC<Props> = () => {
           <WelcomeTabs />
         </div>
       </div>
-
-      <MismatchedDatasourceModal
-        isOpen={datasourceModalOpen}
-        metricsFoundName={metricsByName?.name ?? 'Not found'}
-        metricsExpectedName={metricsByUid?.name ?? 'Not found'}
-        logsFoundName={logsByName?.name ?? 'Not found'}
-        logsExpectedName={logsByUid?.name ?? 'Not found'}
-        onDismiss={() => setDataSouceModalOpen(false)}
-        isSubmitting={loading}
-        onSubmit={() => {
-          if (meta?.jsonData?.metrics?.hostedId && meta?.jsonData?.logs.hostedId) {
-            initialize({
-              metricsSettings: metricsByUid!, // we have already guaranteed that this exists above
-              metricsHostedId: meta.jsonData.metrics.hostedId,
-              logsSettings: logsByUid!, // we have already guaranteed that this exists above
-              logsHostedId: meta.jsonData.logs.hostedId,
-            });
-          } else {
-            setError('Missing datasource hostedId');
-          }
-        }}
-      />
     </PluginPage>
   );
 };

--- a/src/page/WelcomePage.tsx
+++ b/src/page/WelcomePage.tsx
@@ -7,6 +7,7 @@ import { hasRole } from 'utils';
 import { InstanceContext } from 'contexts/InstanceContext';
 import { PluginPage } from 'components/PluginPage';
 import { WelcomeTabs } from 'components/WelcomeTabs/WelcomeTabs';
+
 import { AppInitializer } from './AppInitializer';
 
 interface Props {}

--- a/src/scenes/Common/emptyScene.tsx
+++ b/src/scenes/Common/emptyScene.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { EmbeddedScene, SceneReactObject } from '@grafana/scenes';
-import { Button, Card, useStyles2 } from '@grafana/ui';
+import { Button, Card, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { CheckType, ROUTES } from 'types';
@@ -22,7 +22,7 @@ function getStyles(theme: GrafanaTheme2) {
     `,
     emptyCard: css`
       min-height: 200px;
-      max-width: 600px;
+      max-width: 800px;
       padding: ${theme.spacing(4)};
     `,
     cardButtons: css`
@@ -40,7 +40,13 @@ function EmptyScene({ checkType }: { checkType?: CheckType }) {
     <div className={styles.container}>
       <Card className={styles.emptyCard}>
         <Card.Heading className={styles.cardHeader}>
-          You don&apos;t have any {checkType ? checkType.toUpperCase() : ''} checks running
+          <p>
+            You don&apos;t have any {checkType ? checkType.toUpperCase() : ''} checks running. Click the Create a check
+            button to start monitoring your services with Grafana Cloud, or{' '}
+            <TextLink href="https://grafana.com/docs/grafana-cloud/synthetic-monitoring/" external={true}>
+              check out the Synthetic Monitoring docs.
+            </TextLink>
+          </p>
         </Card.Heading>
         <Card.Actions className={styles.cardButtons}>
           <Button


### PR DESCRIPTION
When the plugin is not initialized, we now display dedicated pages according to each route. 

Home
<img width="1510" alt="image" src="https://github.com/grafana/synthetic-monitoring-app/assets/6271380/a9db3a92-715e-4cba-b37a-4691e7a76f7b">
![2024-06-27 17 37 36](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/a4c58250-367d-4024-96cd-15134809d587)


Checks
![image](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/2586406b-b512-40e0-9ccb-590460cd3697)
![2024-06-27 17 32 54](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/0f6ae723-7eee-44f8-b56f-cfa8889e1d37)


Probes
![image](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/04f3ace0-25ac-467f-bfed-9cf35a5857be)
![2024-06-27 17 32 22](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/611f42b0-4c31-4901-b997-028d58dc8a87)


Alerts
![image](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/c5a91dba-94a1-42a9-a0f2-fc772f24e554)![2024-06-27 17 33 34](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/078ef2da-304c-49b2-9253-544fbd7d0091)

Config
![image](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/b71cd6b3-f715-4488-befe-b635fc988a65)
![image](https://github.com/grafana/synthetic-monitoring-app/assets/6271380/ba478006-942e-4d4f-bfa8-3030b5094420)

Fixes https://github.com/grafana/synthetic-monitoring-app/issues/807

