### PR TITLE
Browser checks dashboard - Iteration 3

### DIFF
--- a/src/scenes/BROWSER/WebVitals/WebVitalGauge.tsx
+++ b/src/scenes/BROWSER/WebVitals/WebVitalGauge.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, LinkButton, Tooltip, useStyles2 } from '@grafana/ui';
+import { useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { WebVitalName } from './types';
@@ -13,41 +13,15 @@ interface WebVitalGaugeProps {
   name: WebVitalName;
   longName: string;
   value: number;
-  description?: string;
-  exploreLink?: string;
 }
 
-export function WebVitalGauge({ value, name, longName, description, exploreLink }: WebVitalGaugeProps) {
+export function WebVitalGauge({ value, name, longName }: WebVitalGaugeProps) {
   const styles = useStyles2(getStyles);
-
   const valueConfig = getWebVitalValueConfig(name, value);
 
   return (
     <div className={styles.container}>
-      <div>
-        <div className={styles.fullNameContainer}>
-          <h3 className={styles.shortName}>{name}</h3>
-          {exploreLink ? (
-            <LinkButton
-              key="explore"
-              tooltip={'Explore'}
-              target="_blank"
-              icon="compass"
-              size="sm"
-              variant="secondary"
-              href={`/explore?left=${exploreLink}`}
-            ></LinkButton>
-          ) : null}
-        </div>
-        <div className={styles.nameWrapper}>
-          <span className={styles.fullName}>{longName}</span>
-          {description ? (
-            <Tooltip content={description}>
-              <Icon name="question-circle" size="sm" />
-            </Tooltip>
-          ) : null}
-        </div>
-      </div>
+      <span className={styles.fullName}>{longName}</span>
 
       <div>
         <WebVitalValue value={valueConfig} />
@@ -64,23 +38,9 @@ export function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       flexDirection: 'column',
       gap: `${theme.spacing(1.5)}`,
+      position: 'relative',
     }),
-    shortName: css({
-      color: `${theme.colors.text.primary}`,
-      fontWeight: '700',
-      marginBottom: '0',
-      textTransform: 'uppercase',
-    }),
-    fullNameContainer: css({
-      color: `${theme.colors.text.secondary}`,
-      display: 'flex',
-      justifyContent: 'space-between',
-    }),
-    nameWrapper: css({
-      display: 'flex',
-      alignItems: 'center',
-      gap: `${theme.spacing(1)}`,
-    }),
+
     fullName: css({
       color: `${theme.colors.text.secondary}`,
       fontSize: `${theme.typography.bodySmall.fontSize}`,

--- a/src/scenes/BROWSER/WebVitals/WebVitalGauge.tsx
+++ b/src/scenes/BROWSER/WebVitals/WebVitalGauge.tsx
@@ -26,14 +26,7 @@ export function WebVitalGauge({ value, name, longName, description, exploreLink 
     <div className={styles.container}>
       <div>
         <div className={styles.fullNameContainer}>
-          <div className={styles.nameWrapper}>
-            <h3 className={styles.shortName}>{name}</h3>
-            {description ? (
-              <Tooltip content={description}>
-                <Icon name="question-circle" size="lg" />
-              </Tooltip>
-            ) : null}
-          </div>
+          <h3 className={styles.shortName}>{name}</h3>
           {exploreLink ? (
             <LinkButton
               key="explore"
@@ -46,8 +39,14 @@ export function WebVitalGauge({ value, name, longName, description, exploreLink 
             ></LinkButton>
           ) : null}
         </div>
-
-        <span className={styles.fullName}>{longName}</span>
+        <div className={styles.nameWrapper}>
+          <span className={styles.fullName}>{longName}</span>
+          {description ? (
+            <Tooltip content={description}>
+              <Icon name="question-circle" size="sm" />
+            </Tooltip>
+          ) : null}
+        </div>
       </div>
 
       <div>
@@ -80,7 +79,7 @@ export function getStyles(theme: GrafanaTheme2) {
     nameWrapper: css({
       display: 'flex',
       alignItems: 'center',
-      gap: `${theme.spacing(2)}`,
+      gap: `${theme.spacing(1)}`,
     }),
     fullName: css({
       color: `${theme.colors.text.secondary}`,

--- a/src/scenes/BROWSER/WebVitals/WebVitalGauge.tsx
+++ b/src/scenes/BROWSER/WebVitals/WebVitalGauge.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
+import { Icon, LinkButton, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { WebVitalName } from './types';
@@ -14,9 +14,10 @@ interface WebVitalGaugeProps {
   longName: string;
   value: number;
   description?: string;
+  exploreLink?: string;
 }
 
-export function WebVitalGauge({ value, name, longName, description }: WebVitalGaugeProps) {
+export function WebVitalGauge({ value, name, longName, description, exploreLink }: WebVitalGaugeProps) {
   const styles = useStyles2(getStyles);
 
   const valueConfig = getWebVitalValueConfig(name, value);
@@ -25,11 +26,24 @@ export function WebVitalGauge({ value, name, longName, description }: WebVitalGa
     <div className={styles.container}>
       <div>
         <div className={styles.fullNameContainer}>
-          <h3 className={styles.shortName}>{name}</h3>
-          {description ? (
-            <Tooltip content={description}>
-              <Icon name="question-circle" size="lg" />
-            </Tooltip>
+          <div className={styles.nameWrapper}>
+            <h3 className={styles.shortName}>{name}</h3>
+            {description ? (
+              <Tooltip content={description}>
+                <Icon name="question-circle" size="lg" />
+              </Tooltip>
+            ) : null}
+          </div>
+          {exploreLink ? (
+            <LinkButton
+              key="explore"
+              tooltip={'Explore'}
+              target="_blank"
+              icon="compass"
+              size="sm"
+              variant="secondary"
+              href={`/explore?left=${exploreLink}`}
+            ></LinkButton>
           ) : null}
         </div>
 
@@ -62,6 +76,11 @@ export function getStyles(theme: GrafanaTheme2) {
       color: `${theme.colors.text.secondary}`,
       display: 'flex',
       justifyContent: 'space-between',
+    }),
+    nameWrapper: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: `${theme.spacing(2)}`,
     }),
     fullName: css({
       color: `${theme.colors.text.secondary}`,

--- a/src/scenes/BROWSER/WebVitals/cumulativeLayoutShift.ts
+++ b/src/scenes/BROWSER/WebVitals/cumulativeLayoutShift.ts
@@ -37,7 +37,7 @@ export function getCumulativeLayoutShift(metrics: DataSourceRef) {
               },
               fieldConfig: {
                 defaults: {
-                  unit: 'ms',
+                  unit: 'none',
                   custom: {
                     drawStyle: GraphDrawStyle.Line,
                     fillOpacity: 10,

--- a/src/scenes/BROWSER/WebVitals/webVitalGaugeScene.tsx
+++ b/src/scenes/BROWSER/WebVitals/webVitalGaugeScene.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { DataFrameView, GrafanaTheme2 } from '@grafana/data';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { useStyles2 } from '@grafana/ui';
+import { Menu, PanelChrome, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { WebVitalName } from './types';
@@ -51,13 +51,17 @@ function WebVitalGaugeRenderer({ model }: SceneComponentProps<WebVitalGaugeScene
 
   return (
     <div className={styles}>
-      <WebVitalGauge
-        value={value}
-        name={name as WebVitalName}
+      <PanelChrome
+        title={name.toUpperCase()}
         description={description}
-        longName={longName}
-        exploreLink={exploreLink}
-      />
+        menu={() => (
+          <Menu>
+            {exploreLink && <Menu.Item label="Explore" icon="compass" url={`/explore?left=${exploreLink}`} />}
+          </Menu>
+        )}
+      >
+        <WebVitalGauge value={value} name={name as WebVitalName} longName={longName} />
+      </PanelChrome>
     </div>
   );
 }
@@ -96,7 +100,5 @@ function setExploreLink(model: WebVitalGaugeScene) {
 
 const getStyles = (theme: GrafanaTheme2) =>
   css({
-    border: `1px solid ${theme.colors.border.weak}`,
-    padding: '.5rem',
     width: '100%',
   });

--- a/src/scenes/BROWSER/WebVitals/webVitalGaugeScene.tsx
+++ b/src/scenes/BROWSER/WebVitals/webVitalGaugeScene.tsx
@@ -14,7 +14,7 @@ interface WebVitalGaugeProps extends SceneObjectState {
   name: string;
   longName: string;
   description?: string;
-  exploreLink: string;
+  exploreLink?: string;
 }
 
 export class WebVitalGaugeScene extends SceneObjectBase<WebVitalGaugeProps> {

--- a/src/scenes/BROWSER/WebVitals/webVitalsTable.ts
+++ b/src/scenes/BROWSER/WebVitals/webVitalsTable.ts
@@ -144,6 +144,18 @@ export function getWebVitalsTable(metrics: DataSourceRef) {
                       },
                     ],
                   },
+                  {
+                    matcher: {
+                      id: 'byName',
+                      options: 'Trend #D',
+                    },
+                    properties: [
+                      {
+                        id: 'unit',
+                        value: 'none',
+                      },
+                    ],
+                  },
                 ],
               },
               options: {

--- a/src/scenes/ExplorablePanel.ts
+++ b/src/scenes/ExplorablePanel.ts
@@ -3,7 +3,7 @@ import { sceneGraph, VizPanel, VizPanelMenu, VizPanelState } from '@grafana/scen
 import { DataQuery } from '@grafana/schema';
 import appEvents from 'grafana/app/core/app_events';
 
-interface DataQueryExtended extends DataQuery {
+export interface DataQueryExtended extends DataQuery {
   expr: string;
 }
 


### PR DESCRIPTION
Improvements to the browser checks dashboard:


- Adds explore links in web vitals panels so users can see how the number is calculated by getting access to the query in Explore.
![image](https://github.com/user-attachments/assets/d22e3173-7ced-4495-9cb3-2d30b23241cd)

- Removes the unit in the CLS column of the web vitals by url table
![image](https://github.com/user-attachments/assets/b4c5d5b6-9ca6-4a20-82b3-d695040ce188)


Part of https://github.com/grafana/synthetic-monitoring-app/issues/866
Addresses https://github.com/grafana/synthetic-monitoring-app/pull/918#pullrequestreview-2297156876