### PR TITLE
fix: update browser examples to use async check

### DIFF
--- a/src/components/BrowserExamplesMenu/snippets/colorscheme.js
+++ b/src/components/BrowserExamplesMenu/snippets/colorscheme.js
@@ -1,4 +1,4 @@
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { browser } from 'k6/browser';
 
 export const options = {
@@ -36,7 +36,7 @@ export default async function() {
         isDarkColorScheme: window.matchMedia('(prefers-color-scheme: dark)').matches
       };
     });
-    check(colorScheme, {
+    await check(colorScheme, {
       'isDarkColorScheme': cs => cs.isDarkColorScheme
     });
   } finally {

--- a/src/components/BrowserExamplesMenu/snippets/cookies.js
+++ b/src/components/BrowserExamplesMenu/snippets/cookies.js
@@ -1,4 +1,4 @@
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { browser } from 'k6/browser';
 
 export const options = {
@@ -23,7 +23,7 @@ export default async function () {
 
   try {
     // get cookies from the browser context
-    check((await context.cookies()).length, {
+    await check((await context.cookies()).length, {
       'initial number of cookies should be zero': (n) => n === 0,
     });
 
@@ -63,10 +63,10 @@ export default async function () {
       },
     ]);
     let cookies = await context.cookies();
-    check(cookies.length, {
+    await check(cookies.length, {
       'number of cookies should be 2': (n) => n === 2,
     });
-    check(cookies[0], {
+    await check(cookies[0], {
       'cookie 1 name should be testcookie': (c) => c.name === 'testcookie',
       'cookie 1 value should be 1': (c) => c.value === '1',
       'cookie 1 should be session cookie': (c) => c.expires === -1,
@@ -76,7 +76,7 @@ export default async function () {
       'cookie 1 should be httpOnly': (c) => c.httpOnly === true,
       'cookie 1 should be secure': (c) => c.secure === true,
     });
-    check(cookies[1], {
+    await check(cookies[1], {
       'cookie 2 name should be testcookie2': (c) => c.name === 'testcookie2',
       'cookie 2 value should be 2': (c) => c.value === '2',
     });
@@ -103,14 +103,14 @@ export default async function () {
       },
     ]);
     cookies = await context.cookies('http://foo.com', 'https://baz.com');
-    check(cookies.length, {
+    await check(cookies.length, {
       'number of filtered cookies should be 2': (n) => n === 2,
     });
-    check(cookies[0], {
+    await check(cookies[0], {
       'the first filtered cookie name should be foo': (c) => c.name === 'foo',
       'the first filtered cookie value should be 42': (c) => c.value === '42',
     });
-    check(cookies[1], {
+    await check(cookies[1], {
       'the second filtered cookie name should be baz': (c) => c.name === 'baz',
       'the second filtered cookie value should be 44': (c) => c.value === '44',
     });
@@ -118,7 +118,7 @@ export default async function () {
     // clear cookies
     await context.clearCookies();
     cookies = await context.cookies();
-    check(cookies.length, {
+    await check(cookies.length, {
       'number of cookies should be zero': (n) => n === 0,
     });
   } finally {

--- a/src/components/BrowserExamplesMenu/snippets/dispatch.js
+++ b/src/components/BrowserExamplesMenu/snippets/dispatch.js
@@ -1,4 +1,4 @@
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { browser } from 'k6/browser';
 
 export const options = {
@@ -29,7 +29,7 @@ export default async function() {
 
     const h3 = page.locator("h3");
     const ok = await h3.textContent() == "Contact us";
-    check(ok, { "header": ok });
+    await check(ok, { "header": ok });
   } finally {
     await page.close();
   }

--- a/src/components/BrowserExamplesMenu/snippets/dispatch.js
+++ b/src/components/BrowserExamplesMenu/snippets/dispatch.js
@@ -7,17 +7,17 @@ export const options = {
       executor: 'shared-iterations',
       options: {
         browser: {
-            type: 'chromium',
+          type: 'chromium',
         },
       },
     },
   },
   thresholds: {
-    checks: ["rate==1.0"]
-  }
-}
+    checks: ['rate==1.0'],
+  },
+};
 
-export default async function() {
+export default async function () {
   const context = await browser.newContext();
   const page = await context.newPage();
 
@@ -25,11 +25,11 @@ export default async function() {
     await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
 
     const contacts = page.locator('a[href="/contacts.php"]');
-    await contacts.dispatchEvent("click");
+    await contacts.dispatchEvent('click');
 
-    const h3 = page.locator("h3");
-    const ok = await h3.textContent() == "Contact us";
-    await check(ok, { "header": ok });
+    await check(page.locator('h3'), {
+      header: async (locator) => (await locator.textContent()) === 'Contact us',
+    });
   } finally {
     await page.close();
   }

--- a/src/components/BrowserExamplesMenu/snippets/evaluate.js
+++ b/src/components/BrowserExamplesMenu/snippets/evaluate.js
@@ -1,4 +1,4 @@
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { browser } from 'k6/browser';
 
 export const options = {
@@ -28,7 +28,7 @@ export default async function () {
     let result = await page.evaluate(() => {
       return Promise.resolve(5 * 42);
     });
-    check(result, {
+    await check(result, {
       'result should be 210': (result) => result == 210,
     });
 
@@ -39,7 +39,7 @@ export default async function () {
       },
       [5, 5]
     );
-    check(result, {
+    await check(result, {
       'result should be 25': (result) => result == 25,
     });
   } finally {

--- a/src/components/BrowserExamplesMenu/snippets/getattribute.js
+++ b/src/components/BrowserExamplesMenu/snippets/getattribute.js
@@ -25,10 +25,9 @@ export default async function () {
     await page.goto('https://googlechromelabs.github.io/dark-mode-toggle/demo/', {
       waitUntil: 'load',
     });
-    let el = await page.$('#dark-mode-toggle-3');
-    const mode = await el.getAttribute('mode');
-    await check(mode, {
-      "GetAttribute('mode')": mode === 'light',
+
+    await check(page.locator('#dark-mode-toggle-3'), {
+      "GetAttribute('mode')": async (locator) => (await locator.getAttribute('mode')) === 'light',
     });
   } finally {
     await page.close();

--- a/src/components/BrowserExamplesMenu/snippets/getattribute.js
+++ b/src/components/BrowserExamplesMenu/snippets/getattribute.js
@@ -1,4 +1,4 @@
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { browser } from 'k6/browser';
 
 export const options = {
@@ -27,7 +27,7 @@ export default async function () {
     });
     let el = await page.$('#dark-mode-toggle-3');
     const mode = await el.getAttribute('mode');
-    check(mode, {
+    await check(mode, {
       "GetAttribute('mode')": mode === 'light',
     });
   } finally {

--- a/src/components/BrowserExamplesMenu/snippets/querying.js
+++ b/src/components/BrowserExamplesMenu/snippets/querying.js
@@ -1,4 +1,4 @@
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { browser } from 'k6/browser';
 
 export const options = {
@@ -27,7 +27,7 @@ export default async function () {
     const titleWithCSS = await page.$('header h1.title').then((e) => e.textContent());
     const titleWithXPath = await page.$(`//header//h1[@class="title"]`).then((e) => e.textContent());
 
-    check(page, {
+    await check(page, {
       'Title with CSS selector': titleWithCSS == 'test.k6.io',
       'Title with XPath selector': titleWithXPath == 'test.k6.io',
     });

--- a/src/components/BrowserExamplesMenu/snippets/querying.js
+++ b/src/components/BrowserExamplesMenu/snippets/querying.js
@@ -24,12 +24,14 @@ export default async function () {
   try {
     await page.goto('https://test.k6.io/');
 
-    const titleWithCSS = await page.$('header h1.title').then((e) => e.textContent());
-    const titleWithXPath = await page.$(`//header//h1[@class="title"]`).then((e) => e.textContent());
+    const title = 'test.k6.io';
 
-    await check(page, {
-      'Title with CSS selector': titleWithCSS == 'test.k6.io',
-      'Title with XPath selector': titleWithXPath == 'test.k6.io',
+    await check(page.locator('header h1.title'), {
+      'Title with CSS selector': async (locator) => (await locator.textContent()) === title,
+    });
+
+    await check(page.locator(`//header//h1[@class="title"]`), {
+      'Title with XPath selector': async (locator) => (await locator.textContent()) === title,
     });
   } finally {
     await page.close();

--- a/src/components/BrowserExamplesMenu/snippets/waitForFunction.js
+++ b/src/components/BrowserExamplesMenu/snippets/waitForFunction.js
@@ -1,4 +1,4 @@
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 import { browser } from 'k6/browser';
 
 export const options = {
@@ -34,7 +34,7 @@ export default async function () {
       polling: 'mutation',
       timeout: 2000,
     });
-    check(ok, { 'waitForFunction successfully resolved': ok.innerHTML() == 'Hello' });
+    await check(ok, { 'waitForFunction successfully resolved': ok.innerHTML() == 'Hello' });
   } finally {
     await page.close();
   }

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -164,7 +164,7 @@ export default function main() {
 }`);
 
 const EXAMPLE_SCRIPT_BROWSER = btoa(`import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
   scenarios: {

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -198,7 +198,7 @@ export default async function () {
     ]);
 
     const header = await page.locator("h2").textContent();
-    check(header, {
+    await check(header, {
       header: (h) => h == "Welcome, admin!",
     });
   } finally {

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -197,9 +197,8 @@ export default async function () {
       page.locator('input[type="submit"]').click(),
     ]);
 
-    const header = await page.locator("h2").textContent();
-    await check(header, {
-      header: (h) => h == "Welcome, admin!",
+    await check(page.locator("h2"), {
+      header: async (locator) => (await locator.textContent()) == "Welcome, admin!",
     });
   } finally {
     await page.close();


### PR DESCRIPTION
Updates browser checks examples to use `async check` from `https://jslib.k6.io/k6-utils/1.5.0/index.js` as recommended in the [FAQ document](https://docs.google.com/document/d/1SbBdhYVGnEQ9XJe6DKYMErPI3O_E3anAp3Hdu_faUo8/edit#heading=h.duuadjcekgl6)

![image](https://github.com/user-attachments/assets/c222c793-bfcb-4a22-9a6d-0a2c66d0f744)

![image](https://github.com/user-attachments/assets/1d554951-4863-4b1a-bbfd-5f90c34335a0)
