### PR TITLE
fix: Publish script

### DIFF
--- a/scripts/publish-gcom.sh
+++ b/scripts/publish-gcom.sh
@@ -1,4 +1,4 @@
- #!/bin/bash
+#!/bin/bash
 # This is used in Drone to generate the version string for automatic PR creation
 set -eufo pipefail
 


### PR DESCRIPTION
**What this PR does / why we need it**:
A space before the bash bang was making it being executed through sh in ubuntu:latest as part of the promote production CI pipeline, on which an option set in the script is not supported. Remove the extra space so the sript is executed in bash and 'set -eufo pipefile' is applied correctly.
