### PR TITLE
chore: remove checkAlert id concept

### DIFF
--- a/src/components/CheckEditor/transformations/toFormValues.alerts.ts
+++ b/src/components/CheckEditor/transformations/toFormValues.alerts.ts
@@ -10,13 +10,11 @@ export function getAlertCheckFormValues(data: CheckAlertsResponse): CheckAlertFo
 
     if (existingAlert) {
       acc[alertType] = {
-        id: existingAlert.id,
         threshold: existingAlert.threshold,
         isSelected: true,
       };
     } else {
       acc[alertType] = {
-        id: undefined,
         threshold: ALL_PREDEFINED_ALERTS.find((alert) => alert.type === alertType)?.default || 0,
         isSelected: false,
       };

--- a/src/components/CheckEditor/transformations/toPayload.alerts.ts
+++ b/src/components/CheckEditor/transformations/toPayload.alerts.ts
@@ -8,7 +8,6 @@ export function getAlertsPayload(formValues?: CheckAlertFormRecord, checkId?: nu
   return Object.entries(formValues).reduce<CheckAlertDraft[]>((alerts, [alertType, alert]) => {
     if (alert.isSelected) {
       alerts.push({
-        id: alert.id,
         name: alertType as CheckAlertType,
         threshold: alert.threshold!!,
       });

--- a/src/datasource/__mocks__/checkAlerts.ts
+++ b/src/datasource/__mocks__/checkAlerts.ts
@@ -10,28 +10,24 @@ export function mockAlertsForCheckData(mockData: CheckAlertsResponse = alertsFro
 export const alertsFromApi: CheckAlertsResponse = {
   alerts: [
     {
-      id: 1,
       name: CheckAlertType['HTTPRequestDurationTooHighP90'],
       threshold: 350,
       created: 1724854935,
       modified: 1724854935,
     },
     {
-      id: 2,
       name: CheckAlertType['HTTPRequestDurationTooHighP95'],
       threshold: 100,
       created: 1724854935,
       modified: 1724854935,
     },
     {
-      id: 3,
       name: CheckAlertType['HTTPTargetCertificateCloseToExpiring'],
       threshold: 90,
       created: 1724854935,
       modified: 1724854935,
     },
     {
-      id: 4,
       name: CheckAlertType['ProbeFailedExecutionsTooHigh'],
       threshold: 20,
       created: 1724854935,

--- a/src/test/fixtures/checkAlerts.ts
+++ b/src/test/fixtures/checkAlerts.ts
@@ -4,28 +4,24 @@ import { CheckAlertsResponse } from 'datasource/responses.types';
 export const BASIC_CHECK_ALERTS: CheckAlertsResponse = {
   alerts: [
     {
-      id: 1,
       name: CheckAlertType['HTTPRequestDurationTooHighP90'],
       threshold: 350,
       created: 1724854935,
       modified: 1724854935,
     },
     {
-      id: 1,
       name: CheckAlertType['HTTPRequestDurationTooHighP95'],
       threshold: 100,
       created: 1724854935,
       modified: 1724854935,
     },
     {
-      id: 1,
       name: CheckAlertType['HTTPTargetCertificateCloseToExpiring'],
       threshold: 90,
       created: 1724854935,
       modified: 1724854935,
     },
     {
-      id: 1,
       name: CheckAlertType['ProbeFailedExecutionsTooHigh'],
       threshold: 20,
       created: 1724854935,

--- a/src/types.ts
+++ b/src/types.ts
@@ -312,7 +312,6 @@ export interface AlertFormValues {
   sensitivity: SelectableValue<AlertSensitivity>;
 }
 export interface CheckAlertFormValues {
-  id?: number;
   threshold?: number;
   isSelected?: boolean;
 }
@@ -654,17 +653,12 @@ export enum CheckAlertCategory {
   RequestDuration = 'Request Duration',
 }
 
-export type CheckAlertBase = {
+export type CheckAlertDraft = {
   name: CheckAlertType;
   threshold: number;
 };
 
-export type CheckAlertDraft = CheckAlertBase & {
-  id?: number;
-};
-
-export type CheckAlertPublished = CheckAlertBase & {
-  id: number;
+export type CheckAlertPublished = CheckAlertDraft & {
   created: number;
   modified: number;
 };


### PR DESCRIPTION
The API is removing the id property for check alerts in https://github.com/grafana/synthetic-monitoring-api/pull/1115 as they can be identified just by their name. 

Updating the frontend code accordingly.