### PR TITLE
chore: Change publish step image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -255,7 +255,7 @@ steps:
         from_secret: updater-app-private-key
 
   - name: publish plugin to grafana.com (release)
-    image: curlimages/curl:7.73.0
+    image: ubuntu:latest
     environment:
       GRAFANA_API_KEY:
         from_secret: signing_token

--- a/scripts/install-ci-deps-apt.sh
+++ b/scripts/install-ci-deps-apt.sh
@@ -13,6 +13,7 @@ apt-get update >/dev/null && apt-get install -y \
   make \
   wget \
   zip \
+  curl \
   >/dev/null
 
 wget -q https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.deb


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the image used for the publish step to ubuntu:latest, so the
CI dependencies script can install the required packages. Since
we are now not using the curl Docker image for this step, curl must be
added to the list of dependencies.