### PR TITLE
fix: revert smwrite permissions to orgroles

### DIFF
--- a/src/hooks/useDSPermission.ts
+++ b/src/hooks/useDSPermission.ts
@@ -1,3 +1,6 @@
+import { OrgRole } from '@grafana/data';
+import { config } from '@grafana/runtime';
+
 import { usePermissionsContext } from 'contexts/PermissionsContext';
 
 type DSOptions = `sm` | `metrics` | `logs`;
@@ -35,6 +38,14 @@ export function useCanReadSM() {
   return useDSPermission(`sm`, `datasources:read`);
 }
 
+// we've rolled this back to respect org roles
+// this will change when we do proper plugin RBAC in the near future
 export function useCanWriteSM() {
-  return useDSPermission(`sm`, `datasources:write`);
+  const orgRole = config.bootData.user.orgRole;
+
+  if (orgRole) {
+    return [OrgRole.Editor, OrgRole.Admin].includes(orgRole);
+  }
+
+  return false;
 }

--- a/src/test/mocks/@grafana/runtime.tsx
+++ b/src/test/mocks/@grafana/runtime.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { OrgRole } from '@grafana/data';
 import { BackendSrvRequest } from '@grafana/runtime';
 import axios from 'axios';
 import { from } from 'rxjs';
@@ -20,6 +21,12 @@ jest.mock('@grafana/runtime', () => {
       featureToggles: {
         ...actual.config.featureToggles,
         topnav: true,
+      },
+      bootData: {
+        user: {
+          ...actual.config.user,
+          orgRole: OrgRole.Admin,
+        },
       },
     },
     getBackendSrv: () => ({

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,10 +1,10 @@
+import { OrgRole } from '@grafana/data';
 import runTime, { config } from '@grafana/runtime';
 import { act, screen, within } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
 import {
   LOGS_DATASOURCE,
   METRICS_DATASOURCE,
-  SM_DATASOURCE,
   VIEWER_DEFAULT_DATASOURCE_ACCESS_CONTROL,
 } from 'test/fixtures/datasources';
 
@@ -64,18 +64,18 @@ export async function fillProbeForm(user: UserEvent) {
 }
 
 export function runTestAsSMViewer() {
-  server.use(
-    apiRoute(`getSMDS`, {
-      result: () => {
-        return {
-          json: {
-            ...SM_DATASOURCE,
-            accessControl: VIEWER_DEFAULT_DATASOURCE_ACCESS_CONTROL,
-          },
-        };
+  // this gets reset in afterEach in jest-setup.js
+  const runtime = require('@grafana/runtime');
+  jest.replaceProperty(runtime, `config`, {
+    ...config,
+    bootData: {
+      ...config.bootData,
+      user: {
+        ...config.bootData.user,
+        orgRole: OrgRole.Viewer,
       },
-    })
-  );
+    },
+  });
 }
 
 export function runTestAsLogsViewer() {


### PR DESCRIPTION
## Problem

In release 1.14.13 we added RBAC support across the SM plugin. This was intended as a halfway house before we added more pointed and fully-featured plugin RBAC support. Unfortunately we made a bad assumption about the default permissions each role is given.

When creating a Datasource an editor gets `datasource:read` by default and not `datasource:write`. The intent and explanations are documented in the [data source management](https://grafana.com/docs/grafana/latest/administration/data-source-management/) section of the Grafana docs.

## Solution

For the time-being we are going to revert SM permissions to respect organisation roles rather than the access policies they have. This is how it worked prior to `1.14.13`.
