### PR TITLE
fix: add displayName on top of name rather than replace

### DIFF
--- a/src/components/CheckEditor/CheckProbes/CheckProbes.tsx
+++ b/src/components/CheckEditor/CheckProbes/CheckProbes.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Field, Stack } from '@grafana/ui';
 
-import { Probe } from 'types';
+import { ProbeWithMetadata } from 'types';
 
 import { PrivateProbesAlert } from './PrivateProbesAlert';
 import { PROBES_FILTER_ID, ProbesFilter } from './ProbesFilter';
@@ -9,7 +9,7 @@ import { ProbesList } from './ProbesList';
 
 interface CheckProbesProps {
   probes: number[];
-  availableProbes: Probe[];
+  availableProbes: ProbeWithMetadata[];
   disabled?: boolean;
   onChange: (probes: number[]) => void;
   onBlur?: () => void;
@@ -17,14 +17,14 @@ interface CheckProbesProps {
   error?: string;
 }
 export function CheckProbes({ probes, availableProbes, onChange, error }: CheckProbesProps) {
-  const [filteredProbes, setFilteredProbes] = useState<Probe[]>(availableProbes);
+  const [filteredProbes, setFilteredProbes] = useState<ProbeWithMetadata[]>(availableProbes);
 
   const publicProbes = useMemo(() => filteredProbes.filter((probe) => probe.public), [filteredProbes]);
   const privateProbes = useMemo(() => filteredProbes.filter((probe) => !probe.public), [filteredProbes]);
 
   const groupedByRegion = useMemo(
     () =>
-      publicProbes.reduce((acc: Record<string, Probe[]>, curr: Probe) => {
+      publicProbes.reduce((acc: Record<string, ProbeWithMetadata[]>, curr: ProbeWithMetadata) => {
         const region = curr.region;
         if (!acc[region]) {
           acc[region] = [];

--- a/src/components/CheckEditor/CheckProbes/ProbesFilter.tsx
+++ b/src/components/CheckEditor/CheckProbes/ProbesFilter.tsx
@@ -1,11 +1,17 @@
 import React, { useState } from 'react';
 
-import { Probe } from 'types';
+import { ProbeWithMetadata } from 'types';
 import { SearchFilter } from 'components/SearchFilter';
 
 export const PROBES_FILTER_ID = 'check-probes-filter';
 
-export const ProbesFilter = ({ probes, onSearch }: { probes: Probe[]; onSearch: (probes: Probe[]) => void }) => {
+export const ProbesFilter = ({
+  probes,
+  onSearch,
+}: {
+  probes: ProbeWithMetadata[];
+  onSearch: (probes: ProbeWithMetadata[]) => void;
+}) => {
   const [showEmptyState, setShowEmptyState] = useState(false);
   const [filterText, setFilterText] = useState('');
 
@@ -15,11 +21,11 @@ export const ProbesFilter = ({ probes, onSearch }: { probes: Probe[]; onSearch: 
       (probe) =>
         probe.region.toLowerCase().includes(searchValue) ||
         probe.name.toLowerCase().includes(searchValue) ||
-        probe.longRegion?.toLowerCase().includes(searchValue) ||
-        probe.city?.toLowerCase().includes(searchValue) ||
-        probe.provider?.toLowerCase().includes(searchValue) ||
-        probe.country?.toLowerCase().includes(searchValue) ||
-        probe.countryCode?.toLowerCase().includes(searchValue)
+        probe.displayName.toLowerCase().includes(searchValue) ||
+        probe.longRegion.toLowerCase().includes(searchValue) ||
+        probe.provider.toLowerCase().includes(searchValue) ||
+        probe.country.toLowerCase().includes(searchValue) ||
+        probe.countryCode.toLowerCase().includes(searchValue)
     );
 
     onSearch(filteredProbes);

--- a/src/components/CheckEditor/CheckProbes/ProbesList.tsx
+++ b/src/components/CheckEditor/CheckProbes/ProbesList.tsx
@@ -3,7 +3,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Checkbox, Label, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
-import { Probe } from 'types';
+import { ProbeWithMetadata } from 'types';
 import { DeprecationNotice } from 'components/DeprecationNotice/DeprecationNotice';
 import { ProbeStatus } from 'components/ProbeCard/ProbeStatus';
 
@@ -14,7 +14,7 @@ export const ProbesList = ({
   onSelectionChange,
 }: {
   title: string;
-  probes: Probe[];
+  probes: ProbeWithMetadata[];
   selectedProbes: number[];
   onSelectionChange: (probes: number[]) => void;
 }) => {
@@ -29,7 +29,7 @@ export const ProbesList = ({
     onSelectionChange([...selected]);
   };
 
-  const handleToggleProbe = (probe: Probe) => {
+  const handleToggleProbe = (probe: ProbeWithMetadata) => {
     if (!probe.id) {
       return;
     }
@@ -73,7 +73,7 @@ export const ProbesList = ({
         </Label>
       </div>
       <div className={styles.probesList}>
-        {probes.map((probe: Probe) => (
+        {probes.map((probe: ProbeWithMetadata) => (
           <div key={probe.id} className={styles.item}>
             <Checkbox
               id={`probe-${probe.id}`}
@@ -83,7 +83,7 @@ export const ProbesList = ({
             <Label htmlFor={`probe-${probe.id}`}>
               <div className={styles.columnLabel}>
                 <ProbeStatus probe={probe} />{' '}
-                {`${probe.name}${probe.countryCode ? `, ${probe.countryCode}` : ''} ${
+                {`${probe.displayName}${probe.countryCode ? `, ${probe.countryCode}` : ''} ${
                   probe.provider ? `(${probe.provider})` : ''
                 }`}
                 {probe.deprecated && (

--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { Field } from '@grafana/ui';
 
-import { CheckFormValues, CheckType, Probe } from 'types';
+import { CheckFormValues, CheckType, ProbeWithMetadata } from 'types';
 import { useProbesWithMetadata } from 'data/useProbes';
 import { SliderInput } from 'components/SliderInput';
 
@@ -73,7 +73,7 @@ function getFrequencyBounds(checkType: CheckType) {
   };
 }
 
-function getAvailableProbes(probes: Probe[], checkType: CheckType) {
+function getAvailableProbes(probes: ProbeWithMetadata[], checkType: CheckType) {
   if (checkType === CheckType.Scripted) {
     return probes.filter((probe) => probe.capabilities.disableScriptedChecks === false);
   }

--- a/src/components/CheckEditor/ProbesMetadata.ts
+++ b/src/components/CheckEditor/ProbesMetadata.ts
@@ -1,4 +1,4 @@
-import { ProbeProvider } from 'types';
+import { ProbeMetadata, ProbeProvider } from 'types';
 
 const REGION_APAC = { code: 'APAC', long: 'Asia-Pacific' };
 const REGION_AMER = { code: 'AMER', long: 'The Americas' };
@@ -23,7 +23,7 @@ const COUNTRY_AE = { code: 'AE', long: 'United Arab Emirates' };
 const COUNTRY_ES = { code: 'ES', long: 'Spain' };
 const COUNTRY_ID = { code: 'ID', long: 'Indonesia' };
 
-export const PROBES_METADATA = [
+export const PROBES_METADATA: ProbeMetadata[] = [
   {
     name: 'Bangalore',
     region: REGION_APAC.code,

--- a/src/components/DeleteProbeButton/DeleteProbeButton.tsx
+++ b/src/components/DeleteProbeButton/DeleteProbeButton.tsx
@@ -49,7 +49,7 @@ export function DeleteProbeButton({ probe, onDeleteSuccess: _onDeleteSuccess }: 
       <>
         You do not have sufficient permissions
         <br />
-        to delete the probe <span className={styles.probeName}>&apos;{probe.name}&apos;</span>.
+        to delete the probe <span className={styles.probeName}>&apos;{probe.displayName}&apos;</span>.
       </>
     );
 

--- a/src/components/DeleteProbeButton/DeleteProbeButton.utils.ts
+++ b/src/components/DeleteProbeButton/DeleteProbeButton.utils.ts
@@ -1,13 +1,13 @@
 import type { BackendError } from './DeleteProbeButton.types';
-import { Probe } from 'types';
+import { ProbeWithMetadata } from 'types';
 
-export function getPrettyError(error: Error | BackendError, probe: Probe) {
+export function getPrettyError(error: Error | BackendError, probe: ProbeWithMetadata) {
   if (!error) {
     return undefined;
   }
 
   if ('data' in error && 'err' in error.data && 'msg' in error.data && typeof error.data.msg === 'string') {
-    return { name: error.data.err, message: error.data.msg.replace(String(probe.id), `'${probe.name}'`) };
+    return { name: error.data.err, message: error.data.msg.replace(String(probe.id), `'${probe.displayName}'`) };
   }
 
   return { name: 'Unknown error', message: 'An unknown error occurred' };

--- a/src/components/ProbeCard/ProbeCard.test.tsx
+++ b/src/components/ProbeCard/ProbeCard.test.tsx
@@ -18,9 +18,9 @@ it(`Displays the correct information`, async () => {
   const probe = probeToExtendedProbe(ONLINE_PROBE);
   render(<ProbeCard probe={probe} />);
 
-  await screen.findByText(probe.name);
+  await screen.findByText(probe.displayName);
 
-  expect(screen.getByText((content) => content.startsWith(probe.name))).toBeInTheDocument();
+  expect(screen.getByText((content) => content.startsWith(probe.displayName))).toBeInTheDocument();
   expect(screen.getByText(/Version:/)).toBeInTheDocument();
   expect(screen.getByText(probe.version, { exact: false })).toBeInTheDocument();
 
@@ -36,7 +36,7 @@ it(`Displays the correct information for an online probe`, async () => {
   const probe = probeToExtendedProbe(ONLINE_PROBE);
 
   render(<ProbeCard probe={probe} />);
-  await screen.findByText(probe.name);
+  await screen.findByText(probe.displayName);
 
   // Check status circle
   const status = screen.getByTestId('probe-online-status');
@@ -47,7 +47,7 @@ it(`Displays the correct information for an online probe`, async () => {
   await userEvent.hover(status);
   const tooltip = await screen.findByTestId('probe-online-status-tooltip');
   expect(tooltip).toBeInTheDocument();
-  expect(tooltip).toHaveTextContent(`Probe ${probe.name} is online`);
+  expect(tooltip).toHaveTextContent(`Probe ${probe.displayName} is online`);
 });
 
 it(`Displays the correct information for an offline probe`, async () => {
@@ -55,7 +55,7 @@ it(`Displays the correct information for an offline probe`, async () => {
   const probe = probeToExtendedProbe(OFFLINE_PROBE);
 
   render(<ProbeCard probe={probe} />);
-  await screen.findByText(probe.name);
+  await screen.findByText(probe.displayName);
 
   // Check status circle
   const status = screen.getByTestId('probe-online-status');
@@ -66,14 +66,14 @@ it(`Displays the correct information for an offline probe`, async () => {
   await userEvent.hover(status);
   const tooltip = await screen.findByTestId('probe-online-status-tooltip');
   expect(tooltip).toBeInTheDocument();
-  expect(tooltip).toHaveTextContent(`Probe ${probe.name} is offline`);
+  expect(tooltip).toHaveTextContent(`Probe ${probe.displayName} is offline`);
 });
 
 it(`Displays the correct information for a private probe`, async () => {
   const probe = probeToExtendedProbe(PRIVATE_PROBE);
 
   render(<ProbeCard probe={probe} />);
-  await screen.findByText(probe.name, { exact: false });
+  await screen.findByText(probe.displayName, { exact: false });
 
   const button = screen.getByTestId('probe-card-action-button');
   expect(button).toBeInTheDocument();
@@ -85,7 +85,7 @@ it(`Displays the correct information for a private probe as a viewer`, async () 
   const probe = probeToExtendedProbe(PRIVATE_PROBE);
 
   render(<ProbeCard probe={probe} />);
-  await screen.findByText(probe.name, { exact: false });
+  await screen.findByText(probe.displayName, { exact: false });
 
   const button = screen.getByTestId('probe-card-action-button');
   expect(button).toBeInTheDocument();
@@ -97,7 +97,7 @@ it(`Displays the correct information for a private probe as a RBAC viewer`, asyn
   const probe = probeToExtendedProbe(PRIVATE_PROBE);
 
   render(<ProbeCard probe={probe} />);
-  await screen.findByText(probe.name, { exact: false });
+  await screen.findByText(probe.displayName, { exact: false });
 
   const button = screen.getByTestId('probe-card-action-button');
   expect(button).toBeInTheDocument();
@@ -108,7 +108,7 @@ it(`Displays the correct information for a public probe`, async () => {
   const probe = probeToExtendedProbe(PUBLIC_PROBE);
 
   render(<ProbeCard probe={probe} />);
-  await screen.findByText(probe.name, { exact: false });
+  await screen.findByText(probe.displayName, { exact: false });
 
   const button = screen.getByTestId('probe-card-action-button');
   expect(button).toBeInTheDocument();
@@ -118,8 +118,8 @@ it(`Displays the correct information for a public probe`, async () => {
 it('handles public probe click', async () => {
   const probe = probeToExtendedProbe(PUBLIC_PROBE);
   const { user } = render(<ProbeCard probe={probe} />);
-  await screen.findByText(probe.name);
-  await user.click(screen.getByText(probe.name));
+  await screen.findByText(probe.displayName);
+  await user.click(screen.getByText(probe.displayName));
 
   expect(screen.getByTestId(DataTestIds.TEST_ROUTER_INFO_PATHNAME)).toHaveTextContent(
     generateRoutePath(ROUTES.ViewProbe, { id: probe.id! })
@@ -129,8 +129,8 @@ it('handles public probe click', async () => {
 it('handles private probe click', async () => {
   const probe = probeToExtendedProbe(PRIVATE_PROBE);
   const { user } = render(<ProbeCard probe={probe} />);
-  await screen.findByText(probe.name);
-  await user.click(screen.getByText(probe.name));
+  await screen.findByText(probe.displayName);
+  await user.click(screen.getByText(probe.displayName));
 
   expect(screen.getByTestId(DataTestIds.TEST_ROUTER_INFO_PATHNAME)).toHaveTextContent(
     generateRoutePath(ROUTES.EditProbe, { id: probe.id! })
@@ -146,7 +146,7 @@ it.each<[ExtendedProbe, string]>([
   async (probe: ExtendedProbe, expectedText: string) => {
     const { user } = render(<ProbeCard probe={probe} />);
 
-    await screen.findByText(probe.name);
+    await screen.findByText(probe.displayName);
 
     const usageLink = screen.getByTestId(DataTestIds.PROBE_USAGE_LINK);
     expect(usageLink).toBeInTheDocument();
@@ -163,7 +163,7 @@ it('Displays the correct information for a probe that is NOT in use', async () =
   const probe = probeToExtendedProbe(PUBLIC_PROBE);
 
   render(<ProbeCard probe={probe} />);
-  await screen.findByText(probe.name);
+  await screen.findByText(probe.displayName);
 
   const usageLink = screen.queryByTestId(DataTestIds.PROBE_USAGE_LINK);
   expect(usageLink).not.toBeInTheDocument();

--- a/src/components/ProbeCard/ProbeCard.tsx
+++ b/src/components/ProbeCard/ProbeCard.tsx
@@ -27,7 +27,7 @@ export const ProbeCard = ({ probe }: { probe: ExtendedProbe }) => {
         <Stack alignItems="center" gap={0}>
           <ProbeStatus probe={probe} />
           <Link href={probeEditHref}>
-            <span>{probe.name}</span>
+            <span>{probe.displayName}</span>
             {probe.region && <span>&nbsp;{`(${probe.region})`}</span>}
           </Link>
           {probe.deprecated && (
@@ -80,7 +80,7 @@ export const ProbeCard = ({ probe }: { probe: ExtendedProbe }) => {
               fill="outline"
               variant="secondary"
               href={probeEditHref}
-              aria-label={`Edit probe ${probe.name}`}
+              aria-label={`Edit probe ${probe.displayName}`}
               tooltip="Edit probe"
             >
               Edit
@@ -94,7 +94,7 @@ export const ProbeCard = ({ probe }: { probe: ExtendedProbe }) => {
             variant="secondary"
             icon="eye"
             tooltip="View probe"
-            aria-label={`View probe ${probe.name}`}
+            aria-label={`View probe ${probe.displayName}`}
           >
             View
           </LinkButton>

--- a/src/components/ProbeCard/ProbeStatus.tsx
+++ b/src/components/ProbeCard/ProbeStatus.tsx
@@ -3,16 +3,16 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
-import { Probe } from 'types';
+import { ProbeWithMetadata } from 'types';
 
-export function ProbeStatus({ probe }: { probe: Probe }) {
+export function ProbeStatus({ probe }: { probe: ProbeWithMetadata }) {
   const styles = useStyles2((theme) => getStyles(theme, probe));
 
   return (
     <Tooltip
       content={
         <div data-testid="probe-online-status-tooltip">
-          Probe {probe.name} is <span className={styles.statusText}>{probe.online ? 'online' : 'offline'}</span>
+          Probe {probe.displayName} is <span className={styles.statusText}>{probe.online ? 'online' : 'offline'}</span>
         </div>
       }
     >
@@ -21,7 +21,7 @@ export function ProbeStatus({ probe }: { probe: Probe }) {
   );
 }
 
-function getStyles(theme: GrafanaTheme2, probe: Probe) {
+function getStyles(theme: GrafanaTheme2, probe: ProbeWithMetadata) {
   return {
     container: css({
       display: 'inline-block',

--- a/src/data/useProbes.ts
+++ b/src/data/useProbes.ts
@@ -3,7 +3,7 @@ import { type QueryKey, useMutation, UseMutationResult, useQuery, useSuspenseQue
 import { isFetchError } from '@grafana/runtime';
 
 import { type MutationProps } from 'data/types';
-import { ExtendedProbe, type Probe } from 'types';
+import { ExtendedProbe, type Probe, ProbeMetadata, ProbeWithMetadata } from 'types';
 import { FaroEvent } from 'faro';
 import { camelCaseToSentence } from 'utils';
 import { SMDataSource } from 'datasource/DataSource';
@@ -11,7 +11,6 @@ import type {
   AddProbeResult,
   DeleteProbeError,
   DeleteProbeResult,
-  ListProbeResult,
   ResetProbeTokenResult,
   UpdateProbeResult,
 } from 'datasource/responses.types';
@@ -41,7 +40,7 @@ export function useProbes() {
 export function useProbesWithMetadata() {
   const { data: probes = [], isLoading } = useProbes();
 
-  const probesWithMetadata = useMemo<ListProbeResult>(() => {
+  const probesWithMetadata = useMemo<ProbeWithMetadata[]>(() => {
     if (isLoading) {
       return [];
     }
@@ -49,13 +48,15 @@ export function useProbesWithMetadata() {
     return probes
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((probe) => {
-        const metadata = PROBES_METADATA.find((info) => info.name === probe.name && info.region === probe.region);
+        const metadata = PROBES_METADATA.find(
+          (info) => info.name === probe.name && info.region === probe.region
+        ) as ProbeMetadata;
         const displayName = camelCaseToSentence(probe.name);
 
         return {
           ...probe,
           ...metadata,
-          name: displayName,
+          displayName,
         };
       });
   }, [probes, isLoading]);

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -9,6 +9,7 @@ import { CheckFiltersType, CheckListViewType, FilterType } from 'page/CheckList/
 import { Check, CheckEnabledStatus, CheckSort, CheckType, Label } from 'types';
 import { MetricCheckSuccess, Time } from 'datasource/responses.types';
 import { useSuspenseChecks } from 'data/useChecks';
+import { useSuspenseProbes } from 'data/useProbes';
 import { useChecksReachabilitySuccessRate } from 'data/useSuccessRates';
 import { findCheckinMetrics } from 'data/utils';
 import { useQueryParametersState } from 'hooks/useQueryParametersState';
@@ -51,6 +52,7 @@ type CheckListContentProps = {
 };
 
 const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps) => {
+  useSuspenseProbes(); // we need to block rendering until we have the probe list so not to initially render a check list that might have probe filters
   const { data: checks } = useSuspenseChecks();
   const { data: reachabilitySuccessRates = [] } = useChecksReachabilitySuccessRate();
   const filters = useCheckFilters();

--- a/src/page/CheckList/CheckList.utils.ts
+++ b/src/page/CheckList/CheckList.utils.ts
@@ -24,11 +24,11 @@ const matchesSearchFilter = ({ target, job, labels }: Check, searchFilter: strin
   // <term> can be one of target, job or a label name
   const filterParts = searchFilter.toLowerCase().trim().split('=');
 
-  const labelMatches = labels.reduce((acc, { name, value }) => {
+  const labelMatches = labels.reduce<string[]>((acc, { name, value }) => {
     acc.push(name);
     acc.push(value);
     return acc;
-  }, [] as string[]);
+  }, []);
 
   return filterParts.some((filterPart) => matchStrings(filterPart, [target, job, ...labelMatches]));
 };

--- a/src/page/CheckList/components/BulkActionsModal.test.tsx
+++ b/src/page/CheckList/components/BulkActionsModal.test.tsx
@@ -5,12 +5,16 @@ import { DEFAULT_PROBES, PRIVATE_PROBE, PUBLIC_PROBE } from 'test/fixtures/probe
 import { apiRoute, getServerRequests } from 'test/handlers';
 import { render } from 'test/render';
 import { server } from 'test/server';
+import { probeToMetadataProbe } from 'test/utils';
 
 import { Check } from 'types';
 
 import { BulkActionsModal } from './BulkActionsModal';
 
 const onDismiss = jest.fn();
+
+const PUBLIC_PROBE_WITHMETADATA = probeToMetadataProbe(PUBLIC_PROBE);
+const PRIVATE_PROBE_WITHMETADATA = probeToMetadataProbe(PRIVATE_PROBE);
 
 const renderBulkEditModal = (action: 'add' | 'remove', checks: Check[]) => {
   return render(<BulkActionsModal onDismiss={onDismiss} checks={checks} action={action} isOpen={true} />);
@@ -41,8 +45,8 @@ test('successfully adds probes', async () => {
   server.use(apiRoute(`bulkUpdateChecks`, {}, record));
 
   const { user } = renderBulkEditModal('add', checksWithASingleProbe);
-  const probe1 = await screen.findByText(PUBLIC_PROBE.name);
-  const probe2 = await screen.findByText(PRIVATE_PROBE.name);
+  const probe1 = await screen.findByText(PUBLIC_PROBE_WITHMETADATA.displayName);
+  const probe2 = await screen.findByText(PRIVATE_PROBE_WITHMETADATA.displayName);
   await user.click(probe1);
   await user.click(probe2);
   const submitButton = await screen.findByText('Add probes');
@@ -67,7 +71,7 @@ test('successfully removes probes', async () => {
   server.use(apiRoute(`bulkUpdateChecks`, {}, record));
 
   const { user } = renderBulkEditModal('remove', [BASIC_HTTP_CHECK, BASIC_PING_CHECK]);
-  const probe1 = await screen.findByText(PUBLIC_PROBE.name);
+  const probe1 = await screen.findByText(PUBLIC_PROBE_WITHMETADATA.displayName);
   await user.click(probe1);
   const submitButton = await screen.findByText('Remove probes');
   await user.click(submitButton);

--- a/src/page/CheckList/components/CheckFilters.tsx
+++ b/src/page/CheckList/components/CheckFilters.tsx
@@ -5,10 +5,9 @@ import { css } from '@emotion/css';
 
 import { CheckFiltersType, CheckTypeFilter, FilterType, ProbeFilter } from 'page/CheckList/CheckList.types';
 import { Check } from 'types';
-import { useProbes } from 'data/useProbes';
+import { useExtendedProbes } from 'data/useProbes';
 import { useCheckTypeOptions } from 'hooks/useCheckTypeOptions';
 import { CHECK_LIST_STATUS_OPTIONS } from 'page/CheckList/CheckList.constants';
-import { defaultFilters } from 'page/CheckList/CheckList.utils';
 import { CheckFilterGroup } from 'page/CheckList/components/CheckFilterGroup';
 import { LabelFilterInput } from 'page/CheckList/components/LabelFilterInput';
 
@@ -16,17 +15,11 @@ interface CheckFiltersProps {
   onReset: () => void;
   onChange: (filters: CheckFiltersType, type: FilterType) => void;
   checks: Check[];
-  checkFilters?: CheckFiltersType;
+  checkFilters: CheckFiltersType;
   includeStatus?: boolean;
 }
 
-export function CheckFilters({
-  onReset,
-  onChange,
-  checks,
-  checkFilters = defaultFilters,
-  includeStatus = true,
-}: CheckFiltersProps) {
+export function CheckFilters({ onReset, onChange, checks, checkFilters, includeStatus = true }: CheckFiltersProps) {
   const checkTypeOptions = useCheckTypeOptions();
   const filterDesc = checkTypeOptions.map((option) => {
     return {
@@ -45,7 +38,7 @@ export function CheckFilters({
 
   const styles = useStyles2(getStyles);
   const [searchValue, setSearchValue] = useState(checkFilters.search);
-  const { data: probes = [] } = useProbes();
+  const [probes] = useExtendedProbes();
   const debounceRef = useRef<NodeJS.Timeout>();
 
   function handleSearchChange(event: ChangeEvent<HTMLInputElement>) {
@@ -66,7 +59,7 @@ export function CheckFilters({
 
   const probesOptions: Array<SelectableValue<ProbeFilter>> = useMemo(() => {
     return probes.map((probe) => {
-      const probeOption: SelectableValue = { label: probe.name, value: probe.id };
+      const probeOption: SelectableValue = { label: probe.displayName, value: probe.id };
       return probeOption;
     });
   }, [probes]);

--- a/src/page/EditProbe/EditProbe.test.tsx
+++ b/src/page/EditProbe/EditProbe.test.tsx
@@ -4,6 +4,7 @@ import { PRIVATE_PROBE, PUBLIC_PROBE, UPDATED_PROBE_TOKEN_RESPONSE } from 'test/
 import { apiRoute, getServerRequests } from 'test/handlers';
 import { render } from 'test/render';
 import { server } from 'test/server';
+import { probeToMetadataProbe } from 'test/utils';
 
 import { Probe } from 'types';
 import { formatDate } from 'utils';
@@ -63,7 +64,7 @@ describe(`Private probes`, () => {
 
     const { body } = await read();
 
-    expect(body).toEqual(PRIVATE_PROBE);
+    expect(body).toMatchObject(PRIVATE_PROBE);
   });
 
   it(`shows the token modal on update`, async () => {
@@ -91,7 +92,7 @@ function getResetTokenButton() {
 }
 
 function checkInformation(probe: Probe) {
-  expect(screen.getByDisplayValue(probe.name)).toBeInTheDocument();
+  expect(screen.getByDisplayValue(probeToMetadataProbe(probe).displayName)).toBeInTheDocument();
   expect(screen.getByText(probe.region)).toBeInTheDocument();
   expect(screen.getByDisplayValue(probe.latitude)).toBeInTheDocument();
   expect(screen.getByDisplayValue(probe.longitude)).toBeInTheDocument();

--- a/src/page/EditProbe/EditProbe.utils.tsx
+++ b/src/page/EditProbe/EditProbe.utils.tsx
@@ -1,10 +1,10 @@
-import { type Probe } from 'types';
+import { type ProbeWithMetadata } from 'types';
 
-export function getTitle(probe?: Probe, canEdit?: boolean) {
+export function getTitle(probe?: ProbeWithMetadata, canEdit?: boolean) {
   const verb = canEdit ? 'Editing' : 'Viewing';
   const type = !probe ? `` : probe.public ? 'public' : 'private';
 
-  return `${verb} ${type} probe ${probe ? probe.name : ``}`;
+  return `${verb} ${type} probe ${probe ? probe.displayName : ``}`;
 }
 
 type ErrorInfo = Error | null;

--- a/src/page/NewCheck/__tests__/NewCheck.journey.test.tsx
+++ b/src/page/NewCheck/__tests__/NewCheck.journey.test.tsx
@@ -3,7 +3,7 @@ import { DataTestIds } from 'test/dataTestIds';
 import { PUBLIC_PROBE } from 'test/fixtures/probes';
 import { apiRoute } from 'test/handlers';
 import { server } from 'test/server';
-import { runTestAsHGFreeUserOverLimit, runTestWithoutLogsAccess } from 'test/utils';
+import { probeToMetadataProbe, runTestAsHGFreeUserOverLimit, runTestWithoutLogsAccess } from 'test/utils';
 
 import { CheckType } from 'types';
 import { fillMandatoryFields } from 'page/__testHelpers__/apiEndPoint';
@@ -239,7 +239,7 @@ describe(`<NewCheck /> journey`, () => {
     await user.type(minutesInput, `{backspace}1`);
     await user.type(secondsInput, '10');
 
-    const probeCheckbox = await screen.findByLabelText(PUBLIC_PROBE.name);
+    const probeCheckbox = await screen.findByLabelText(probeToMetadataProbe(PUBLIC_PROBE).displayName);
     await user.click(probeCheckbox);
 
     await submitForm(user);

--- a/src/page/NewProbe/NewProbe.tsx
+++ b/src/page/NewProbe/NewProbe.tsx
@@ -3,7 +3,7 @@ import { PluginPage } from '@grafana/runtime';
 import { Alert, Label, useTheme2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
-import { ExtendedProbe, type Probe } from 'types';
+import { ExtendedProbe, type Probe, ProbeProvider } from 'types';
 import { ROUTES } from 'routing/types';
 import { type AddProbeResult } from 'datasource/responses.types';
 import { useCreateProbe } from 'data/useProbes';
@@ -29,6 +29,11 @@ export const TEMPLATE_PROBE: ExtendedProbe = {
     disableScriptedChecks: false,
     disableBrowserChecks: false,
   },
+  provider: ProbeProvider.AWS,
+  country: '',
+  countryCode: '',
+  longRegion: '',
+  displayName: '',
   checks: [],
 };
 

--- a/src/page/Probes/Probes.test.tsx
+++ b/src/page/Probes/Probes.test.tsx
@@ -3,6 +3,7 @@ import { screen, within } from '@testing-library/react';
 import { DataTestIds } from 'test/dataTestIds';
 import { PRIVATE_PROBE, PUBLIC_PROBE } from 'test/fixtures/probes';
 import { render } from 'test/render';
+import { probeToMetadataProbe } from 'test/utils';
 
 import { Probes } from './Probes';
 
@@ -13,14 +14,14 @@ const renderProbeList = () => {
 it(`renders private probes in the correct list`, async () => {
   renderProbeList();
   const privateProbesList = await screen.findByTestId(DataTestIds.PRIVATE_PROBES_LIST);
-  const privateProbe = await within(privateProbesList).findByText(PRIVATE_PROBE.name);
+  const privateProbe = await within(privateProbesList).findByText(probeToMetadataProbe(PRIVATE_PROBE).displayName);
   expect(privateProbe).toBeInTheDocument();
 });
 
 it(`renders public probes in the correct list`, async () => {
   renderProbeList();
   const publicProbesList = await screen.findByTestId(DataTestIds.PUBLIC_PROBES_LIST);
-  const publicProbe = await within(publicProbesList).findByText(PUBLIC_PROBE.name);
+  const publicProbe = await within(publicProbesList).findByText(probeToMetadataProbe(PUBLIC_PROBE).displayName);
   expect(publicProbe).toBeInTheDocument();
 });
 

--- a/src/page/__testHelpers__/apiEndPoint.ts
+++ b/src/page/__testHelpers__/apiEndPoint.ts
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
 import { PRIVATE_PROBE } from 'test/fixtures/probes';
+import { probeToMetadataProbe } from 'test/utils';
 
 import { CheckType } from 'types';
 
@@ -28,7 +29,7 @@ export async function fillMandatoryFields({ user, fieldsToOmit = [], checkType }
   await goToSection(user, 5);
 
   if (!fieldsToOmit.includes('probes')) {
-    const probeCheckbox = await screen.findByLabelText(PRIVATE_PROBE.name);
+    const probeCheckbox = await screen.findByLabelText(probeToMetadataProbe(PRIVATE_PROBE).displayName);
     await user.click(probeCheckbox);
   }
 }

--- a/src/page/__testHelpers__/multiStep.ts
+++ b/src/page/__testHelpers__/multiStep.ts
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
 import { PRIVATE_PROBE } from 'test/fixtures/probes';
+import { probeToMetadataProbe } from 'test/utils';
 
 import { CheckType } from 'types';
 
@@ -28,7 +29,7 @@ export async function fillMandatoryFields({ user, fieldsToOmit = [], checkType }
   await goToSection(user, 5);
 
   if (!fieldsToOmit.includes('probes')) {
-    const probeCheckbox = await screen.findByLabelText(PRIVATE_PROBE.name);
+    const probeCheckbox = await screen.findByLabelText(probeToMetadataProbe(PRIVATE_PROBE).displayName);
     await user.click(probeCheckbox);
   }
 }

--- a/src/page/__testHelpers__/scripted.ts
+++ b/src/page/__testHelpers__/scripted.ts
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
 import { PRIVATE_PROBE } from 'test/fixtures/probes';
+import { probeToMetadataProbe } from 'test/utils';
 
 import { CheckType } from 'types';
 
@@ -28,7 +29,7 @@ export async function fillMandatoryFields({ user, fieldsToOmit = [], checkType }
   await goToSection(user, 5);
 
   if (!fieldsToOmit.includes('probes')) {
-    const probeCheckbox = await screen.findByLabelText(PRIVATE_PROBE.name);
+    const probeCheckbox = await screen.findByLabelText(probeToMetadataProbe(PRIVATE_PROBE).displayName);
     await user.click(probeCheckbox);
   }
 }

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -8,7 +8,8 @@ import {
   VIEWER_DEFAULT_DATASOURCE_ACCESS_CONTROL,
 } from 'test/fixtures/datasources';
 
-import { ExtendedProbe, FeatureName, type Probe } from 'types';
+import { ExtendedProbe, FeatureName, type Probe, ProbeProvider, ProbeWithMetadata } from 'types';
+import { camelCaseToSentence } from 'utils';
 
 import { FULL_ADMIN_ACCESS, FULL_READONLY_ACCESS, FULL_WRITER_ACCESS } from './fixtures/rbacPermissions';
 import { apiRoute } from './handlers';
@@ -298,7 +299,17 @@ export const selectOption = async (user: UserEvent, options: SelectOptions, cont
   await user.click(option);
 };
 
-export const probeToExtendedProbe = (probe: Probe, usedByChecks: number[] = []): ExtendedProbe => ({
+export const probeToMetadataProbe = (probe: Probe): ProbeWithMetadata => ({
   ...probe,
+  provider: ProbeProvider.AWS,
+  country: 'country',
+  countryCode: 'cc',
+  region: 'region',
+  longRegion: 'long region',
+  displayName: camelCaseToSentence(probe.name),
+});
+
+export const probeToExtendedProbe = (probe: Probe, usedByChecks: number[] = []): ExtendedProbe => ({
+  ...probeToMetadataProbe(probe),
   checks: usedByChecks,
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,16 +122,24 @@ export interface Probe extends ExistingObject {
   version: string;
   deprecated: boolean;
   capabilities: ProbeCapabilities;
-
-  provider?: ProbeProvider;
-  city?: string;
-  country?: string;
-  countryCode?: string;
-  longRegion?: string;
 }
 
+export type ProbeMetadata = {
+  name: string;
+  provider: ProbeProvider;
+  country: string;
+  countryCode: string;
+  longRegion: string;
+  region: string;
+};
+
+export type ProbeWithMetadata = Probe &
+  ProbeMetadata & {
+    displayName: string;
+  };
+
 // Used to extend the Probe object with additional properties (see Probes.tsx component)
-export type ExtendedProbe = Probe & { checks: number[] };
+export type ExtendedProbe = ProbeWithMetadata & { checks: number[] };
 
 interface ProbeCapabilities {
   disableScriptedChecks: boolean;


### PR DESCRIPTION
## Problem

Introduced a small regression in https://github.com/grafana/synthetic-monitoring-app/pull/1050. Naively mutated the `name` attribute in the probes rather than add an additional field. This caused the linking to the checks list with a probe filter to break.

## Solution

In the interest of keeping backwards compatibility, I've made the displayName field additive rather than mutate the name field. I've added a test for the probe filter (it was the only filter type missing a test 😅 ) on the Checks List page so it doesn't regress again.

I've also gone through and adapted the types so they are more accurate, adding a `ProbeWithMetadata` type after it gets mapped onto.

