### PR TITLE
Feat: extra validations for browser checks

### DIFF
--- a/src/page/NewCheck/__tests__/BrowserChecks/Scripted/1-script.ui.test.tsx
+++ b/src/page/NewCheck/__tests__/BrowserChecks/Scripted/1-script.ui.test.tsx
@@ -7,7 +7,8 @@ const checkType = CheckType.Browser;
 
 const browserImport = `import { browser } from 'k6/browser';`;
 const exportOptions = `export const options = { };`;
-const exportCorrectOptions = `export const options = {scenarios: {
+const exportCorrectOptions = `export const options = { 
+   scenarios: {
     ui: {
       options: {
         browser: {
@@ -60,6 +61,78 @@ describe(`BrowserCheck - 1 (Script) UI`, () => {
 
       await submitForm(user);
       const err = await screen.findByText('Script must set the type to chromium in the browser options.');
+      expect(err).toBeInTheDocument();
+    });
+
+    it(`will display an error when it defines a duration prop`, async () => {
+      const { user } = await renderNewForm(checkType);
+      const scriptTextAreaPreSubmit = screen.getByTestId(`code-editor`);
+      await user.clear(scriptTextAreaPreSubmit);
+
+      const invalidDurationOptions = `export const options = { 
+        scenarios: {
+          ui: {
+            duration: '1m',
+            options: {
+              browser: {
+                type: 'chromium',
+              },
+            },
+          },
+        },
+      };`;
+      await user.type(scriptTextAreaPreSubmit, browserImport + invalidDurationOptions);
+
+      await submitForm(user);
+      const err = await screen.findByText("Script can't define a duration value for this check");
+      expect(err).toBeInTheDocument();
+    });
+
+    it(`will display an error when it defines vus > 1`, async () => {
+      const { user } = await renderNewForm(checkType);
+      const scriptTextAreaPreSubmit = screen.getByTestId(`code-editor`);
+      await user.clear(scriptTextAreaPreSubmit);
+
+      const invalidVusOptions = `export const options = { 
+        scenarios: {
+          ui: {
+            vus: 2,
+            options: {
+              browser: {
+                type: 'chromium',
+              },
+            },
+          },
+        },
+      };`;
+      await user.type(scriptTextAreaPreSubmit, browserImport + invalidVusOptions);
+
+      await submitForm(user);
+      const err = await screen.findByText("Script can't define vus > 1 for this check");
+      expect(err).toBeInTheDocument();
+    });
+
+    it(`will display an error when it defines iterations > 1`, async () => {
+      const { user } = await renderNewForm(checkType);
+      const scriptTextAreaPreSubmit = screen.getByTestId(`code-editor`);
+      await user.clear(scriptTextAreaPreSubmit);
+
+      const invalidIterationsOptions = `export const options = { 
+        scenarios: {
+          ui: {
+            iterations: 2,
+            options: {
+              browser: {
+                type: 'chromium',
+              },
+            },
+          },
+        },
+      };`;
+      await user.type(scriptTextAreaPreSubmit, browserImport + invalidIterationsOptions);
+
+      await submitForm(user);
+      const err = await screen.findByText("Script can't define iterations > 1 for this check");
       expect(err).toBeInTheDocument();
     });
   });

--- a/src/schemas/forms/script/parser.ts
+++ b/src/schemas/forms/script/parser.ts
@@ -32,7 +32,7 @@ function getPropertyValueByPath(obj: ObjectExpression, path: string[]): any {
     } else if (property?.value.type === 'Literal') {
       current = property.value.value;
     } else {
-      return undefined;
+      return property?.value;
     }
   }
   return current;

--- a/src/schemas/forms/script/parser.ts
+++ b/src/schemas/forms/script/parser.ts
@@ -61,11 +61,21 @@ const optionExportMatcher: SimpleVisitors<{ options: ObjectExpression | null }> 
 };
 
 export function checkForChromium(objectExpression: ObjectExpression): boolean {
-  // Path to the property we're interested in
-  const path = ['scenarios', 'ui', 'options', 'browser', 'type'];
-  const value = getPropertyValueByPath(objectExpression, path);
+  const scenarios = getPropertyValueByPath(objectExpression, ['scenarios']);
+  if (!scenarios || scenarios.type !== 'ObjectExpression') {
+    return false;
+  }
 
-  return value === 'chromium';
+  for (const scenario of scenarios.properties) {
+    if (scenario.key.type === 'Identifier') {
+      const type = getPropertyValueByPath(scenario.value, ['options', 'browser', 'type']);
+      if (type === 'chromium') {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 interface ImportBrowserState {

--- a/src/schemas/forms/script/parser.ts
+++ b/src/schemas/forms/script/parser.ts
@@ -78,6 +78,29 @@ export function checkForChromium(objectExpression: ObjectExpression): boolean {
   return false;
 }
 
+export function hasInvalidProperties(objectExpression: ObjectExpression): boolean {
+  const scenarios = getPropertyValueByPath(objectExpression, ['scenarios']);
+  if (!scenarios || scenarios.type !== 'ObjectExpression') {
+    return false;
+  }
+
+  const invalidProps = ['duration', 'vus', 'iterations'];
+
+  for (const scenario of scenarios.properties) {
+    if (scenario.key.type === 'Identifier') {
+      const uiValue = scenario.value;
+      for (const prop of invalidProps) {
+        const propValue = getPropertyValueByPath(uiValue, [prop]);
+        if (propValue !== undefined) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
 interface ImportBrowserState {
   importStatement: Node | null;
 }

--- a/src/schemas/forms/script/parser.ts
+++ b/src/schemas/forms/script/parser.ts
@@ -60,7 +60,7 @@ const optionExportMatcher: SimpleVisitors<{ options: ObjectExpression | null }> 
   },
 };
 
-export function checkForChromium(objectExpression: ObjectExpression): boolean {
+export function getProperty(objectExpression: ObjectExpression, propPath: string[]) {
   const scenarios = getPropertyValueByPath(objectExpression, ['scenarios']);
   if (!scenarios || scenarios.type !== 'ObjectExpression') {
     return false;
@@ -68,37 +68,10 @@ export function checkForChromium(objectExpression: ObjectExpression): boolean {
 
   for (const scenario of scenarios.properties) {
     if (scenario.key.type === 'Identifier') {
-      const type = getPropertyValueByPath(scenario.value, ['options', 'browser', 'type']);
-      if (type === 'chromium') {
-        return true;
-      }
+      const propValue = getPropertyValueByPath(scenario.value, propPath);
+      return propValue;
     }
   }
-
-  return false;
-}
-
-export function hasInvalidProperties(objectExpression: ObjectExpression): boolean {
-  const scenarios = getPropertyValueByPath(objectExpression, ['scenarios']);
-  if (!scenarios || scenarios.type !== 'ObjectExpression') {
-    return false;
-  }
-
-  const invalidProps = ['duration', 'vus', 'iterations'];
-
-  for (const scenario of scenarios.properties) {
-    if (scenario.key.type === 'Identifier') {
-      const uiValue = scenario.value;
-      for (const prop of invalidProps) {
-        const propValue = getPropertyValueByPath(uiValue, [prop]);
-        if (propValue !== undefined) {
-          return true;
-        }
-      }
-    }
-  }
-
-  return false;
 }
 
 interface ImportBrowserState {

--- a/src/schemas/forms/script/validation.ts
+++ b/src/schemas/forms/script/validation.ts
@@ -53,7 +53,7 @@ export function validateBrowserScript(script: string, context: RefinementCtx) {
   }
 
   const vus = getProperty(options, ['vus']);
-  const hasInvaludVus = vus !== undefined && vus > 1;
+  const hasInvaludVus = vus !== undefined && vus !== 1;
   if (hasInvaludVus) {
     return context.addIssue({
       code: ZodIssueCode.custom,
@@ -62,7 +62,7 @@ export function validateBrowserScript(script: string, context: RefinementCtx) {
   }
 
   const iterations = getProperty(options, ['iterations']);
-  const hasInvalidIterations = iterations !== undefined && iterations > 1;
+  const hasInvalidIterations = iterations !== undefined && iterations !== 1;
   if (hasInvalidIterations) {
     return context.addIssue({
       code: ZodIssueCode.custom,

--- a/src/schemas/forms/script/validation.ts
+++ b/src/schemas/forms/script/validation.ts
@@ -1,6 +1,12 @@
 import { RefinementCtx, ZodIssueCode } from 'zod';
 
-import { checkForChromium, extractImportStatement, extractOptionsExport, parseScript } from './parser';
+import {
+  checkForChromium,
+  extractImportStatement,
+  extractOptionsExport,
+  hasInvalidProperties,
+  parseScript,
+} from './parser';
 
 const MAX_SCRIPT_IN_KB = 128;
 
@@ -40,6 +46,13 @@ export function validateBrowserScript(script: string, context: RefinementCtx) {
     return context.addIssue({
       code: ZodIssueCode.custom,
       message: 'Script must set the type to chromium in the browser options.',
+    });
+  }
+
+  if (hasInvalidProperties(options)) {
+    return context.addIssue({
+      code: ZodIssueCode.custom,
+      message: "Script can't define vus, duration or iteration values for this check",
     });
   }
 


### PR DESCRIPTION
To prevent execution errors, we're adding some extra validations, in particular, these properties are not allowed in the `options` object:
- `duration`
- `vus` > 1
- `iterations` > 1

![image](https://github.com/user-attachments/assets/67cbac4c-435b-4dc1-aec6-4fdce99eff40)
![image](https://github.com/user-attachments/assets/4c608ab4-0435-4b02-84ad-03b6cc0500d9)
![image](https://github.com/user-attachments/assets/3e1bfd3c-812e-4169-9a8d-49d78665dfde)
