### PR TITLE
Fix success rate graph when showing failures

### DIFF
--- a/src/scenes/BROWSER/browserScene.ts
+++ b/src/scenes/BROWSER/browserScene.ts
@@ -96,7 +96,7 @@ export function getBrowserScene(
           }),
           new SceneFlexLayout({
             direction: 'row',
-            children: [getAssertionTable(logs, checkType, minStep)],
+            children: [getAssertionTable(logs, checkType, checks?.[0]?.frequency)],
           }),
           new SceneFlexLayout({
             direction: 'row',

--- a/src/scenes/Common/AssertionsTable/AssertionsTable.tsx
+++ b/src/scenes/Common/AssertionsTable/AssertionsTable.tsx
@@ -16,6 +16,7 @@ import { Alert, LinkButton, LoadingPlaceholder, useStyles2 } from '@grafana/ui';
 
 import { CheckType } from 'types';
 import { Table, TableColumn } from 'components/Table';
+import { getMinStepFromFrequency } from 'scenes/utils';
 
 import { getTablePanelStyles } from '../../SCRIPTED/getTablePanelStyles';
 import { AssertionTableRow } from './AssertionsTableRow';
@@ -292,7 +293,8 @@ export class AssertionsTableSceneObject extends SceneObjectBase<AssertionsTableS
   }
 }
 
-export function getAssertionTable(logs: DataSourceRef, checkType: CheckType, minStep: string) {
+export function getAssertionTable(logs: DataSourceRef, checkType: CheckType, frequency: number) {
+  const minStep = getMinStepFromFrequency(frequency, 2);
   return new SceneFlexItem({
     body: new AssertionsTableSceneObject({
       $data: getQueryRunner(logs),

--- a/src/scenes/SCRIPTED/scriptedScene.ts
+++ b/src/scenes/SCRIPTED/scriptedScene.ts
@@ -82,7 +82,7 @@ export function getScriptedScene(
           }),
           new SceneFlexLayout({
             direction: 'row',
-            children: [getAssertionTable(logs, checkType, minStep)],
+            children: [getAssertionTable(logs, checkType, checks?.[0]?.frequency)],
           }),
           new SceneFlexLayout({
             direction: 'row',

--- a/src/scenes/utils.ts
+++ b/src/scenes/utils.ts
@@ -1,5 +1,8 @@
-export function getMinStepFromFrequency(ms?: number): string {
+export function getMinStepFromFrequency(ms?: number, incrementFactor?: number): string {
   const frequencyVal = (ms ?? 600000) / 1000 / 60; // turn ms to minutes
-  const minStep = `${Math.max(Math.floor(frequencyVal), 1)}m`;
-  return minStep;
+  let minStep = Math.max(Math.floor(frequencyVal), 1);
+  if (incrementFactor) {
+    minStep = minStep * incrementFactor;
+  }
+  return `${minStep}m`;
 }


### PR DESCRIPTION
## Description

The current Success Rate graph on the dashboards for MultiHTTP, Scripted, and Browser checks does not accurately display failure events. The issue arises because the query used for this visualization uses an interval that matches the frequency of the checks. This setup can leads to an incomplete visualization, as failures are nont captured effectively within the same interval.

**Problem**
The interval used in the query is equal to the check frequency, which can cause the graph to miss or inadequately represent failure events.
This results in a visualization that may not accurately reflect the true success rate, particularly in the presence of failures.

**Solution**
To improve the accuracy of the failure representation in the Success Rate graph, this PR modifies the interval to be a multiple of the check frequency. Specifically, the interval is set to twice the check frequency.

See the following visualizations for a check that runs every 2m:

- With an interval of `2m`
<img width="1168" alt="image" src="https://github.com/user-attachments/assets/5a5a3408-7b8a-43f6-aea2-66458ba5df2b">


- With an interval of `4m`
<img width="1159" alt="image" src="https://github.com/user-attachments/assets/a24b5c09-289c-47d2-aef0-c3f952336a79">



Fixes https://github.com/grafana/synthetic-monitoring-app/issues/786

