### PR TITLE
fix: make sure valid http and tcp checks can be submitted without reg…

### DIFF
--- a/src/components/CheckEditor/transformations/toFormValues.utils.ts
+++ b/src/components/CheckEditor/transformations/toFormValues.utils.ts
@@ -9,7 +9,7 @@ export function selectableValueFrom<T>(value: T, label?: string): SelectableValu
 }
 
 export const getTlsConfigFormValues = (tlsConfig?: TLSConfig) => {
-  if (!tlsConfig) {
+  if (!tlsConfig || Object.keys(tlsConfig).length === 0) {
     return {};
   }
 

--- a/src/page/EditCheck/__tests__/ApiEndPointChecks/HTTPCheck/Submit.test.tsx
+++ b/src/page/EditCheck/__tests__/ApiEndPointChecks/HTTPCheck/Submit.test.tsx
@@ -1,0 +1,48 @@
+import { PRIVATE_PROBE } from 'test/fixtures/probes';
+import { apiRoute } from 'test/handlers';
+import { server } from 'test/server';
+
+import { HTTPCheck, HttpMethod, IpVersion } from 'types';
+import { renderEditForm, submitForm } from 'page/__testHelpers__/checkForm';
+
+const MIN_HTTP_CHECK: HTTPCheck = {
+  id: 1,
+  tenantId: 1,
+  frequency: 60000,
+  timeout: 3000,
+  enabled: true,
+  labels: [],
+  settings: {
+    http: {
+      ipVersion: IpVersion.V4,
+      method: HttpMethod.GET,
+      noFollowRedirects: false,
+      failIfSSL: false,
+      failIfNotSSL: false,
+      tlsConfig: {},
+    },
+  },
+  probes: [PRIVATE_PROBE.id] as number[],
+  target: 'https://http.com',
+  job: 'Job name for http',
+  basicMetricsOnly: true,
+  alertSensitivity: 'none',
+};
+
+it(`HTTPCheck -- can successfully submit an existing check with no editing`, async () => {
+  server.use(
+    apiRoute(`listChecks`, {
+      result: () => {
+        return {
+          json: [MIN_HTTP_CHECK],
+        };
+      },
+    })
+  );
+
+  const { read, user } = await renderEditForm({ id: MIN_HTTP_CHECK.id, settings: MIN_HTTP_CHECK.settings });
+  await submitForm(user);
+
+  const { body } = await read();
+  expect(body).toBeTruthy();
+});

--- a/src/page/EditCheck/__tests__/ApiEndPointChecks/TCPCheck/Submit.test.tsx
+++ b/src/page/EditCheck/__tests__/ApiEndPointChecks/TCPCheck/Submit.test.tsx
@@ -1,0 +1,44 @@
+import { PRIVATE_PROBE } from 'test/fixtures/probes';
+import { apiRoute } from 'test/handlers';
+import { server } from 'test/server';
+
+import { IpVersion, TCPCheck } from 'types';
+import { renderEditForm, submitForm } from 'page/__testHelpers__/checkForm';
+
+const MIN_TCP_CHECK: TCPCheck = {
+  id: 1,
+  tenantId: 1,
+  frequency: 60000,
+  timeout: 3000,
+  enabled: true,
+  labels: [],
+  settings: {
+    tcp: {
+      ipVersion: IpVersion.V4,
+      tlsConfig: {},
+    },
+  },
+  probes: [PRIVATE_PROBE.id] as number[],
+  target: 'grafana.com:43',
+  job: 'Job name for tcp',
+  basicMetricsOnly: true,
+  alertSensitivity: 'none',
+};
+
+it(`TCPCheck -- can successfully submit an existing check with no editing`, async () => {
+  server.use(
+    apiRoute(`listChecks`, {
+      result: () => {
+        return {
+          json: [MIN_TCP_CHECK],
+        };
+      },
+    })
+  );
+
+  const { read, user } = await renderEditForm({ id: MIN_TCP_CHECK.id, settings: MIN_TCP_CHECK.settings });
+  await submitForm(user);
+
+  const { body } = await read();
+  expect(body).toBeTruthy();
+});

--- a/src/schemas/forms/TCPCheckSchema.ts
+++ b/src/schemas/forms/TCPCheckSchema.ts
@@ -8,7 +8,7 @@ import { BaseCheckSchema } from './BaseCheckSchema';
 
 const TCPSettingsSchema: ZodType<TcpSettingsFormValues> = z.object({
   ipVersion: z.nativeEnum(IpVersion),
-  tls: z.boolean(),
+  tls: z.boolean().optional(),
   tlsConfig: TLSConfigSchema,
   queryResponse: z.array(
     z.object({

--- a/src/schemas/general/TLSConfig.ts
+++ b/src/schemas/general/TLSConfig.ts
@@ -9,17 +9,26 @@ const CERT_ERROR_MESSAGE = 'Certificate must be in the PEM format.';
 
 export const TLSConfigSchema: ZodType<TLSConfig | undefined> = z
   .object({
-    caCert: z.string().refine(validateTLSCACert, {
-      message: CERT_ERROR_MESSAGE,
-    }),
-    clientCert: z.string().refine(validateTLSClientCert, {
-      message: CERT_ERROR_MESSAGE,
-    }),
-    clientKey: z.string().refine(validateTLSClientKey, {
-      message: 'Key must be in the PEM format.',
-    }),
+    caCert: z
+      .string()
+      .refine(validateTLSCACert, {
+        message: CERT_ERROR_MESSAGE,
+      })
+      .optional(),
+    clientCert: z
+      .string()
+      .refine(validateTLSClientCert, {
+        message: CERT_ERROR_MESSAGE,
+      })
+      .optional(),
+    clientKey: z
+      .string()
+      .refine(validateTLSClientKey, {
+        message: 'Key must be in the PEM format.',
+      })
+      .optional(),
     insecureSkipVerify: z.boolean().optional(),
-    serverName: z.string(),
+    serverName: z.string().optional(),
   })
   .optional();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,7 +158,7 @@ export interface BrowserSettings {
 
 export interface TcpSettings {
   ipVersion: IpVersion;
-  tls: boolean;
+  tls?: boolean;
   tlsConfig?: TLSConfig;
   queryResponse?: TCPQueryResponse[];
 }


### PR DESCRIPTION
During some spot checking on ops for the `1.14.11` release I found an issue with what happens when `react-hook-form` fields don't get to 'register' and submitting perfectly valid checks.

I've updated the schemas and added some regression tests.