### PR TITLE
fix: change query for uptime stat panel

### DIFF
--- a/src/page/DashboardPage.tsx
+++ b/src/page/DashboardPage.tsx
@@ -3,9 +3,10 @@ import { useParams } from 'react-router-dom';
 import { SceneApp, SceneAppPage } from '@grafana/scenes';
 import { Spinner } from '@grafana/ui';
 
-import { CheckPageParams, CheckType, DashboardSceneAppConfig } from 'types';
+import { CheckPageParams, CheckType, DashboardSceneAppConfig, FeatureName } from 'types';
 import { getCheckType } from 'utils';
 import { useChecks } from 'data/useChecks';
+import { useFeatureFlag } from 'hooks/useFeatureFlag';
 import { useLogsDS } from 'hooks/useLogsDS';
 import { useMetricsDS } from 'hooks/useMetricsDS';
 import { useSMDS } from 'hooks/useSMDS';
@@ -27,6 +28,8 @@ function DashboardPageContent() {
   const { id } = useParams<CheckPageParams>();
 
   const checkToView = checks.find((check) => String(check.id) === id);
+
+  const newUptimeQuery = useFeatureFlag(FeatureName.UptimeQueryV2)?.isEnabled;
 
   const scene = useMemo(() => {
     const metricsDef = {
@@ -56,7 +59,7 @@ function DashboardPageContent() {
             new SceneAppPage({
               title: checkToView.job,
               url,
-              getScene: getDNSScene(config, [checkToView]),
+              getScene: getDNSScene(config, [checkToView], newUptimeQuery),
             }),
           ],
         });
@@ -67,7 +70,7 @@ function DashboardPageContent() {
             new SceneAppPage({
               title: checkToView.job,
               url,
-              getScene: getHTTPScene(config, [checkToView]),
+              getScene: getHTTPScene(config, [checkToView], newUptimeQuery),
             }),
           ],
         });
@@ -78,7 +81,7 @@ function DashboardPageContent() {
             new SceneAppPage({
               title: checkToView.job,
               url,
-              getScene: getBrowserScene(config, [checkToView], checkType),
+              getScene: getBrowserScene(config, [checkToView], checkType, newUptimeQuery),
             }),
           ],
         });
@@ -90,7 +93,7 @@ function DashboardPageContent() {
             new SceneAppPage({
               title: checkToView.job,
               url,
-              getScene: getScriptedScene(config, [checkToView], checkType),
+              getScene: getScriptedScene(config, [checkToView], checkType, newUptimeQuery),
             }),
           ],
         });
@@ -101,7 +104,7 @@ function DashboardPageContent() {
             new SceneAppPage({
               title: checkToView.job,
               url,
-              getScene: getPingScene(config, [checkToView]),
+              getScene: getPingScene(config, [checkToView], newUptimeQuery),
             }),
           ],
         });
@@ -112,7 +115,7 @@ function DashboardPageContent() {
             new SceneAppPage({
               title: checkToView.job,
               url,
-              getScene: getTcpScene(config, [checkToView]),
+              getScene: getTcpScene(config, [checkToView], newUptimeQuery),
             }),
           ],
         });
@@ -135,13 +138,13 @@ function DashboardPageContent() {
             new SceneAppPage({
               title: checkToView.job,
               url,
-              getScene: getGRPCScene(config, [checkToView]),
+              getScene: getGRPCScene(config, [checkToView], newUptimeQuery),
             }),
           ],
         });
       }
     }
-  }, [smDS, metricsDS, logsDS, checkToView]);
+  }, [smDS, metricsDS, logsDS, checkToView, newUptimeQuery]);
 
   if (!scene || isLoading) {
     return <Spinner />;

--- a/src/scenes/BROWSER/browserScene.ts
+++ b/src/scenes/BROWSER/browserScene.ts
@@ -31,7 +31,8 @@ import { getProbeDuration } from './probeDuration';
 export function getBrowserScene(
   { metrics, logs, singleCheckMode }: DashboardSceneAppConfig,
   checks: Check[] = [],
-  checkType: CheckType
+  checkType: CheckType,
+  newUptimeQuery = false,
 ) {
   return () => {
     if (checks.length === 0) {
@@ -49,7 +50,7 @@ export function getBrowserScene(
     const minStep = getMinStepFromFrequency(checks?.[0]?.frequency);
 
     const reachability = getReachabilityStat(metrics, minStep);
-    const uptime = getUptimeStat(metrics, minStep);
+    const uptime = getUptimeStat(metrics, minStep, newUptimeQuery);
 
     const distinctTargets = getDistinctTargets(metrics);
     const probeDuration = getProbeDuration(metrics);

--- a/src/scenes/Common/uptimeStat.ts
+++ b/src/scenes/Common/uptimeStat.ts
@@ -13,40 +13,45 @@ function getMinStep(minStep: string) {
   }
 }
 
-function getQueryRunner(metrics: DataSourceRef, minStep: string) {
+function getQueryRunner(metrics: DataSourceRef, minStep: string, newUptimeQuery: boolean) {
   // The min step for most queries is a minimum of 1 minute. For uptime, however, we want to make sure we have steps of at least 5 minutes in order for the math to work out.
   const uptimeMinStep = getMinStep(minStep);
+
+  const uptimeCalculationQueryV1 = `# the inner query is going to produce a non-zero value if there was at least one successful check during the 5 minute window
+    # so make it a 1 if there was at least one success and a 0 otherwise
+    ceil(
+      # the number of successes across all probes
+      sum by (instance, job) (increase(probe_all_success_sum{instance="$instance", job="$job"}[$__rate_interval]))
+      /
+      # the total number of times we checked across all probes
+      (sum by (instance, job) (increase(probe_all_success_count{instance="$instance", job="$job"}[$__rate_interval])) + 1) # + 1 because we want to make sure it goes to 1, not 2
+    )`;
+
+  //The query to calculate the uptime doesn't return the expected result in all cases
+  //For this reason we created a new version that we'll be progressively rolling out
+  //See https://github.com/grafana/support-escalations/issues/11197#issuecomment-2307435564 for context and details.
+  const uptimeCalculationQueryV2 = `floor(
+      # Report a 1 if there's a location where most observations were successful and 0 if most observations failed for all probes.
+      max by (instance, job) (
+        round(
+          # the number of successes for each probe
+          (increase(probe_all_success_sum{instance="$instance", job="$job"}[$__rate_interval]))
+          /
+          # the total number of times we checked for each probe
+          ((increase(probe_all_success_count{instance="$instance", job="$job"}[$__rate_interval])))
+        )
+      )
+    )`;
+
+  const uptimeQuery = newUptimeQuery ? uptimeCalculationQueryV2 : uptimeCalculationQueryV1;
+
   const runner = new SceneQueryRunner({
     datasource: metrics,
     queries: [
       {
         editorMode: 'code',
         exemplar: true,
-        expr: `
-        sum_over_time(
- # the inner query is going to produce a non-zero value if there was at least one successful check during the 5 minute window
- # so make it a 1 if there was at least one success and a 0 otherwise
- ceil(
-   # the number of successes across all probes
-   sum by (instance, job) (increase(probe_all_success_sum{instance="$instance", job="$job"}[$__rate_interval]))
-   /
-   # the total number of times we checked across all probes
-   (sum by (instance, job) (increase(probe_all_success_count{instance="$instance", job="$job"}[$__rate_interval])) + 1) # + 1 because we want to make sure it goes to 1, not 2
- )
- [$__range:]
-)
-/
-count_over_time(
- # the inner query is going to produce a non-zero value if there was at least one successful check during the 5 minute window
- # so make it a 1 if there was at least one success and a 0 otherwise
- ceil(
-   # the number of successes across all probes
-   sum by (instance, job) (increase(probe_all_success_sum{instance="$instance", job="$job"}[$__rate_interval]))
-   /
-   # the total number of times we checked across all probes
-   (sum by (instance, job) (increase(probe_all_success_count{instance="$instance", job="$job"}[$__rate_interval])) + 1) # + 1 because we want to make sure it goes to 1, not 2
- )
- [$__range:])`,
+        expr: uptimeQuery,
         hide: false,
         instant: false,
         interval: uptimeMinStep,
@@ -70,12 +75,12 @@ count_over_time(
   });
 }
 
-export function getUptimeStat(metrics: DataSourceRef, minStep: string) {
+export function getUptimeStat(metrics: DataSourceRef, minStep: string, newUptimeQuery = false) {
   return new ExplorablePanel({
     pluginId: 'stat',
     title: 'Uptime',
     description: UPTIME_DESCRIPTION,
-    $data: getQueryRunner(metrics, minStep),
+    $data: getQueryRunner(metrics, minStep, newUptimeQuery),
     fieldConfig: {
       defaults: {
         decimals: 2,

--- a/src/scenes/DNS/dnsScene.ts
+++ b/src/scenes/DNS/dnsScene.ts
@@ -31,7 +31,7 @@ import { getMinStepFromFrequency } from 'scenes/utils';
 import { getAnswerRecordsStat } from './answerRecords';
 import { getResourcesRecordsPanel } from './resourceRecords';
 
-export function getDNSScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[]) {
+export function getDNSScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[], newUptimeQuery = false) {
   return () => {
     if (checks.length === 0) {
       return getEmptyScene(CheckType.DNS);
@@ -48,7 +48,7 @@ export function getDNSScene({ metrics, logs, singleCheckMode }: DashboardSceneAp
 
     const minStep = getMinStepFromFrequency(checks?.[0]?.frequency);
     const errorMap = getErrorRateMapPanel(metrics, minStep);
-    const uptime = getUptimeStat(metrics, minStep);
+    const uptime = getUptimeStat(metrics, minStep, newUptimeQuery);
     const reachability = getReachabilityStat(metrics, minStep);
     const avgLatency = getAvgLatencyStat(metrics, minStep);
     const answerRecords = getAnswerRecordsStat(metrics);

--- a/src/scenes/GRPC/getGRPCScene.ts
+++ b/src/scenes/GRPC/getGRPCScene.ts
@@ -31,7 +31,7 @@ import { getMinStepFromFrequency } from '../utils';
 
 // This is a placeholder scene for GRPC checks (basically a copy of the TCP scene)
 // TODO: Implement the actual GRPC scene
-export function getGRPCScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[]) {
+export function getGRPCScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[], newUptimeQuery = false) {
   return () => {
     if (checks.length === 0) {
       return getEmptyScene(CheckType.GRPC);
@@ -46,7 +46,7 @@ export function getGRPCScene({ metrics, logs, singleCheckMode }: DashboardSceneA
     const variables = new SceneVariableSet({ variables: [probe, job, instance] });
     const minStep = getMinStepFromFrequency(checks?.[0]?.frequency);
     const errorMap = getErrorRateMapPanel(metrics, minStep);
-    const uptime = getUptimeStat(metrics, minStep);
+    const uptime = getUptimeStat(metrics, minStep, newUptimeQuery);
     const reachability = getReachabilityStat(metrics, minStep);
     const avgLatency = getAvgLatencyStat(metrics, minStep);
     const frequency = getFrequencyStat(metrics);

--- a/src/scenes/HTTP/httpScene.ts
+++ b/src/scenes/HTTP/httpScene.ts
@@ -31,7 +31,7 @@ import {
 import { getErrorRateTimeseries } from './errorRateTimeseries';
 import { getLatencyByPhasePanel } from './latencyByPhase';
 
-export function getHTTPScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[]) {
+export function getHTTPScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[], newUptimeQuery = false) {
   return () => {
     const timeRange = new SceneTimeRange({
       from: 'now-1h',
@@ -47,7 +47,7 @@ export function getHTTPScene({ metrics, logs, singleCheckMode }: DashboardSceneA
     const variableSet = new SceneVariableSet({ variables: [probe, job, instance] });
 
     const mapPanel = getErrorRateMapPanel(metrics, minStep);
-    const uptime = getUptimeStat(metrics, minStep);
+    const uptime = getUptimeStat(metrics, minStep, newUptimeQuery);
     const reachability = getReachabilityStat(metrics, minStep);
     const avgLatency = getAvgLatencyStat(metrics, minStep);
     const sslExpiryStat = getSSLExpiryStat(metrics);

--- a/src/scenes/PING/pingScene.ts
+++ b/src/scenes/PING/pingScene.ts
@@ -30,7 +30,7 @@ import { getMinStepFromFrequency } from 'scenes/utils';
 
 import { getLatencyByPhasePanel } from './latencyByPhase';
 
-export function getPingScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[]) {
+export function getPingScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[], newUptimeQuery = false) {
   return () => {
     if (checks.length === 0) {
       return getEmptyScene(CheckType.PING);
@@ -47,7 +47,7 @@ export function getPingScene({ metrics, logs, singleCheckMode }: DashboardSceneA
 
     const minStep = getMinStepFromFrequency(checks?.[0]?.frequency);
     const errorMap = getErrorRateMapPanel(metrics, minStep);
-    const uptime = getUptimeStat(metrics, minStep);
+    const uptime = getUptimeStat(metrics, minStep, newUptimeQuery);
     const reachability = getReachabilityStat(metrics, minStep);
     const avgLatency = getAvgLatencyStat(metrics, minStep);
     const frequency = getFrequencyStat(metrics);

--- a/src/scenes/SCRIPTED/scriptedScene.ts
+++ b/src/scenes/SCRIPTED/scriptedScene.ts
@@ -30,7 +30,8 @@ import { getProbeDuration } from './probeDuration';
 export function getScriptedScene(
   { metrics, logs, singleCheckMode }: DashboardSceneAppConfig,
   checks: Check[] = [],
-  checkType: CheckType
+  checkType: CheckType,
+  newUptimeQuery = false,
 ) {
   return () => {
     if (checks.length === 0) {
@@ -48,7 +49,7 @@ export function getScriptedScene(
     const minStep = getMinStepFromFrequency(checks?.[0]?.frequency);
 
     const reachability = getReachabilityStat(metrics, minStep);
-    const uptime = getUptimeStat(metrics, minStep);
+    const uptime = getUptimeStat(metrics, minStep, newUptimeQuery);
 
     const distinctTargets = getDistinctTargets(metrics);
     const probeDuration = getProbeDuration(metrics);

--- a/src/scenes/TCP/getTcpScene.ts
+++ b/src/scenes/TCP/getTcpScene.ts
@@ -29,7 +29,7 @@ import { getEmptyScene } from 'scenes/Common/emptyScene';
 import { getErrorRateTimeseries } from 'scenes/HTTP/errorRateTimeseries';
 import { getMinStepFromFrequency } from 'scenes/utils';
 
-export function getTcpScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[]) {
+export function getTcpScene({ metrics, logs, singleCheckMode }: DashboardSceneAppConfig, checks: Check[], newUptimeQuery = false) {
   return () => {
     if (checks.length === 0) {
       return getEmptyScene(CheckType.TCP);
@@ -46,7 +46,7 @@ export function getTcpScene({ metrics, logs, singleCheckMode }: DashboardSceneAp
 
     const minStep = getMinStepFromFrequency(checks?.[0]?.frequency);
     const errorMap = getErrorRateMapPanel(metrics, minStep);
-    const uptime = getUptimeStat(metrics, minStep);
+    const uptime = getUptimeStat(metrics, minStep, newUptimeQuery);
     const reachability = getReachabilityStat(metrics, minStep);
     const avgLatency = getAvgLatencyStat(metrics, minStep);
     const sslExpiry = getSSLExpiryStat(metrics);

--- a/src/types.ts
+++ b/src/types.ts
@@ -648,6 +648,7 @@ export enum FeatureName {
   GRPCChecks = 'grpc-checks',
   ScriptedChecks = 'scripted-checks',
   UnifiedAlerting = 'ngalert',
+  UptimeQueryV2 = 'uptime-query-v2',
   __TURNOFF = 'test-only-do-not-use',
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the query that is used to calculate the uptime stat panel for each check. As described in this [escalation](https://github.com/grafana/support-escalations/issues/11197), this panel was displaying a value of `100%` even when the probes had 100% errors reaching the target.

**Which issue(s) this PR fixes**: 

Part of https://github.com/grafana/support-escalations/issues/11197. This solution addresses the first problem described here https://github.com/grafana/support-escalations/issues/11197#issuecomment-2195657543