### PR TITLE
Render unknown check types in the checks list page

### DIFF
--- a/src/hooks/useUsageCalc.ts
+++ b/src/hooks/useUsageCalc.ts
@@ -41,7 +41,7 @@ export function useUsageCalc(calcUsageValues: CalculateUsageValues[]) {
         assertionCount,
         probeCount,
         frequencySeconds,
-        seriesPerProbe: data.AccountingClasses[accountingClass].Series,
+        seriesPerProbe: data.AccountingClasses[accountingClass]?.Series,
       });
 
       return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -177,7 +177,8 @@ export function getCheckTypeGroup(checkType: CheckType): CheckTypeGroup {
   const group = CHECK_TYPE_OPTIONS.find((option) => option.value === checkType)?.group;
 
   if (!group) {
-    throw new Error(`Check type ${checkType} not found in check type options`);
+    console.log(`Check type ${checkType} not found in check type options`);
+    return CHECK_TYPE_OPTIONS[0].group;
   }
 
   return group;


### PR DESCRIPTION
## Problem

When we have a new check type in development (like browser checks) and we create one of those checks, when we go to a branch which doesn't support those checks the check list page errors out and becomes unusable.

![Screenshot of the checks list page in the Synthetic Monitoring plugin. It doesn't show anything except a red alert banner saying 'Something went wrong'.](https://github.com/user-attachments/assets/55e8ade3-6177-4ef0-a845-640cbf9bc435)


## Solution

Fix the logic so that the check card still renders so the checks list page is still usable.

![Screenshot of the checks list page in the Synthetic Monitoring plugin. It shows a browser check rendering despite this branch doesn't support browser checks.](https://github.com/user-attachments/assets/abb76308-10ed-4629-badd-5b295ff0a49c)
