### PR TITLE
fix: add in follow redirects checkbox with test

### DIFF
--- a/src/components/CheckForm/FormLayouts/CheckHttpLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckHttpLayout.tsx
@@ -30,6 +30,10 @@ export const HTTP_REQUEST_FIELDS: HttpRequestFields<CheckFormValuesHttp> = {
     name: `settings.http.ipVersion`,
     section: 0,
   },
+  followRedirects: {
+    name: `settings.http.followRedirects`,
+    section: 0,
+  },
   requestBody: {
     name: `settings.http.body`,
     section: 2,

--- a/src/page/NewCheck/__tests__/ApiEndPointChecks/HTTPCheck/1-request_options.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/ApiEndPointChecks/HTTPCheck/1-request_options.payload.test.tsx
@@ -57,4 +57,16 @@ describe(`HttpCheck - Section 1 (Request) Request Options payload`, () => {
     const { body } = await read();
     expect(body.settings.http.ipVersion).toBe(IP_VERSION);
   });
+
+  it(`can submit follow redirects`, async () => {
+    const { read, user } = await renderNewForm(checkType);
+    await user.click(screen.getByText('Request options'));
+    await user.click(screen.getByLabelText('Follow redirects'));
+
+    await fillMandatoryFields({ user, checkType });
+    await submitForm(user);
+
+    const { body } = await read();
+    expect(body.settings.http.noFollowRedirects).toBe(true);
+  });
 });


### PR DESCRIPTION
## Problem

There was an oversight and forgot to add in the 'Follow redirects' checkbox to http checks. [The problem was reported in Slack](https://raintank-corp.slack.com/archives/C0162C1K9E1/p1723630702600789).

## Solution

Add it back in with appropriate test to ensure it doesn't regress again.