### PR TITLE
chore: Add datasource to includes

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -66,6 +66,11 @@
       "name": "Config",
       "path": "/a/grafana-synthetic-monitoring-app/config",
       "addToNav": true
+    },
+    {
+      "type": "datasource",
+      "name": "Synthetic Monitoring API",
+      "path": "datasource/plugin.json"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to support eventually loading the synthentic monitoring appn assets from a CDN, the plugin.json needs to list all nested plugins in the includes.

<!--
**Which issue(s) this PR fixes**:


- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"


Fixes #

**Special notes for your reviewer**:


  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
