### PR TITLE
fix: remove dynamic and unused data-fs-element attributes

### DIFF
--- a/src/components/CheckEditor/FormComponents/HttpRequest.tsx
+++ b/src/components/CheckEditor/FormComponents/HttpRequest.tsx
@@ -149,7 +149,6 @@ const HttpRequestOptions = forwardRef<HandleErrorRef, HttpRequestOptionsProps>(
             disabled={disabled}
             label="Request header"
             name={requestHeadersName}
-            data-fs-element="Request headers"
           />
           {followRedirectsName && <HttpCheckFollowRedirects name={followRedirectsName} />}
           {ipVersionName && (

--- a/src/components/MultiHttp/MultiHttpCollapse.tsx
+++ b/src/components/MultiHttp/MultiHttpCollapse.tsx
@@ -35,7 +35,6 @@ export const MultiHttpCollapse = forwardRef<HTMLButtonElement, PropsWithChildren
             onToggle();
           }}
           ref={ref}
-          data-fs-element={`Collapse header ${label}`}
           type="button"
           aria-expanded={isOpen}
         >


### PR DESCRIPTION
## Problem

We've had reports that the way we are generating `data-fs-elements` is causing us to hit a limit in FullStory.

## Solution

Remove two of the main offenders in the check creation flow:

1. The request headers data-fs-element attribute
2. The MultiHttpCollapse data-fs-element attribute