### PR TITLE
fix: add synthetic-monitoring-dev as owners of release files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,12 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 
 * @grafana/synthetic-monitoring-fe
+
+# These files are updated by release-please and we need any member of the
+# larger team to be able to approve them.
+#
+# The docs seem to suggest that the last matching pattern is the one that is
+# used, so we need to keep the * pattern above this one.
+/CHANGELOG.md @grafana/synthetic-monitoring-fe @grafana/synthetic-monitoring-dev
+/package.json @grafana/synthetic-monitoring-fe @grafana/synthetic-monitoring-dev
+/.github/release-please/release-please-config.json @grafana/synthetic-monitoring-fe @grafana/synthetic-monitoring-dev


### PR DESCRIPTION
CHANGELOG.md, package.json and
.github/release-please/release-please-config.json are updated as part of creating a release. In order to allow anybody in the team to run that process, add synthetic-monitoring-dev as owners of those files.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
