### PR TITLE
fix: avoid horizontal scrolling on check's dashboard

### DIFF
--- a/src/scenes/SCRIPTED/ResultsByTargetTable/ResultByTargetTable.tsx
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/ResultByTargetTable.tsx
@@ -211,6 +211,7 @@ export class ResultsByTargetTableSceneObject extends SceneObjectBase<ResultsByTa
           <Table<DataRow>
             columns={columns}
             data={tableData}
+            className={styles.table}
             expandableRows
             dataTableProps={{
               expandableRowsComponentProps: { tableViz: model, metrics, checkType },
@@ -235,6 +236,7 @@ export class ResultsByTargetTableSceneObject extends SceneObjectBase<ResultsByTa
 
 export function getResultsByTargetTable(metrics: DataSourceRef, checkType: CheckType) {
   return new SceneFlexItem({
+    maxWidth: '100%',
     body: new ResultsByTargetTableSceneObject({
       $data: getQueryRunner(metrics, checkType),
       metrics,

--- a/src/scenes/SCRIPTED/getTablePanelStyles.ts
+++ b/src/scenes/SCRIPTED/getTablePanelStyles.ts
@@ -10,7 +10,7 @@ export function getTablePanelStyles(theme: GrafanaTheme2) {
     }),
     title: css({
       label: 'panel-title',
-      display: 'flex',
+      display: 'block',
       marginBottom: 0, // override default h6 margin-bottom
       padding: theme.spacing(theme.components.panel.padding),
       textOverflow: 'ellipsis',
@@ -29,6 +29,11 @@ export function getTablePanelStyles(theme: GrafanaTheme2) {
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
+    }),
+    table: css({
+      '& > div': {
+        display: 'flex',
+      },
     }),
   };
 }


### PR DESCRIPTION
When the URL of a check was too long, the dashboard for scripted and multihttp checks was displaying a horizontal scroll which made it hard to navigate. This PR fixes that.

https://github.com/grafana/synthetic-monitoring-app/assets/6271380/788058a7-9a6b-4e8d-aba2-608398a52190

Fixes https://github.com/grafana/synthetic-monitoring-app/issues/833
