### PR TITLE
Chore: Remove references to `topnav`

### DIFF
--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef, RefObject, useCallback, useState } from 'react';
 import { FormProvider, SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import { GrafanaTheme2 } from '@grafana/data';
+import { PluginPage } from '@grafana/runtime';
 import { Alert, Button, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -31,7 +32,6 @@ import { CheckUsage } from 'components/CheckUsage';
 import { fallbackCheckMap } from 'components/constants';
 import { LabelField } from 'components/LabelField';
 import { OverLimitAlert } from 'components/OverLimitAlert';
-import { PluginPage } from 'components/PluginPage';
 
 import { CheckFormContextProvider, useCheckFormContext } from './CheckFormContext/CheckFormContext';
 import { BrowserCheckLayout } from './FormLayouts/CheckBrowserLayout';

--- a/src/components/ChooseCheckGroup.tsx
+++ b/src/components/ChooseCheckGroup.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
+import { PluginPage } from '@grafana/runtime';
 import { Badge, Icon, LinkButton, Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { DataTestIds } from 'test/dataTestIds';
@@ -8,7 +9,6 @@ import { CheckTypeGroup, ROUTES } from 'types';
 import { CheckTypeGroupOption, ProtocolOption, useCheckTypeGroupOptions } from 'hooks/useCheckTypeGroupOptions';
 import { useCheckTypeOptions } from 'hooks/useCheckTypeOptions';
 import { useLimits } from 'hooks/useLimits';
-import { PluginPage } from 'components/PluginPage';
 import { getRoute } from 'components/Routing.utils';
 import { Toggletip } from 'components/Toggletip';
 

--- a/src/components/PluginPage.tsx
+++ b/src/components/PluginPage.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import { config, PluginPage as RealPluginPage, PluginPageProps } from '@grafana/runtime';
-
-export const PluginPage = RealPluginPage && config.featureToggles.topnav ? RealPluginPage : PluginPageFallback;
-
-function PluginPageFallback(props: PluginPageProps) {
-  return <div>{props.children}</div>;
-}

--- a/src/components/Routing.tsx
+++ b/src/components/Routing.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
-import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { AppRootProps } from '@grafana/data';
-import { config } from '@grafana/runtime';
 
 import { ROUTES } from 'types';
 import { useMeta } from 'hooks/useMeta';
@@ -12,7 +11,6 @@ import { AlertingWelcomePage } from 'page/AlertingWelcomePage';
 import { CheckRouter } from 'page/CheckRouter';
 import { ChecksWelcomePage } from 'page/ChecksWelcomePage';
 import { ConfigPage } from 'page/ConfigPage';
-import { getNavModel } from 'page/pageDefinitions';
 import { ProbeRouter } from 'page/ProbeRouter';
 import { ProbesWelcomePage } from 'page/ProbesWelcomePage';
 import { SceneHomepage } from 'page/SceneHomepage';
@@ -25,16 +23,6 @@ import { SceneRedirecter } from './SceneRedirecter';
 export const InitialisedRouter = ({ onNavChanged }: Pick<AppRootProps, 'onNavChanged'>) => {
   const queryParams = useQuery();
   const navigate = useNavigation();
-  const location = useLocation();
-  const meta = useMeta();
-  const logo = meta.info.logos.large;
-
-  useEffect(() => {
-    const navModel = getNavModel(logo, location.pathname);
-    if (!config.featureToggles.topnav) {
-      onNavChanged(navModel);
-    }
-  }, [logo, onNavChanged, location.pathname]);
 
   const page = queryParams.get('page');
 

--- a/src/contexts/SMDatasourceContext.tsx
+++ b/src/contexts/SMDatasourceContext.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, PropsWithChildren, useContext } from 'react';
+import { PluginPage } from '@grafana/runtime';
 
 import { SMDataSource } from 'datasource/DataSource';
 import { useGetSMDatasource } from 'data/useSMSetup';
 import { CenteredSpinner } from 'components/CenteredSpinner';
-import { PluginPage } from 'components/PluginPage';
 import { UninitialisedRouter } from 'components/Routing';
 
 type SMDatasourceContextValue = {

--- a/src/page/AlertingPage.tsx
+++ b/src/page/AlertingPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
+import { PluginPage } from '@grafana/runtime';
 import { Alert, Button, Modal, Spinner, Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
@@ -8,7 +9,6 @@ import { useAlerts } from 'hooks/useAlerts';
 import { useCanReadMetrics, useDSPermission } from 'hooks/useDSPermission';
 import { transformAlertFormValues } from 'components/alertingTransformations';
 import { AlertRuleForm } from 'components/AlertRuleForm';
-import { PluginPage } from 'components/PluginPage';
 
 type SplitAlertRules = {
   recordingRules: AlertRule[];

--- a/src/page/ConfigPage/ConfigPage.tsx
+++ b/src/page/ConfigPage/ConfigPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
+import { PluginPage } from '@grafana/runtime';
 import { Container, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
@@ -7,7 +8,6 @@ import { useMeta } from 'hooks/useMeta';
 import { BackendAddress } from 'components/BackendAddress';
 import { ConfigActions } from 'components/ConfigActions';
 import { LinkedDatasourceView } from 'components/LinkedDatasourceView';
-import { PluginPage } from 'components/PluginPage';
 import { ProgrammaticManagement } from 'components/ProgrammaticManagement';
 
 export function ConfigPage({ initialized }: { initialized?: boolean }) {

--- a/src/page/EditProbe/EditProbe.tsx
+++ b/src/page/EditProbe/EditProbe.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { PluginPage } from '@grafana/runtime';
 import { Button, ConfirmModal } from '@grafana/ui';
 
 import { type Probe, type ProbePageParams, ROUTES } from 'types';
 import { useDeleteProbe, useSuspenseProbe, useUpdateProbe } from 'data/useProbes';
 import { useCanEditProbe } from 'hooks/useCanEditProbe';
 import { useNavigation } from 'hooks/useNavigation';
-import { PluginPage } from 'components/PluginPage';
 import { ProbeEditor } from 'components/ProbeEditor';
 import { ProbeStatus } from 'components/ProbeStatus';
 import { ProbeTokenModal } from 'components/ProbeTokenModal';

--- a/src/page/NewProbe/NewProbe.tsx
+++ b/src/page/NewProbe/NewProbe.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import { PluginPage } from '@grafana/runtime';
 import { Alert, useTheme2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
@@ -8,7 +9,6 @@ import { useCreateProbe } from 'data/useProbes';
 import { useNavigation } from 'hooks/useNavigation';
 import { BackendAddress } from 'components/BackendAddress';
 import { DocsLink } from 'components/DocsLink';
-import { PluginPage } from 'components/PluginPage';
 import { ProbeEditor } from 'components/ProbeEditor';
 import { ProbeTokenModal } from 'components/ProbeTokenModal';
 

--- a/src/page/Probes/Probes.tsx
+++ b/src/page/Probes/Probes.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PluginPage } from '@grafana/runtime';
 import { LinkButton, useTheme2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { DataTestIds } from 'test/dataTestIds';
@@ -8,7 +9,6 @@ import { useProbes } from 'data/useProbes';
 import { useCanWriteSM } from 'hooks/useDSPermission';
 import { CenteredSpinner } from 'components/CenteredSpinner';
 import { DocsLink } from 'components/DocsLink';
-import { PluginPage } from 'components/PluginPage';
 import { ProbeList } from 'components/ProbeList';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
 import { getRoute } from 'components/Routing.utils';

--- a/src/page/SubsectionWelcomePage.tsx
+++ b/src/page/SubsectionWelcomePage.tsx
@@ -1,11 +1,11 @@
 import React, { PropsWithChildren } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
+import { PluginPage } from '@grafana/runtime';
 import { Stack, Text, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { ROUTES } from 'types';
 import { Card } from 'components/Card';
-import { PluginPage } from 'components/PluginPage';
 
 import { AppInitializer } from './AppInitializer';
 

--- a/src/page/UnprovisionedSetup.tsx
+++ b/src/page/UnprovisionedSetup.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
+import { PluginPage } from '@grafana/runtime';
 import { Alert, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
-
-import { PluginPage } from 'components/PluginPage';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   container: css`

--- a/src/page/WelcomePage.tsx
+++ b/src/page/WelcomePage.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
+import { PluginPage } from '@grafana/runtime';
 import { Stack, Text, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { useMeta } from 'hooks/useMeta';
-import { PluginPage } from 'components/PluginPage';
 import { WelcomeTabs } from 'components/WelcomeTabs/WelcomeTabs';
 
 import { AppInitializer } from './AppInitializer';

--- a/src/test/mocks/@grafana/runtime.tsx
+++ b/src/test/mocks/@grafana/runtime.tsx
@@ -20,7 +20,6 @@ jest.mock('@grafana/runtime', () => {
       },
       featureToggles: {
         ...actual.config.featureToggles,
-        topnav: true,
       },
       bootData: {
         user: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:

- remove references to `topnav`
  - `topnav` has been default enabled since v9.5
  - we intend to remove the toggle soon™️ 
  - removes the `PluginPage` wrapper in favour of using `PluginPage` directly from `@grafana/runtime`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
