### PR TITLE
fix: make loki query fetch range instead of instant logs

### DIFF
--- a/src/components/CheckTestResult.tsx
+++ b/src/components/CheckTestResult.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { DataFrame, DateTime, dateTime, GrafanaTheme2, LoadingState } from '@grafana/data';
+import { DataFrame, dateTime, GrafanaTheme2, LoadingState } from '@grafana/data';
 import { PanelRenderer } from '@grafana/runtime';
 import { Badge, Collapse, Icon, Spinner, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -8,12 +8,10 @@ interface Props {
   probeName: string;
   success: boolean;
   loading: boolean;
-  start: DateTime;
-  end: DateTime;
   logs: DataFrame;
 }
 
-export function CheckTestResult({ probeName, success, loading, logs, start, end }: Props) {
+export function CheckTestResult({ probeName, success, loading, logs }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const styles = useStyles2(getStyles);
   const header = (

--- a/src/components/CheckTestResultsModal.tsx
+++ b/src/components/CheckTestResultsModal.tsx
@@ -66,8 +66,7 @@ export function CheckTestResultsModal({ testResponse, isOpen, onDismiss }: Props
   const [now] = useState(Date.now());
   const [resultsByProbe, setResultsByProbe] = useState<Record<string, any>>({});
   const start = dateTime(now).subtract(5, 'm');
-  const end = dateTime(now);
-  const { data } = useLogData(query, { start, end, skip: !testResponse || !isOpen });
+  const { data } = useLogData(query, { start, skip: !testResponse || !isOpen });
   const { data: probes = [] } = useProbes();
 
   // This effect is to handle the whole test taking longer than 30 seconds. It checks for any probes that haven't given a response and fills in a fake metrics/logs response that indicates a failure.
@@ -144,8 +143,6 @@ export function CheckTestResultsModal({ testResponse, isOpen, onDismiss }: Props
             probeName={probe?.name ?? ''}
             success={success}
             loading={!result}
-            start={start}
-            end={end}
             logs={result?.logs}
           />
         );

--- a/src/hooks/useLogData.ts
+++ b/src/hooks/useLogData.ts
@@ -6,7 +6,7 @@ import { InstanceContext } from 'contexts/InstanceContext';
 
 interface UseLogOptions {
   start: DateTime;
-  end: DateTime;
+  end?: DateTime;
   skip: boolean;
 }
 
@@ -18,7 +18,7 @@ export function useLogData(query: string, options: UseLogOptions) {
   const [data, setData] = useState<any[]>([]);
   const [error, setError] = useState<string | undefined>();
   const start = options.start.unix();
-  const end = options.end.unix();
+  const end = options.end?.unix();
 
   // refresh data every 3 seconds
   useEffect(() => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -213,22 +213,20 @@ export const queryLogsLegacy = async (
   url: string,
   query: string,
   start: number,
-  end: number
+  end?: number // defaults to now
 ): Promise<LogQueryResponse> => {
   const backendSrv = getBackendSrv();
   const params = {
-    direction: 'BACKWARD',
     limit: 1000,
     query,
-    start: start,
-    end: end,
-    // step: ,
+    start,
+    end,
   };
 
   try {
     const response = await backendSrv.datasourceRequest({
       method: 'GET',
-      url: `${url}/loki/api/v1/query`,
+      url: `${url}/loki/api/v1/query_range`,
       params,
     });
     return {


### PR DESCRIPTION
Instant queries sometimes don't return log data when executing scripts that take a long time. In these cases it's better to use range queries. 
This PR changes the query used to fetch logs when testing ad-hoc checks to be of type `range`. Also, we were sending a fixed `end` value that didn't update to the current time on consecutive requests, staying always in the past. By removing the parameter in the request, it will default to the current `$now` value (https://grafana.com/docs/loki/latest/reference/loki-http-api/#query-logs-within-a-range-of-time).


https://github.com/grafana/synthetic-monitoring-app/assets/6271380/7f067ccb-6989-4519-8b51-212c4f11fca5



Fixes https://github.com/grafana/synthetic-monitoring-app/issues/832