### PR TITLE
fix: fix rendering of scripted checks

### DIFF
--- a/src/page/CheckRouter.test.tsx
+++ b/src/page/CheckRouter.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import { BASIC_HTTP_CHECK, BASIC_SCRIPTED_CHECK } from 'test/fixtures/checks';
 import { render } from 'test/render';
 
 import { CheckType, CheckTypeGroup, ROUTES } from 'types';
@@ -20,11 +21,12 @@ describe(`<CheckRouter />`, () => {
       expect(history.location.pathname).toBe(`${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${CheckTypeGroup.ApiTest}`)
     );
     expect(history.location.search).toBe(`?checkType=${checkType}`);
+    expect(screen.getByText(`New API Endpoint check`)).toBeInTheDocument();
   });
 
   it(`should redirect from the old edit check route to the new one`, async () => {
     const checkType = CheckType.HTTP;
-    const checkID = 1;
+    const checkID = BASIC_HTTP_CHECK.id;
 
     const { history } = render(<CheckRouter />, {
       path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/edit/${checkType}/${checkID}`,
@@ -36,5 +38,32 @@ describe(`<CheckRouter />`, () => {
         `${PLUGIN_URL_PATH}${ROUTES.Checks}/edit/${CheckTypeGroup.ApiTest}/${checkID}`
       )
     );
+    const title = await screen.findByText(`Editing ${BASIC_HTTP_CHECK.job}`);
+    expect(title).toBeInTheDocument();
+  });
+
+  it(`renders the new scripted check page`, async () => {
+    const checkType = CheckType.Scripted;
+
+    render(<CheckRouter />, {
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/new/${checkType}`,
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
+    });
+
+    const title = await screen.findByText(`New Scripted check`);
+    expect(title).toBeInTheDocument();
+  });
+
+  it(`renders the edit scripted check page`, async () => {
+    const checkType = CheckType.Scripted;
+    const checkID = BASIC_SCRIPTED_CHECK.id;
+
+    render(<CheckRouter />, {
+      path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/edit/${checkType}/${checkID}`,
+      route: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
+    });
+
+    const title = await screen.findByText(`Editing ${BASIC_SCRIPTED_CHECK.job}`);
+    expect(title).toBeInTheDocument();
   });
 });

--- a/src/page/CheckRouter.tsx
+++ b/src/page/CheckRouter.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
 
+import { CheckType } from 'types';
 import { CHECK_TYPE_OPTIONS } from 'hooks/useCheckTypeOptions';
 import { CheckList } from 'components/CheckList';
 import { ChooseCheckGroup } from 'components/ChooseCheckGroup';
@@ -35,7 +36,7 @@ export function CheckRouter() {
       <Route path={`${path}/:id/dashboard`} exact>
         <DashboardPage />
       </Route>
-      <Route path={`${path}/new/:checkTypeGroup?`}>
+      <Route path={`${path}/new/:checkTypeGroup`}>
         <NewCheck />
       </Route>
       <Route path={`${path}/edit/:checkTypeGroup/:id`} exact>
@@ -48,12 +49,16 @@ export function CheckRouter() {
   );
 }
 
-const NEW_CHECK_REDIRECTS = CHECK_TYPE_OPTIONS.map(({ group, value }) => ({
+// these result in the same from/to values so redirect infinitely
+const excludedCheckTypes = [CheckType.Scripted];
+const filteredCheckTypes = CHECK_TYPE_OPTIONS.filter(({ value }) => !excludedCheckTypes.includes(value));
+
+const NEW_CHECK_REDIRECTS = filteredCheckTypes.map(({ group, value }) => ({
   from: `/new/${value}`,
   to: `/new/${group}?checkType=${value}`,
 }));
 
-const EDIT_CHECK_REDIRECTS = CHECK_TYPE_OPTIONS.map(({ group, value }) => ({
+const EDIT_CHECK_REDIRECTS = filteredCheckTypes.map(({ group, value }) => ({
   from: `/edit/${value}/:id`,
   to: `/edit/${group}`,
 }));


### PR DESCRIPTION
## Problem

The redirect logic in the `<CheckRouter />` ended up in the same from/to values for scripted checks so ended up not rendering them to the page.

## Solution

Add a filter to exclude scripted from the redirect array. It is an array because browser checks will have the same problem and be added at a later date.