### PR TITLE
chore: Fix publish version

### DIFF
--- a/scripts/publish-gcom.sh
+++ b/scripts/publish-gcom.sh
@@ -2,7 +2,8 @@
 # This is used in Drone to generate the version string for automatic PR creation
 set -eufo pipefail
 
-VERSION="${DRONE_TAG#v}"
+ROOT_DIR=$(git rev-parse --show-toplevel)
+VERSION="$(grep version ${ROOT_DIR}/package.json | cut -d':' -f2 | tr -d "\"', \r")"
 
 echo "${VERSION}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the version parsing from publish-gcom.sh script. Since there is no longer a tag Drone pipeline, the variable DRONE_TAG is not set when promoting to production from the push pipeline. Therefore obtain the version from the package.json file.
