### PR TITLE
Fix: Update asc / desc reachability sorting

### DIFF
--- a/src/components/CheckList/CheckList.tsx
+++ b/src/components/CheckList/CheckList.tsx
@@ -253,21 +253,21 @@ function sortChecks(checks: Check[], sortType: CheckSort, reachabilitySuccessRat
 
   if ([CheckSort.ReachabilityAsc, CheckSort.ReachabilityDesc].includes(sortType)) {
     const checkWithMetrics = checks.map((check) => {
-      const metricValue = findCheckinMetrics(reachabilitySuccessRates, check);
-      const value = metricValue === undefined ? -1 : metricValue.value[1];
+      const reachabilityMetric = findCheckinMetrics(reachabilitySuccessRates, check);
+      const reachability = reachabilityMetric === undefined ? -1 : reachabilityMetric.value[1];
 
       return {
         ...check,
-        metric: value,
+        reachability,
       };
     });
 
     return checkWithMetrics.sort((a, b) => {
       if (sortType === CheckSort.ReachabilityAsc) {
-        return a.metric - b.metric;
+        return a.reachability - b.reachability;
       }
 
-      return b.metric - a.metric;
+      return b.reachability - a.reachability;
     });
   }
 

--- a/src/components/CheckList/CheckList.tsx
+++ b/src/components/CheckList/CheckList.tsx
@@ -77,7 +77,7 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
 
   const filteredChecks = filterChecks(checks, checkFilters);
   const sortedChecks = sortChecks(filteredChecks, sortType, reachabilitySuccessRates);
-  const currentPageChecks = filteredChecks.slice((currentPage - 1) * CHECKS_PER_PAGE, currentPage * CHECKS_PER_PAGE);
+  const currentPageChecks = sortedChecks.slice((currentPage - 1) * CHECKS_PER_PAGE, currentPage * CHECKS_PER_PAGE);
 
   const isAllSelected = selectedCheckIds.size === filteredChecks.length;
   const totalPages = Math.ceil(filteredChecks.length / CHECKS_PER_PAGE);
@@ -251,18 +251,23 @@ function sortChecks(checks: Check[], sortType: CheckSort, reachabilitySuccessRat
     return checks.sort((a, b) => b.job.localeCompare(a.job));
   }
 
-  if (sortType === CheckSort.ReachabilityAsc) {
-    return checks.sort((a, b) => {
-      const [sortA, sortB] = getMetricValues(a, b, reachabilitySuccessRates);
-      return sortB - sortA;
+  if ([CheckSort.ReachabilityAsc, CheckSort.ReachabilityDesc].includes(sortType)) {
+    const checkWithMetrics = checks.map((check) => {
+      const metricValue = findCheckinMetrics(reachabilitySuccessRates, check);
+      const value = metricValue === undefined ? -1 : metricValue.value[1];
+
+      return {
+        ...check,
+        metric: value,
+      };
     });
-  }
 
-  if (sortType === CheckSort.ReachabilityDesc) {
-    return checks.sort((a, b) => {
-      const [sortA, sortB] = getMetricValues(a, b, reachabilitySuccessRates);
+    return checkWithMetrics.sort((a, b) => {
+      if (sortType === CheckSort.ReachabilityAsc) {
+        return a.metric - b.metric;
+      }
 
-      return sortA - sortB;
+      return b.metric - a.metric;
     });
   }
 
@@ -281,16 +286,6 @@ function sortChecks(checks: Check[], sortType: CheckSort, reachabilitySuccessRat
   }
 
   return checks;
-}
-
-function getMetricValues(checkA: Check, checkB: Check, metrics: MetricCheckSuccessParsed[]) {
-  const metricA = findCheckinMetrics(metrics, checkA);
-  const metricB = findCheckinMetrics(metrics, checkB);
-
-  const sortA = metricA?.value[1] || 101;
-  const sortB = metricB?.value[1] || 101;
-
-  return [sortA, sortB];
 }
 
 function getNumberOfExecutions(checkA: Check, checkB: Check) {


### PR DESCRIPTION
## Problem

We had a [bug reported internally in Slack](https://raintank-corp.slack.com/archives/C0162C1K9E1/p1727773255480849) that our reachability Asc / Desc. were reporting the wrong way round.


## Solution

This PR switches the order of Asc / Desc. As I was fixing this I noticed that undefined and other falsey values of reachability were given a value of 101 so put them above 100% (which I think is what led to this bug implementation in the first place).

I noticed as I was fixing it that the code could be much more performant and use less CPU cycles, too 😄 


**Before**
![The checks list page with ascending reachability. The checks show 0, N/A, 0, 100, 100 for their reachability values.](https://github.com/user-attachments/assets/9f617d5d-39e3-4e98-95aa-d4de22869d9f)
![The checks list page with descending reachability. The checks show 48.5, 59.8, 98.6, 100, 100 for their reachability values.](https://github.com/user-attachments/assets/e1cf9602-5515-46ef-aa1c-d52b76e87839)

**After**

![The checks list page with ascending reachability. The checks show N/A, 48.5, 59.6  for their reachability values.](https://github.com/user-attachments/assets/91a35989-8f1b-4123-a3bf-da77d2e64d25)
![The checks list page with ascending reachability. The checks show 100, 100, 100, 100, 100 for their reachability values.](https://github.com/user-attachments/assets/f154b944-2079-44d8-987f-ca1c772bd352)

