### PR TITLE
feat: sort probes alphabetically

### DIFF
--- a/src/components/CheckEditor/CheckProbes/CheckProbes.tsx
+++ b/src/components/CheckEditor/CheckProbes/CheckProbes.tsx
@@ -50,15 +50,17 @@ export function CheckProbes({ probes, availableProbes, onChange, error }: CheckP
           <ProbesFilter probes={availableProbes} onSearch={setFilteredProbes} />
           <Stack wrap="wrap">
             <Stack wrap="nowrap">
-              {Object.entries(groupedByRegion).map(([region, allProbes]) => (
-                <ProbesList
-                  key={region}
-                  title={region}
-                  probes={allProbes}
-                  selectedProbes={probes}
-                  onSelectionChange={onChange}
-                />
-              ))}
+              {Object.entries(groupedByRegion)
+                .sort(([regionA], [regionB]) => regionA.localeCompare(regionB))
+                .map(([region, allProbes]) => (
+                  <ProbesList
+                    key={region}
+                    title={region}
+                    probes={allProbes}
+                    selectedProbes={probes}
+                    onSelectionChange={onChange}
+                  />
+                ))}
             </Stack>
 
             {privateProbes.length > 0 && (

--- a/src/data/useProbes.ts
+++ b/src/data/useProbes.ts
@@ -5,6 +5,7 @@ import { isFetchError } from '@grafana/runtime';
 import { type MutationProps } from 'data/types';
 import { ExtendedProbe, type Probe } from 'types';
 import { FaroEvent } from 'faro';
+import { camelCaseToSentence } from 'utils';
 import { SMDataSource } from 'datasource/DataSource';
 import type {
   AddProbeResult,
@@ -44,20 +45,26 @@ export function useProbesWithMetadata() {
     if (isLoading) {
       return [];
     }
-    
-    return probes.map((probe) => {
-      const metadata = PROBES_METADATA.find(
-        (info) => info.name === probe.name && info.region === probe.region
-      );
-      return metadata ? { ...probe, ...metadata } : probe;
-    });
+
+    return probes
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((probe) => {
+        const metadata = PROBES_METADATA.find((info) => info.name === probe.name && info.region === probe.region);
+        const displayName = camelCaseToSentence(probe.name);
+
+        return {
+          ...probe,
+          ...metadata,
+          name: displayName,
+        };
+      });
   }, [probes, isLoading]);
 
   return { data: probesWithMetadata, isLoading };
 }
 
 export function useExtendedProbes(): [ExtendedProbe[], boolean] {
-  const { data: probes = [], isLoading: isLoadingProbes } = useProbes();
+  const { data: probes = [], isLoading: isLoadingProbes } = useProbesWithMetadata();
   const { data: checks = [], isLoading: isLoadingChecks } = useChecks();
   const isLoading = isLoadingProbes || isLoadingChecks;
 

--- a/src/page/Probes/Probes.tsx
+++ b/src/page/Probes/Probes.tsx
@@ -58,7 +58,6 @@ const ProbesContent = () => {
   };
 
   const { publicProbes, privateProbes } = extendedProbes
-    .sort((probeA, probeB) => probeA.name.localeCompare(probeB.name))
     .filter((probe) => Boolean(probe.id))
     .reduce((acc, probe) => {
       if (!probe.id) {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { getRandomProbes } from 'utils';
+import { camelCaseToSentence, getRandomProbes } from 'utils';
 
 it('gets random probes', async () => {
   const probes = [11, 23, 5, 5212, 43, 3, 4, 6];
@@ -12,4 +12,14 @@ it('gets random probes', async () => {
 
   const random2 = getRandomProbes(probes, 2);
   expect(random2.length).toBe(2);
+});
+
+describe(`camelCaseToSentence`, () => {
+  it(`converts camelCase to sentence`, () => {
+    expect(camelCaseToSentence('camelCaseToSentence')).toBe('Camel Case To Sentence');
+  });
+
+  it(`doesn't convert values which are all uppercase`, () => {
+    expect(camelCaseToSentence('ALLUPPERCASE')).toBe('ALLUPPERCASE');
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -426,3 +426,11 @@ export function createNavModel(base: NavModelItem, items: NavModelItem[]): NavMo
     };
   }, base);
 }
+
+export function camelCaseToSentence(value: string) {
+  if (value.toUpperCase() === value || value.toLowerCase() === value) {
+    return value;
+  }
+
+  return value.replace(/([A-Z])/g, ' $1').replace(/^./, (str) => str.toUpperCase());
+}


### PR DESCRIPTION
## Problem

Currently, the probe list can be a little difficult to find the probe you after when searching through the list. The probes come back in ID order which is different per region that a user's stack is located in.

The second issue is that the probe names are in pascal case, which isn't so intuitive and familiar for a user to find when using the probe search. 

## Solution

1. Sort the probes alphabetically in `useProbesWithMetadata`
2. Change the name to utilize the display name
3. Alphabetize the region in the check probes display

**Before**

![Screenshot of the probe selection during check creation. The regions aren't sorted alphabetically, nor are the probe lists in each one.](https://github.com/user-attachments/assets/cf86fa8a-5141-495f-bc34-b3537a835a3e)
![Searching for 'new york' in the probe search input. It shows there are no probes matching your criteria.](https://github.com/user-attachments/assets/2699e8a3-24d8-4c37-aa52-a221da781eef)

**After**
![Screenshot of the probe selection during check creation. The regions and probe lists are all sorted alphabetically.](https://github.com/user-attachments/assets/c3dee433-decd-48ec-b6e6-60372f963453)
![Searching for 'new york' in the probe search input. It shows the new york probe in the results.](https://github.com/user-attachments/assets/3fb150fe-b9b0-4364-bc31-cb9a6dc58d13)

