### PR TITLE
Restrict access to certain pages/actions when user is Viewer

### DIFF
--- a/src/components/AlertRuleForm.tsx
+++ b/src/components/AlertRuleForm.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import { useAsyncCallback } from 'react-async-hook';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
-import { AppEvents, GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { AppEvents, GrafanaTheme2, OrgRole, SelectableValue } from '@grafana/data';
 import { FetchResponse } from '@grafana/runtime';
 import { Alert, Button, Field, Icon, Input, Label, Select, Stack, useStyles2 } from '@grafana/ui';
 import appEvents from 'grafana/app/core/app_events';
@@ -15,6 +15,7 @@ import { alertDescriptionFromRule, transformAlertFormValues } from './alertingTr
 import { AlertLabels } from './AlertLabels';
 import { ALERT_SENSITIVITY_OPTIONS, TIME_UNIT_OPTIONS } from './constants';
 import { SubCollapse } from './SubCollapse';
+import { hasRole } from 'utils';
 
 export enum AlertTimeUnits {
   Milliseconds = 'ms',
@@ -313,7 +314,7 @@ export const AlertRuleForm = ({ rule, onSubmit }: Props) => {
             </SubCollapse>
             <hr className={styles.breakLine} />
             <Stack>
-              <Button type="submit" disabled={submitting}>
+              <Button type="submit" disabled={submitting || !hasRole(OrgRole.Editor)}>
                 Save alert
               </Button>
               <Button variant="secondary" type="button" onClick={onCancel}>

--- a/src/components/AlertRuleForm.tsx
+++ b/src/components/AlertRuleForm.tsx
@@ -8,6 +8,7 @@ import appEvents from 'grafana/app/core/app_events';
 import { css } from '@emotion/css';
 
 import { AlertRule, AlertSensitivity, Label as LabelType, TimeUnits } from 'types';
+import { hasRole } from 'utils';
 import { InstanceContext } from 'contexts/InstanceContext';
 
 import { AlertAnnotations } from './AlertAnnotations';
@@ -15,7 +16,6 @@ import { alertDescriptionFromRule, transformAlertFormValues } from './alertingTr
 import { AlertLabels } from './AlertLabels';
 import { ALERT_SENSITIVITY_OPTIONS, TIME_UNIT_OPTIONS } from './constants';
 import { SubCollapse } from './SubCollapse';
-import { hasRole } from 'utils';
 
 export enum AlertTimeUnits {
   Milliseconds = 'ms',

--- a/src/components/Routing.test.tsx
+++ b/src/components/Routing.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import runTime from '@grafana/runtime';
+import { OrgRole } from '@grafana/data';
+import runTime, { config } from '@grafana/runtime';
 import { screen } from '@testing-library/react';
 import { type CustomRenderOptions, render } from 'test/render';
 
@@ -8,9 +9,6 @@ import { PLUGIN_URL_PATH } from 'components/Routing.consts';
 
 import { Routing } from './Routing';
 import { getRoute } from './Routing.utils';
-
-import { config } from '@grafana/runtime';
-import { OrgRole } from '@grafana/data';
 
 function renderRouting(options?: CustomRenderOptions) {
   return render(<Routing onNavChanged={jest.fn} />, options);

--- a/src/components/Routing.test.tsx
+++ b/src/components/Routing.test.tsx
@@ -9,6 +9,9 @@ import { PLUGIN_URL_PATH } from 'components/Routing.consts';
 import { Routing } from './Routing';
 import { getRoute } from './Routing.utils';
 
+import { config } from '@grafana/runtime';
+import { OrgRole } from '@grafana/data';
+
 function renderRouting(options?: CustomRenderOptions) {
   return render(<Routing onNavChanged={jest.fn} />, options);
 }
@@ -148,6 +151,21 @@ describe('Routes to pages correctly', () => {
     );
     expect(configText).toBeInTheDocument();
   });
+
+  test('Config page redirects to homepage when the user is viewer', async () => {
+    jest.replaceProperty(config, 'bootData', {
+      // @ts-expect-error
+      user: {
+        orgRole: OrgRole.Viewer,
+      },
+    });
+
+    renderRouting({ path: getRoute(ROUTES.Config) });
+
+    const homePageText = await screen.findByText('Home page', { selector: 'h1' });
+    expect(homePageText).toBeInTheDocument();
+  });
+
   test('Non-existent route redirects to homepage', async () => {
     renderRouting({ path: notaRoute });
     const homePageText = await screen.findByText('Home page', { selector: 'h1' });

--- a/src/components/Routing.test.tsx
+++ b/src/components/Routing.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { OrgRole } from '@grafana/data';
-import runTime, { config } from '@grafana/runtime';
+import runTime from '@grafana/runtime';
 import { screen } from '@testing-library/react';
 import { type CustomRenderOptions, render } from 'test/render';
+import { runTestAsViewer } from 'test/utils';
 
 import { ROUTES } from 'types';
 import { PLUGIN_URL_PATH } from 'components/Routing.consts';
@@ -151,12 +151,7 @@ describe('Routes to pages correctly', () => {
   });
 
   test('Config page redirects to homepage when the user is viewer', async () => {
-    jest.replaceProperty(config, 'bootData', {
-      // @ts-expect-error
-      user: {
-        orgRole: OrgRole.Viewer,
-      },
-    });
+    runTestAsViewer();
 
     renderRouting({ path: getRoute(ROUTES.Config) });
 

--- a/src/components/Routing.tsx
+++ b/src/components/Routing.tsx
@@ -1,9 +1,10 @@
 import React, { useContext, useEffect, useLayoutEffect } from 'react';
 import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
-import { AppRootProps } from '@grafana/data';
+import { AppRootProps, OrgRole } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { ROUTES } from 'types';
+import { hasRole } from 'utils';
 import { InstanceContext } from 'contexts/InstanceContext';
 import { QueryParamMap, useNavigation } from 'hooks/useNavigation';
 import { useQuery } from 'hooks/useQuery';
@@ -76,7 +77,7 @@ export const Routing = ({ onNavChanged }: Pick<AppRootProps, 'onNavChanged'>) =>
         {initialized ? <AlertingPage /> : <AlertingWelcomePage />}
       </Route>
       <Route path={getRoute(ROUTES.Config)}>
-        <ConfigPage />
+        {hasRole(OrgRole.Editor) ? <ConfigPage /> : <Redirect to={getRoute(ROUTES.Home)} />}
       </Route>
 
       {/* Default route (only redirect if the path matches the plugin's URL) */}

--- a/src/page/AlertingPage.tsx
+++ b/src/page/AlertingPage.tsx
@@ -5,13 +5,13 @@ import { Alert, Button, Icon, Modal, Spinner, Stack, useStyles2 } from '@grafana
 import { css } from '@emotion/css';
 
 import { AlertFormValues, AlertRule } from 'types';
+import { hasRole } from 'utils';
 import { InstanceContext } from 'contexts/InstanceContext';
 import { useAlerts } from 'hooks/useAlerts';
 import { useUnifiedAlertsEnabled } from 'hooks/useUnifiedAlertsEnabled';
 import { transformAlertFormValues } from 'components/alertingTransformations';
 import { AlertRuleForm } from 'components/AlertRuleForm';
 import { PluginPage } from 'components/PluginPage';
-import { hasRole } from 'utils';
 
 type SplitAlertRules = {
   recordingRules: AlertRule[];

--- a/src/page/AlertingPage.tsx
+++ b/src/page/AlertingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, OrgRole } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Alert, Button, Icon, Modal, Spinner, Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -11,6 +11,7 @@ import { useUnifiedAlertsEnabled } from 'hooks/useUnifiedAlertsEnabled';
 import { transformAlertFormValues } from 'components/alertingTransformations';
 import { AlertRuleForm } from 'components/AlertRuleForm';
 import { PluginPage } from 'components/PluginPage';
+import { hasRole } from 'utils';
 
 type SplitAlertRules = {
   recordingRules: AlertRule[];
@@ -108,7 +109,7 @@ const Alerting = () => {
             You do not have any default alerts for Synthetic Monitoring yet. Click below to get some default alerts. You
             can also create custom alerts for checks using Grafana Cloud Alerting.
           </span>
-          <Button size="md" disabled={updatingDefaultRules} onClick={populateDefaultAlerts}>
+          <Button size="md" disabled={updatingDefaultRules || !hasRole(OrgRole.Editor)} onClick={populateDefaultAlerts}>
             Populate default alerts
           </Button>
         </div>
@@ -118,7 +119,12 @@ const Alerting = () => {
       ))}
       {Boolean(alertRules?.length) ? (
         <Stack justifyContent="flex-end">
-          <Button variant="destructive" type="button" onClick={() => setShowResetModal(true)}>
+          <Button
+            variant="destructive"
+            type="button"
+            onClick={() => setShowResetModal(true)}
+            disabled={!hasRole(OrgRole.Editor)}
+          >
             Reset to defaults
           </Button>
         </Stack>

--- a/src/page/CheckRouter.test.tsx
+++ b/src/page/CheckRouter.test.tsx
@@ -9,16 +9,9 @@ import { CheckType, CheckTypeGroup, ROUTES } from 'types';
 import { PLUGIN_URL_PATH } from 'components/Routing.consts';
 
 import { CheckRouter } from './CheckRouter';
+import { runTestAsViewer } from 'test/utils';
 
 describe(`<CheckRouter />`, () => {
-  beforeAll(() => {
-    jest.replaceProperty(config, 'bootData', {
-      // @ts-expect-error
-      user: {
-        orgRole: OrgRole.Editor,
-      },
-    });
-  });
   it(`should redirect from the old add new check route to the new one`, async () => {
     const checkType = CheckType.HTTP;
 
@@ -79,13 +72,8 @@ describe(`<CheckRouter />`, () => {
 
   describe('Permissions', () => {
     describe('When user is viewer', () => {
-      beforeAll(() => {
-        jest.replaceProperty(config, 'bootData', {
-          // @ts-expect-error
-          user: {
-            orgRole: OrgRole.Viewer,
-          },
-        });
+      beforeEach(() => {
+        runTestAsViewer();
       });
       it(`Should not load the edit check route and redirect to the homepage`, async () => {
         const checkType = CheckType.Scripted;
@@ -101,14 +89,6 @@ describe(`<CheckRouter />`, () => {
     });
 
     describe('When user is editor', () => {
-      beforeAll(() => {
-        jest.replaceProperty(config, 'bootData', {
-          // @ts-expect-error
-          user: {
-            orgRole: OrgRole.Editor,
-          },
-        });
-      });
       it(`Should load the edit check route`, async () => {
         const checkType = CheckType.Scripted;
         const checkID = BASIC_SCRIPTED_CHECK.id;

--- a/src/page/CheckRouter.test.tsx
+++ b/src/page/CheckRouter.test.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import { OrgRole } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { screen, waitFor } from '@testing-library/react';
 import { BASIC_HTTP_CHECK, BASIC_SCRIPTED_CHECK } from 'test/fixtures/checks';
 import { render } from 'test/render';
+import { runTestAsViewer } from 'test/utils';
 
 import { CheckType, CheckTypeGroup, ROUTES } from 'types';
 import { PLUGIN_URL_PATH } from 'components/Routing.consts';
 
 import { CheckRouter } from './CheckRouter';
-import { runTestAsViewer } from 'test/utils';
 
 describe(`<CheckRouter />`, () => {
   it(`should redirect from the old add new check route to the new one`, async () => {

--- a/src/page/CheckRouter.test.tsx
+++ b/src/page/CheckRouter.test.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { OrgRole } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { screen, waitFor } from '@testing-library/react';
 import { BASIC_HTTP_CHECK, BASIC_SCRIPTED_CHECK } from 'test/fixtures/checks';
 import { render } from 'test/render';
@@ -9,6 +11,14 @@ import { PLUGIN_URL_PATH } from 'components/Routing.consts';
 import { CheckRouter } from './CheckRouter';
 
 describe(`<CheckRouter />`, () => {
+  beforeAll(() => {
+    jest.replaceProperty(config, 'bootData', {
+      // @ts-expect-error
+      user: {
+        orgRole: OrgRole.Editor,
+      },
+    });
+  });
   it(`should redirect from the old add new check route to the new one`, async () => {
     const checkType = CheckType.HTTP;
 
@@ -65,5 +75,52 @@ describe(`<CheckRouter />`, () => {
 
     const title = await screen.findByText(`Editing ${BASIC_SCRIPTED_CHECK.job}`);
     expect(title).toBeInTheDocument();
+  });
+
+  describe('Permissions', () => {
+    describe('When user is viewer', () => {
+      beforeAll(() => {
+        jest.replaceProperty(config, 'bootData', {
+          // @ts-expect-error
+          user: {
+            orgRole: OrgRole.Viewer,
+          },
+        });
+      });
+      it(`Should not load the edit check route and redirect to the homepage`, async () => {
+        const checkType = CheckType.Scripted;
+        const checkID = BASIC_SCRIPTED_CHECK.id;
+
+        const { history } = render(<CheckRouter />, {
+          path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/edit/${checkType}/${checkID}`,
+          route: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
+        });
+
+        await waitFor(() => expect(history.location.pathname).toBe(`${PLUGIN_URL_PATH}${ROUTES.Checks}`));
+      });
+    });
+
+    describe('When user is editor', () => {
+      beforeAll(() => {
+        jest.replaceProperty(config, 'bootData', {
+          // @ts-expect-error
+          user: {
+            orgRole: OrgRole.Editor,
+          },
+        });
+      });
+      it(`Should load the edit check route`, async () => {
+        const checkType = CheckType.Scripted;
+        const checkID = BASIC_SCRIPTED_CHECK.id;
+
+        render(<CheckRouter />, {
+          path: `${PLUGIN_URL_PATH}${ROUTES.Checks}/edit/${checkType}/${checkID}`,
+          route: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
+        });
+
+        const title = await screen.findByText(`Editing ${BASIC_SCRIPTED_CHECK.job}`);
+        expect(title).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/page/CheckRouter.tsx
+++ b/src/page/CheckRouter.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
+import { OrgRole } from '@grafana/data';
 
 import { CheckType } from 'types';
+import { hasRole } from 'utils';
 import { CHECK_TYPE_OPTIONS } from 'hooks/useCheckTypeOptions';
 import { CheckList } from 'components/CheckList';
 import { ChooseCheckGroup } from 'components/ChooseCheckGroup';
@@ -40,7 +42,7 @@ export function CheckRouter() {
         <NewCheck />
       </Route>
       <Route path={`${path}/edit/:checkTypeGroup/:id`} exact>
-        <EditCheck />
+        {hasRole(OrgRole.Editor) ? <EditCheck /> : <Redirect to={`${path}`} />}
       </Route>
       <Route path={`${path}/choose-type`} exact>
         <ChooseCheckGroup />

--- a/src/page/pageDefinitions.ts
+++ b/src/page/pageDefinitions.ts
@@ -1,7 +1,8 @@
 import React from 'react';
-import { AppRootProps, NavModelItem } from '@grafana/data';
+import { AppRootProps, NavModelItem, OrgRole } from '@grafana/data';
 
 import { Settings } from 'types';
+import { hasRole } from 'utils';
 import { PLUGIN_URL_PATH } from 'components/Routing.consts';
 
 export type PageDefinition = {
@@ -33,12 +34,15 @@ const pages: NavModelItem[] = [
     id: 'alerts',
     url: `${PLUGIN_URL_PATH}alerts`,
   },
-  {
+];
+
+if (hasRole(OrgRole.Editor)) {
+  pages.push({
     text: 'Config',
     id: 'config',
     url: `${PLUGIN_URL_PATH}config`,
-  },
-];
+  });
+}
 
 export const getNavModel = (logo: string, path: string) => {
   const node = {

--- a/src/scenes/Common/editButton.tsx
+++ b/src/scenes/Common/editButton.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { OrgRole } from '@grafana/data';
 import { SceneReactObject, SceneVariable, VariableValue } from '@grafana/scenes';
 import { LinkButton } from '@grafana/ui';
 
 import { Check, ROUTES } from 'types';
-import { getCheckType, getCheckTypeGroup } from 'utils';
+import { getCheckType, getCheckTypeGroup, hasRole } from 'utils';
 import { useChecks } from 'data/useChecks';
 import { getRoute } from 'components/Routing.utils';
 
@@ -17,7 +18,7 @@ function EditCheckButton({ job, instance }: Props) {
   const url = getUrl(checks, instance.getValue(), job.getValue());
 
   return (
-    <LinkButton variant="secondary" href={url} disabled={isLoading || !url} icon={isLoading ? 'fa fa-spinner' : 'edit'}>
+    <LinkButton variant="secondary" href={url} disabled={isLoading || !url || !hasRole(OrgRole.Editor)} icon={isLoading ? 'fa fa-spinner' : 'edit'}>
       Edit check
     </LinkButton>
   );


### PR DESCRIPTION
Users with the role of `viewer` should be more restricted in what they can do/click in the app. 

For `viewer` users, this PR:
- Disables "Edit check" button in dashboards page
![image](https://github.com/user-attachments/assets/ca376ce0-36cf-4665-9d00-de0b071da346)
- Redirects the edit page route to home
- Redirects the config page to home
- Disables the "Populate default alerts", "Reset default alert rules" and "Save alerts" buttons in Alerting



Fixes https://github.com/grafana/support-escalations/issues/11601