### PR TITLE
chore: enforce named exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,13 @@ module.exports = {
   rules: {
     'no-redeclare': 'off', // we use typescript's 'no-redeclare' rule instead
     '@typescript-eslint/no-redeclare': ['error'],
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ExportDefaultDeclaration',
+        message: 'Prefer named exports',
+      },
+    ],
     ['simple-import-sort/imports']: [
       'error',
       {

--- a/__mocks__/grafana/app/core/app_events.ts
+++ b/__mocks__/grafana/app/core/app_events.ts
@@ -1,4 +1,5 @@
-const appEvents = {
+export const appEvents = {
   emit: () => {},
 };
+// eslint-disable-next-line no-restricted-syntax
 export default appEvents;

--- a/src/components/CheckEditor/CheckProbes.tsx
+++ b/src/components/CheckEditor/CheckProbes.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 export const PROBES_SELECT_ID = 'check-probes-select';
 
-const CheckProbes = forwardRef(
+export const CheckProbes = forwardRef(
   ({ probes, availableProbes, isEditor, onChange, onBlur, invalid, error }: Props, ref) => {
     const [currentProbes, setCurrentProbes] = useState<number[]>(probes);
 
@@ -124,5 +124,3 @@ const CheckProbes = forwardRef(
 );
 
 CheckProbes.displayName = 'CheckProbes';
-
-export default CheckProbes;

--- a/src/components/CheckEditor/FormComponents/RequestTargetInput.tsx
+++ b/src/components/CheckEditor/FormComponents/RequestTargetInput.tsx
@@ -7,7 +7,7 @@ import { get } from 'lodash';
 
 import { CheckFormValues, CheckType } from 'types';
 import { parseUrl } from 'utils';
-import QueryParams from 'components/QueryParams';
+import { QueryParams } from 'components/QueryParams';
 
 type RequestMethodInputProps = {
   'aria-label'?: string;

--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -10,7 +10,7 @@ import { useProbes } from 'data/useProbes';
 import { SliderInput } from 'components/SliderInput';
 import { Subheader } from 'components/Subheader';
 
-import CheckProbes from './CheckProbes';
+import { CheckProbes } from './CheckProbes';
 
 interface Props {
   checkType: CheckType;

--- a/src/components/CheckFilters.tsx
+++ b/src/components/CheckFilters.tsx
@@ -8,7 +8,7 @@ import { useProbes } from 'data/useProbes';
 import { FilterType } from 'hooks/useCheckFilters';
 import { useCheckTypeOptions } from 'hooks/useCheckTypeOptions';
 
-import CheckFilterGroup from './CheckList/CheckFilterGroup';
+import { CheckFilterGroup } from './CheckList/CheckFilterGroup';
 import { CHECK_LIST_STATUS_OPTIONS } from './constants';
 import { LabelFilterInput } from './LabelFilterInput';
 

--- a/src/components/CheckList/CheckFilterGroup.tsx
+++ b/src/components/CheckList/CheckFilterGroup.tsx
@@ -17,7 +17,7 @@ interface Props {
   filters: CheckFiltersType;
 }
 
-const CheckFilterGroup = ({ children, onReset, filters }: Props) => {
+export const CheckFilterGroup = ({ children, onReset, filters }: Props) => {
   const [openFilters, setOpenFilters] = useState(false);
   const [activeFilters, setActiveFilters] = useState(0);
   const styles = useStyles2(groupStyles);
@@ -89,5 +89,3 @@ const CheckFilterGroup = ({ children, onReset, filters }: Props) => {
     </>
   );
 };
-
-export default CheckFilterGroup;

--- a/src/components/CheckList/CheckList.tsx
+++ b/src/components/CheckList/CheckList.tsx
@@ -11,7 +11,7 @@ import { useSuspenseChecks } from 'data/useChecks';
 import { useChecksReachabilitySuccessRate } from 'data/useSuccessRates';
 import { findCheckinMetrics } from 'data/utils';
 import { FilterType, useCheckFilters } from 'hooks/useCheckFilters';
-import useQueryParametersState from 'hooks/useQueryParametersState';
+import { useQueryParametersState } from 'hooks/useQueryParametersState';
 import { CHECK_LIST_STATUS_OPTIONS, CHECKS_PER_PAGE_CARD, CHECKS_PER_PAGE_LIST } from 'components/constants';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
 
@@ -19,7 +19,7 @@ import { CheckListItem } from '../CheckListItem';
 import { matchesAllFilters } from './checkFilters';
 import { CheckListHeader } from './CheckListHeader';
 import { CheckListScene } from './CheckListScene';
-import EmptyCheckList from './EmptyCheckList';
+import { EmptyCheckList } from './EmptyCheckList';
 
 export const CheckList = () => {
   const [viewType, setViewType] = useQueryParametersState<CheckListViewType>({

--- a/src/components/CheckList/CheckListHeader.tsx
+++ b/src/components/CheckList/CheckListHeader.tsx
@@ -9,7 +9,7 @@ import { FilterType } from 'hooks/useCheckFilters';
 import { CheckFilters } from 'components/CheckFilters';
 import { CHECK_LIST_SORT_OPTIONS } from 'components/constants';
 
-import ThresholdGlobalSettings from '../Thresholds/ThresholdGlobalSettings';
+import { ThresholdGlobalSettings } from '../Thresholds/ThresholdGlobalSettings';
 import { AddNewCheckButton } from './AddNewCheckButton';
 import { BulkActions } from './BulkActions';
 import { CheckListViewSwitcher } from './CheckListViewSwitcher';

--- a/src/components/CheckList/EmptyCheckList.tsx
+++ b/src/components/CheckList/EmptyCheckList.tsx
@@ -24,7 +24,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
 });
 
-const EmptyCheckList = () => {
+export const EmptyCheckList = () => {
   const navigate = useNavigation();
   const styles = useStyles2(getStyles);
 
@@ -43,5 +43,3 @@ const EmptyCheckList = () => {
     </div>
   );
 };
-
-export default EmptyCheckList;

--- a/src/components/CodeEditor/k6.types.ts
+++ b/src/components/CodeEditor/k6.types.ts
@@ -14,6 +14,7 @@ import k6Ws from '!raw-loader!@types/k6/ws.d.ts';
 
 export { default as k6GlobalTypes } from '!raw-loader!@types/k6/global.d.ts';
 
+// eslint-disable-next-line no-restricted-syntax
 export default {
   k6: k6Types,
   'k6/http': k6Http,

--- a/src/components/LinkedDatasourceView.tsx
+++ b/src/components/LinkedDatasourceView.tsx
@@ -10,7 +10,7 @@ interface Props {
   type: 'loki' | 'prometheus';
 }
 
-const LinkedDatasourceView = ({ type }: Props) => {
+export const LinkedDatasourceView = ({ type }: Props) => {
   const navigate = useNavigation();
   const { instance, meta } = useContext(InstanceContext);
   if (!instance.metrics || !instance.logs) {
@@ -47,5 +47,3 @@ const LinkedDatasourceView = ({ type }: Props) => {
     </div>
   );
 };
-
-export default LinkedDatasourceView;

--- a/src/components/MultiHttp/Tabs/TabSection.tsx
+++ b/src/components/MultiHttp/Tabs/TabSection.tsx
@@ -109,5 +109,3 @@ export const TabSection = ({ activeTab, index, onTabClick }: RequestTabsProps) =
     </div>
   );
 };
-
-export default TabSection;

--- a/src/components/QueryParamInput.tsx
+++ b/src/components/QueryParamInput.tsx
@@ -17,7 +17,7 @@ interface Props {
   onBlur?: () => void;
 }
 
-const QueryParamInput = ({ index, queryParam, onChange, onDelete, onBlur }: Props) => (
+export const QueryParamInput = ({ index, queryParam, onChange, onDelete, onBlur }: Props) => (
   <>
     <Input
       aria-label={`Query param key ${index + 1}`}
@@ -59,5 +59,3 @@ const QueryParamInput = ({ index, queryParam, onChange, onDelete, onBlur }: Prop
     />
   </>
 );
-
-export default QueryParamInput;

--- a/src/components/QueryParams.test.tsx
+++ b/src/components/QueryParams.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { render } from 'test/render';
 
-import QueryParams from './QueryParams';
+import { QueryParams } from './QueryParams';
 
 const onChange = jest.fn();
 

--- a/src/components/QueryParams.tsx
+++ b/src/components/QueryParams.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useReducer, useState } from 'react';
 import { Button, Field, Label } from '@grafana/ui';
 import { css } from '@emotion/css';
 
-import QueryParamInput, { QueryParam } from './QueryParamInput';
+import { QueryParam,QueryParamInput } from './QueryParamInput';
 
 interface Props {
   target: URL;
@@ -59,7 +59,7 @@ function queryParamReducer(state: QueryParam[], action: Action) {
   }
 }
 
-const QueryParams = ({ target, onChange, className, onBlur }: Props) => {
+export const QueryParams = ({ target, onChange, className, onBlur }: Props) => {
   const [formattedParams, dispatch] = useReducer(queryParamReducer, target, init);
   const [shouldUpdate, setShouldUpdate] = useState(false);
 
@@ -121,5 +121,3 @@ const QueryParams = ({ target, onChange, className, onBlur }: Props) => {
     </div>
   );
 };
-
-export default QueryParams;

--- a/src/components/Thresholds/ThresholdFormSection.tsx
+++ b/src/components/Thresholds/ThresholdFormSection.tsx
@@ -93,7 +93,13 @@ const displayDowntimeEstimate = (percentage: number) => {
   }
 };
 
-const ThresholdFormSection = ({ label, unit, description, thresholds, setThresholds }: ThresholdSectionProps) => {
+export const ThresholdFormSection = ({
+  label,
+  unit,
+  description,
+  thresholds,
+  setThresholds,
+}: ThresholdSectionProps) => {
   const styles = useStyles2(getSectionStyles());
   const isLatency = unit === 'ms';
   const handleUpdateThreshold = useCallback(
@@ -186,5 +192,3 @@ const ThresholdFormSection = ({ label, unit, description, thresholds, setThresho
     </div>
   );
 };
-
-export default ThresholdFormSection;

--- a/src/components/Thresholds/ThresholdGlobalSettings.test.tsx
+++ b/src/components/Thresholds/ThresholdGlobalSettings.test.tsx
@@ -5,7 +5,7 @@ import { apiRoute, getServerRequests } from 'test/handlers';
 import { render } from 'test/render';
 import { server } from 'test/server';
 
-import ThresholdGlobalSettings from './ThresholdGlobalSettings';
+import { ThresholdGlobalSettings } from './ThresholdGlobalSettings';
 
 const onDismiss = jest.fn();
 

--- a/src/components/Thresholds/ThresholdGlobalSettings.tsx
+++ b/src/components/Thresholds/ThresholdGlobalSettings.tsx
@@ -4,7 +4,7 @@ import { Button, Modal, Stack } from '@grafana/ui';
 import { ThresholdSettings, ThresholdValues } from 'types';
 import { useThresholds, useUpdateThresholds } from 'data/useThresholds';
 
-import ThresholdFormSection from './ThresholdFormSection';
+import { ThresholdFormSection } from './ThresholdFormSection';
 
 interface Props {
   onDismiss: () => void;
@@ -21,7 +21,7 @@ const thresholdMsDefaults: ThresholdValues = {
   lowerLimit: 200,
 };
 
-const ThresholdGlobalSettings = ({ onDismiss, isOpen }: Props) => {
+export const ThresholdGlobalSettings = ({ onDismiss, isOpen }: Props) => {
   const { data } = useThresholds();
 
   if (!data) {
@@ -100,5 +100,3 @@ const ThresholdGlobalSettingsContent = ({ onSuccess, thresholds }: ThresholdGlob
     </>
   );
 };
-
-export default ThresholdGlobalSettings;

--- a/src/datasource/ConfigEditor.tsx
+++ b/src/datasource/ConfigEditor.tsx
@@ -4,7 +4,7 @@ import { Container, LegacyForms } from '@grafana/ui';
 
 import { SecureJsonData,SMOptions } from './types';
 import { InstanceProvider } from 'components/InstanceProvider';
-import LinkedDatasourceView from 'components/LinkedDatasourceView';
+import { LinkedDatasourceView } from 'components/LinkedDatasourceView';
 
 interface Props extends DataSourcePluginOptionsEditorProps<SMOptions, SecureJsonData> {}
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -37,10 +37,12 @@ declare module 'constrained-editor-plugin' {
   }
 
   export declare function constrainedEditor(monaco: typeof monacoTypes): ConstrainedEditorInstance;
+  // eslint-disable-next-line no-restricted-syntax
   export default constrainedEditor;
 }
 
 declare module '*?raw' {
   const content: string;
+  // eslint-disable-next-line no-restricted-syntax
   export default content;
 }

--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -13,8 +13,8 @@ import {
   SM_ALERTING_NAMESPACE,
 } from 'components/constants';
 
-import useGrafanaVersion from './useGrafanaVersion';
-import useUnifiedAlertsEnabled from './useUnifiedAlertsEnabled';
+import { useGrafanaVersion } from './useGrafanaVersion';
+import { useUnifiedAlertsEnabled } from './useUnifiedAlertsEnabled';
 
 enum AlertThresholds {
   High = 95,

--- a/src/hooks/useCheckFilters.ts
+++ b/src/hooks/useCheckFilters.ts
@@ -5,7 +5,7 @@ import { CheckEnabledStatus, CheckType, CheckTypeFilter, ProbeFilter } from 'typ
 import { useProbes } from 'data/useProbes';
 import { defaultFilters } from 'components/CheckFilters';
 
-import useQueryParametersState from './useQueryParametersState';
+import { useQueryParametersState } from './useQueryParametersState';
 
 export type FilterType = 'search' | 'labels' | 'type' | 'status' | 'probes';
 

--- a/src/hooks/useGrafanaVersion.ts
+++ b/src/hooks/useGrafanaVersion.ts
@@ -19,7 +19,7 @@ function parseVersion(version: string): GrafanaVersion | undefined {
   }
 }
 
-export default function useGrafanaVersion() {
+export function useGrafanaVersion() {
   const version = config.buildInfo.version;
   return parseVersion(version) ?? { major: 0, minor: 0, patch: '' };
 }

--- a/src/hooks/useQueryParametersState.test.tsx
+++ b/src/hooks/useQueryParametersState.test.tsx
@@ -2,7 +2,7 @@ import { useLocation as useLocationFromReactRouter } from 'react-router-dom';
 import { act, renderHook } from '@testing-library/react';
 import { Location } from 'history';
 
-import useQueryParametersState from './useQueryParametersState';
+import { useQueryParametersState } from './useQueryParametersState';
 
 const historyPushMock = jest.fn();
 const historyReplaceMock = jest.fn();

--- a/src/hooks/useQueryParametersState.ts
+++ b/src/hooks/useQueryParametersState.ts
@@ -16,7 +16,7 @@ interface QueryParametersStateProps<ValueType> {
   strategy?: HistoryStrategy;
 }
 
-const useQueryParametersState = <ValueType>({
+export const useQueryParametersState = <ValueType>({
   key,
   initialValue,
   encode = JSON.stringify,
@@ -65,5 +65,3 @@ const useQueryParametersState = <ValueType>({
 
   return [parsedExistingValue || initialValue, updateState];
 };
-
-export default useQueryParametersState;

--- a/src/hooks/useUnifiedAlertsEnabled.ts
+++ b/src/hooks/useUnifiedAlertsEnabled.ts
@@ -4,7 +4,7 @@ import { FeatureName } from 'types';
 
 import { useFeatureFlag } from './useFeatureFlag';
 
-export default function useUnifiedAlertsEnabled() {
+export function useUnifiedAlertsEnabled() {
   const { isEnabled: isEnabledByFF } = useFeatureFlag(FeatureName.UnifiedAlerting);
 
   return isEnabledByFF || config.unifiedAlertingEnabled;

--- a/src/img/img.d.ts
+++ b/src/img/img.d.ts
@@ -1,9 +1,11 @@
 declare module '*.png' {
   const content: string;
+  // eslint-disable-next-line no-restricted-syntax
   export default content;
 }
 
 declare module '*.svg' {
   const content: string;
+  // eslint-disable-next-line no-restricted-syntax
   export default content;
 }

--- a/src/page/AlertingPage.tsx
+++ b/src/page/AlertingPage.tsx
@@ -7,7 +7,7 @@ import { css } from '@emotion/css';
 import { AlertFormValues, AlertRule } from 'types';
 import { InstanceContext } from 'contexts/InstanceContext';
 import { useAlerts } from 'hooks/useAlerts';
-import useUnifiedAlertsEnabled from 'hooks/useUnifiedAlertsEnabled';
+import { useUnifiedAlertsEnabled } from 'hooks/useUnifiedAlertsEnabled';
 import { transformAlertFormValues } from 'components/alertingTransformations';
 import { AlertRuleForm } from 'components/AlertRuleForm';
 import { PluginPage } from 'components/PluginPage';

--- a/src/page/ConfigPage.tsx
+++ b/src/page/ConfigPage.tsx
@@ -6,7 +6,7 @@ import { css } from '@emotion/css';
 import { InstanceContext } from 'contexts/InstanceContext';
 import { BackendAddress } from 'components/BackendAddress';
 import { ConfigActions } from 'components/ConfigActions';
-import LinkedDatasourceView from 'components/LinkedDatasourceView';
+import { LinkedDatasourceView } from 'components/LinkedDatasourceView';
 import { PluginPage } from 'components/PluginPage';
 import { ProgrammaticManagement } from 'components/ProgrammaticManagement';
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -77,4 +77,5 @@ const config = async (env): Promise<Configuration> => {
   return res;
 };
 
+// eslint-disable-next-line no-restricted-syntax
 export default config;


### PR DESCRIPTION
- Added a `eslint` rule to enforce named exports
- Replaced existing usages of default exports to named exports.

This was discussed as an enhancement here https://github.com/grafana/synthetic-monitoring-app/pull/839#discussion_r1661022157