### PR TITLE
chore: update fillform example to use async check

### DIFF
--- a/src/components/BrowserExamplesMenu/snippets/fillform.js
+++ b/src/components/BrowserExamplesMenu/snippets/fillform.js
@@ -36,8 +36,8 @@ export default async function () {
     await Promise.all([page.waitForNavigation(), page.locator('input[type="submit"]').click()]);
 
     await check(page.locator('h2'), {
-      header: async (lo) => {
-        return (await lo.textContent()) == 'Welcome, admin!';
+      header: async (element) => {
+        return (await element.textContent()) == 'Welcome, admin!';
       },
     });
 

--- a/src/components/BrowserExamplesMenu/snippets/fillform.js
+++ b/src/components/BrowserExamplesMenu/snippets/fillform.js
@@ -1,5 +1,5 @@
-import { check } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {
@@ -35,15 +35,17 @@ export default async function () {
     // to resolve.
     await Promise.all([page.waitForNavigation(), page.locator('input[type="submit"]').click()]);
 
-    const h2 = page.locator('h2');
-    const headerOK = (await h2.textContent()) == 'Welcome, admin!';
-    check(headerOK, { header: headerOK });
+    await check(page.locator('h2'), {
+      header: async (lo) => {
+        return (await lo.textContent()) == 'Welcome, admin!';
+      },
+    });
 
     // Check whether we receive cookies from the logged site.
-    check(await context.cookies(), {
-      'session cookie is set': (cookies) => {
-        const sessionID = cookies.find((c) => c.name == 'sid');
-        return typeof sessionID !== 'undefined';
+    await check(context, {
+      'session cookie is set': async (ctx) => {
+        const cookies = await ctx.cookies();
+        return cookies.find((c) => c.name == 'sid') !== undefined;
       },
     });
   } finally {


### PR DESCRIPTION
The browser squad now recommends using the async `check` polyfill in all code examples and has updated the `fillform` example in https://github.com/grafana/xk6-browser/tree/main/examples

In order to be consistent, the `fillform` example for synthetics browser checks has been updated as well.