### PR TITLE
feat: add private preview badge to browser checks

### DIFF
--- a/src/components/CheckEditor/FormComponents/CheckStatusBadge.tsx
+++ b/src/components/CheckEditor/FormComponents/CheckStatusBadge.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Badge, BadgeColor } from '@grafana/ui';
+
+import { CheckStatus } from 'types';
+
+export const CheckStatusBadge = ({ status }: { status: CheckStatus }) => {
+  const colorMap: Record<CheckStatus, { text: string; color: BadgeColor }> = {
+    [CheckStatus.EXPERIMENTAL]: {
+      color: 'orange',
+      text: `Experimental`,
+    },
+    [CheckStatus.PRIVATE_PREVIEW]: {
+        color: 'purple',
+        text: `Private preview`,
+      },
+    [CheckStatus.PUBLIC_PREVIEW]: {
+      color: 'blue',
+      text: `Public preview`,
+    },
+  };
+
+  const { text, color } = colorMap[status];
+
+  return <Badge text={text} color={color} />;
+};

--- a/src/components/CheckEditor/FormComponents/CheckStatusBadge.tsx
+++ b/src/components/CheckEditor/FormComponents/CheckStatusBadge.tsx
@@ -1,25 +1,77 @@
 import React from 'react';
-import { Badge, BadgeColor } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Badge, BadgeColor, Icon, Stack, TextLink, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 
 import { CheckStatus } from 'types';
+import { Toggletip } from 'components/Toggletip';
 
-export const CheckStatusBadge = ({ status }: { status: CheckStatus }) => {
-  const colorMap: Record<CheckStatus, { text: string; color: BadgeColor }> = {
-    [CheckStatus.EXPERIMENTAL]: {
-      color: 'orange',
-      text: `Experimental`,
-    },
-    [CheckStatus.PRIVATE_PREVIEW]: {
-        color: 'purple',
-        text: `Private preview`,
-      },
-    [CheckStatus.PUBLIC_PREVIEW]: {
-      color: 'blue',
-      text: `Public preview`,
-    },
-  };
+export interface CheckStatusBadgeProps {
+  value: CheckStatus;
+  description?: string;
+  docsLink?: string;
+}
 
-  const { text, color } = colorMap[status];
-
-  return <Badge text={text} color={color} />;
+const colorMap: Record<CheckStatus, { text: string; color: BadgeColor }> = {
+  [CheckStatus.EXPERIMENTAL]: {
+    color: 'orange',
+    text: `Experimental`,
+  },
+  [CheckStatus.PRIVATE_PREVIEW]: {
+    color: 'purple',
+    text: `Private preview`,
+  },
+  [CheckStatus.PUBLIC_PREVIEW]: {
+    color: 'green',
+    text: `Public preview`,
+  },
 };
+
+export const CheckStatusBadge = ({ description, docsLink, value }: CheckStatusBadgeProps) => {
+  const { text, color } = colorMap[value];
+  const styles = useStyles2((theme: GrafanaTheme2) => getStyles(theme, color));
+
+  return (
+    <Stack>
+      <Toggletip
+        content={
+          <div>
+            {description}
+            {docsLink && (
+              <>
+                {` `}
+                <TextLink href={docsLink} external variant="bodySmall">
+                  Read more
+                </TextLink>
+              </>
+            )}
+          </div>
+        }
+      >
+        <button className={styles.badgeLink} type="button">
+          <Badge
+            text={
+              <Stack gap={0.5} alignItems={`center`}>
+                <div>{text}</div>
+                <Icon name={`info-circle`} size="sm" />
+              </Stack>
+            }
+            color={color}
+          />
+        </button>
+      </Toggletip>
+    </Stack>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2, color: string) => ({
+  badgeLink: css({
+    background: `none`,
+    border: `none`,
+    padding: 0,
+
+    '&:hover': {
+      background: theme.colors.emphasize(theme.visualization.getColorByName(color), 0.15),
+    },
+  }),
+});

--- a/src/components/CheckEditor/FormComponents/ChooseCheckType.tsx
+++ b/src/components/CheckEditor/FormComponents/ChooseCheckType.tsx
@@ -8,7 +8,6 @@ import { useCheckTypeOptions } from 'hooks/useCheckTypeOptions';
 import { fallbackCheckMap } from 'components/constants';
 
 import { toFormValues } from '../checkFormTransformations';
-import { CheckStatusBadge } from './CheckStatusBadge';
 
 type RefType = Partial<Record<CheckType, CheckFormValues>>;
 
@@ -40,7 +39,7 @@ export const ChooseCheckType = ({ checkType, checkTypeGroup, disabled }: ChooseC
     return null;
   }
 
-  const { description, status } = groupOptions.find((option) => option.value === checkType) || {};
+  const { description } = groupOptions.find((option) => option.value === checkType) || {};
   const requestTypeOptions = groupOptions.map(({ label, value }) => {
     const standard = { label, value };
 
@@ -73,15 +72,11 @@ export const ChooseCheckType = ({ checkType, checkTypeGroup, disabled }: ChooseC
               {description}
             </Text>
           )}
-          {status ? <CheckStatusBadge status={status} /> : <BadgePlaceholder />}
         </Stack>
       </Stack>
     </div>
   );
 };
-
-// so the text doesn't bounce up and down when there area a mix of badges / no-badges
-const BadgePlaceholder = () => <div style={{ height: `22px` }} />;
 
 function updateCheckTypeValues(refValues: RefType, checkType: CheckType, currentCheckType: CheckType) {
   if (Object.hasOwnProperty.call(refValues, checkType)) {

--- a/src/components/CheckEditor/FormComponents/ChooseCheckType.tsx
+++ b/src/components/CheckEditor/FormComponents/ChooseCheckType.tsx
@@ -1,13 +1,14 @@
 import React, { useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
-import { Badge, BadgeColor, Label, RadioButtonGroup, Stack, Text } from '@grafana/ui';
+import { Label, RadioButtonGroup, Stack, Text } from '@grafana/ui';
 
-import { CheckFormValues, CheckStatus, CheckType, CheckTypeGroup } from 'types';
+import { CheckFormValues, CheckType, CheckTypeGroup } from 'types';
 import { useCheckTypeOptions } from 'hooks/useCheckTypeOptions';
 import { fallbackCheckMap } from 'components/constants';
 
 import { toFormValues } from '../checkFormTransformations';
+import { CheckStatusBadge } from './CheckStatusBadge';
 
 type RefType = Partial<Record<CheckType, CheckFormValues>>;
 
@@ -72,28 +73,11 @@ export const ChooseCheckType = ({ checkType, checkTypeGroup, disabled }: ChooseC
               {description}
             </Text>
           )}
-          {status ? <CheckBadge status={status} /> : <BadgePlaceholder />}
+          {status ? <CheckStatusBadge status={status} /> : <BadgePlaceholder />}
         </Stack>
       </Stack>
     </div>
   );
-};
-
-const colorMap: Record<CheckStatus, { text: string; color: BadgeColor }> = {
-  [CheckStatus.EXPERIMENTAL]: {
-    color: 'orange',
-    text: `Experimental`,
-  },
-  [CheckStatus.PUBLIC_PREVIEW]: {
-    color: 'blue',
-    text: `Public preview`,
-  },
-};
-
-const CheckBadge = ({ status }: { status: CheckStatus }) => {
-  const { text, color } = colorMap[status];
-
-  return <Badge text={text} color={color} />;
 };
 
 // so the text doesn't bounce up and down when there area a mix of badges / no-badges

--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, RefObject, useCallback, useState } from 'react';
 import { FormProvider, SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Alert, Button, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Stack, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { DataTestIds } from 'test/dataTestIds';
@@ -165,6 +165,22 @@ export const CheckForm = ({ check, disabled, pageTitle }: CheckFormProps) => {
               schema={schema}
             >
               {!isExistingCheck && <OverLimitAlert checkType={checkType} />}
+
+              {checkType === CheckType.Browser && (
+                <Alert severity="info" title="">
+                  <div>
+                    Browser checks are in private preview. During the preview they are free to use: test executions will
+                    not be billed.{' '}
+                    <TextLink
+                      href="https://grafana.com/docs/grafana-cloud/cost-management-and-billing/understand-your-invoice/synthetic-monitoring-invoice/"
+                      external={true}
+                    >
+                      Read more
+                    </TextLink>
+                  </div>
+                </Alert>
+              )}
+
               <FormLayout.Section label={checkTypeStep1Label[checkType]} fields={[`job`, ...defineCheckFields]}>
                 <Stack direction={`column`} gap={4}>
                   <CheckJobName />

--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -2,13 +2,14 @@ import React, { forwardRef, RefObject, useCallback, useState } from 'react';
 import { FormProvider, SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Alert, Button, Stack, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { DataTestIds } from 'test/dataTestIds';
 
 import { Check, CheckFormPageParams, CheckFormValues, CheckType } from 'types';
 import { AdHocCheckResponse } from 'datasource/responses.types';
+import { useCheckTypeOptions } from 'hooks/useCheckTypeOptions';
 import { useCanReadLogs, useCanWriteSM } from 'hooks/useDSPermission';
 import { useLimits } from 'hooks/useLimits';
 import { toFormValues } from 'components/CheckEditor/checkFormTransformations';
@@ -78,6 +79,7 @@ export const CheckForm = ({ check, disabled, pageTitle }: CheckFormProps) => {
   const initialCheck = check || fallbackCheckMap[checkType];
   const schema = useCheckFormSchema(check);
   const styles = useStyles2(getStyles);
+  const status = useCheckTypeOptions().find((option) => option.value === checkType)?.status;
   const isExistingCheck = Boolean(check);
   const { isLoading, isOverCheckLimit, isOverScriptedLimit, isReady } = useLimits();
   const overLimit =
@@ -166,22 +168,11 @@ export const CheckForm = ({ check, disabled, pageTitle }: CheckFormProps) => {
             >
               {!isExistingCheck && <OverLimitAlert checkType={checkType} />}
 
-              {checkType === CheckType.Browser && (
-                <Alert severity="info" title="">
-                  <div>
-                    Browser checks are in private preview. During the preview they are free to use: test executions will
-                    not be billed.{' '}
-                    <TextLink
-                      href="https://grafana.com/docs/grafana-cloud/cost-management-and-billing/understand-your-invoice/synthetic-monitoring-invoice/"
-                      external={true}
-                    >
-                      Read more
-                    </TextLink>
-                  </div>
-                </Alert>
-              )}
-
-              <FormLayout.Section label={checkTypeStep1Label[checkType]} fields={[`job`, ...defineCheckFields]}>
+              <FormLayout.Section
+                label={checkTypeStep1Label[checkType]}
+                fields={[`job`, ...defineCheckFields]}
+                status={status}
+              >
                 <Stack direction={`column`} gap={4}>
                   <CheckJobName />
                   <Stack direction={`column`} gap={2}>
@@ -190,17 +181,17 @@ export const CheckForm = ({ check, disabled, pageTitle }: CheckFormProps) => {
                   </Stack>
                 </Stack>
               </FormLayout.Section>
-              <FormLayout.Section label="Define uptime" fields={defineUptimeFields}>
+              <FormLayout.Section label="Define uptime" fields={defineUptimeFields} status={status}>
                 {UptimeComponent}
               </FormLayout.Section>
-              <FormLayout.Section label="Labels" fields={[`labels`, ...labelsFields]}>
+              <FormLayout.Section label="Labels" fields={[`labels`, ...labelsFields]} status={status}>
                 {labelsComponent}
                 <CheckLabels />
               </FormLayout.Section>
-              <FormLayout.Section label="Alerting" fields={[`alertSensitivity`]}>
+              <FormLayout.Section label="Alerting" fields={[`alertSensitivity`]} status={status}>
                 <CheckFormAlert />
               </FormLayout.Section>
-              <FormLayout.Section label="Execution" fields={[`probes`, `frequency`, ...probesFields]}>
+              <FormLayout.Section label="Execution" fields={[`probes`, `frequency`, ...probesFields]} status={status}>
                 <CheckProbeOptions checkType={checkType} />
                 {ProbesComponent}
                 <CheckUsage checkType={checkType} />

--- a/src/components/CheckForm/FormLayout/FormSection.tsx
+++ b/src/components/CheckForm/FormLayout/FormSection.tsx
@@ -1,10 +1,11 @@
 import React, { ReactNode } from 'react';
 import { FieldPath } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Box, Text, useStyles2 } from '@grafana/ui';
+import { Box, Stack, Text, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { CheckFormValues } from 'types';
+import { CheckStatusBadge, CheckStatusBadgeProps } from 'components/CheckEditor/FormComponents/CheckStatusBadge';
 
 import { FORM_MAX_WIDTH } from './FormLayout';
 
@@ -14,6 +15,7 @@ export type FormSectionProps = {
   label: string;
   fields?: Array<FieldPath<CheckFormValues>>;
   index: number;
+  status?: CheckStatusBadgeProps;
 };
 
 // return doesn't matter as we take over how this behaves internally
@@ -21,7 +23,7 @@ export const FormSection = (props: Omit<FormSectionProps, 'index' | 'activeSecti
   return props.children;
 };
 
-export const FormSectionInternal = ({ activeSection, children, label, index }: FormSectionProps) => {
+export const FormSectionInternal = ({ activeSection, children, label, index, status }: FormSectionProps) => {
   const styles = useStyles2(getStyles);
   const isActive = activeSection === index;
 
@@ -32,7 +34,12 @@ export const FormSectionInternal = ({ activeSection, children, label, index }: F
   return (
     <div data-fs-element={`Form section ${label}`}>
       <Box marginBottom={4}>
-        <Text element="h2" variant="h3">{`${index + 1}. ${label}`}</Text>
+        <Text element="h2" variant="h3">
+          <Stack gap={2}>
+            {`${index + 1}. ${label}`}
+            {status && <CheckStatusBadge {...status} />}
+          </Stack>
+        </Text>
       </Box>
       <div className={styles.sectionContent}>{children}</div>
     </div>

--- a/src/components/CheckUsage.tsx
+++ b/src/components/CheckUsage.tsx
@@ -31,7 +31,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
 });
 
-const hideTelemetryForTypes = [CheckType.Scripted, CheckType.MULTI_HTTP];
+const hideTelemetryForTypes = [CheckType.Scripted, CheckType.MULTI_HTTP, CheckType.Browser];
 
 export const CheckUsage = ({ checkType }: { checkType: CheckType }) => {
   const styles = useStyles2(getStyles);

--- a/src/components/ChooseCheckGroup.tsx
+++ b/src/components/ChooseCheckGroup.tsx
@@ -6,6 +6,7 @@ import { DataTestIds } from 'test/dataTestIds';
 
 import { CheckTypeGroup, ROUTES } from 'types';
 import { CheckTypeGroupOption, ProtocolOption, useCheckTypeGroupOptions } from 'hooks/useCheckTypeGroupOptions';
+import { useCheckTypeOptions } from 'hooks/useCheckTypeOptions';
 import { useLimits } from 'hooks/useLimits';
 import { PluginPage } from 'components/PluginPage';
 import { getRoute } from 'components/Routing.utils';
@@ -40,6 +41,10 @@ export const ChooseCheckGroup = () => {
 const CheckGroupCard = ({ group }: { group: CheckTypeGroupOption }) => {
   const styles = useStyles2(getStyles);
   const { isOverCheckLimit, isOverScriptedLimit } = useLimits();
+  const checkOptions = useCheckTypeOptions().filter((option) => option.group === group.value);
+  const checksWithStatus = checkOptions.filter((option) => option.status);
+  const shouldShowStatus = checksWithStatus.length === checkOptions.length;
+
   const disabled =
     isOverCheckLimit ||
     ([CheckTypeGroup.MultiStep, CheckTypeGroup.Scripted].includes(group.value) && isOverScriptedLimit);
@@ -60,14 +65,18 @@ const CheckGroupCard = ({ group }: { group: CheckTypeGroupOption }) => {
           </LinkButton>
         </div>
         <div className={styles.protocols}>
-          <Stack direction={`column`}>
+          <Stack direction={`column`} gap={2}>
             Supported protocols:
             <Stack justifyContent={`center`}>
               {group.protocols.map((protocol) => {
                 return <Protocol key={protocol.label} {...protocol} href={disabled ? undefined : protocol.href} />;
               })}
             </Stack>
-            <Stack justifyContent={`center`}>{group.status && <CheckStatusBadge status={group.status} />}</Stack>
+            {shouldShowStatus && checksWithStatus[0].status && (
+              <Stack justifyContent={`center`}>
+                <CheckStatusBadge {...checksWithStatus[0].status} />
+              </Stack>
+            )}
           </Stack>
         </div>
       </Stack>

--- a/src/components/ChooseCheckGroup.tsx
+++ b/src/components/ChooseCheckGroup.tsx
@@ -11,6 +11,7 @@ import { PluginPage } from 'components/PluginPage';
 import { getRoute } from 'components/Routing.utils';
 import { Toggletip } from 'components/Toggletip';
 
+import { CheckStatusBadge } from './CheckEditor/FormComponents/CheckStatusBadge';
 import { Card } from './Card';
 import { OverLimitAlert } from './OverLimitAlert';
 
@@ -66,6 +67,7 @@ const CheckGroupCard = ({ group }: { group: CheckTypeGroupOption }) => {
                 return <Protocol key={protocol.label} {...protocol} href={disabled ? undefined : protocol.href} />;
               })}
             </Stack>
+            <Stack justifyContent={`center`}>{group.status && <CheckStatusBadge status={group.status} />}</Stack>
           </Stack>
         </div>
       </Stack>

--- a/src/components/Toggletip/Toggletip.tsx
+++ b/src/components/Toggletip/Toggletip.tsx
@@ -25,5 +25,7 @@ const ContentWrapper = ({ children }: ContentWrapperProps) => {
 const getStyles = (theme: GrafanaTheme2) => ({
   toggletipCard: css({
     margin: theme.spacing(-1, 0, -1, 0),
+    paddingRight: theme.spacing(2),
+    lineHeight: theme.typography.body.lineHeight,
   }),
 });

--- a/src/hooks/useCheckTypeGroupOptions.tsx
+++ b/src/hooks/useCheckTypeGroupOptions.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useContext } from 'react';
 import { IconName } from '@grafana/data';
 
-import { CheckType, CheckTypeGroup, FeatureName, ROUTES } from 'types';
+import { CheckStatus, CheckType, CheckTypeGroup, FeatureName, ROUTES } from 'types';
 import { FeatureFlagContext } from 'contexts/FeatureFlagContext';
 import { getRoute } from 'components/Routing.utils';
 
@@ -20,6 +20,7 @@ export interface CheckTypeGroupOption {
   value: CheckTypeGroup;
   icon: IconName;
   protocols: ProtocolOption[];
+  status?: CheckStatus;
 }
 
 export const CHECK_TYPE_GROUP_OPTIONS: CheckTypeGroupOption[] = [
@@ -79,6 +80,7 @@ export const CHECK_TYPE_GROUP_OPTIONS: CheckTypeGroupOption[] = [
     description: `Monitor the availability and performance of a website using a real browser.`,
     value: CheckTypeGroup.Browser,
     icon: `globe`,
+    status: CheckStatus.PRIVATE_PREVIEW,
     protocols: [
       {
         label: `HTTP`,

--- a/src/hooks/useCheckTypeGroupOptions.tsx
+++ b/src/hooks/useCheckTypeGroupOptions.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useContext } from 'react';
 import { IconName } from '@grafana/data';
 
-import { CheckStatus, CheckType, CheckTypeGroup, FeatureName, ROUTES } from 'types';
+import { CheckType, CheckTypeGroup, FeatureName, ROUTES } from 'types';
 import { FeatureFlagContext } from 'contexts/FeatureFlagContext';
 import { getRoute } from 'components/Routing.utils';
 
@@ -20,7 +20,6 @@ export interface CheckTypeGroupOption {
   value: CheckTypeGroup;
   icon: IconName;
   protocols: ProtocolOption[];
-  status?: CheckStatus;
 }
 
 export const CHECK_TYPE_GROUP_OPTIONS: CheckTypeGroupOption[] = [
@@ -80,7 +79,6 @@ export const CHECK_TYPE_GROUP_OPTIONS: CheckTypeGroupOption[] = [
     description: `Monitor the availability and performance of a website using a real browser.`,
     value: CheckTypeGroup.Browser,
     icon: `globe`,
-    status: CheckStatus.PRIVATE_PREVIEW,
     protocols: [
       {
         label: `HTTP`,

--- a/src/hooks/useCheckTypeOptions.ts
+++ b/src/hooks/useCheckTypeOptions.ts
@@ -20,7 +20,10 @@ export const CHECK_TYPE_OPTIONS = [
     label: 'gRPC',
     value: CheckType.GRPC,
     description: 'Use the gRPC Health Checking Protocol to ensure a gRPC service is healthy.',
-    status: CheckStatus.EXPERIMENTAL,
+    status: {
+      value: CheckStatus.EXPERIMENTAL,
+      description: `gRPC checks are experimental. We're actively working on improving the experience and adding more features.`,
+    },
     featureToggle: FeatureName.GRPCChecks,
     group: CheckTypeGroup.ApiTest,
   },
@@ -52,7 +55,10 @@ export const CHECK_TYPE_OPTIONS = [
     label: 'Scripted',
     value: CheckType.Scripted,
     description: 'Write a k6 script to run custom checks.',
-    status: CheckStatus.PUBLIC_PREVIEW,
+    status: {
+      value: CheckStatus.PUBLIC_PREVIEW,
+      description: `Scripted checks are in public preview. We're actively working on improving the experience and adding more features.`,
+    },
     featureToggle: FeatureName.ScriptedChecks,
     group: CheckTypeGroup.Scripted,
   },
@@ -60,7 +66,12 @@ export const CHECK_TYPE_OPTIONS = [
     label: 'Browser',
     value: CheckType.Browser,
     description: 'Leverage k6 browser module to run checks in a browser.',
-    status: CheckStatus.EXPERIMENTAL,
+    status: {
+      value: CheckStatus.PRIVATE_PREVIEW,
+      description: `Browser checks are in private preview. During the preview they are free to use: test executions will not be billed.`,
+      docsLink:
+        'https://grafana.com/docs/grafana-cloud/cost-management-and-billing/understand-your-invoice/synthetic-monitoring-invoice/',
+    },
     featureToggle: FeatureName.BrowserChecks,
     group: CheckTypeGroup.Browser,
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -799,6 +799,7 @@ export type PrometheusAlertingRule = {
 
 export enum CheckStatus {
   EXPERIMENTAL = 'experimental',
+  PRIVATE_PREVIEW = 'private-preview',
   PUBLIC_PREVIEW = 'public-preview',
 }
 


### PR DESCRIPTION
- Adds a private preview badge to the browser checks option in the Check Creation view
![image](https://github.com/user-attachments/assets/d06b48c8-c7fd-42c1-b203-5d86c8a0edb2)

- Adds banner on the create/edit form for Browser Checks indicating usage is free for private preview.
![image](https://github.com/user-attachments/assets/9cf48841-562d-48b4-85ce-51be0afebf24)

Closes https://github.com/grafana/synthetic-monitoring/issues/146
