### PR TITLE
chore: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,4 @@
 # https://help.github.com/articles/about-codeowners/
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-* @ckbedwell
-* @w1kman
-* @VikaCep
+* @ckbedwell @w1kman @VikaCep

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,6 @@
 # https://help.github.com/articles/about-codeowners/
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-* @grafana/synthetic-monitoring-dev
+* @ckbedwell
+* @w1kman
+* @VikaCep

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # https://help.github.com/articles/about-codeowners/
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-* @ckbedwell @w1kman @VikaCep
+* @grafana/synthetic-monitoring-fe


### PR DESCRIPTION
## Problem

@grafana/synthetic-monitoring-dev currently gets automatically assigned as a reviewer for this repository.

## Solution

The above made sense when the team was much smaller but as the team is now significantly bigger with three engineers effectively owning this repository it makes sense to update the owners to be reflective of that and remove the manual step of assigning the frontend engineers in SM as reviewers.
