### PR TITLE
fix: set browser checks min frequency

### DIFF
--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -57,7 +57,7 @@ function getFrequencyBounds(checkType: CheckType) {
       maxFrequency: oneHour,
     };
   }
-  if (checkType === CheckType.MULTI_HTTP || checkType === CheckType.Scripted) {
+  if (checkType === CheckType.MULTI_HTTP || checkType === CheckType.Scripted || checkType === CheckType.Browser) {
     return {
       minFrequency: 60.0,
       maxFrequency: oneHour,


### PR DESCRIPTION
Setting the min frequency of Browser Checks to 60 seconds, same as Scripted and Multihttp checks.

![image](https://github.com/user-attachments/assets/81ae0516-23b5-4e16-87dd-c756cee00d60)
