### PR TITLE
fix: wrap labels to always display View dashboard button

### DIFF
--- a/src/page/CheckList/components/CheckItemActionButtons.tsx
+++ b/src/page/CheckList/components/CheckItemActionButtons.tsx
@@ -75,5 +75,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: flex;
     align-items: center;
     gap: ${theme.spacing(1)};
+    flex-grow: 1;
+    justify-content: flex-end;
   `,
 });

--- a/src/page/CheckList/components/CheckListItemCard.tsx
+++ b/src/page/CheckList/components/CheckListItemCard.tsx
@@ -95,7 +95,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     flexWrap: 'wrap',
     flexGrow: 1,
-    maxWidth: '90%',
     gap: theme.spacing(1),
   }),
   heading: css({

--- a/src/page/CheckList/components/CheckListItemCard.tsx
+++ b/src/page/CheckList/components/CheckListItemCard.tsx
@@ -73,7 +73,7 @@ export const CheckListItemCard = ({
             </div>
           </div>
           <Stack>
-            <Stack grow={1} alignItems="center">
+            <Stack grow={1} alignItems="center" wrap={'wrap'}>
               {check.labels.map((label: Label, index) => (
                 <CheckCardLabel key={index} label={label} onLabelSelect={onLabelSelect} />
               ))}

--- a/src/page/CheckList/components/CheckListItemCard.tsx
+++ b/src/page/CheckList/components/CheckListItemCard.tsx
@@ -72,7 +72,7 @@ export const CheckListItemCard = ({
               )}
             </div>
           </div>
-          <Stack wrap={'wrap'} justifyContent={'flex-start'}>
+          <Stack wrap="wrap" justifyContent="flex-start">
             <div className={styles.labelsContainer}>
               {check.labels.map((label: Label, index) => (
                 <CheckCardLabel key={index} label={label} onLabelSelect={onLabelSelect} />

--- a/src/page/CheckList/components/CheckListItemCard.tsx
+++ b/src/page/CheckList/components/CheckListItemCard.tsx
@@ -72,12 +72,12 @@ export const CheckListItemCard = ({
               )}
             </div>
           </div>
-          <Stack>
-            <Stack grow={1} alignItems="center" wrap={'wrap'}>
+          <Stack wrap={'wrap'} justifyContent={'flex-start'}>
+            <div className={styles.labelsContainer}>
               {check.labels.map((label: Label, index) => (
                 <CheckCardLabel key={index} label={label} onLabelSelect={onLabelSelect} />
               ))}
-            </Stack>
+            </div>
             <CheckItemActionButtons check={check} />
           </Stack>
         </div>
@@ -90,6 +90,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
   container: css({
     backgroundColor: theme.colors.background.secondary,
     borderRadius: '2px',
+  }),
+  labelsContainer: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    flexGrow: 1,
+    maxWidth: '90%',
+    gap: theme.spacing(1),
   }),
   heading: css({
     marginBottom: `0`,

--- a/src/page/CheckList/components/CheckListItemDetails.tsx
+++ b/src/page/CheckList/components/CheckListItemDetails.tsx
@@ -68,9 +68,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     font-size: ${theme.typography.bodySmall.fontSize};
     line-height: ${theme.typography.bodySmall.lineHeight};
     white-space: nowrap;
-    display: flex;
     align-items: center;
-    width: 600px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   `,
   labelWidth: css`
     max-width: 350px;


### PR DESCRIPTION
Closes #1042 

With a large number of labels, the View Dashboard, Edit and Delete buttons get overlapped. This PR fixes it by wrapping them.

https://github.com/user-attachments/assets/ba9afe55-6a18-4209-bf74-a2d4ae102537



