### PR TITLE
chore: change browser checks to public preview status

### DIFF
--- a/src/hooks/useCheckTypeOptions.ts
+++ b/src/hooks/useCheckTypeOptions.ts
@@ -55,10 +55,6 @@ export const CHECK_TYPE_OPTIONS = [
     label: 'Scripted',
     value: CheckType.Scripted,
     description: 'Write a k6 script to run custom checks.',
-    status: {
-      value: CheckStatus.PUBLIC_PREVIEW,
-      description: `Scripted checks are in public preview. We're actively working on improving the experience and adding more features.`,
-    },
     featureToggle: FeatureName.ScriptedChecks,
     group: CheckTypeGroup.Scripted,
   },

--- a/src/hooks/useCheckTypeOptions.ts
+++ b/src/hooks/useCheckTypeOptions.ts
@@ -67,8 +67,8 @@ export const CHECK_TYPE_OPTIONS = [
     value: CheckType.Browser,
     description: 'Leverage k6 browser module to run checks in a browser.',
     status: {
-      value: CheckStatus.PRIVATE_PREVIEW,
-      description: `Browser checks are in private preview. During the preview they are free to use: test executions will not be billed.`,
+      value: CheckStatus.PUBLIC_PREVIEW,
+      description: `Browser checks are in public preview. During the preview they are free to use: test executions will not be billed.`,
       docsLink:
         'https://grafana.com/docs/grafana-cloud/cost-management-and-billing/understand-your-invoice/synthetic-monitoring-invoice/',
     },


### PR DESCRIPTION
Changes browser checks to public preview status

![image](https://github.com/user-attachments/assets/22bc2216-5ad4-4da8-93c1-bdc4973cc7d3)
![image](https://github.com/user-attachments/assets/8f1f238e-e293-4616-9e6a-147d9b68804b)

We're also removing the public preview badge for scripted checks as they go GA.

![image](https://github.com/user-attachments/assets/8a2ef48c-2e74-481d-ae2b-849c54faa36a)

