### PR TITLE
Prevent commas and quotes in job names

### DIFF
--- a/src/page/NewCheck/__tests__/NewCheck.test.tsx
+++ b/src/page/NewCheck/__tests__/NewCheck.test.tsx
@@ -107,7 +107,7 @@ describe(`<NewCheck />`, () => {
     const jobNameField = await screen.findByLabelText(/Job name/);
     await waitFor(() => expect(jobNameField).toHaveFocus());
 
-    expect(screen.getByText(/Job names can't contain commas or single quotes/)).toBeInTheDocument();
+    expect(screen.getByText(/Job names can't contain commas or quotes/)).toBeInTheDocument();
   });
 
   it(`should display an error message when the job name contains single quotes`, async () => {
@@ -122,8 +122,24 @@ describe(`<NewCheck />`, () => {
     const jobNameField = await screen.findByLabelText(/Job name/);
     await waitFor(() => expect(jobNameField).toHaveFocus());
 
-    expect(screen.getByText(/Job names can't contain commas or single quotes/)).toBeInTheDocument();
+    expect(screen.getByText(/Job names can't contain commas or quotes/)).toBeInTheDocument();
   });
+
+  it(`should display an error message when the job name contains double quotes`, async () => {
+    const { user } = await renderNewForm(CheckType.HTTP);
+
+    const jobNameInput = await screen.findByLabelText('Job name', { exact: false });
+    await user.type(jobNameInput, `job name with " double quote`);
+
+    await fillMandatoryFields({ user, checkType: CheckType.HTTP, fieldsToOmit: ['job'] });
+    await submitForm(user);
+
+    const jobNameField = await screen.findByLabelText(/Job name/);
+    await waitFor(() => expect(jobNameField).toHaveFocus());
+
+    expect(screen.getByText(/Job names can't contain commas or quotes/)).toBeInTheDocument();
+  });
+
 
 
   it(`should disable the test button when the user doesn't have logs access`, async () => {

--- a/src/page/NewCheck/__tests__/NewCheck.test.tsx
+++ b/src/page/NewCheck/__tests__/NewCheck.test.tsx
@@ -140,7 +140,18 @@ describe(`<NewCheck />`, () => {
     expect(screen.getByText(/Job names can't contain commas or quotes/)).toBeInTheDocument();
   });
 
+  it(`trims white spaces from job name`, async () => {
+    const { read, user } = await renderNewForm(CheckType.HTTP);
 
+    const jobNameInput = await screen.findByLabelText('Job name', { exact: false });
+    await user.type(jobNameInput, `   my job name   `);
+
+    await fillMandatoryFields({ user, checkType: CheckType.HTTP, fieldsToOmit: ['job'] });
+    await submitForm(user);
+
+    const { body } = await read();
+    expect(body.job).toBe('my job name');
+  });
 
   it(`should disable the test button when the user doesn't have logs access`, async () => {
     runTestWithoutLogsAccess();

--- a/src/page/NewCheck/__tests__/NewCheck.test.tsx
+++ b/src/page/NewCheck/__tests__/NewCheck.test.tsx
@@ -95,6 +95,37 @@ describe(`<NewCheck />`, () => {
     await waitFor(() => expect(probesSelect).toHaveFocus());
   });
 
+  it(`should display an error message when the job name contains commas`, async () => {
+    const { user } = await renderNewForm(CheckType.HTTP);
+
+    const jobNameInput = await screen.findByLabelText('Job name', { exact: false });
+    await user.type(jobNameInput, `job name with, comma`);
+
+    await fillMandatoryFields({ user, checkType: CheckType.HTTP, fieldsToOmit: ['job'] });
+    await submitForm(user);
+
+    const jobNameField = await screen.findByLabelText(/Job name/);
+    await waitFor(() => expect(jobNameField).toHaveFocus());
+
+    expect(screen.getByText(/Job names can't contain commas or single quotes/)).toBeInTheDocument();
+  });
+
+  it(`should display an error message when the job name contains single quotes`, async () => {
+    const { user } = await renderNewForm(CheckType.HTTP);
+
+    const jobNameInput = await screen.findByLabelText('Job name', { exact: false });
+    await user.type(jobNameInput, `job name with ' single quote`);
+
+    await fillMandatoryFields({ user, checkType: CheckType.HTTP, fieldsToOmit: ['job'] });
+    await submitForm(user);
+
+    const jobNameField = await screen.findByLabelText(/Job name/);
+    await waitFor(() => expect(jobNameField).toHaveFocus());
+
+    expect(screen.getByText(/Job names can't contain commas or single quotes/)).toBeInTheDocument();
+  });
+
+
   it(`should disable the test button when the user doesn't have logs access`, async () => {
     runTestWithoutLogsAccess();
     const { user } = await renderNewForm(CheckType.HTTP);

--- a/src/schemas/general/Job.ts
+++ b/src/schemas/general/Job.ts
@@ -7,9 +7,9 @@ export const JobSchema = z
   .min(1, { message: 'Job name is required' })
   .max(128, { message: 'Job name must be 128 characters or less' })
   .superRefine((value, ctx) => {
-    if (value.includes("'") || value.includes(',')) {
+    if (value.includes("'") || value.includes(',') || value.includes('"')) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: `Job names can't contain commas or single quotes`,
+        message: `Job names can't contain commas or quotes`,
       });
     }})

--- a/src/schemas/general/Job.ts
+++ b/src/schemas/general/Job.ts
@@ -5,4 +5,11 @@ export const JobSchema = z
     required_error: 'Job name is required',
   })
   .min(1, { message: 'Job name is required' })
-  .max(128, { message: 'Job name must be 128 characters or less' });
+  .max(128, { message: 'Job name must be 128 characters or less' })
+  .superRefine((value, ctx) => {
+    if (value.includes("'") || value.includes(',')) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Job names can't contain commas or single quotes`,
+      });
+    }})

--- a/src/schemas/general/Job.ts
+++ b/src/schemas/general/Job.ts
@@ -4,6 +4,7 @@ export const JobSchema = z
   .string({
     required_error: 'Job name is required',
   })
+  .trim()
   .min(1, { message: 'Job name is required' })
   .max(128, { message: 'Job name must be 128 characters or less' })
   .superRefine((value, ctx) => {
@@ -12,4 +13,5 @@ export const JobSchema = z
         code: z.ZodIssueCode.custom,
         message: `Job names can't contain commas or quotes`,
       });
-    }})
+    }
+  });


### PR DESCRIPTION
When checks contain single quotes or commas in their job names, it causes the queries executed by the panels to return no data. We should add a frontend validation in the job name field in order to prevent users to input these characters.

Fixes https://github.com/grafana/synthetic-monitoring-app/issues/900 

![image](https://github.com/user-attachments/assets/3c2b95f1-7194-4095-8bfa-eb9c6fe17f01)

There have been several escalations related to this problem:
- https://github.com/grafana/support-escalations/issues/11944
- https://github.com/grafana/support-escalations/issues/6235
- https://github.com/grafana/synthetic-monitoring-app/issues/676



