### PR TITLE
Feat: increase check timeout to scripted, browser and multihttp checks

### DIFF
--- a/src/components/CheckForm/CheckForm.constants.tsx
+++ b/src/components/CheckForm/CheckForm.constants.tsx
@@ -1,0 +1,15 @@
+import { CheckType } from 'types';
+
+const CheckTimeoutValues = {
+  [CheckType.PING]: { min: 1, max: 60 },
+  [CheckType.TCP]: { min: 1, max: 60 },
+  [CheckType.Traceroute]: { min: 30, max: 30 },
+  [CheckType.DNS]: { min: 1, max: 60 },
+  [CheckType.GRPC]: { min: 1, max: 60 },
+  [CheckType.HTTP]: { min: 1, max: 60 },
+  [CheckType.MULTI_HTTP]: { min: 5, max: 90 },
+  [CheckType.Scripted]: { min: 5, max: 90 },
+  [CheckType.Browser]: { min: 5, max: 90 },
+};
+
+export { CheckTimeoutValues };

--- a/src/components/CheckForm/FormLayouts/CheckBrowserLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckBrowserLayout.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { Stack, TextLink } from '@grafana/ui';
 
 import { LayoutSection, Section } from './Layout.types';
-import { CheckFormValuesBrowser } from 'types';
+import { CheckFormValuesBrowser, CheckType } from 'types';
 import { BrowserFields } from 'components/CheckEditor/CheckEditor.types';
 import { BrowserCheckInstance } from 'components/CheckEditor/FormComponents/BrowserCheckInstance';
 import { BrowserCheckScript } from 'components/CheckEditor/FormComponents/BrowserCheckScript';
 import { Timeout } from 'components/CheckEditor/FormComponents/Timeout';
+
+import { CheckTimeoutValues } from '../CheckForm.constants';
 
 export const BROWSER_CHECK_FIELDS: BrowserFields = {
   script: {
@@ -37,7 +39,7 @@ export const BrowserCheckLayout: Partial<Record<LayoutSection, Section<CheckForm
             running checks in a k6 script.
           </TextLink>
         </div>
-        <Timeout min={5.0} />
+        <Timeout min={CheckTimeoutValues[CheckType.Browser].min} max={CheckTimeoutValues[CheckType.Browser].max} />
       </Stack>
     ),
   },

--- a/src/components/CheckForm/FormLayouts/CheckDNSLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckDNSLayout.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 
 import { LayoutSection, Section } from './Layout.types';
-import { CheckFormValuesDns } from 'types';
+import { CheckFormValuesDns, CheckType } from 'types';
 import { useNestedRequestErrors } from 'hooks/useNestedRequestErrors';
 import { DNSRequestFields } from 'components/CheckEditor/CheckEditor.types';
 import { CheckPublishedAdvanceMetrics } from 'components/CheckEditor/FormComponents/CheckPublishedAdvanceMetrics';
@@ -10,6 +10,7 @@ import { DNSCheckValidResponseCodes } from 'components/CheckEditor/FormComponent
 import { DNSRequest } from 'components/CheckEditor/FormComponents/DNSRequest';
 import { Timeout } from 'components/CheckEditor/FormComponents/Timeout';
 
+import { CheckTimeoutValues } from '../CheckForm.constants';
 import { useCheckFormContext } from '../CheckFormContext/CheckFormContext';
 
 export const DNS_REQUEST_FIELDS: DNSRequestFields = {
@@ -65,7 +66,7 @@ export const DNSCheckLayout: Partial<Record<LayoutSection, Section<CheckFormValu
       <>
         <DNSCheckValidResponseCodes />
         <DNSCheckResponseMatches />
-        <Timeout />
+        <Timeout min={CheckTimeoutValues[CheckType.DNS].min} max={CheckTimeoutValues[CheckType.DNS].max} />
       </>
     ),
   },

--- a/src/components/CheckForm/FormLayouts/CheckGrpcLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckGrpcLayout.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback } from 'react';
 
 import { LayoutSection, Section } from './Layout.types';
-import { CheckFormValuesGRPC } from 'types';
+import { CheckFormValuesGRPC, CheckType } from 'types';
 import { useNestedRequestErrors } from 'hooks/useNestedRequestErrors';
 import { GRPCRequestFields } from 'components/CheckEditor/CheckEditor.types';
 import { CheckPublishedAdvanceMetrics } from 'components/CheckEditor/FormComponents/CheckPublishedAdvanceMetrics';
 import { GRPCRequest } from 'components/CheckEditor/FormComponents/GRPCRequest';
 import { Timeout } from 'components/CheckEditor/FormComponents/Timeout';
 
+import { CheckTimeoutValues } from '../CheckForm.constants';
 import { useCheckFormContext } from '../CheckFormContext/CheckFormContext';
 
 export const GRPC_REQUEST_FIELDS: GRPCRequestFields = {
@@ -73,7 +74,7 @@ export const GRPCCheckLayout: Partial<Record<LayoutSection, Section<CheckFormVal
     fields: [`timeout`],
     Component: (
       <>
-        <Timeout />
+        <Timeout min={CheckTimeoutValues[CheckType.GRPC].min} max={CheckTimeoutValues[CheckType.GRPC].max} />
       </>
     ),
   },

--- a/src/components/CheckForm/FormLayouts/CheckHttpLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckHttpLayout.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 
 import { LayoutSection, Section } from './Layout.types';
-import { CheckFormValues, CheckFormValuesHttp } from 'types';
+import { CheckFormValues, CheckFormValuesHttp, CheckType } from 'types';
 import { useNestedRequestErrors } from 'hooks/useNestedRequestErrors';
 import { HttpRequestFields } from 'components/CheckEditor/CheckEditor.types';
 import { CheckPublishedAdvanceMetrics } from 'components/CheckEditor/FormComponents/CheckPublishedAdvanceMetrics';
@@ -13,6 +13,7 @@ import { HttpCheckValidStatusCodes } from 'components/CheckEditor/FormComponents
 import { HttpRequest } from 'components/CheckEditor/FormComponents/HttpRequest';
 import { Timeout } from 'components/CheckEditor/FormComponents/Timeout';
 
+import { CheckTimeoutValues } from '../CheckForm.constants';
 import { useCheckFormContext } from '../CheckFormContext/CheckFormContext';
 
 export const HTTP_REQUEST_FIELDS: HttpRequestFields<CheckFormValuesHttp> = {
@@ -109,7 +110,7 @@ export const HttpCheckLayout: Partial<Record<LayoutSection, Section<CheckFormVal
         <HttpCheckSSLOptions />
         <HttpCheckRegExValidation />
         <HttpCheckCompressionOption />
-        <Timeout />
+        <Timeout min={CheckTimeoutValues[CheckType.HTTP].min} max={CheckTimeoutValues[CheckType.HTTP].max} />
       </>
     ),
   },

--- a/src/components/CheckForm/FormLayouts/CheckMultiHttpLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckMultiHttpLayout.tsx
@@ -6,8 +6,8 @@ import { MultiHttpAssertions } from 'components/CheckEditor/FormComponents/Multi
 import { MultiHttpCheckRequests } from 'components/CheckEditor/FormComponents/MultiHttpCheckRequests';
 import { Timeout } from 'components/CheckEditor/FormComponents/Timeout';
 
-import { ENTRY_INDEX_CHAR } from '../FormLayout/formlayout.utils';
 import { CheckTimeoutValues } from '../CheckForm.constants';
+import { ENTRY_INDEX_CHAR } from '../FormLayout/formlayout.utils';
 
 export const MultiHTTPCheckLayout: Partial<Record<LayoutSection, Section<CheckFormValuesMultiHttp>>> = {
   [LayoutSection.Check]: {

--- a/src/components/CheckForm/FormLayouts/CheckMultiHttpLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckMultiHttpLayout.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
 import { LayoutSection, Section } from './Layout.types';
-import { CheckFormValuesMultiHttp } from 'types';
+import { CheckFormValuesMultiHttp, CheckType } from 'types';
 import { MultiHttpAssertions } from 'components/CheckEditor/FormComponents/MultiHttpAssertions';
 import { MultiHttpCheckRequests } from 'components/CheckEditor/FormComponents/MultiHttpCheckRequests';
 import { Timeout } from 'components/CheckEditor/FormComponents/Timeout';
 
 import { ENTRY_INDEX_CHAR } from '../FormLayout/formlayout.utils';
+import { CheckTimeoutValues } from '../CheckForm.constants';
 
 export const MultiHTTPCheckLayout: Partial<Record<LayoutSection, Section<CheckFormValuesMultiHttp>>> = {
   [LayoutSection.Check]: {
@@ -25,7 +26,10 @@ export const MultiHTTPCheckLayout: Partial<Record<LayoutSection, Section<CheckFo
     Component: (
       <>
         <MultiHttpAssertions />
-        <Timeout min={5.0} />
+        <Timeout
+          min={CheckTimeoutValues[CheckType.MULTI_HTTP].min}
+          max={CheckTimeoutValues[CheckType.MULTI_HTTP].max}
+        />
       </>
     ),
   },

--- a/src/components/CheckForm/FormLayouts/CheckPingLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckPingLayout.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback } from 'react';
 
 import { LayoutSection, Section } from './Layout.types';
-import { CheckFormValuesPing } from 'types';
+import { CheckFormValuesPing, CheckType } from 'types';
 import { useNestedRequestErrors } from 'hooks/useNestedRequestErrors';
 import { PingRequestFields } from 'components/CheckEditor/CheckEditor.types';
 import { CheckPublishedAdvanceMetrics } from 'components/CheckEditor/FormComponents/CheckPublishedAdvanceMetrics';
 import { PingRequest } from 'components/CheckEditor/FormComponents/PingRequest';
 import { Timeout } from 'components/CheckEditor/FormComponents/Timeout';
 
+import { CheckTimeoutValues } from '../CheckForm.constants';
 import { useCheckFormContext } from '../CheckFormContext/CheckFormContext';
 
 const PING_FIELDS: PingRequestFields = {
@@ -49,7 +50,7 @@ export const PingCheckLayout: Partial<Record<LayoutSection, Section<CheckFormVal
     fields: [`timeout`],
     Component: (
       <>
-        <Timeout />
+        <Timeout min={CheckTimeoutValues[CheckType.PING].min} max={CheckTimeoutValues[CheckType.PING].max} />
       </>
     ),
   },

--- a/src/components/CheckForm/FormLayouts/CheckScriptedLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckScriptedLayout.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { Stack, TextLink } from '@grafana/ui';
 
 import { LayoutSection, Section } from './Layout.types';
-import { CheckFormValuesScripted } from 'types';
+import { CheckFormValuesScripted, CheckType } from 'types';
 import { ScriptedFields } from 'components/CheckEditor/CheckEditor.types';
 import { ScriptedCheckInstance } from 'components/CheckEditor/FormComponents/ScriptedCheckInstance';
 import { ScriptedCheckScript } from 'components/CheckEditor/FormComponents/ScriptedCheckScript';
 import { Timeout } from 'components/CheckEditor/FormComponents/Timeout';
+
+import { CheckTimeoutValues } from '../CheckForm.constants';
 
 export const SCRIPTED_CHECK_FIELDS: ScriptedFields = {
   script: {
@@ -37,7 +39,7 @@ export const ScriptedCheckLayout: Partial<Record<LayoutSection, Section<CheckFor
             running checks in a k6 script.
           </TextLink>
         </div>
-        <Timeout min={5.0} />
+        <Timeout min={CheckTimeoutValues[CheckType.Scripted].min} max={CheckTimeoutValues[CheckType.Scripted].max} />
       </Stack>
     ),
   },

--- a/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckTCPLayout.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 
 import { LayoutSection, Section } from './Layout.types';
-import { CheckFormValuesTcp } from 'types';
+import { CheckFormValuesTcp, CheckType } from 'types';
 import { useNestedRequestErrors } from 'hooks/useNestedRequestErrors';
 import { TCPRequestFields } from 'components/CheckEditor/CheckEditor.types';
 import { CheckPublishedAdvanceMetrics } from 'components/CheckEditor/FormComponents/CheckPublishedAdvanceMetrics';
@@ -9,6 +9,7 @@ import { TCPCheckQueryAndResponse } from 'components/CheckEditor/FormComponents/
 import { TCPRequest } from 'components/CheckEditor/FormComponents/TCPRequest';
 import { Timeout } from 'components/CheckEditor/FormComponents/Timeout';
 
+import { CheckTimeoutValues } from '../CheckForm.constants';
 import { useCheckFormContext } from '../CheckFormContext/CheckFormContext';
 
 const TCP_REQUEST_FIELDS: TCPRequestFields = {
@@ -71,7 +72,7 @@ export const TCPCheckLayout: Partial<Record<LayoutSection, Section<CheckFormValu
     Component: (
       <>
         <TCPCheckQueryAndResponse />
-        <Timeout />
+        <Timeout min={CheckTimeoutValues[CheckType.TCP].min} max={CheckTimeoutValues[CheckType.TCP].max} />
       </>
     ),
   },

--- a/src/components/CheckForm/FormLayouts/CheckTracerouteLayout.tsx
+++ b/src/components/CheckForm/FormLayouts/CheckTracerouteLayout.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 
 import { LayoutSection, Section } from './Layout.types';
-import { CheckFormValuesTraceroute } from 'types';
+import { CheckFormValuesTraceroute, CheckType } from 'types';
 import { useNestedRequestErrors } from 'hooks/useNestedRequestErrors';
 import { TracerouteRequestFields } from 'components/CheckEditor/CheckEditor.types';
 import { CheckPublishedAdvanceMetrics } from 'components/CheckEditor/FormComponents/CheckPublishedAdvanceMetrics';
 import { Timeout } from 'components/CheckEditor/FormComponents/Timeout';
 import { TracerouteRequest } from 'components/CheckEditor/FormComponents/TracerouteRequest';
 
+import { CheckTimeoutValues } from '../CheckForm.constants';
 import { useCheckFormContext } from '../CheckFormContext/CheckFormContext';
 
 const TRACEROUTE_FIELDS: TracerouteRequestFields = {
@@ -47,7 +48,10 @@ export const TracerouteCheckLayout: Partial<Record<LayoutSection, Section<CheckF
     fields: [`timeout`],
     Component: (
       <>
-        <Timeout max={30.0} min={30.0} />
+        <Timeout
+          min={CheckTimeoutValues[CheckType.Traceroute].min}
+          max={CheckTimeoutValues[CheckType.Traceroute].max}
+        />
       </>
     ),
   },

--- a/src/components/TimeSlider/styles.ts
+++ b/src/components/TimeSlider/styles.ts
@@ -92,7 +92,7 @@ export const getStyles = (theme: GrafanaTheme2, hasMarks = false) => {
     sliderInputField: css({
       marginLeft: theme.spacing(3),
       marginRight: theme.spacing(1),
-      width: '60px',
+      maxWidth: '60px',
       minWidth: '40px',
       input: {
         textAlign: 'center',

--- a/src/page/NewCheck/__tests__/BrowserChecks/Scripted/5-execution.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/BrowserChecks/Scripted/5-execution.payload.test.tsx
@@ -38,4 +38,27 @@ describe(`BrowserCheck - Section 5 (Execution) payload`, () => {
 
     expect(body.frequency).toBe(ONE_MINUTE_IN_MS);
   });
+
+    it(`can add timeout up to 90 seconds`, async () => {
+      const MAX_TIMEOUT_MS = 90000;
+  
+      const { user, read } = await renderNewForm(checkType);
+      await fillMandatoryFields({ user, checkType });
+  
+      await goToSection(user, 2);
+  
+      const timeoutMinutesInput = screen.getByLabelText('timeout minutes input');
+      const timeoutSecondsInput = screen.getByLabelText('timeout seconds input');
+  
+      await user.clear(timeoutMinutesInput);
+      await user.clear(timeoutSecondsInput);
+      await user.type(timeoutMinutesInput, `{backspace}1`);
+      await user.type(timeoutSecondsInput, `30`);
+  
+      await submitForm(user);
+  
+      const { body } = await read();
+  
+      expect(body.timeout).toBe(MAX_TIMEOUT_MS);
+    });
 });

--- a/src/page/NewCheck/__tests__/MultiStepChecks/MultiHTTP/5-execution.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/MultiStepChecks/MultiHTTP/5-execution.payload.test.tsx
@@ -38,4 +38,27 @@ describe(`MultiHTTPCheck - Section 5 (Execution) payload`, () => {
 
     expect(body.frequency).toBe(ONE_MINUTE_IN_MS);
   });
+
+    it(`can add timeout up to 90 seconds`, async () => {
+      const MAX_TIMEOUT_MS = 90000;
+  
+      const { user, read } = await renderNewForm(checkType);
+      await fillMandatoryFields({ user, checkType });
+  
+      await goToSection(user, 2);
+  
+      const timeoutMinutesInput = screen.getByLabelText('timeout minutes input');
+      const timeoutSecondsInput = screen.getByLabelText('timeout seconds input');
+  
+      await user.clear(timeoutMinutesInput);
+      await user.clear(timeoutSecondsInput);
+      await user.type(timeoutMinutesInput, `{backspace}1`);
+      await user.type(timeoutSecondsInput, `30`);
+  
+      await submitForm(user);
+  
+      const { body } = await read();
+  
+      expect(body.timeout).toBe(MAX_TIMEOUT_MS);
+    });
 });

--- a/src/page/NewCheck/__tests__/ScriptedChecks/Scripted/5-execution.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/ScriptedChecks/Scripted/5-execution.payload.test.tsx
@@ -38,4 +38,27 @@ describe(`ScriptedCheck - Section 5 (Execution) payload`, () => {
 
     expect(body.frequency).toBe(ONE_MINUTE_IN_MS);
   });
+
+  it(`can add timeout up to 90 seconds`, async () => {
+    const MAX_TIMEOUT_MS = 90000;
+
+    const { user, read } = await renderNewForm(checkType);
+    await fillMandatoryFields({ user, checkType });
+
+    await goToSection(user, 2);
+
+    const timeoutMinutesInput = screen.getByLabelText('timeout minutes input');
+    const timeoutSecondsInput = screen.getByLabelText('timeout seconds input');
+
+    await user.clear(timeoutMinutesInput);
+    await user.clear(timeoutSecondsInput);
+    await user.type(timeoutMinutesInput, `{backspace}1`);
+    await user.type(timeoutSecondsInput, `30`);
+
+    await submitForm(user);
+
+    const { body } = await read();
+
+    expect(body.timeout).toBe(MAX_TIMEOUT_MS);
+  });
 });

--- a/src/schemas/forms/BaseCheckSchema.ts
+++ b/src/schemas/forms/BaseCheckSchema.ts
@@ -6,15 +6,26 @@ import { z, ZodType } from 'zod';
 
 import { AlertSensitivity, CheckFormValuesBase } from 'types';
 
-export const BaseCheckSchema: ZodType<CheckFormValuesBase> = z.object({
-  job: JobSchema,
-  target: z.string(),
-  frequency: FrequencySchema,
-  id: z.number().optional(),
-  timeout: z.number(),
-  enabled: z.boolean(),
-  probes: CheckProbesSchema,
-  alertSensitivity: z.nativeEnum(AlertSensitivity),
-  labels: LabelsSchema,
-  publishAdvancedMetrics: z.boolean(),
-});
+export const BaseCheckSchema: ZodType<CheckFormValuesBase> = z
+  .object({
+    job: JobSchema,
+    target: z.string(),
+    frequency: FrequencySchema,
+    id: z.number().optional(),
+    timeout: z.number(),
+    enabled: z.boolean(),
+    probes: CheckProbesSchema,
+    alertSensitivity: z.nativeEnum(AlertSensitivity),
+    labels: LabelsSchema,
+    publishAdvancedMetrics: z.boolean(),
+  })
+  .superRefine((data, ctx) => {
+    const { frequency, timeout } = data;
+    if (frequency < timeout) {
+      ctx.addIssue({
+        path: ['frequency'],
+        message: `Frequency must be greater than or equal to timeout (${timeout} seconds)`,
+        code: z.ZodIssueCode.custom,
+      });
+    }
+  });


### PR DESCRIPTION
Closes #1048 

- Allows a timeout of 90 seconds for `browser`, `scripted` and `multihttp` checks
- Adds validation to prevent frequency lower than the chosen timeout
- Adds tests

https://github.com/user-attachments/assets/bc15e366-6940-406c-b366-343a3bed43dc

