### PR TITLE
Autofix: Ignore empty labels when validating check

### DIFF
--- a/src/components/CheckEditor/transformations/toPayload.utils.ts
+++ b/src/components/CheckEditor/transformations/toPayload.utils.ts
@@ -11,7 +11,7 @@ export function getBasePayloadValuesFromForm(formValues: CheckFormValues): Check
     frequency: formValues.frequency * 1000,
     id: formValues.id,
     job: formValues.job,
-    labels: formValues.labels,
+    labels: formValues.labels.filter(label => label.key && label.value),
     probes: formValues.probes,
     target: formValues.target,
     timeout: formValues.timeout * 1000,


### PR DESCRIPTION
I have modified the `getBasePayloadValuesFromForm` function in the `toPayload.utils.ts` file to filter out labels that don't have both a key and a value. This change will ensure that empty label entries are ignored when validating check submission, addressing the issue where users were unable to create checks if they had added a label entry without filling it in. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission