### PR TITLE
feat: allow to disable browser checks in probe creation

### DIFF
--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -73,5 +73,9 @@ function getAvailableProbes(probes: Probe[], checkType: CheckType) {
   if (checkType === CheckType.Scripted) {
     return probes.filter((probe) => probe.capabilities.disableScriptedChecks === false);
   }
+
+  if (checkType === CheckType.Browser) {
+    return probes.filter((probe) => probe.capabilities.disableBrowserChecks === false);
+  }
   return probes;
 }

--- a/src/components/FeatureFlag.tsx
+++ b/src/components/FeatureFlag.tsx
@@ -7,7 +7,7 @@ interface FlagProps {
 
 interface Props {
   name: FeatureName;
-  children: (flagProps: FlagProps) => JSX.Element;
+  children: (flagProps: FlagProps) => JSX.Element | null;
 }
 
 export const FeatureFlag = ({ name, children }: Props) => {

--- a/src/components/ProbeEditor/ProbeEditor.test.tsx
+++ b/src/components/ProbeEditor/ProbeEditor.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { config } from '@grafana/runtime';
 import { screen, waitFor } from '@testing-library/react';
 import { PRIVATE_PROBE, PUBLIC_PROBE } from 'test/fixtures/probes';
 import { render } from 'test/render';
 import { fillProbeForm, runTestAsViewer, UPDATED_VALUES } from 'test/utils';
 
-import { ROUTES } from 'types';
+import { FeatureName, ROUTES } from 'types';
 import { getRoute } from 'components/Routing.utils';
 import { TEMPLATE_PROBE } from 'page/NewProbe';
 
@@ -76,6 +77,11 @@ it('disables save button on invalid values', async () => {
 });
 
 it('saves new probe', async () => {
+  jest.replaceProperty(config, 'featureToggles', {
+    // @ts-expect-error
+    [FeatureName.BrowserChecks]: true,
+  });
+
   const probe = PRIVATE_PROBE;
   const { user } = await renderProbeEditor({ probe });
   await fillProbeForm(user);

--- a/src/components/ProbeEditor/ProbeEditor.tsx
+++ b/src/components/ProbeEditor/ProbeEditor.tsx
@@ -6,8 +6,9 @@ import { css } from '@emotion/css';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ProbeSchema } from 'schemas/forms/ProbeSchema';
 
-import { Probe, ROUTES } from 'types';
+import { FeatureName, Probe, ROUTES } from 'types';
 import { useCanEditProbe } from 'hooks/useCanEditProbe';
+import { FeatureFlag } from 'components/FeatureFlag';
 import { HorizontalCheckboxField } from 'components/HorizonalCheckboxField';
 import { LabelField } from 'components/LabelField';
 import { ProbeRegionsSelect } from 'components/ProbeRegionsSelect';
@@ -164,6 +165,19 @@ export const ProbeEditor = ({
                     disabled={!canEdit}
                     id="capabilities.disableScriptedChecks"
                   />
+                  <FeatureFlag name={FeatureName.BrowserChecks}>
+                    {({ isEnabled }) =>
+                      isEnabled ? (
+                        <HorizontalCheckboxField
+                          {...form.register('capabilities.disableBrowserChecks')}
+                          label="Disable browser checks"
+                          description="Prevent probe from running k6 based browser checks."
+                          disabled={!canEdit}
+                          id="capabilities.disableBrowserChecks"
+                        />
+                      ) : null
+                    }
+                  </FeatureFlag>
                 </div>
                 <div className={styles.buttonWrapper}>
                   {canEdit && (

--- a/src/page/NewProbe/NewProbe.test.tsx
+++ b/src/page/NewProbe/NewProbe.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { config } from '@grafana/runtime';
 import { screen, waitFor } from '@testing-library/react';
 import { ADD_PROBE_TOKEN_RESPONSE } from 'test/fixtures/probes';
 import { render } from 'test/render';
 import { fillProbeForm } from 'test/utils';
 
-import { ROUTES } from 'types';
+import { FeatureName, ROUTES } from 'types';
 import { getRoute } from 'components/Routing.utils';
 
 import { NewProbe } from './NewProbe';
@@ -19,6 +20,11 @@ const renderNewProbe = () => {
 };
 
 it(`creates a new probe, displays the modal and redirects on close`, async () => {
+  jest.replaceProperty(config, 'featureToggles', {
+    // @ts-expect-error
+    [FeatureName.BrowserChecks]: true,
+  });
+
   const { history, user } = renderNewProbe();
   await fillProbeForm(user);
 

--- a/src/page/NewProbe/NewProbe.tsx
+++ b/src/page/NewProbe/NewProbe.tsx
@@ -25,6 +25,7 @@ export const TEMPLATE_PROBE: Probe = {
   deprecated: false,
   capabilities: {
     disableScriptedChecks: false,
+    disableBrowserChecks: false,
   },
 };
 

--- a/src/schemas/forms/ProbeSchema.ts
+++ b/src/schemas/forms/ProbeSchema.ts
@@ -50,5 +50,6 @@ export const ProbeSchema: ZodType<Probe> = z.object({
   deprecated: z.boolean(),
   capabilities: z.object({
     disableScriptedChecks: z.boolean(),
+    disableBrowserChecks: z.boolean(),
   }),
 });

--- a/src/test/fixtures/probes.ts
+++ b/src/test/fixtures/probes.ts
@@ -19,6 +19,7 @@ export const PRIVATE_PROBE: Probe = {
   created: 1694212496.731247,
   capabilities: {
     disableScriptedChecks: false,
+    disableBrowserChecks: false,
   },
 } as const satisfies Probe;
 
@@ -38,6 +39,7 @@ export const PUBLIC_PROBE: Probe = {
   created: 1694212496.731247,
   capabilities: {
     disableScriptedChecks: false,
+    disableBrowserChecks: false,
   },
 } as const satisfies Probe;
 
@@ -55,6 +57,7 @@ export const SCRIPTED_DISABLED_PROBE: Probe = {
   ...PRIVATE_PROBE,
   capabilities: {
     disableScriptedChecks: true,
+    disableBrowserChecks: true,
   },
 };
 
@@ -74,6 +77,7 @@ export const UNSELECTED_PRIVATE_PROBE: Probe = {
   created: 1694212496.731247,
   capabilities: {
     disableScriptedChecks: false,
+    disableBrowserChecks: false,
   },
 } as const satisfies Probe;
 

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -21,6 +21,7 @@ export const UPDATED_VALUES: Pick<Probe, 'name' | 'latitude' | 'longitude' | 're
   labels: [{ name: 'UPDATED', value: 'PROBE' }],
   capabilities: {
     disableScriptedChecks: true,
+    disableBrowserChecks: true,
   },
 };
 
@@ -61,6 +62,9 @@ export async function fillProbeForm(user: UserEvent) {
 
   const disableScriptedChecks = await screen.findByLabelText('Disable scripted checks', { exact: false });
   await user.click(disableScriptedChecks);
+
+  const disableBrowserChecks = await screen.findByLabelText('Disable browser checks', { exact: false });
+  await user.click(disableBrowserChecks);
 }
 
 export function runTestAsSMViewer() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,7 @@ export interface Probe extends ExistingObject {
 
 interface ProbeCapabilities {
   disableScriptedChecks: boolean;
+  disableBrowserChecks: boolean;
 }
 
 export enum ResponseMatchType {


### PR DESCRIPTION
This PR addresses the UI changes needed in order to limit probe locations for browser checks. In particular:

- Adds disable browser checks checkbox in probe creation form (default false, and under the browser checks FF)
- Restricts available probes for browser checks based on capabilities

**Custom probe creation form**
![image](https://github.com/user-attachments/assets/bea4c2c7-c6ce-4297-8b00-c3b4f4dafd26)

**Only Oregon and Paris public probes are enabled for Browser Checks:**
![image](https://github.com/user-attachments/assets/14efb89e-74ee-45e9-98ae-94ec838607b2)
![image](https://github.com/user-attachments/assets/141d404c-342a-460f-918d-3edd903476f3)

![image](https://github.com/user-attachments/assets/4bb8a458-803d-4918-be68-44ea134eb478)


Part of https://github.com/grafana/synthetic-monitoring/issues/116