### PR TITLE
fix: handle deprecated probes in the UI

### DIFF
--- a/src/components/CheckEditor/CheckProbes/ProbesList.tsx
+++ b/src/components/CheckEditor/CheckProbes/ProbesList.tsx
@@ -1,10 +1,12 @@
 import React, { useMemo } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Checkbox, Label, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Checkbox, Icon, Label, Stack, Text, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { Probe } from 'types';
 import { ProbeStatus } from 'components/ProbeCard/ProbeStatus';
+import { warn } from 'console';
+import { DeprecationNotice } from 'components/DeprecationNotice/DeprecationNotice';
 
 export const ProbesList = ({
   title,
@@ -84,6 +86,22 @@ export const ProbesList = ({
               {`${probe.name}${probe.countryCode ? `, ${probe.countryCode}` : ''} ${
                 probe.provider ? `(${probe.provider})` : ''
               }`}
+              {probe.deprecated && (
+                <DeprecationNotice
+                  tooltipContent={
+                    <div>
+                      This probe is deprecated and will be removed soon. For more information{' '}
+                      <TextLink
+                        variant={'bodySmall'}
+                        href="https://grafana.com/docs/grafana-cloud/whats-new/2024-11-07-eight-synthetics-probe-locations-being-replaced-in-february-2025/"
+                        external
+                      >
+                        click here.
+                      </TextLink>
+                    </div>
+                  }
+                />
+              )}
             </Label>
           </div>
         ))}

--- a/src/components/CheckEditor/CheckProbes/ProbesList.tsx
+++ b/src/components/CheckEditor/CheckProbes/ProbesList.tsx
@@ -24,15 +24,12 @@ export const ProbesList = ({
       onSelectionChange(selectedProbes.filter((id) => !probes.some((probe) => probe.id === id)));
       return;
     }
-    const selected = new Set([
-      ...selectedProbes,
-      ...probes.filter((probe) => !probe.deprecated).map((probe) => probe.id!),
-    ]);
+    const selected = new Set([...selectedProbes, ...probes.map((probe) => probe.id!)]);
     onSelectionChange([...selected]);
   };
 
   const handleToggleProbe = (probe: Probe) => {
-    if (!probe.id || probe.deprecated) {
+    if (!probe.id) {
       return;
     }
     if (selectedProbes.includes(probe.id)) {

--- a/src/components/DeprecationNotice/DeprecationNotice.tsx
+++ b/src/components/DeprecationNotice/DeprecationNotice.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, PopoverContent, Tooltip, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+interface DeprecationNoticeProps {
+  tooltipContent: string | PopoverContent;
+}
+
+export const DeprecationNotice = ({ tooltipContent }: DeprecationNoticeProps) => {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Tooltip interactive={true} content={tooltipContent}>
+      <Icon title="deprecation-notice" name="exclamation-triangle" size="md" className={styles.deprecationWarning} />
+    </Tooltip>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  deprecationWarning: css({
+    marginLeft: theme.spacing(1),
+    color: theme.colors.warning.text,
+  }),
+});

--- a/src/components/ProbeCard/ProbeCard.tsx
+++ b/src/components/ProbeCard/ProbeCard.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Card, Link, LinkButton, useStyles2 } from '@grafana/ui';
+import { Card, Link, LinkButton, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { type ExtendedProbe, type Label } from 'types';
 import { ROUTES } from 'routing/types';
 import { generateRoutePath } from 'routing/utils';
 import { useCanEditProbe } from 'hooks/useCanEditProbe';
+import { DeprecationNotice } from 'components/DeprecationNotice/DeprecationNotice';
 import { SuccessRateGaugeProbe } from 'components/Gauges';
 
 import { ProbeUsageLink } from '../ProbeUsageLink';
@@ -29,6 +30,22 @@ export const ProbeCard = ({ probe }: { probe: ExtendedProbe }) => {
             <span>{probe.name}</span>
             {probe.region && <span>&nbsp;{`(${probe.region})`}</span>}
           </Link>
+          {probe.deprecated && (
+            <DeprecationNotice
+              tooltipContent={
+                <div>
+                  This probe is deprecated and will be removed soon. For more information{' '}
+                  <TextLink
+                    variant={'bodySmall'}
+                    href="https://grafana.com/docs/grafana-cloud/whats-new/2024-11-07-eight-synthetics-probe-locations-being-replaced-in-february-2025/"
+                    external
+                  >
+                    click here.
+                  </TextLink>
+                </div>
+              }
+            />
+          )}
         </div>
       </Card.Heading>
 


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-app/issues/1038

Currently, deprecated probes can't be selected. Besides that, we must add a visual clue indicating their status, as currently there is no indication of this status:

![2025-01-13 11 21 23](https://github.com/user-attachments/assets/4e193880-c5e4-4a98-a75e-003172efb1d4)


This PR shows a warning next to the probe name both in the check form and probe list views. 

- Check form
![image](https://github.com/user-attachments/assets/ab3d277a-5033-45c9-9a8a-d9dc269b1008)

- Probes list
![image](https://github.com/user-attachments/assets/2ed72b43-7878-488b-8b5b-6b8266a86ead)

The link goes to https://grafana.com/docs/grafana-cloud/whats-new/2024-11-07-eight-synthetics-probe-locations-being-replaced-in-february-2025/
