### PR TITLE
fix: probe selector column header color

### DIFF
--- a/src/components/CheckEditor/CheckProbes/ProbesList.tsx
+++ b/src/components/CheckEditor/CheckProbes/ProbesList.tsx
@@ -140,7 +140,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   headerLabel: css({
     fontWeight: theme.typography.fontWeightLight,
     fontSize: theme.typography.h5.fontSize,
-    color: 'white',
+    color: theme.colors.text.primary,
   }),
 
   columnLabel: css({


### PR DESCRIPTION
Fixes the color of the column header probe selector for the Light theme.

Light theme
![image](https://github.com/user-attachments/assets/8f37f5a9-3d44-4ffa-9c60-f18e32cc1fdf)

Dark theme
![image](https://github.com/user-attachments/assets/425a7ac2-86cb-4b40-bd8d-8dc00b370c1a)