### PR TITLE
fix: regression for longitude validation fix

### DIFF
--- a/src/page/NewProbe/NewProbe.test.tsx
+++ b/src/page/NewProbe/NewProbe.test.tsx
@@ -35,8 +35,13 @@ test(`Doesn't show a validation error for valid longitude values`, async () => {
   const { user } = renderNewProbe();
   const saveButton = await screen.findByText('Add new probe');
   const longitudeInput = await screen.findByLabelText('Longitude');
-  await user.type(longitudeInput, '116.3971');
+  await user.type(longitudeInput, '180.01');
   await user.click(saveButton);
+
   const errorMsg = await screen.queryByText('Longitude must be less than 180');
+  expect(errorMsg).toBeInTheDocument();
+
+  await user.clear(longitudeInput);
+  await user.type(longitudeInput, '116.3971');
   expect(expect(errorMsg).not.toBeInTheDocument());
 });

--- a/src/page/NewProbe/NewProbe.test.tsx
+++ b/src/page/NewProbe/NewProbe.test.tsx
@@ -31,7 +31,7 @@ it(`creates a new probe, displays the modal and redirects on close`, async () =>
 });
 
 //regression for https://github.com/grafana/support-escalations/issues/11171
-test(`Doesn't show a validation error for valid longitud values`, async () => {
+test(`Doesn't show a validation error for valid longitude values`, async () => {
   const { user } = renderNewProbe();
   const saveButton = await screen.findByText('Add new probe');
   const longitudeInput = await screen.findByLabelText('Longitude');

--- a/src/page/NewProbe/NewProbe.test.tsx
+++ b/src/page/NewProbe/NewProbe.test.tsx
@@ -43,5 +43,5 @@ test(`Doesn't show a validation error for valid longitude values`, async () => {
 
   await user.clear(longitudeInput);
   await user.type(longitudeInput, '116.3971');
-  expect(expect(errorMsg).not.toBeInTheDocument());
+  expect(errorMsg).not.toBeInTheDocument();
 });

--- a/src/page/NewProbe/NewProbe.test.tsx
+++ b/src/page/NewProbe/NewProbe.test.tsx
@@ -29,3 +29,14 @@ it(`creates a new probe, displays the modal and redirects on close`, async () =>
   await user.click(dismiss);
   await waitFor(() => expect(history.location.pathname).toBe(getRoute(ROUTES.Probes)));
 });
+
+//regression for https://github.com/grafana/support-escalations/issues/11171
+test(`Doesn't show a validation error for valid longitud values`, async () => {
+  const { user } = renderNewProbe();
+  const saveButton = await screen.findByText('Add new probe');
+  const longitudeInput = await screen.findByLabelText('Longitude');
+  await user.type(longitudeInput, '116.3971');
+  await user.click(saveButton);
+  const errorMsg = await screen.queryByText('Longitude must be less than 180');
+  expect(expect(errorMsg).not.toBeInTheDocument());
+});


### PR DESCRIPTION
Adds a regression test for the fix on longitude validation on creating new probes in https://github.com/grafana/synthetic-monitoring-app/pull/836