### PR TITLE
Fix flaky tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "sign": "npx --yes @grafana/sign-plugin@latest",
     "spellcheck": "cspell -c cspell.config.json \"**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}\"",
     "test": "jest --all",
-    "test:accessibility": "pa11y --runner axe --reporter json http://localhost:3000/a/grafana-synthetic-monitoring-app/?page=checks > pa11y-report.json",
-    "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "test:changed": "jest --watch --onlyChanged",
     "typecheck": "tsc --noEmit"
   },

--- a/src/components/CheckList/CheckList.test.tsx
+++ b/src/components/CheckList/CheckList.test.tsx
@@ -28,8 +28,6 @@ jest.mock('hooks/useNavigation', () => {
 });
 const useNavigationHook = require('hooks/useNavigation');
 
-jest.setTimeout(20000);
-
 const renderCheckList = async (checks = BASIC_CHECK_LIST, searchParams = '') => {
   server.use(
     apiRoute(`listChecks`, {

--- a/src/page/AlertingPage.test.tsx
+++ b/src/page/AlertingPage.test.tsx
@@ -24,7 +24,6 @@ const useAlertsHook = require('hooks/useAlerts');
 const { defaultRules } = jest.requireActual('hooks/useAlerts');
 const setDefaultRules = jest.fn();
 const setRules = jest.fn().mockImplementation(() => Promise.resolve({ ok: true }));
-jest.setTimeout(30000);
 
 const renderAlerting = () => {
   return render(<AlertingPage />);

--- a/src/page/ChecksPage.test.tsx
+++ b/src/page/ChecksPage.test.tsx
@@ -12,15 +12,13 @@ import { PLUGIN_URL_PATH } from 'components/Routing.consts';
 
 import { CheckRouter } from './CheckRouter';
 
-jest.setTimeout(20000);
-
 const renderChecksPage = async () => {
   const res = render(<CheckRouter />, {
     path: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
     route: `${PLUGIN_URL_PATH}${ROUTES.Checks}`,
   });
 
-  await waitFor(() => expect(screen.getByText('Add new check')).toBeInTheDocument());
+  await waitFor(() => expect(screen.getByText('Add new check')).toBeInTheDocument(), { timeout: 10000 });
   return res;
 };
 
@@ -150,7 +148,6 @@ test(`renders retry button when unable to fetch alerts`, async () => {
   );
 
   const { user } = await renderChecksPage();
-  await waitFor(() => {}, { timeout: 10000 });
   const refetchButton = await screen.findByLabelText('Unable to fetch alerting rules. Retry?');
 
   server.use(

--- a/src/page/__testHelpers__/checkForm.tsx
+++ b/src/page/__testHelpers__/checkForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, within } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
 import { DataTestIds } from 'test/dataTestIds';
 import { apiRoute, getServerRequests } from 'test/handlers';
@@ -33,11 +33,26 @@ export async function renderNewForm(checkType: CheckType) {
     path: `${PLUGIN_URL_PATH}${ROUTES.NewCheck}/${checkTypeGroup}?checkType=${checkType}`,
   });
 
-  await screen.findByTestId(DataTestIds.PAGE_READY);
+  await waitFor(async () => await screen.findByTestId(DataTestIds.PAGE_READY), { timeout: 10000 });
+
+  const typeButReallyPaste = async (target: Element, value: string, args?: any) => {
+    if (target instanceof HTMLElement) {
+      await act(() => {
+        target.focus();
+      });
+      await res.user.paste(value);
+    }
+  };
+
+  const user: UserEvent = {
+    ...res.user,
+    type: typeButReallyPaste,
+  };
 
   return {
     ...res,
     read,
+    user,
   };
 }
 
@@ -52,7 +67,7 @@ export async function renderEditForm(check: Pick<Check, 'id' | 'settings'>) {
     path: `${PLUGIN_URL_PATH}${ROUTES.EditCheck}/edit/${checkTypeGroup}/${check.id}`,
   });
 
-  await screen.findByText(/^Editing/);
+  await waitFor(async () => await screen.findByText(/^Editing/), { timeout: 10000 });
 
   return {
     ...res,


### PR DESCRIPTION
## Problem

With the new CheckForm testing meta framework which added significantly to our testing coverage and by extension our testing overhead, we were starting to see increasingly flaky tests in the CI/CD pipelines as well as when running them locally (I had recently resorted to getting a fan to cool my laptop when running them as it was heating up significantly...).

Our testing approach is 100% the correct way we should be doing testing so we shouldn't shy away from writing long-running integration tests as the alternatives are either:

1. moving the same tests to an e2e framework which can be equally (if not more so) flaky and will take magnitudes longer to run and get feedback. 
2. writing a ton of smaller unit tests that are often too closely coupled with the implementation and slow down developer velocity.

## Solution

I noticed the flaky tests always seemed to be the ones involving the TCP section of requests (HTTP, gRPC, TCP) and that they took a long time to run and then timed out. As jest tests run in separate worker pools it often seemed like when these TCP tests were running they could cause other tests running at the same time to error out randomly too -- presumably because they were hogging so many CPU resources the other tests were suffering.

Recently [in another PR](https://github.com/grafana/synthetic-monitoring-app/pull/869#pullrequestreview-2185711661), I noticed that our schema validations are running multiple times per onChange event when a user is typing. It is still something worth investigating at a future date but it makes no discernible impact to real users utilising our application.

However it occurred to me that the TCP fields require typing in valid PEM certificates and keys. The testing key we use is 1750 characters long. If the validation is running 4 or 5 times per character stroke each of these tests is having to validate the input ~10,000 times on top of all the additional computations the input / validation would trigger.

The solution is in the checkform testing helper to override the default `user.type` method and actually turn it into a focus / paste the content so it only triggers the input onChange handlers once. I was considering only making this change to the TCP fields with the large inputs but I couldn't think of a good reason why we shouldn't add the override at this level (there's an argument we should even add it to our custom render function in `test/render`?).

I've also done a little bit of cleanup and removed the custom jest.timeout declarations and ensured the `waitFor` methods in tests wait much longer than their default 1 second to ensure our test flakiness is kept to a minimum.

**Before**

```
Test Suites: 2 failed, 79 passed, 81 total
Tests:       2 failed, 4 skipped, 398 passed, 404 total
Snapshots:   0 total
Time:        126.822 s
Ran all test suites.
```

Had to have a fan running not to overheat my computer 🥵 
![A laptop propped up on books to increase airflow and running jest tests in the terminal. There is a portable fan behind the laptop.](https://github.com/user-attachments/assets/d371e266-8ae5-4c46-86ec-591362203130)


**After**
```
Test Suites: 81 passed, 81 total
Tests:       4 skipped, 400 passed, 404 total
Snapshots:   0 total
Time:        85.987 s
Ran all test suites.
✨  Done in 86.58s.
```

No more fan 😎 
![A laptop running jest tests in the terminal.](https://github.com/user-attachments/assets/efe1990d-3100-4d6f-af7c-630fd9f3f608)

