### PR TITLE
Fix scripts encoding error

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "ip-address": "^7.1.0",
     "is-base64": "^1.1.0",
+    "js-base64": "^3.7.7",
     "lodash": "4.17.21",
     "ol": "8.2.0",
     "prismjs": "1.29.0",

--- a/src/components/CheckEditor/transformations/toFormValues.browser.ts
+++ b/src/components/CheckEditor/transformations/toFormValues.browser.ts
@@ -1,3 +1,5 @@
+import { decode } from 'js-base64';
+
 import { BrowserCheck, CheckFormValuesBrowser, CheckType } from 'types';
 import { getBaseFormValuesFromCheck } from 'components/CheckEditor/transformations/toFormValues.utils';
 
@@ -9,7 +11,7 @@ export function getBrowserCheckFormValues(check: BrowserCheck): CheckFormValuesB
     checkType: CheckType.Browser,
     settings: {
       browser: {
-        script: atob(check.settings?.browser?.script),
+        script: decode(check.settings?.browser?.script),
       },
     },
   };

--- a/src/components/CheckEditor/transformations/toFormValues.scripted.ts
+++ b/src/components/CheckEditor/transformations/toFormValues.scripted.ts
@@ -1,3 +1,5 @@
+import { decode } from 'js-base64';
+
 import { CheckFormValuesScripted, CheckType, ScriptedCheck } from 'types';
 import { getBaseFormValuesFromCheck } from 'components/CheckEditor/transformations/toFormValues.utils';
 
@@ -9,7 +11,7 @@ export function getScriptedCheckFormValues(check: ScriptedCheck): CheckFormValue
     checkType: CheckType.Scripted,
     settings: {
       scripted: {
-        script: atob(check.settings?.scripted?.script),
+        script: decode(check.settings?.scripted?.script),
       },
     },
   };

--- a/src/components/CheckEditor/transformations/toPayload.browser.ts
+++ b/src/components/CheckEditor/transformations/toPayload.browser.ts
@@ -1,3 +1,5 @@
+import { encode } from 'js-base64';
+
 import { BrowserCheck, CheckFormValuesBrowser } from 'types';
 import { getBasePayloadValuesFromForm } from 'components/CheckEditor/transformations/toPayload.utils';
 
@@ -8,7 +10,7 @@ export function getBrowserPayload(formValues: CheckFormValuesBrowser): BrowserCh
     ...base,
     settings: {
       browser: {
-        script: btoa(formValues.settings.browser.script),
+        script: encode(formValues.settings.browser.script),
       },
     },
   };

--- a/src/components/CheckEditor/transformations/toPayload.scripted.ts
+++ b/src/components/CheckEditor/transformations/toPayload.scripted.ts
@@ -1,3 +1,5 @@
+import { encode } from 'js-base64';
+
 import { CheckFormValuesScripted, ScriptedCheck } from 'types';
 import { getBasePayloadValuesFromForm } from 'components/CheckEditor/transformations/toPayload.utils';
 
@@ -8,7 +10,7 @@ export function getScriptedPayload(formValues: CheckFormValuesScripted): Scripte
     ...base,
     settings: {
       scripted: {
-        script: btoa(formValues.settings.scripted.script),
+        script: encode(formValues.settings.scripted.script),
       },
     },
   };

--- a/src/page/NewCheck/__tests__/BrowserChecks/Scripted/5-execution.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/BrowserChecks/Scripted/5-execution.payload.test.tsx
@@ -5,7 +5,7 @@ import { goToSection, renderNewForm, submitForm } from 'page/__testHelpers__/che
 
 import { fillMandatoryFields } from '../../../../__testHelpers__/scripted';
 
-const checkType = CheckType.Scripted;
+const checkType = CheckType.Browser;
 
 describe(`BrowserCheck - Section 5 (Execution) payload`, () => {
   it(`has the correct default values submitted`, async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7426,6 +7426,11 @@ jquery@3.7.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
 
+js-base64@^3.7.7:
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
+  integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
+
 js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
@@ -11354,10 +11359,10 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.94.0:
-  version "5.94.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.94.0.tgz#77a6089c716e7ab90c1c67574a28da518a20970f"
-  integrity sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==
+webpack@^5.86.0:
+  version "5.95.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.95.0.tgz#8fd8c454fa60dad186fbe36c400a55848307b4c0"
+  integrity sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==
   dependencies:
     "@types/estree" "^1.0.5"
     "@webassemblyjs/ast" "^1.12.1"


### PR DESCRIPTION
Closes: [#910](https://github.com/grafana/synthetic-monitoring-agent/issues/910)

This pull request addresses an issue where forms containing Unicode characters were unable to save in both browser and scripted checks. The error encountered was:

```
DOMException: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.
```

The root of the problem lies in the native `btoa` and `atob` methods, which are designed to handle only ASCII characters. When Unicode characters—such as emojis—are present, these methods throw an error.

To resolve this issue, this PR replaces the use of `btoa` and `atob` with the `js-base64` library, which fully supports encoding and decoding of Unicode strings. This change ensures that our application can handle a wider range of characters without encountering errors.

![2024-10-01 16 25 20](https://github.com/user-attachments/assets/3d0f2491-c991-4805-af8f-a2f846a7e5e3)
