### PR TITLE
fix: get web vitals value for gauge component

### DIFF
--- a/src/scenes/BROWSER/WebVitals/webVitalGaugeScene.tsx
+++ b/src/scenes/BROWSER/WebVitals/webVitalGaugeScene.tsx
@@ -30,14 +30,14 @@ function WebVitalGaugeRenderer({ model }: SceneComponentProps<WebVitalGaugeScene
   setExploreLink(model);
 
   const { data } = sceneGraph.getData(model).useState();
-  const { name, description, longName, refId, exploreLink } = model.useState();
+  const { name, description, longName, exploreLink } = model.useState();
   const value = useMemo(() => {
     if (data != null && data.state === 'Done') {
       if (!data || data.series.length === 0) {
         return 0;
       }
 
-      const frame = data.series.find((s) => s.refId === refId);
+      const frame = data.series[0];
 
       if (!frame) {
         return 0;
@@ -47,7 +47,7 @@ function WebVitalGaugeRenderer({ model }: SceneComponentProps<WebVitalGaugeScene
 
       return view.toArray()[0]?.Mean;
     }
-  }, [data, refId]);
+  }, [data]);
 
   return (
     <div className={styles}>


### PR DESCRIPTION
Fixes the web vitals components as they were displaying 0.0 instead of the reduced data series value. This happened because we were relying on the `refId` of the series in order to obtain its value, but this value has been changed recently and it broke our implementation. Since there’s only one series per query, I simplified the implementation to directly access the first series, removing the need for `refId` filtering.

Closes https://github.com/grafana/support-escalations/issues/14520

Before
![image](https://github.com/user-attachments/assets/558c1bf2-998a-441e-9e1b-b9b1c5fc8589)

After
![image](https://github.com/user-attachments/assets/0dab13e5-dab6-4389-b4bc-ea1c145db46e)

Notes:

The `refId` value from the data series changed to return a prefix of the transformation applied to it (`reduce` in our case): 

![image](https://github.com/user-attachments/assets/05892f8c-3de5-498a-a412-f1a2fd0f98df)


which the current app code wasn't expecting:

![image](https://github.com/user-attachments/assets/30cb8e36-c7f9-47a5-9a89-c8fcf4beff4b)


