### PR TITLE
Update scripted check default example/snippet

### DIFF
--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -151,16 +151,25 @@ export const TIME_UNIT_OPTIONS = [
 export const TEN_MINUTES_IN_MS = 1000 * 60 * 10;
 export const FIVE_MINUTES_IN_MS = 1000 * 60 * 5;
 
-const EXAMPLE_SCRIPT_SCRIPTED = btoa(`import { check } from 'k6'
+const EXAMPLE_SCRIPT_SCRIPTED = btoa(`import { check, fail } from 'k6'
 import http from 'k6/http'
 
 export default function main() {
-  const res = http.get('http://test.k6.io/');
+  const result = http.get('http://test.k6.io/');
+
   // console.log will be represented as logs in Loki
   console.log('got a response')
-  check(res, {
+  
+  // Use check() to test conditions. These show as 'assertions' in the dashboard
+  // Note: failed check() calls do not impact uptime and reachability
+  const pass = check(result, {
     'is status 200': (r) => r.status === 200,
   });
+
+  // Use fail() to abort and fail a test, impacting uptime and reachability
+  if(!pass){
+    fail(\`non 200 result ${result.status}\`)
+  }
 }`);
 
 const EXAMPLE_SCRIPT_BROWSER = btoa(`import { browser } from 'k6/browser';

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -158,7 +158,7 @@ export default function main() {
   const result = http.get('http://test.k6.io/');
 
   // console.log will be represented as logs in Loki
-  console.log('got a response')
+  console.log('got a response');
   
   // Use check() to test conditions. These show as 'assertions' in the dashboard
   // Note: failed check() calls do not impact uptime and reachability
@@ -168,7 +168,7 @@ export default function main() {
 
   // Use fail() to abort and fail a test, impacting uptime and reachability
   if(!pass){
-    fail(\`non 200 result ${result.status}\`)
+    fail(\`non 200 result \${result.status}\`);
   }
 }`);
 


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR updates the default scripted check example to add use of the `fail()` function, and explains why you would use it. 
 
Many people assume that if a `check()` does not pass,  the test run will fail and this will impact reachability and uptime.  They are unaware of the `fail()` function and why they should use it. 
 
This makes the default script longer, but it is still short enough that it fits on a typical laptop screen:

<img width="1329" alt="image" src="https://github.com/user-attachments/assets/23579829-2f16-4365-88f9-71930c245d07">
