### PR TITLE
fix: probe filtering behaviour and reset button

### DIFF
--- a/src/components/CheckEditor/ProbesMetadata.ts
+++ b/src/components/CheckEditor/ProbesMetadata.ts
@@ -23,6 +23,16 @@ const COUNTRY_AE = { code: 'AE', long: 'United Arab Emirates' };
 const COUNTRY_ES = { code: 'ES', long: 'Spain' };
 const COUNTRY_ID = { code: 'ID', long: 'Indonesia' };
 
+export const EMPTY_METADATA: ProbeMetadata = {
+  name: '',
+  displayName: '',
+  region: '',
+  longRegion: '',
+  provider: ProbeProvider.PRIVATE,
+  countryCode: '',
+  country: '',
+};
+
 export const PROBES_METADATA: ProbeMetadata[] = [
   {
     name: 'Bangalore',

--- a/src/components/CheckEditor/ProbesMetadata.ts
+++ b/src/components/CheckEditor/ProbesMetadata.ts
@@ -26,6 +26,7 @@ const COUNTRY_ID = { code: 'ID', long: 'Indonesia' };
 export const PROBES_METADATA: ProbeMetadata[] = [
   {
     name: 'Bangalore',
+    displayName: `Bangalore`,
     region: REGION_APAC.code,
     longRegion: REGION_APAC.long,
     provider: ProbeProvider.DIGITAL_OCEAN,
@@ -34,6 +35,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Mumbai',
+    displayName: `Mumbai`,
     region: REGION_APAC.code,
     longRegion: REGION_APAC.long,
     provider: ProbeProvider.AWS,
@@ -42,6 +44,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Seoul',
+    displayName: `Seoul`,
     region: REGION_APAC.code,
     longRegion: REGION_APAC.long,
     provider: ProbeProvider.AWS,
@@ -50,6 +53,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Singapore',
+    displayName: `Singapore`,
     region: REGION_APAC.code,
     longRegion: REGION_APAC.long,
     provider: ProbeProvider.AWS,
@@ -58,6 +62,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Sydney',
+    displayName: `Sydney`,
     region: REGION_APAC.code,
     longRegion: REGION_APAC.long,
     provider: ProbeProvider.AWS,
@@ -66,6 +71,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Tokyo',
+    displayName: `Tokyo`,
     region: REGION_APAC.code,
     longRegion: REGION_APAC.long,
     provider: ProbeProvider.AWS,
@@ -75,6 +81,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
 
   {
     name: 'Atlanta',
+    displayName: `Atlanta`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.LINODE,
@@ -83,6 +90,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Dallas',
+    displayName: `Dallas`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.LINODE,
@@ -91,6 +99,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Newark',
+    displayName: `Newark`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.LINODE,
@@ -99,6 +108,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Toronto',
+    displayName: `Toronto`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.LINODE,
@@ -107,6 +117,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'NewYork',
+    displayName: `New York`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.DIGITAL_OCEAN,
@@ -115,6 +126,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'SanFrancisco',
+    displayName: `San Francisco`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.DIGITAL_OCEAN,
@@ -123,6 +135,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'NorthCalifornia',
+    displayName: `North California`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.AWS,
@@ -131,6 +144,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'NorthVirginia',
+    displayName: `North Virginia`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.AWS,
@@ -139,6 +153,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Ohio',
+    displayName: `Ohio`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.AWS,
@@ -147,6 +162,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Oregon',
+    displayName: `Oregon`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.AWS,
@@ -155,6 +171,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'SaoPaulo',
+    displayName: `Sao Paulo`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.AWS,
@@ -164,6 +181,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
 
   {
     name: 'Amsterdam',
+    displayName: `Amsterdam`,
     region: REGION_EMEA.code,
     longRegion: REGION_EMEA.long,
     provider: ProbeProvider.DIGITAL_OCEAN,
@@ -172,6 +190,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'CapeTown',
+    displayName: `Cape Town`,
     region: REGION_EMEA.code,
     longRegion: REGION_EMEA.long,
     provider: ProbeProvider.AWS,
@@ -180,6 +199,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Frankfurt',
+    displayName: `Frankfurt`,
     region: REGION_EMEA.code,
     longRegion: REGION_EMEA.long,
     provider: ProbeProvider.AWS,
@@ -188,6 +208,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'London',
+    displayName: `London`,
     region: REGION_EMEA.code,
     longRegion: REGION_EMEA.long,
     provider: ProbeProvider.AWS,
@@ -196,6 +217,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Paris',
+    displayName: `Paris`,
     region: REGION_EMEA.code,
     longRegion: REGION_EMEA.long,
     provider: ProbeProvider.AWS,
@@ -204,6 +226,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Zurich',
+    displayName: `Zurich`,
     region: REGION_EMEA.code,
     longRegion: REGION_EMEA.long,
     provider: ProbeProvider.AWS,
@@ -212,6 +235,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Stockholm',
+    displayName: `Stockholm`,
     region: REGION_EMEA.code,
     longRegion: REGION_EMEA.long,
     provider: ProbeProvider.AWS,
@@ -220,6 +244,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Montreal',
+    displayName: `Montreal`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.AWS,
@@ -228,6 +253,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Calgary',
+    displayName: `Calgary`,
     region: REGION_AMER.code,
     longRegion: REGION_AMER.long,
     provider: ProbeProvider.AWS,
@@ -236,6 +262,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'UAE',
+    displayName: `UAE`,
     region: REGION_EMEA.code,
     longRegion: REGION_EMEA.long,
     provider: ProbeProvider.AWS,
@@ -244,6 +271,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Hyderabad',
+    displayName: `Hyderabad`,
     region: REGION_APAC.code,
     longRegion: REGION_APAC.long,
     provider: ProbeProvider.AWS,
@@ -252,6 +280,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Spain',
+    displayName: `Spain`,
     region: REGION_EMEA.code,
     longRegion: REGION_EMEA.long,
     provider: ProbeProvider.AWS,
@@ -260,6 +289,7 @@ export const PROBES_METADATA: ProbeMetadata[] = [
   },
   {
     name: 'Jakarta',
+    displayName: `Jakarta`,
     region: REGION_APAC.code,
     longRegion: REGION_APAC.long,
     provider: ProbeProvider.AWS,

--- a/src/data/useProbes.ts
+++ b/src/data/useProbes.ts
@@ -49,12 +49,11 @@ export function useProbesWithMetadata() {
       .map((probe) => {
         const metadata =
           PROBES_METADATA.find((info) => info.name === probe.name && info.region === probe.region) || EMPTY_METADATA;
-        const displayName = metadata.displayName || probe.name;
 
         return {
-          ...probe,
           ...metadata,
-          displayName,
+          ...probe,
+          displayName: metadata.displayName || probe.name,
         };
       });
   }, [probes, isLoading]);

--- a/src/data/useProbes.ts
+++ b/src/data/useProbes.ts
@@ -3,7 +3,7 @@ import { type QueryKey, useMutation, UseMutationResult, useQuery, useSuspenseQue
 import { isFetchError } from '@grafana/runtime';
 
 import { type MutationProps } from 'data/types';
-import { ExtendedProbe, type Probe, ProbeMetadata, ProbeWithMetadata } from 'types';
+import { ExtendedProbe, type Probe, ProbeWithMetadata } from 'types';
 import { FaroEvent } from 'faro';
 import { SMDataSource } from 'datasource/DataSource';
 import type {
@@ -15,7 +15,7 @@ import type {
 } from 'datasource/responses.types';
 import { queryClient } from 'data/queryClient';
 import { useSMDS } from 'hooks/useSMDS';
-import { PROBES_METADATA } from 'components/CheckEditor/ProbesMetadata';
+import { EMPTY_METADATA, PROBES_METADATA } from 'components/CheckEditor/ProbesMetadata';
 
 import { useChecks } from './useChecks';
 
@@ -47,10 +47,9 @@ export function useProbesWithMetadata() {
     return probes
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((probe) => {
-        const metadata = PROBES_METADATA.find(
-          (info) => info.name === probe.name && info.region === probe.region
-        ) as ProbeMetadata;
-        const displayName = metadata?.displayName || probe.name;
+        const metadata =
+          PROBES_METADATA.find((info) => info.name === probe.name && info.region === probe.region) || EMPTY_METADATA;
+        const displayName = metadata.displayName || probe.name;
 
         return {
           ...probe,

--- a/src/data/useProbes.ts
+++ b/src/data/useProbes.ts
@@ -5,7 +5,6 @@ import { isFetchError } from '@grafana/runtime';
 import { type MutationProps } from 'data/types';
 import { ExtendedProbe, type Probe, ProbeMetadata, ProbeWithMetadata } from 'types';
 import { FaroEvent } from 'faro';
-import { pascalCaseToSentence } from 'utils';
 import { SMDataSource } from 'datasource/DataSource';
 import type {
   AddProbeResult,
@@ -51,7 +50,7 @@ export function useProbesWithMetadata() {
         const metadata = PROBES_METADATA.find(
           (info) => info.name === probe.name && info.region === probe.region
         ) as ProbeMetadata;
-        const displayName = pascalCaseToSentence(probe.name);
+        const displayName = metadata?.displayName || probe.name;
 
         return {
           ...probe,

--- a/src/data/useProbes.ts
+++ b/src/data/useProbes.ts
@@ -5,7 +5,7 @@ import { isFetchError } from '@grafana/runtime';
 import { type MutationProps } from 'data/types';
 import { ExtendedProbe, type Probe, ProbeMetadata, ProbeWithMetadata } from 'types';
 import { FaroEvent } from 'faro';
-import { camelCaseToSentence } from 'utils';
+import { pascalCaseToSentence } from 'utils';
 import { SMDataSource } from 'datasource/DataSource';
 import type {
   AddProbeResult,
@@ -51,7 +51,7 @@ export function useProbesWithMetadata() {
         const metadata = PROBES_METADATA.find(
           (info) => info.name === probe.name && info.region === probe.region
         ) as ProbeMetadata;
-        const displayName = camelCaseToSentence(probe.name);
+        const displayName = pascalCaseToSentence(probe.name);
 
         return {
           ...probe,

--- a/src/page/CheckList/CheckList.hooks.ts
+++ b/src/page/CheckList/CheckList.hooks.ts
@@ -3,7 +3,7 @@ import { capitalize } from 'lodash';
 
 import { CheckTypeFilter, ProbeFilter } from 'page/CheckList/CheckList.types';
 import { CheckEnabledStatus, CheckType } from 'types';
-import { useProbes } from 'data/useProbes';
+import { useProbesWithMetadata } from 'data/useProbes';
 import { useQueryParametersState } from 'hooks/useQueryParametersState';
 import { defaultFilters } from 'page/CheckList/CheckList.utils';
 
@@ -22,7 +22,7 @@ interface CheckFiltersProps {
 }
 
 export function useCheckFilters() {
-  const { data: probes = [] } = useProbes();
+  const { data: probes = [] } = useProbesWithMetadata();
 
   const filters: CheckFiltersProps = {
     search: useQueryParametersState<string>({
@@ -68,8 +68,8 @@ export function useCheckFilters() {
         const labels = value.split(',');
 
         return probes
-          .filter((probe) => labels.includes(probe.name))
-          .map((probe) => ({ label: probe.name, value: probe.id } as SelectableValue<ProbeFilter>));
+          .filter((probe) => labels.includes(probe.displayName))
+          .map((probe) => ({ label: probe.displayName, value: probe.id } as SelectableValue<ProbeFilter>));
       },
     }),
   };

--- a/src/page/CheckList/CheckList.test.tsx
+++ b/src/page/CheckList/CheckList.test.tsx
@@ -321,6 +321,30 @@ test('clicking status chiclet adds it to filter', async () => {
   expect(checks.length).toBe(1);
 });
 
+test(`clicking filters reset button works correctly`, async () => {
+  const DNS_CHECK_DISABLED = {
+    ...BASIC_DNS_CHECK,
+    enabled: false,
+  };
+
+  const { user } = await renderCheckList([DNS_CHECK_DISABLED, BASIC_HTTP_CHECK]);
+  const disabledChiclet = await screen.findAllByText('Disabled');
+  await user.click(disabledChiclet[0]);
+  const additionalFilters = await screen.findByText(/Additional filters/i);
+  await user.click(additionalFilters);
+
+  const dialog = getModalContainer();
+  const statusFilter = await within(dialog).findByText(`Disabled`);
+  expect(statusFilter).toBeInTheDocument();
+
+  const checks = await screen.findAllByTestId('check-card');
+  expect(checks.length).toBe(1);
+
+  await user.click(await within(dialog).findByText(`Reset`));
+  const resetChecks = await screen.findAllByTestId('check-card');
+  expect(resetChecks.length).toBe(2);
+});
+
 test('clicking add new is handled', async () => {
   const navigate = jest.fn();
   useNavigationHook.useNavigation = jest.fn(() => navigate); // TODO: COME BACK TO

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import { Pagination, useStyles2 } from '@grafana/ui';
@@ -53,6 +54,8 @@ type CheckListContentProps = {
 
 const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps) => {
   useSuspenseProbes(); // we need to block rendering until we have the probe list so not to initially render a check list that might have probe filters
+  const navigate = useNavigate();
+  const location = useLocation();
   const { data: checks } = useSuspenseChecks();
   const { data: reachabilitySuccessRates = [] } = useChecksReachabilitySuccessRate();
   const filters = useCheckFilters();
@@ -118,11 +121,7 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
   };
 
   const handleResetFilters = () => {
-    setSearch(null);
-    setLabels(null);
-    setType(null);
-    setProbes(null);
-    setStatus(null);
+    navigate(`${location.pathname}${sortType ? `?sort=${sortType}` : ''}`);
   };
 
   const handleLabelSelect = (label: Label) => {

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -9,7 +9,7 @@ import {
 } from 'test/fixtures/datasources';
 
 import { ExtendedProbe, FeatureName, type Probe, ProbeProvider, ProbeWithMetadata } from 'types';
-import { camelCaseToSentence } from 'utils';
+import { pascalCaseToSentence } from 'utils';
 
 import { FULL_ADMIN_ACCESS, FULL_READONLY_ACCESS, FULL_WRITER_ACCESS } from './fixtures/rbacPermissions';
 import { apiRoute } from './handlers';
@@ -306,7 +306,7 @@ export const probeToMetadataProbe = (probe: Probe): ProbeWithMetadata => ({
   countryCode: 'cc',
   region: 'region',
   longRegion: 'long region',
-  displayName: camelCaseToSentence(probe.name),
+  displayName: pascalCaseToSentence(probe.name),
 });
 
 export const probeToExtendedProbe = (probe: Probe, usedByChecks: number[] = []): ExtendedProbe => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,7 @@ export interface Probe extends ExistingObject {
 
 export type ProbeMetadata = {
   name: string;
+  displayName: string;
   provider: ProbeProvider;
   country: string;
   countryCode: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export enum ProbeProvider {
   AWS = 'AWS',
   LINODE = 'Linode',
   DIGITAL_OCEAN = 'Digital Ocean',
+  PRIVATE = '',
 }
 
 export interface HeaderMatch {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { camelCaseToSentence, getRandomProbes } from 'utils';
+import { getRandomProbes, pascalCaseToSentence } from 'utils';
 
 it('gets random probes', async () => {
   const probes = [11, 23, 5, 5212, 43, 3, 4, 6];
@@ -14,12 +14,24 @@ it('gets random probes', async () => {
   expect(random2.length).toBe(2);
 });
 
-describe(`camelCaseToSentence`, () => {
+describe(`pascalCaseToSentence`, () => {
   it(`converts camelCase to sentence`, () => {
-    expect(camelCaseToSentence('camelCaseToSentence')).toBe('Camel Case To Sentence');
+    expect(pascalCaseToSentence('camelCaseToSentence')).toBe('Camel Case To Sentence');
+  });
+
+  it(`converts pascalCase to sentence`, () => {
+    expect(pascalCaseToSentence('PascalCaseToSentence')).toBe('Pascal Case To Sentence');
   });
 
   it(`doesn't convert values which are all uppercase`, () => {
-    expect(camelCaseToSentence('ALLUPPERCASE')).toBe('ALLUPPERCASE');
+    expect(pascalCaseToSentence('ALLUPPERCASE')).toBe('ALLUPPERCASE');
+  });
+
+  it(`doesn't convert values which are all lowercase`, () => {
+    expect(pascalCaseToSentence('alllowercase')).toBe('alllowercase');
+  });
+
+  it(`doesn't convert values which already have spaces`, () => {
+    expect(pascalCaseToSentence('Has Spaces')).toBe('Has Spaces');
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -427,10 +427,10 @@ export function createNavModel(base: NavModelItem, items: NavModelItem[]): NavMo
   }, base);
 }
 
-export function camelCaseToSentence(value: string) {
-  if (value.toUpperCase() === value || value.toLowerCase() === value) {
+export const pascalCaseToSentence = (value: string): string => {
+  if (value === value.toUpperCase() || value === value.toLowerCase()) {
     return value;
   }
 
-  return value.replace(/([A-Z])/g, ' $1').replace(/^./, (str) => str.toUpperCase());
-}
+  return value.charAt(0).toUpperCase() + value.slice(1).replace(/(?<! )([A-Z])/g, ' $1');
+};


### PR DESCRIPTION
## Problem

We had a bug where you couldn't filter most probes correctly on the check list page. We were made aware of it in this escalation: https://github.com/grafana/support-escalations/issues/14671

We had unit and integration tests covering this problem but none that were comprehensive enough to catch the bug.

Whilst fixing this bug I discovered the reset button also wasn't working so put in a quick fix.

## Solution

I've added the `displayName` property to our hard-coded probe meta data list. Upon reflection this is the safer way to handle this problem as it no longer transforms private probe names, which would likely want to restrict their display to the user-inputted name.

Regardless, I've updated `camelCaseToSentence` to `pascalCaseToSentence`. It ensures that if the first letter is a capital it doesn't get prepended with a space and for values which already have a space it no longer double pads them.

I've also changed the `reset` button so it directly alters the URL, which the state then passes down to the filters to update themselves accordingly. This isn't an ideal fix but as we have re-doing the check list page on the horizon I don't want to invest an unnecessary amount of time for something that is likely to change in some capacity in the future.