### PR TITLE
feat: set default timeout for browser checks to 1 min

### DIFF
--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -321,7 +321,7 @@ export const FALLBACK_CHECK_SCRIPTED: ScriptedCheck = {
 export const FALLBACK_CHECK_BROWSER: BrowserCheck = {
   ...FALLBACK_CHECK_BASE,
   frequency: FIVE_MINUTES_IN_MS,
-  timeout: 15000,
+  timeout: 60000,
   settings: {
     browser: {
       script: EXAMPLE_SCRIPT_BROWSER,

--- a/src/page/NewCheck/__tests__/BrowserChecks/Scripted/2-defineUptime.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/BrowserChecks/Scripted/2-defineUptime.payload.test.tsx
@@ -9,13 +9,13 @@ const checkType = CheckType.Browser;
 
 describe(`BrowserCheck - Section 2 (Define uptime) payload`, () => {
   it(`has the correct default values submitted`, async () => {
-    const FIFTEEN_SECONDS_IN_MS = 15 * 1000;
+    const SIXTY_SECONDS_IN_MS = 60 * 1000;
     const { read, user } = await renderNewForm(checkType);
     await fillMandatoryFields({ user, checkType });
     await submitForm(user);
     const { body } = await read();
 
-    expect(body.timeout).toBe(FIFTEEN_SECONDS_IN_MS);
+    expect(body.timeout).toBe(SIXTY_SECONDS_IN_MS);
   });
 
   it(`can set the timeout`, async () => {
@@ -25,13 +25,13 @@ describe(`BrowserCheck - Section 2 (Define uptime) payload`, () => {
 
     const minutesInput = screen.getByLabelText('timeout minutes input');
     const secondsInput = screen.getByLabelText('timeout seconds input');
-    await user.type(minutesInput, '1');
+    await user.clear(minutesInput);
     await user.clear(secondsInput);
+    await user.type(secondsInput, '15');
 
     await submitForm(user);
 
     const { body } = await read();
-
-    expect(body.timeout).toBe(60000);
+    expect(body.timeout).toBe(15000);
   });
 });


### PR DESCRIPTION
Sets default browser checks timeout to 1 min.

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/19d43ec9-0d5b-40ff-9574-1d78d6f368fb">

Closes https://github.com/grafana/synthetic-monitoring-app/issues/943

