### PR TITLE
chore: Fix release CI/CD

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -254,18 +254,6 @@ steps:
       github_app_private_key:
         from_secret: updater-app-private-key
 
-image_pull_secrets:
-  - dockerconfigjson
----
-kind: pipeline
-type: docker
-name: publish-gcom
-
-trigger:
-  event:
-    - tag
-
-steps:
   - name: publish plugin to grafana.com (release)
     image: curlimages/curl:7.73.0
     environment:


### PR DESCRIPTION
**What this PR does / why we need it**:

After the change in the release process, the tag is now generated when the release PR is merged to main. At this point, there is a current trigger for a tag that tries to publish to gcom the released plugin. However, this step should not happen automatically on the tag generation but happen when promoting the release to production. Therefore, move this step as the last step for the promote->production event trigger.