### PR TITLE
fix: prevent submitting alerts per check when FF is off

### DIFF
--- a/src/components/CheckForm/checkForm.hooks.ts
+++ b/src/components/CheckForm/checkForm.hooks.ts
@@ -10,11 +10,12 @@ import { ScriptedCheckSchema } from 'schemas/forms/ScriptedCheckSchema';
 import { TCPCheckSchema } from 'schemas/forms/TCPCheckSchema';
 import { TracerouteCheckSchema } from 'schemas/forms/TracerouteCheckSchema';
 
-import { Check, CheckAlertDraft, CheckAlertFormRecord, CheckFormValues, CheckType } from 'types';
+import { Check, CheckAlertDraft, CheckAlertFormRecord, CheckFormValues, CheckType, FeatureName } from 'types';
 import { ROUTES } from 'routing/types';
 import { AdHocCheckResponse } from 'datasource/responses.types';
 import { useUpdateAlertsForCheck } from 'data/useCheckAlerts';
 import { useCUDChecks, useTestCheck } from 'data/useChecks';
+import { useFeatureFlag } from 'hooks/useFeatureFlag';
 import { useNavigation } from 'hooks/useNavigation';
 import { toPayload } from 'components/CheckEditor/checkFormTransformations';
 import { getAlertsPayload } from 'components/CheckEditor/transformations/toPayload.alerts';
@@ -54,6 +55,7 @@ export function useCheckForm({ check, checkType, onTestSuccess }: UseCheckFormPr
   const { mutate: testCheck, isPending, error: testError } = useTestCheck({ eventInfo: { checkType } });
 
   const navigateToChecks = useCallback(() => navigate(ROUTES.Checks), [navigate]);
+  const alertsEnabled = useFeatureFlag(FeatureName.AlertsPerCheck).isEnabled;
 
   const onError = (err: Error | unknown) => {
     setSubmittingToApi(false);
@@ -102,9 +104,9 @@ export function useCheckForm({ check, checkType, onTestSuccess }: UseCheckFormPr
         return testCheck(toSubmit, { onSuccess: onTestSuccess });
       }
 
-      mutateCheck(toSubmit, checkValues?.alerts);
+      mutateCheck(toSubmit, alertsEnabled ? checkValues?.alerts : undefined);
     },
-    [mutateCheck, onTestSuccess, testCheck]
+    [mutateCheck, onTestSuccess, testCheck, alertsEnabled]
   );
 
   const handleInvalid = useCallback((errs: FieldErrors) => {

--- a/src/page/NewCheck/__tests__/ApiEndPointChecks/CommonFields.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/ApiEndPointChecks/CommonFields.payload.test.tsx
@@ -99,9 +99,8 @@ describe('Api endpoint checks - common fields payload', () => {
             [FeatureName.AlertsPerCheck]: true,
           });
 
-          
           const { user, read } = await renderNewForm(checkType);
-          
+
           await fillMandatoryFields({ user, checkType });
 
           await goToSection(user, 4);
@@ -121,6 +120,27 @@ describe('Api endpoint checks - common fields payload', () => {
           const { body: alertsBody } = await read(1);
 
           expect(alertsBody).toEqual({ alerts: [{ name: 'ProbeFailedExecutionsTooHigh', threshold: 0.1 }] });
+        });
+
+        it(`does not submit aletrs per check when the feature flag is disabled`, async () => {
+          jest.replaceProperty(config, 'featureToggles', {
+            // @ts-expect-error
+            [FeatureName.AlertsPerCheck]: false,
+          });
+
+          const { user, read } = await renderNewForm(checkType);
+
+          await fillMandatoryFields({ user, checkType });
+
+          await goToSection(user, 4);
+
+          expect(screen.queryByText('Predefined alerts')).not.toBeInTheDocument();
+
+          await submitForm(user);
+
+          const { body: alertsBody } = await read(1);
+
+          expect(alertsBody).toEqual(undefined);
         });
       });
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevents executing the new alerts `POST` request to update alerts when saving a check if the feature flag is off.

**Special notes for your reviewer**:

This was a regression introduced after a refactor PR. Before, we were relying on the absence of the `alerts` property from the form in order to save them or not. Since after the refactor the `alerts` prop is always present, I'm now relying on the status of the feature flag directly.

Ref https://raintank-corp.slack.com/archives/C0162C1K9E1/p1739894967044089