### PR TITLE
fix: obtain sm datasource by type and not name

### DIFF
--- a/src/data/useSMSetup.ts
+++ b/src/data/useSMSetup.ts
@@ -12,10 +12,24 @@ export const queryKeys: Record<'list', QueryKey> = {
   list: ['get-sm-datasource'],
 };
 
+const getDataSourceName = () => {
+  const smDs = getDataSourceSrv()
+    .getList()
+    .find((ds) => ds.type === 'synthetic-monitoring-datasource');
+
+  return smDs?.name;
+};
+
 export function useGetSMDatasource() {
   return useQuery({
     queryKey: queryKeys.list,
-    queryFn: () => getDataSourceSrv().get(`Synthetic Monitoring`) as Promise<SMDataSource>,
+    queryFn: () => {
+      const smDsName = getDataSourceName();
+      if (!smDsName) {
+        return undefined;
+      }
+      return getDataSourceSrv().get(smDsName) as Promise<SMDataSource>;
+    },
   });
 }
 

--- a/src/test/mocks/@grafana/runtime.tsx
+++ b/src/test/mocks/@grafana/runtime.tsx
@@ -44,13 +44,8 @@ jest.mock('@grafana/runtime', () => {
       },
     }),
     getDataSourceSrv: () => ({
-      get: (name: string) => {
-        if (name === `Synthetic Monitoring`) {
-          return Promise.resolve(new SMDataSource(SM_DATASOURCE));
-        }
-
-        throw new Error(`Requested unknown datasource: ${name}`);
-      },
+      getList: () => [METRICS_DATASOURCE, LOGS_DATASOURCE, SM_DATASOURCE],
+      get: () => Promise.resolve(new SMDataSource(SM_DATASOURCE)),
     }),
     getLocationSrv: () => ({
       update: (args: any) => args,

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -140,7 +140,7 @@ export function runTestWithoutSMAccess() {
   jest.spyOn(runTime, 'getDataSourceSrv').mockImplementation(() => {
     return {
       ...jest.requireActual('@grafana/runtime').getDatasourceSrv(),
-      get: () => Promise.resolve(),
+      getList: () => [METRICS_DATASOURCE, LOGS_DATASOURCE],
     };
   });
 }


### PR DESCRIPTION
Given that the name of the SM datasource (by default `Synthetic Monitoring`) can be changed in the datasource configuration page and the type is a fixed string (`synthetic-monitoring-datasource`), we should obtain this DS it by that value instead of the name.
 
Otherwise, if the app fails to find it by the default name, it won't be able to obtain it and will stay in an uninitialized status.

Closes https://github.com/grafana/synthetic-monitoring-app/issues/920

**Before:**
![image](https://github.com/user-attachments/assets/638fe6bf-27fb-449b-b796-fd32faf640cd)
![image](https://github.com/user-attachments/assets/54281436-5fbf-4d8c-90ef-7853d2adffb8)

**After:**
![image](https://github.com/user-attachments/assets/60b87477-32a5-40db-8e9b-d4acb23388f9)
![image](https://github.com/user-attachments/assets/b5be922d-e5a7-4f7f-ab5e-fdb16f323b9e)
