### PR TITLE
fix: filter by probe on data transferred and assertions panels for browser and scripted checks

### DIFF
--- a/src/scenes/BROWSER/WebVitals/cumulativeLayoutShift.ts
+++ b/src/scenes/BROWSER/WebVitals/cumulativeLayoutShift.ts
@@ -9,7 +9,7 @@ function getQueryRunner(metrics: DataSourceRef) {
     queries: [
       {
         refId: 'A',
-        expr: `avg by (job, instance) (quantile_over_time(0.75, probe_browser_web_vital_cls{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (job, instance) (quantile_over_time(0.75, probe_browser_web_vital_cls{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
         legendFormat: 'CLS',
       },
     ],

--- a/src/scenes/BROWSER/WebVitals/inputResponseTime.ts
+++ b/src/scenes/BROWSER/WebVitals/inputResponseTime.ts
@@ -9,12 +9,12 @@ function getQueryRunner(metrics: DataSourceRef) {
     queries: [
       {
         refId: 'A',
-        expr: `avg by (job, instance) (quantile_over_time(0.75, probe_browser_web_vital_fid{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (job, instance) (quantile_over_time(0.75, probe_browser_web_vital_fid{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
         legendFormat: 'FID',
       },
       {
         refId: 'B',
-        expr: `avg by (job, instance) (quantile_over_time(0.75, probe_browser_web_vital_inp{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (job, instance) (quantile_over_time(0.75, probe_browser_web_vital_inp{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
         legendFormat: 'INP',
       },
     ],

--- a/src/scenes/BROWSER/WebVitals/pageLoad.ts
+++ b/src/scenes/BROWSER/WebVitals/pageLoad.ts
@@ -9,17 +9,17 @@ function getQueryRunner(metrics: DataSourceRef) {
     queries: [
       {
         refId: 'A',
-        expr: `avg by (instance, job) (quantile_over_time(0.75, probe_browser_web_vital_fcp{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (instance, job) (quantile_over_time(0.75, probe_browser_web_vital_fcp{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
         legendFormat: 'FCP',
       },
       {
         refId: 'B',
-        expr: `avg by (instance, job) (quantile_over_time(0.75, probe_browser_web_vital_lcp{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (instance, job) (quantile_over_time(0.75, probe_browser_web_vital_lcp{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
         legendFormat: 'LCP',
       },
       {
         refId: 'C',
-        expr: `avg by (instance, job) (quantile_over_time(0.75, probe_browser_web_vital_ttfb{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (instance, job) (quantile_over_time(0.75, probe_browser_web_vital_ttfb{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
         legendFormat: 'TTFB',
       },
     ],

--- a/src/scenes/BROWSER/WebVitals/webVitals.ts
+++ b/src/scenes/BROWSER/WebVitals/webVitals.ts
@@ -11,7 +11,7 @@ function getQueryRunner(metrics: DataSourceRef, refId: string) {
     queries: [
       {
         refId: `wv-${refId}`,
-        expr: `avg by (instance, job) (quantile_over_time(0.75, probe_browser_web_vital_${refId}{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (instance, job) (quantile_over_time(0.75, probe_browser_web_vital_${refId}{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
       },
     ],
   });

--- a/src/scenes/BROWSER/WebVitals/webVitalsTable.ts
+++ b/src/scenes/BROWSER/WebVitals/webVitalsTable.ts
@@ -73,27 +73,27 @@ function getQueryRunner(metrics: DataSourceRef) {
     queries: [
       {
         refId: 'A',
-        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_fcp{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_fcp{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
       },
       {
         refId: 'B',
-        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_lcp{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_lcp{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
       },
       {
         refId: 'C',
-        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_ttfb{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_ttfb{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
       },
       {
         refId: 'D',
-        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_cls{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_cls{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
       },
       {
         refId: 'E',
-        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_fid{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_fid{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
       },
       {
         refId: 'F',
-        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_inp{instance="$instance", job="$job"}[$__range]))`,
+        expr: `avg by (url, instance, job) (quantile_over_time(0.75, probe_browser_web_vital_inp{instance="$instance", job="$job", probe=~"$probe"}[$__range]))`,
       },
     ],
   });

--- a/src/scenes/BROWSER/dataTransferred.ts
+++ b/src/scenes/BROWSER/dataTransferred.ts
@@ -8,7 +8,7 @@ function getSentQueryRunner(metrics: DataSourceRef) {
     datasource: metrics,
     queries: [
       {
-        expr: `sum by (probe) (probe_browser_data_sent{job="$job", instance="$instance"})`,
+        expr: `sum by (probe) (probe_browser_data_sent{probe=~"$probe", job="$job", instance="$instance"})`,
         instant: false,
         legendFormat: '{{ probe }}',
         range: true,
@@ -23,7 +23,7 @@ function getReceivedQueryRunner(metrics: DataSourceRef) {
     datasource: metrics,
     queries: [
       {
-        expr: `sum by (probe) (probe_browser_data_received{job="$job", instance="$instance"})`,
+        expr: `sum by (probe) (probe_browser_data_received{probe=~"$probe", job="$job", instance="$instance"})`,
         instant: false,
         legendFormat: '{{ probe }}',
         range: true,

--- a/src/scenes/Common/AssertionsTable/AssertionsTable.tsx
+++ b/src/scenes/Common/AssertionsTable/AssertionsTable.tsx
@@ -28,7 +28,7 @@ function getQueryRunner(logs: DataSourceRef) {
       {
         refId: 'A',
         expr: `count_over_time (
-          {job="$job", instance="$instance"}
+          {job="$job", instance="$instance", probe=~"$probe"}
           | logfmt check, value, msg
           | __error__ = ""
           | msg = "check result"
@@ -38,7 +38,7 @@ function getQueryRunner(logs: DataSourceRef) {
         )
         / 
         count_over_time (
-            {job="$job", instance="$instance"}
+            {job="$job", instance="$instance", probe=~"$probe"}
             | logfmt check, msg
             | __error__ = ""
             | msg = "check result"
@@ -51,7 +51,7 @@ function getQueryRunner(logs: DataSourceRef) {
       {
         refId: 'B',
         expr: `count_over_time (
-          {job="$job", instance="$instance"}
+          {job="$job", instance="$instance", probe=~"$probe"}
           | logfmt check, value, msg
           | __error__ = ""
           | msg = "check result"
@@ -65,7 +65,7 @@ function getQueryRunner(logs: DataSourceRef) {
       {
         refId: 'C',
         expr: `count_over_time (
-          {job="$job", instance="$instance"}
+          {job="$job", instance="$instance", probe=~"$probe"}
           | logfmt check, value, msg
           | __error__ = ""
           | msg = "check result"

--- a/src/scenes/Common/AssertionsTable/successOverTimeByProbe.ts
+++ b/src/scenes/Common/AssertionsTable/successOverTimeByProbe.ts
@@ -11,7 +11,7 @@ function getQueryRunner(metrics: DataSourceRef, name: string, minStep: string) {
       {
         expr: `
           count_over_time (
-            {job="$job", instance="$instance"}
+            {job="$job", instance="$instance", probe=~"$probe"}
             | logfmt check, value, msg, probe
             | __error__ = ""
             | msg = "check result"
@@ -22,7 +22,7 @@ function getQueryRunner(metrics: DataSourceRef, name: string, minStep: string) {
           )
           / 
           count_over_time  (
-              {job="$job", instance="$instance"}
+              {job="$job", instance="$instance", probe=~"$probe"}
               | logfmt check, msg, probe
               | __error__ = ""
               | msg = "check result"

--- a/src/scenes/Common/uptimeStat.ts
+++ b/src/scenes/Common/uptimeStat.ts
@@ -21,10 +21,10 @@ function getQueryRunner(metrics: DataSourceRef, minStep: string, newUptimeQuery:
     # so make it a 1 if there was at least one success and a 0 otherwise
     ceil(
       # the number of successes across all probes
-      sum by (instance, job) (increase(probe_all_success_sum{instance="$instance", job="$job"}[$__rate_interval]))
+      sum by (instance, job) (increase(probe_all_success_sum{instance="$instance", job="$job", probe=~"$probe"}[$__rate_interval]))
       /
       # the total number of times we checked across all probes
-      (sum by (instance, job) (increase(probe_all_success_count{instance="$instance", job="$job"}[$__rate_interval])) + 1) # + 1 because we want to make sure it goes to 1, not 2
+      (sum by (instance, job) (increase(probe_all_success_count{instance="$instance", job="$job", probe=~"$probe"}[$__rate_interval])) + 1) # + 1 because we want to make sure it goes to 1, not 2
     )`;
 
   //The query to calculate the uptime doesn't return the expected result in all cases
@@ -35,10 +35,10 @@ function getQueryRunner(metrics: DataSourceRef, minStep: string, newUptimeQuery:
       max by (instance, job) (
         round(
           # the number of successes for each probe
-          (increase(probe_all_success_sum{instance="$instance", job="$job"}[$__rate_interval]))
+          (increase(probe_all_success_sum{instance="$instance", job="$job", probe=~"$probe"}[$__rate_interval]))
           /
           # the total number of times we checked for each probe
-          ((increase(probe_all_success_count{instance="$instance", job="$job"}[$__rate_interval])))
+          ((increase(probe_all_success_count{instance="$instance", job="$job", probe=~"$probe"}[$__rate_interval])))
         )
       )
     )`;

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/durationByTargetProbe.ts
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/durationByTargetProbe.ts
@@ -8,7 +8,7 @@ function getQueryRunner(metrics: DataSourceRef, labelName: string, labelValue: s
     datasource: metrics,
     queries: [
       {
-        expr: `sum by (probe) (probe_http_total_duration_seconds{probe=~".*", job="$job", instance="$instance", ${labelName}="${labelValue}", method="${method}"})`,
+        expr: `sum by (probe) (probe_http_total_duration_seconds{probe=~"$probe", job="$job", instance="$instance", ${labelName}="${labelValue}", method="${method}"})`,
         refId: 'A',
         legendFormat: '{{probe}}',
       },

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/errorRateByTargetProbe.ts
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/errorRateByTargetProbe.ts
@@ -8,11 +8,11 @@ function getQueryRunner(metrics: DataSourceRef, labelName: string, labelValue: s
     {
       exemplar: true,
       expr: `sum by (probe, method) (
-        probe_http_requests_failed_total{instance="$instance", job="$job", probe=~".*", ${labelName}="${labelValue}", method="${method}"}
+        probe_http_requests_failed_total{instance="$instance", job="$job", probe=~"$probe", ${labelName}="${labelValue}", method="${method}"}
       )
       /
       sum by (probe, method) (
-        probe_http_requests_total{instance="$instance", job="$job", probe=~".*", ${labelName}="${labelValue}", method="${method}"}
+        probe_http_requests_total{instance="$instance", job="$job", probe=~"$probe", ${labelName}="${labelValue}", method="${method}"}
       )`,
       hide: false,
       range: true,

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/resultsByTargetTableQueries.ts
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/resultsByTargetTableQueries.ts
@@ -16,9 +16,9 @@ export function getQueryRunner(metrics: DataSourceRef, checkType: CheckType) {
         expr: `
           avg_over_time(
             (
-              sum by (${label}, method) (probe_http_requests_failed_total{job="$job", instance="$instance"})
+              sum by (${label}, method) (probe_http_requests_failed_total{job="$job", instance="$instance", probe=~"$probe"})
               /
-              sum by (${label}, method) (probe_http_requests_total{job="$job", instance="$instance"})
+              sum by (${label}, method) (probe_http_requests_total{job="$job", instance="$instance", probe=~"$probe"})
             )[$__range:]
           )
           `,
@@ -35,9 +35,9 @@ export function getQueryRunner(metrics: DataSourceRef, checkType: CheckType) {
         expr: `
           avg_over_time(
             (
-              sum by (${label}, method) (probe_http_got_expected_response{job="$job", instance="$instance"})
+              sum by (${label}, method) (probe_http_got_expected_response{job="$job", instance="$instance", probe=~"$probe"})
               /
-              count by (${label}, method)(probe_http_got_expected_response{job="$job", instance="$instance"})
+              count by (${label}, method)(probe_http_got_expected_response{job="$job", instance="$instance", probe=~"$probe"})
             )[$__range:]
           )`,
         format: 'table',
@@ -53,7 +53,7 @@ export function getQueryRunner(metrics: DataSourceRef, checkType: CheckType) {
         expr: `
           avg_over_time(
             (
-              sum by (${label}, method)(probe_http_duration_seconds{job="$job", instance="$instance"})
+              sum by (${label}, method)(probe_http_duration_seconds{job="$job", instance="$instance", probe=~"$probe"})
             )[$__range:]
           )`,
         format: 'table',

--- a/src/scenes/SCRIPTED/dataTransferred.ts
+++ b/src/scenes/SCRIPTED/dataTransferred.ts
@@ -8,7 +8,7 @@ function getSentQueryRunner(metrics: DataSourceRef) {
     datasource: metrics,
     queries: [
       {
-        expr: `probe_data_sent_bytes{job="$job", instance="$instance"}`,
+        expr: `probe_data_sent_bytes{probe=~"$probe", job="$job", instance="$instance"}`,
         instant: false,
         legendFormat: '{{ probe }}',
         range: true,
@@ -23,7 +23,7 @@ function getReceivedQueryRunner(metrics: DataSourceRef) {
     datasource: metrics,
     queries: [
       {
-        expr: `probe_data_received_bytes{job="$job", instance="$instance"}`,
+        expr: `probe_data_received_bytes{probe=~"$probe", job="$job", instance="$instance"}`,
         instant: false,
         legendFormat: '{{ probe }}',
         range: true,


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-app/issues/1029

The data transferred and assertions panels in the Browser and Scripted dashboards aren't taking into account filtered probes. This PR fixes that. 

Since in dev we only have one running probe location, I've validated the queries work as expected using Explorer in my prod account:

**Before setting the probe filter (as it currently works in the dashboards):**

Data sent chart:
![image](https://github.com/user-attachments/assets/6e9da9f6-114e-4e2c-866c-99127ccebd95)

Data received chart:
![image](https://github.com/user-attachments/assets/6d834829-6703-43b7-9923-d05b2d446d7a)

Success rate chart:
![image](https://github.com/user-attachments/assets/9bcfc44c-75c3-4b34-9213-5fb688689efb)

**After setting the probe filter (after this PR implementation):**

Data sent chart:
![image](https://github.com/user-attachments/assets/9cd33488-7f90-4f7d-85db-f80769b5f576)

Data received chart:
![image](https://github.com/user-attachments/assets/882a0e85-ff30-4e0a-8bfc-ada1ac74162c)

Success rate chart:
![image](https://github.com/user-attachments/assets/cb1cd002-bfe6-43d9-89e4-307a89b53a6d)

