### PR TITLE
fix: hide grpc option in check cards when feature flag off

### DIFF
--- a/src/components/ChooseCheckGroup.test.tsx
+++ b/src/components/ChooseCheckGroup.test.tsx
@@ -29,15 +29,16 @@ async function renderChooseCheckGroup({ checkLimit = 10, scriptedLimit = 10 } = 
 
   return res;
 }
-it('shows check type options with scripted feature off', async () => {
+it('shows check type options correctly with feature flags off', async () => {
   await renderChooseCheckGroup();
 
   expect(screen.getByText('API Endpoint')).toBeInTheDocument();
   expect(screen.getByText('Multi Step')).toBeInTheDocument();
   expect(screen.queryByText('Scripted')).not.toBeInTheDocument();
+  expect(screen.queryByText('Browser')).not.toBeInTheDocument();
 });
 
-it('shows check type options with scripted feature on', async () => {
+it('shows the scripted card with correct feature flag on', async () => {
   jest.replaceProperty(config, 'featureToggles', {
     // @ts-expect-error
     [FeatureName.ScriptedChecks]: true,
@@ -45,6 +46,31 @@ it('shows check type options with scripted feature on', async () => {
 
   await renderChooseCheckGroup();
   expect(screen.getByText('Scripted')).toBeInTheDocument();
+});
+
+it('shows the browser card with correct feature flag on', async () => {
+  jest.replaceProperty(config, 'featureToggles', {
+    // @ts-expect-error
+    [FeatureName.BrowserChecks]: true,
+  });
+
+  await renderChooseCheckGroup();
+  expect(screen.getByText('Browser')).toBeInTheDocument();
+});
+
+it(`doesn't show gRPC option by default`, async () => {
+  await renderChooseCheckGroup();
+  expect(screen.queryByText('gRPC')).not.toBeInTheDocument();
+});
+
+it('shows gRPC option when feature is enabled', async () => {
+  jest.replaceProperty(config, 'featureToggles', {
+    // @ts-expect-error
+    [FeatureName.GRPCChecks]: true,
+  });
+
+  await renderChooseCheckGroup();
+  expect(screen.getByText('gRPC')).toBeInTheDocument();
 });
 
 it('shows error alert when check limit is reached', async () => {


### PR DESCRIPTION
## Problem

The gRPC shortcut label was showing on the check group cards when the gRPC feature flag was off.

![The API Endpoint card showing the gRPC option in the supported protocols.](https://github.com/user-attachments/assets/8bdf17be-fd33-4b99-b741-6a9000b1dc1e)

## Solution

Alter the logic in the `useCheckTypeGroupOptions` so that it is filtering protocols that have a featureToggle value.

![The API Endpoint card only showing HTTP, Ping, DNS, TCP and Traceroute in the supported protocols.](https://github.com/user-attachments/assets/e27e6c4e-371d-423d-9436-ca2498cc5e09)

There is a slight downside to this solution that we now have two places to update when we remove / change the status of feature flags however this should be mitigated by the additional and updated tests I've added.
[
Slack thread where it was discovered.](https://raintank-corp.slack.com/archives/C0162C1K9E1/p1724344339996369)