### PR TITLE
fix: strip back ci.yml checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,5 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable --prefer-offline
 
-      - name: Check types
-        run: yarn typecheck
       - name: Lint
         run: yarn lint
-      - name: Unit tests
-        run: yarn test:ci
-      - name: Build frontend
-        run: yarn build


### PR DESCRIPTION
Keeping ci.yml but stripped it back. Need to migrate away from Drone in the near future.