### PR TITLE
chore: Add git to publish step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -260,6 +260,7 @@ steps:
       GRAFANA_API_KEY:
         from_secret: signing_token
     commands:
+      - ./scripts/install-ci-deps-apt.sh
       - ls -al ./scripts
       - ./scripts/publish-gcom.sh
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Installs git as a requirement before publishing the plugin when promoting to production.
