### PR TITLE
fix: revert the way we do ds lookups

### DIFF
--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -70,6 +70,8 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
     return interpolated;
   }
 
+  // these are assumptions which may not hold true in all cases
+  // see https://github.com/grafana/synthetic-monitoring-app/pull/911 for more details
   getMetricsDS() {
     const info = this.instanceSettings.jsonData.metrics;
     const ds = findLinkedDatasource({ ...info, uid: 'grafanacloud-metrics' });

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -71,15 +71,21 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   }
 
   getMetricsDS() {
-    const { uid } = this.instanceSettings.jsonData.metrics;
-
-    return findLinkedDatasource(uid);
+    const info = this.instanceSettings.jsonData.metrics;
+    const ds = findLinkedDatasource({ ...info, uid: 'grafanacloud-metrics' });
+    if (ds) {
+      return ds;
+    }
+    return findLinkedDatasource(info);
   }
 
   getLogsDS() {
-    const { uid } = this.instanceSettings.jsonData.logs;
-
-    return findLinkedDatasource(uid);
+    const info = this.instanceSettings.jsonData.logs;
+    const ds = findLinkedDatasource({ ...info, uid: 'grafanacloud-logs' });
+    if (ds) {
+      return ds;
+    }
+    return findLinkedDatasource(this.instanceSettings.jsonData.logs);
   }
 
   async query(options: DataQueryRequest<SMQuery>): Promise<DataQueryResponse> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,8 +38,14 @@ export function findSMDataSources(): Array<DataSourceInstanceSettings<SMOptions>
   }) as unknown as Array<DataSourceInstanceSettings<SMOptions>>;
 }
 
-export function findLinkedDatasource(uid: string): DataSourceInstanceSettings | undefined {
-  return Object.values(config.datasources).find((ds) => ds.uid === uid);
+export function findLinkedDatasource(linkedDSInfo: LinkedDatasourceInfo): DataSourceInstanceSettings | undefined {
+  if (linkedDSInfo.uid) {
+    const linkedDS = Object.values(config.datasources).find((ds) => ds.uid === linkedDSInfo.uid);
+    if (linkedDS) {
+      return linkedDS;
+    }
+  }
+  return config.datasources[linkedDSInfo.grafanaName];
 }
 
 interface DatasourcePayload {


### PR DESCRIPTION
## Problem

_Background context_

Synthetic Monitoring relies on two supporting databases to work at full capacity: a Grafana Cloud-hosted prometheus database and a Grafana Cloud-hosted Loki database.

A Grafana Cloud instance automatically provisions two datasource 'connectors' which connect to each respectively, confusingly referred to as a Prometheus **Datasource** and a Loki **Datasource**. In theory these should all remain stable, are named predictably and are immutable.

The problem which lies with the plugin is that it based on certain assumptions which may be untrue in certain situations (it is worth noting they are rare but do and will continue to exist and some clients specifically ask to bypass these assumptions):

- That the Synthetic Monitoring tenant is using the default set-up
  - This assumption becomes incorrect if someone were to update their Synthetic Monitoring database provisioning file  
- That the provisioning `jsonData` for the Synthetic Monitoring Datasource is the source of truth for  these connections.
  - This assumption becomes incorrect if someone has utilised the SM api `/api/v1/tenant/update` route to reassign different instances to associate with
  -  This assumption also becomes incorrect if the default provisioned datasources have been renamed in some way (i.e. altering their provisioning files)

The next problem that the Synthetic Monitoring plugin faces is that the metrics and logs api are queried via their datasources within Grafana. We query datasources by their UIDs, however the SM tenant endpoint (which is the _real_ source of truth) does not concern itself with associating with **datasources** but with Grafana Cloud-hosted **database instances**.

The api can provide the `hostedId` of the database **instances** it is writing to but it has no knowledge of what **datasources** a Grafana Cloud instance has which it uses to query against.

If we do not wish to rely on the assumptions above to know what datasources we can utilise it is currently up to to the plugin to ask the SM tenant endpoint and search through a user's available datasources and ask for the hostedIds of each (in this case the `basicAuthUser === hostedId`). It is worth noting this may not always be reliable because a user may have access to multiple datasources which share the same hostedId but have different access policies.

<hr />

_Actual problem_

In the previous update we worked on the assumption that _somewhere_ during the Grafana Cloud bootup that the datasources provided by `getDatasourceSrv.getList()` was mutating the provisioning data and doing the cross-referencing for us. See below in our development environment where the jsonData provided by the SM `/settings` endpoint omits the uid but it is present when querying the Synthetic Monitoring jsonData provided by `getDatasourceSrv.getList()`

![Screenshot of the browser dev tools. It shows a the settings network request response alongside the console data.](https://github.com/user-attachments/assets/83e6ecad-fa24-4041-b9cd-f8ec8252a95e)

It appears this new assumption is wrong and that not all instances have this data available.

## Solution

Unfortunately the solution for now is to go back to the original assumptions that the provisioning data provided by the SM plugin is correct and do the datasource look ups utilising this information.

A more thorough solution will be explored in future work.


