### PR TITLE
feat: add script examples to browser checks

### DIFF
--- a/src/components/BrowserExamplesMenu/constants.ts
+++ b/src/components/BrowserExamplesMenu/constants.ts
@@ -1,0 +1,125 @@
+import { SelectableOptGroup } from '@grafana/ui';
+
+import COLOR_SCHEME_SCRIPT from './snippets/colorscheme.js?raw';
+import COOKIES_SCRIPT from './snippets/cookies.js?raw';
+import DISPATCH_SCRIPT from './snippets/dispatch.js?raw';
+import EVALUATE_SCRIPT from './snippets/evaluate.js?raw';
+import FILL_FORM_SCRIPT from './snippets/fillform.js?raw';
+import GET_ATTRIBUTE_SCRIPT from './snippets/getattribute.js?raw';
+import KEYBOARD_SCRIPT from './snippets/keyboard.js?raw';
+import MOUSE_SCRIPT from './snippets/mouse.js?raw';
+import QUERYING_SCRIPT from './snippets/querying.js?raw';
+import TOUCHSCREEN_SCRIPT from './snippets/touchscreen.js?raw';
+import WAIT_FOR_EVENT_SCRIPT from './snippets/waitForEvent.js?raw';
+import WAIT_FOR_FUNCTION_SCRIPT from './snippets/waitForFunction.js?raw';
+
+const COLOR_SCHEME = [
+  {
+    label: 'Color Scheme',
+    script: COLOR_SCHEME_SCRIPT,
+    value: 'colorscheme.js',
+  },
+];
+
+const COOKIES = [
+  {
+    label: 'Cookies Manipulation',
+    script: COOKIES_SCRIPT,
+    value: 'cookies.js',
+  },
+];
+
+const DISPATCH = [
+  {
+    label: 'Dispatch',
+    script: DISPATCH_SCRIPT,
+    value: 'dispatch.js',
+  },
+];
+
+const EVALUATE = [
+  {
+    label: 'Evaluate',
+    script: EVALUATE_SCRIPT,
+    value: 'evaluate.js',
+  },
+];
+
+const FILL_FORM = [
+  {
+    label: 'Fill Form',
+    script: FILL_FORM_SCRIPT,
+    value: 'fillform.js',
+  },
+];
+
+const GET_ATTRIBUTE = [
+  {
+    label: 'Get Attribute',
+    script: GET_ATTRIBUTE_SCRIPT,
+    value: 'getattribute.js',
+  },
+];
+
+const KEYBOARD = [
+  {
+    label: 'Keyboard Interaction',
+    script: KEYBOARD_SCRIPT,
+    value: 'keyboard.js',
+  },
+];
+
+const MOUSE = [
+  {
+    label: 'Mouse Interaction',
+    script: MOUSE_SCRIPT,
+    value: 'mouse.js',
+  },
+];
+
+const QUERYING = [
+  {
+    label: 'Querying',
+    script: QUERYING_SCRIPT,
+    value: 'querying.js',
+  },
+];
+
+const TOUCHSCREEN = [
+  {
+    label: 'Touchscreen Interaction',
+    script: TOUCHSCREEN_SCRIPT,
+    value: 'touchscreen.js',
+  },
+];
+
+const WAIT_FOR_EVENT = [
+  {
+    label: 'Wait for Event',
+    script: WAIT_FOR_EVENT_SCRIPT,
+    value: 'waitForEvent.js',
+  },
+];
+
+const WAIT_FOR_FUNCTION = [
+  {
+    label: 'Wait for Function',
+    script: WAIT_FOR_FUNCTION_SCRIPT,
+    value: 'waitForFunction.js',
+  },
+];
+
+export const BROWSER_EXAMPLE_CHOICES: SelectableOptGroup[] = [
+  { label: 'Fill Form', options: FILL_FORM },
+  { label: 'Cookies Manipulation', options: COOKIES },
+  { label: 'Dispatch', options: DISPATCH },
+  { label: 'Evaluate', options: EVALUATE },
+  { label: 'Get Attribute', options: GET_ATTRIBUTE },
+  { label: 'Keyboard Interaction', options: KEYBOARD },
+  { label: 'Mouse Interaction', options: MOUSE },
+  { label: 'Querying', options: QUERYING },
+  { label: 'Touchscreen Interaction', options: TOUCHSCREEN },
+  { label: 'Wait for Event', options: WAIT_FOR_EVENT },
+  { label: 'Wait for Function', options: WAIT_FOR_FUNCTION },
+  { label: 'Color Scheme', options: COLOR_SCHEME },
+];

--- a/src/components/BrowserExamplesMenu/snippets/colorscheme.js
+++ b/src/components/BrowserExamplesMenu/snippets/colorscheme.js
@@ -1,0 +1,45 @@
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const preferredColorScheme = 'dark';
+
+  const context = await browser.newContext({
+    // valid values are "light", "dark" or "no-preference"
+    colorScheme: preferredColorScheme,
+  });
+  const page = await context.newPage();
+
+  try {
+    await page.goto(
+      'https://googlechromelabs.github.io/dark-mode-toggle/demo/',
+      { waitUntil: 'load' },
+    )
+    const colorScheme = await page.evaluate(() => {
+      return {
+        isDarkColorScheme: window.matchMedia('(prefers-color-scheme: dark)').matches
+      };
+    });
+    check(colorScheme, {
+      'isDarkColorScheme': cs => cs.isDarkColorScheme
+    });
+  } finally {
+    await page.close();
+  }
+}

--- a/src/components/BrowserExamplesMenu/snippets/cookies.js
+++ b/src/components/BrowserExamplesMenu/snippets/cookies.js
@@ -1,0 +1,127 @@
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+  const context = page.context();
+
+  try {
+    // get cookies from the browser context
+    check((await context.cookies()).length, {
+      'initial number of cookies should be zero': (n) => n === 0,
+    });
+
+    // add some cookies to the browser context
+    const unixTimeSinceEpoch = Math.round(new Date() / 1000);
+    const day = 60 * 60 * 24;
+    const dayAfter = unixTimeSinceEpoch + day;
+    const dayBefore = unixTimeSinceEpoch - day;
+    await context.addCookies([
+      // this cookie expires at the end of the session
+      {
+        name: 'testcookie',
+        value: '1',
+        sameSite: 'Strict',
+        domain: '127.0.0.1',
+        path: '/',
+        httpOnly: true,
+        secure: true,
+      },
+      // this cookie expires in a day
+      {
+        name: 'testcookie2',
+        value: '2',
+        sameSite: 'Lax',
+        domain: '127.0.0.1',
+        path: '/',
+        expires: dayAfter,
+      },
+      // this cookie expires in the past, so it will be removed.
+      {
+        name: 'testcookie3',
+        value: '3',
+        sameSite: 'Lax',
+        domain: '127.0.0.1',
+        path: '/',
+        expires: dayBefore,
+      },
+    ]);
+    let cookies = await context.cookies();
+    check(cookies.length, {
+      'number of cookies should be 2': (n) => n === 2,
+    });
+    check(cookies[0], {
+      'cookie 1 name should be testcookie': (c) => c.name === 'testcookie',
+      'cookie 1 value should be 1': (c) => c.value === '1',
+      'cookie 1 should be session cookie': (c) => c.expires === -1,
+      'cookie 1 should have domain': (c) => c.domain === '127.0.0.1',
+      'cookie 1 should have path': (c) => c.path === '/',
+      'cookie 1 should have sameSite': (c) => c.sameSite == 'Strict',
+      'cookie 1 should be httpOnly': (c) => c.httpOnly === true,
+      'cookie 1 should be secure': (c) => c.secure === true,
+    });
+    check(cookies[1], {
+      'cookie 2 name should be testcookie2': (c) => c.name === 'testcookie2',
+      'cookie 2 value should be 2': (c) => c.value === '2',
+    });
+
+    // let's add more cookies to filter by urls.
+    await context.addCookies([
+      {
+        name: 'foo',
+        value: '42',
+        sameSite: 'Strict',
+        url: 'http://foo.com',
+      },
+      {
+        name: 'bar',
+        value: '43',
+        sameSite: 'Lax',
+        url: 'https://bar.com',
+      },
+      {
+        name: 'baz',
+        value: '44',
+        sameSite: 'Lax',
+        url: 'https://baz.com',
+      },
+    ]);
+    cookies = await context.cookies('http://foo.com', 'https://baz.com');
+    check(cookies.length, {
+      'number of filtered cookies should be 2': (n) => n === 2,
+    });
+    check(cookies[0], {
+      'the first filtered cookie name should be foo': (c) => c.name === 'foo',
+      'the first filtered cookie value should be 42': (c) => c.value === '42',
+    });
+    check(cookies[1], {
+      'the second filtered cookie name should be baz': (c) => c.name === 'baz',
+      'the second filtered cookie value should be 44': (c) => c.value === '44',
+    });
+
+    // clear cookies
+    await context.clearCookies();
+    cookies = await context.cookies();
+    check(cookies.length, {
+      'number of cookies should be zero': (n) => n === 0,
+    });
+  } finally {
+    await page.close();
+  }
+}

--- a/src/components/BrowserExamplesMenu/snippets/dispatch.js
+++ b/src/components/BrowserExamplesMenu/snippets/dispatch.js
@@ -1,0 +1,36 @@
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+            type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ["rate==1.0"]
+  }
+}
+
+export default async function() {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+
+    const contacts = page.locator('a[href="/contacts.php"]');
+    await contacts.dispatchEvent("click");
+
+    const h3 = page.locator("h3");
+    const ok = await h3.textContent() == "Contact us";
+    check(ok, { "header": ok });
+  } finally {
+    await page.close();
+  }
+}

--- a/src/components/BrowserExamplesMenu/snippets/evaluate.js
+++ b/src/components/BrowserExamplesMenu/snippets/evaluate.js
@@ -1,0 +1,48 @@
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+export default async function () {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/', { waitUntil: 'load' });
+
+    // calling evaluate without arguments
+    let result = await page.evaluate(() => {
+      return Promise.resolve(5 * 42);
+    });
+    check(result, {
+      'result should be 210': (result) => result == 210,
+    });
+
+    // calling evaluate with arguments
+    result = await page.evaluate(
+      ([x, y]) => {
+        return Promise.resolve(x * y);
+      },
+      [5, 5]
+    );
+    check(result, {
+      'result should be 25': (result) => result == 25,
+    });
+  } finally {
+    await page.close();
+  }
+}

--- a/src/components/BrowserExamplesMenu/snippets/fillform.js
+++ b/src/components/BrowserExamplesMenu/snippets/fillform.js
@@ -1,0 +1,52 @@
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+export default async function () {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    // Goto front page, find login link and click it
+    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await Promise.all([page.waitForNavigation(), page.locator('a[href="/my_messages.php"]').click()]);
+
+    // Enter login credentials and login
+    await page.locator('input[name="login"]').type('admin');
+    await page.locator('input[name="password"]').type('123');
+
+    // We expect the form submission to trigger a navigation, so to prevent a
+    // race condition, setup a waiter concurrently while waiting for the click
+    // to resolve.
+    await Promise.all([page.waitForNavigation(), page.locator('input[type="submit"]').click()]);
+
+    const h2 = page.locator('h2');
+    const headerOK = (await h2.textContent()) == 'Welcome, admin!';
+    check(headerOK, { header: headerOK });
+
+    // Check whether we receive cookies from the logged site.
+    check(await context.cookies(), {
+      'session cookie is set': (cookies) => {
+        const sessionID = cookies.find((c) => c.name == 'sid');
+        return typeof sessionID !== 'undefined';
+      },
+    });
+  } finally {
+    await page.close();
+  }
+}

--- a/src/components/BrowserExamplesMenu/snippets/getattribute.js
+++ b/src/components/BrowserExamplesMenu/snippets/getattribute.js
@@ -1,0 +1,36 @@
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+export default async function () {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    await page.goto('https://googlechromelabs.github.io/dark-mode-toggle/demo/', {
+      waitUntil: 'load',
+    });
+    let el = await page.$('#dark-mode-toggle-3');
+    const mode = await el.getAttribute('mode');
+    check(mode, {
+      "GetAttribute('mode')": mode === 'light',
+    });
+  } finally {
+    await page.close();
+  }
+}

--- a/src/components/BrowserExamplesMenu/snippets/keyboard.js
+++ b/src/components/BrowserExamplesMenu/snippets/keyboard.js
@@ -1,0 +1,33 @@
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
+
+  const userInput = page.locator('input[name="login"]');
+  await userInput.click();
+  await page.keyboard.type('admin');
+
+  const pwdInput = page.locator('input[name="password"]');
+  await pwdInput.click();
+  await page.keyboard.type('123');
+
+  await page.keyboard.press('Enter'); // submit
+  await page.waitForNavigation();
+
+  await page.close();
+}

--- a/src/components/BrowserExamplesMenu/snippets/mouse.js
+++ b/src/components/BrowserExamplesMenu/snippets/mouse.js
@@ -1,0 +1,28 @@
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+
+  // Obtain ElementHandle for news link and navigate to it
+  // by clicking in the 'a' element's bounding box
+  const newsLinkBox = await page.$('a[href="/news.php"]').then((e) => e.boundingBox());
+
+  await Promise.all([page.waitForNavigation(), page.mouse.click(newsLinkBox.x + newsLinkBox.width / 2, newsLinkBox.y)]);
+
+  await page.close();
+}

--- a/src/components/BrowserExamplesMenu/snippets/querying.js
+++ b/src/components/BrowserExamplesMenu/snippets/querying.js
@@ -1,0 +1,37 @@
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+export default async function () {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    await page.goto('https://test.k6.io/');
+
+    const titleWithCSS = await page.$('header h1.title').then((e) => e.textContent());
+    const titleWithXPath = await page.$(`//header//h1[@class="title"]`).then((e) => e.textContent());
+
+    check(page, {
+      'Title with CSS selector': titleWithCSS == 'test.k6.io',
+      'Title with XPath selector': titleWithXPath == 'test.k6.io',
+    });
+  } finally {
+    await page.close();
+  }
+}

--- a/src/components/BrowserExamplesMenu/snippets/touchscreen.js
+++ b/src/components/BrowserExamplesMenu/snippets/touchscreen.js
@@ -1,0 +1,34 @@
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+
+  // Obtain ElementHandle for news link and navigate to it
+  // by tapping in the 'a' element's bounding box
+  const newsLinkBox = await page.$('a[href="/news.php"]').then((e) => e.boundingBox());
+
+  // Wait until the navigation is done before closing the page.
+  // Otherwise, there will be a race condition between the page closing
+  // and the navigation.
+  await Promise.all([
+    page.waitForNavigation(),
+    page.touchscreen.tap(newsLinkBox.x + newsLinkBox.width / 2, newsLinkBox.y),
+  ]);
+
+  await page.close();
+}

--- a/src/components/BrowserExamplesMenu/snippets/waitForEvent.js
+++ b/src/components/BrowserExamplesMenu/snippets/waitForEvent.js
@@ -1,0 +1,41 @@
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const context = await browser.newContext();
+
+  // We want to wait for two page creations before carrying on.
+  var counter = 0;
+  const promise = context.waitForEvent('page', {
+    predicate: (page) => {
+      if (++counter == 2) {
+        return true;
+      }
+      return false;
+    },
+  });
+
+  // Now we create two pages.
+  const page = await context.newPage();
+  const page2 = await context.newPage();
+
+  // We await for the page creation events to be processed and the predicate
+  // to pass.
+  await promise;
+  console.log('predicate passed');
+
+  await page.close();
+  await page2.close();
+}

--- a/src/components/BrowserExamplesMenu/snippets/waitForFunction.js
+++ b/src/components/BrowserExamplesMenu/snippets/waitForFunction.js
@@ -1,0 +1,41 @@
+import { check } from 'k6';
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+  thresholds: {
+    checks: ['rate==1.0'],
+  },
+};
+
+export default async function () {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    await page.evaluate(() => {
+      setTimeout(() => {
+        const el = document.createElement('h1');
+        el.innerHTML = 'Hello';
+        document.body.appendChild(el);
+      }, 1000);
+    });
+
+    const ok = await page.waitForFunction("document.querySelector('h1')", {
+      polling: 'mutation',
+      timeout: 2000,
+    });
+    check(ok, { 'waitForFunction successfully resolved': ok.innerHTML() == 'Hello' });
+  } finally {
+    await page.close();
+  }
+}

--- a/src/components/CheckEditor/FormComponents/BrowserCheckScript.tsx
+++ b/src/components/CheckEditor/FormComponents/BrowserCheckScript.tsx
@@ -5,7 +5,7 @@ import { FieldValidationMessage, Tab, TabContent, TabsBar } from '@grafana/ui';
 import { CheckFormValuesBrowser } from 'types';
 import { CodeEditor } from 'components/CodeEditor';
 import { CodeSnippet } from 'components/CodeSnippet';
-import { SCRIPT_EXAMPLES } from 'components/WelcomeTabs/constants';
+import { BROWSER_EXAMPLES } from 'components/WelcomeTabs/constants';
 
 enum ScriptEditorTabs {
   Script = 'script',
@@ -52,7 +52,7 @@ export const BrowserCheckScript = () => {
               {
                 value: 'Example scripts',
                 label: '',
-                groups: SCRIPT_EXAMPLES.map(({ label, script }) => ({
+                groups: BROWSER_EXAMPLES.map(({ label, script }) => ({
                   value: label,
                   label,
                   code: script,

--- a/src/components/WelcomeTabs/constants.ts
+++ b/src/components/WelcomeTabs/constants.ts
@@ -1,17 +1,24 @@
+import { SelectableOptGroup } from '@grafana/ui';
+
+import { BROWSER_EXAMPLE_CHOICES } from 'components/BrowserExamplesMenu/constants';
 import { ExampleScript, SCRIPT_EXAMPLE_CHOICES } from 'components/ScriptExamplesMenu/constants';
 
-export const SCRIPT_EXAMPLES = SCRIPT_EXAMPLE_CHOICES.reduce<ExampleScript[]>((acc, group) => {
-  group.options.forEach((option) => {
-    if (option.label) {
-      acc.push({
-        label: option.label,
-        script: option.script,
-        value: option.value,
-      });
-    }
-  });
-  return acc;
-}, []);
+const formatScriptExamples = (input: SelectableOptGroup[]) =>
+  input.reduce<ExampleScript[]>((acc, group) => {
+    group.options.forEach((option) => {
+      if (option.label) {
+        acc.push({
+          label: option.label,
+          script: option.script,
+          value: option.value,
+        });
+      }
+    });
+    return acc;
+  }, []);
+
+export const SCRIPT_EXAMPLES = formatScriptExamples(SCRIPT_EXAMPLE_CHOICES);
+export const BROWSER_EXAMPLES = formatScriptExamples(BROWSER_EXAMPLE_CHOICES);
 
 const DNS_BASIC = `data "grafana_synthetic_monitoring_probes" "main" {}
 resource "grafana_synthetic_monitoring_check" "dns" {


### PR DESCRIPTION
Adds script examples to browser checks, taken from https://github.com/grafana/xk6-browser/tree/main/examples

![image](https://github.com/user-attachments/assets/506d6d96-df37-4a0d-be64-2f3ae379e221)

Some of them were omitted as they include features we don't support yet, such as page screenshots. 