### PR TITLE
feat: add validation to make sure browser type is chromium

### DIFF
--- a/src/page/NewCheck/__tests__/BrowserChecks/Scripted/1-script.ui.test.tsx
+++ b/src/page/NewCheck/__tests__/BrowserChecks/Scripted/1-script.ui.test.tsx
@@ -5,6 +5,19 @@ import { renderNewForm, submitForm } from 'page/__testHelpers__/checkForm';
 
 const checkType = CheckType.Browser;
 
+const browserImport = `import { browser } from 'k6/browser';`;
+const exportOptions = `export const options = { };`;
+const exportCorrectOptions = `export const options = {scenarios: {
+    ui: {
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};`;
+
 describe(`BrowserCheck - 1 (Script) UI`, () => {
   describe('will validate the script', () => {
     it(`will display an error when the script is missing`, async () => {
@@ -21,7 +34,7 @@ describe(`BrowserCheck - 1 (Script) UI`, () => {
       const { user } = await renderNewForm(checkType);
       const scriptTextAreaPreSubmit = screen.getByTestId(`code-editor`);
       await user.clear(scriptTextAreaPreSubmit);
-      await user.type(scriptTextAreaPreSubmit, "import { check } from 'k6'; export const options = {}");
+      await user.type(scriptTextAreaPreSubmit, exportCorrectOptions);
 
       await submitForm(user);
       const err = await screen.findByText("Script must import { browser } from 'k6/browser'");
@@ -32,10 +45,21 @@ describe(`BrowserCheck - 1 (Script) UI`, () => {
       const { user } = await renderNewForm(checkType);
       const scriptTextAreaPreSubmit = screen.getByTestId(`code-editor`);
       await user.clear(scriptTextAreaPreSubmit);
-      await user.type(scriptTextAreaPreSubmit, "import { check } from 'k6';");
+      await user.type(scriptTextAreaPreSubmit, browserImport);
 
       await submitForm(user);
       const err = await screen.findByText('Script does not export any options.');
+      expect(err).toBeInTheDocument();
+    });
+
+    it(`will display an error when it does set the browser type to 'chromium'`, async () => {
+      const { user } = await renderNewForm(checkType);
+      const scriptTextAreaPreSubmit = screen.getByTestId(`code-editor`);
+      await user.clear(scriptTextAreaPreSubmit);
+      await user.type(scriptTextAreaPreSubmit, browserImport + exportOptions);
+
+      await submitForm(user);
+      const err = await screen.findByText('Script must set the type to chromium in the browser options.');
       expect(err).toBeInTheDocument();
     });
   });

--- a/src/schemas/forms/script/validation.ts
+++ b/src/schemas/forms/script/validation.ts
@@ -1,6 +1,6 @@
 import { RefinementCtx, ZodIssueCode } from 'zod';
 
-import { extractImportStatement, extractOptionsExport, parseScript } from './parser';
+import { checkForChromium, extractImportStatement, extractOptionsExport, parseScript } from './parser';
 
 const MAX_SCRIPT_IN_KB = 128;
 
@@ -33,6 +33,13 @@ export function validateBrowserScript(script: string, context: RefinementCtx) {
     return context.addIssue({
       code: ZodIssueCode.custom,
       message: 'Script does not export any options.',
+    });
+  }
+
+  if (!checkForChromium(options)) {
+    return context.addIssue({
+      code: ZodIssueCode.custom,
+      message: 'Script must set the type to chromium in the browser options.',
     });
   }
 


### PR DESCRIPTION
After a review session with @roobre, she gave me a heads up that the browser script options must be configured to use `chromium`, otherwise it will fail.

In this PR I improve the validation to make sure that it is correctly set.

Part of https://github.com/grafana/synthetic-monitoring-app/issues/864

Examples:

- `type` property missing
![image](https://github.com/user-attachments/assets/8e204500-a0f3-460c-ae8f-0b62186dd406)

- `type` property set to firefox
![image](https://github.com/user-attachments/assets/e2ca71bd-d99a-4e7a-9486-d0be2894e05f)

- `type` property correctly set
![image](https://github.com/user-attachments/assets/0857ea83-19f3-49c7-b90e-69ecf8147f93)
