### PR TITLE
fix: cursor type on cards without links

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -34,7 +34,6 @@ function getStyles(theme: GrafanaTheme2) {
 
       '&:hover': {
         background: theme.colors.emphasize(theme.colors.background.secondary, 0.03),
-        cursor: 'pointer',
         zIndex: 1,
       },
     }),
@@ -88,6 +87,7 @@ const getHeadingStyles = (theme: GrafanaTheme2, variant: 'h1' | 'h2' | 'h3' | 'h
       left: 0,
       right: 0,
       borderRadius: theme.shape.radius.default,
+      cursor: 'pointer',
     },
 
     '&:focus-visible': {

--- a/src/components/ChooseCheckType.tsx
+++ b/src/components/ChooseCheckType.tsx
@@ -110,7 +110,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   card: css({
     ':hover': {
-      cursor: 'pointer',
       background: theme.colors.emphasize(theme.colors.background.secondary, 0.03),
     },
   }),


### PR DESCRIPTION
# Problem

I noticed in the [non-initialized pages improvements PR](https://github.com/grafana/synthetic-monitoring-app/pull/839) that cards without links are displaying the hover cursor incorrectly.

# Solution

Remove the `cursor: pointer` from the unneeded places and add it to the `:after` pseudo element on the title link.