### PR TITLE
Update changelog to 1.14.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-# [1.14.12](https://github.com/grafana/synthetic-monitoring-app/compare/v1.14.11...v1.14.12) (2024-8-19)
+# [1.14.13](https://github.com/grafana/synthetic-monitoring-app/compare/v1.14.11...v1.14.13) (2024-8-20)
 
 - Added datasource RBAC support in the plugin. The plugin now respects RBAC permissions for its datasources.
 - Fix a bug with saving existing checks with empty TLS configs


### PR DESCRIPTION
I'm bumping the changelog to do a release. Officially 1.14.12 went out but was quickly rolled back due to a critical bug. I am updating the changelog so this release is 1.14.13 with the same features and we are skipping publishing 1.14.12 officially.