### PR TITLE
fix: disable hasUnsavedChanges prop for now

### DIFF
--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -191,7 +191,6 @@ export const CheckForm = ({ check, disabled }: CheckFormProps) => {
               onValid={handleValid}
               onInvalid={handleInvalid}
               schema={schema}
-              hasUnsavedChanges={hasUnsavedChanges}
             >
               {!isExistingCheck && <OverLimitAlert checkType={checkType} />}
 
@@ -228,6 +227,7 @@ export const CheckForm = ({ check, disabled }: CheckFormProps) => {
         </CheckFormContextProvider>
       </FormProvider>
       <CheckTestResultsModal isOpen={openTestCheckModal} onDismiss={closeModal} testResponse={adhocTestData} />
+      {/* This will not work on checks that has been tested with the Test button, has it technically submits the form */}
       <ConfirmLeavingPage enabled={hasUnsavedChanges} />
     </PluginPage>
   );

--- a/src/page/EditCheck/__tests__/ApiEndPointChecks/HTTPCheck/Submit.test.tsx
+++ b/src/page/EditCheck/__tests__/ApiEndPointChecks/HTTPCheck/Submit.test.tsx
@@ -32,7 +32,8 @@ const MIN_HTTP_CHECK: HTTPCheck = {
   alertSensitivity: 'none',
 };
 
-it(`HTTPCheck -- can not submit an existing check without editing`, async () => {
+// This should not be enabled when issue #1026 is fixed
+it.skip(`HTTPCheck -- can not submit an existing check without editing`, async () => {
   server.use(
     apiRoute(`listChecks`, {
       result: () => {
@@ -44,6 +45,5 @@ it(`HTTPCheck -- can not submit an existing check without editing`, async () => 
   );
 
   await renderEditForm(MIN_HTTP_CHECK.id);
-  // This should not be enabled when issue #1026 is fixed
-  expect(await screen.findByTestId(DataTestIds.CHECK_FORM_SUBMIT_BUTTON)).toBeEnabled();
+  expect(await screen.findByTestId(DataTestIds.CHECK_FORM_SUBMIT_BUTTON)).not.toBeEnabled();
 });

--- a/src/page/EditCheck/__tests__/ApiEndPointChecks/HTTPCheck/Submit.test.tsx
+++ b/src/page/EditCheck/__tests__/ApiEndPointChecks/HTTPCheck/Submit.test.tsx
@@ -44,5 +44,6 @@ it(`HTTPCheck -- can not submit an existing check without editing`, async () => 
   );
 
   await renderEditForm(MIN_HTTP_CHECK.id);
-  expect(await screen.findByTestId(DataTestIds.CHECK_FORM_SUBMIT_BUTTON)).not.toBeEnabled();
+  // This should not be enabled when issue #1026 is fixed
+  expect(await screen.findByTestId(DataTestIds.CHECK_FORM_SUBMIT_BUTTON)).toBeEnabled();
 });

--- a/src/page/EditCheck/__tests__/ApiEndPointChecks/TCPCheck/Submit.test.tsx
+++ b/src/page/EditCheck/__tests__/ApiEndPointChecks/TCPCheck/Submit.test.tsx
@@ -28,7 +28,8 @@ const MIN_TCP_CHECK: TCPCheck = {
   alertSensitivity: 'none',
 };
 
-it(`TCPCheck -- can not submit an existing check without editing`, async () => {
+// This should not be enabled when issue #1026 is fixed
+it.skip(`TCPCheck -- can not submit an existing check without editing`, async () => {
   server.use(
     apiRoute(`listChecks`, {
       result: () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**: When using the "Test" button in the CheckForm, the form is technically submitted but not saved. After testing, the formState is no longer "dirty", which results in the "Save" button being disabled and the "You have unsaved changes" dialog to not appear.

This fix removes the logic that disables the "Save" button when the formState is clean.
This fix DOES NOT resolve the fact that a user can navigate away from an unsaved check without getting prompted. 

**Which issue(s) this PR fixes**:
Resolves https://github.com/grafana/synthetic-monitoring-app/issues/1024

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
