### PR TITLE
Fix: terraform export fixes

### DIFF
--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -204,5 +204,5 @@ export const probeToTF = (probe: Probe): TFProbe => ({
   region: probe.region,
   public: false,
   labels: labelsToTFLabels(probe.labels),
-  capabilities: probe.capabilities,
+  ...probe.capabilities,
 });

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -88,18 +88,27 @@ const settingsToTF = (check: Check): TFCheckSettings => {
         record_type: check.settings.dns.recordType,
         protocol: check.settings.dns.protocol,
         valid_r_codes: check.settings.dns.validRCodes,
-        validate_answer_rrs: {
-          fail_if_matches_regexp: check.settings.dns.validateAnswerRRS?.failIfMatchesRegexp,
-          fail_if_not_matches_regexp: check.settings.dns.validateAnswerRRS?.failIfNotMatchesRegexp,
-        },
-        validate_authority_rrs: {
-          fail_if_matches_regexp: check.settings.dns.validateAuthorityRRS?.failIfMatchesRegexp,
-          fail_if_not_matches_regexp: check.settings.dns.validateAuthorityRRS?.failIfNotMatchesRegexp,
-        },
-        validate_additional_rrs: {
-          fail_if_matches_regexp: check.settings.dns.validateAdditionalRRS?.failIfMatchesRegexp,
-          fail_if_not_matches_regexp: check.settings.dns.validateAdditionalRRS?.failIfNotMatchesRegexp,
-        },
+        ...((check.settings.dns.validateAnswerRRS?.failIfMatchesRegexp ||
+          check.settings.dns.validateAnswerRRS?.failIfNotMatchesRegexp) && {
+          validate_answer_rrs: {
+            fail_if_matches_regexp: check.settings.dns.validateAnswerRRS.failIfMatchesRegexp,
+            fail_if_not_matches_regexp: check.settings.dns.validateAnswerRRS.failIfNotMatchesRegexp,
+          },
+        }),
+        ...((check.settings.dns.validateAuthorityRRS?.failIfMatchesRegexp ||
+          check.settings.dns.validateAuthorityRRS?.failIfNotMatchesRegexp) && {
+          validate_authority_rrs: {
+            fail_if_matches_regexp: check.settings.dns.validateAuthorityRRS.failIfMatchesRegexp,
+            fail_if_not_matches_regexp: check.settings.dns.validateAuthorityRRS.failIfNotMatchesRegexp,
+          },
+        }),
+        ...((check.settings.dns.validateAdditionalRRS?.failIfMatchesRegexp ||
+          check.settings.dns.validateAdditionalRRS?.failIfNotMatchesRegexp) && {
+          validate_additional_rrs: {
+            fail_if_matches_regexp: check.settings.dns.validateAdditionalRRS.failIfMatchesRegexp,
+            fail_if_not_matches_regexp: check.settings.dns.validateAdditionalRRS.failIfNotMatchesRegexp,
+          },
+        }),
       },
     };
   }

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -215,5 +215,6 @@ export const probeToTF = (probe: Probe): TFProbe => ({
   region: probe.region,
   public: false,
   labels: labelsToTFLabels(probe.labels),
-  ...probe.capabilities,
+  disable_browser_checks: probe.capabilities.disableBrowserChecks,
+  disable_scripted_checks: probe.capabilities.disableScriptedChecks,
 });

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -181,6 +181,8 @@ export const checkToTF = (check: Check): TFCheck => {
     probes: check.probes,
     labels: labelsToTFLabels(check.labels),
     settings: settingsToTF(check),
+    frequency: check.frequency,
+    timeout: check.timeout,
   };
 
   return tfCheck;

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -38,6 +38,8 @@ export interface TFCheck {
   probes: number[];
   labels: TFLabels;
   settings: TFCheckSettings;
+  frequency: number;
+  timeout: number;
 }
 
 export type TFLabels = { [key: string]: string };

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -205,6 +205,8 @@ export interface TFProbeConfig {
   [key: string]: TFProbe;
 }
 
-export interface TFProbe extends Omit<Probe, 'online' | 'onlineChange' | 'version' | 'deprecated' | 'labels'> {
+export interface TFProbe extends Omit<Probe, 'online' | 'onlineChange' | 'version' | 'deprecated' | 'labels' | 'capabilities'> {
   labels: TFLabels;
+  disableScriptedChecks?: boolean;
+  disableBrowserChecks?: boolean;
 }

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -104,9 +104,9 @@ interface TFDnsSettings
   ip_version?: string;
   record_type?: string;
   valid_r_codes?: string[];
-  validate_answer_rrs: TFFailIfMatchesNotMatches;
-  validate_authority_rrs: TFFailIfMatchesNotMatches;
-  validate_additional_rrs: TFFailIfMatchesNotMatches;
+  validate_answer_rrs?: TFFailIfMatchesNotMatches;
+  validate_authority_rrs?: TFFailIfMatchesNotMatches;
+  validate_additional_rrs?: TFFailIfMatchesNotMatches;
 }
 
 interface TFGRPCSettings extends Omit<GRPCSettings, 'ipVersion' | 'tlsConfig'> {

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -209,6 +209,6 @@ export interface TFProbeConfig {
 
 export interface TFProbe extends Omit<Probe, 'online' | 'onlineChange' | 'version' | 'deprecated' | 'labels' | 'capabilities'> {
   labels: TFLabels;
-  disableScriptedChecks?: boolean;
-  disableBrowserChecks?: boolean;
+  disable_scripted_checks: boolean;
+  disable_browser_checks: boolean;
 }

--- a/src/hooks/useTerraformConfig.test.tsx
+++ b/src/hooks/useTerraformConfig.test.tsx
@@ -109,6 +109,7 @@ describe('terraform config generation', () => {
           a_really_really_really_really_really_really_really_really_really_long_jobname_areallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongexample_com:
             {
               enabled: true,
+              frequency: BASIC_PING_CHECK.frequency,
               job: 'a really really really really really really really really really long jobname',
               labels: {
                 [BASIC_PING_CHECK.labels[0].name]: BASIC_PING_CHECK.labels[0].value,
@@ -121,10 +122,12 @@ describe('terraform config generation', () => {
                 },
               },
               target: 'areallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongexample.com',
+              timeout: BASIC_PING_CHECK.timeout
             },
           a_really_really_really_really_really_really_really_really_really_long_jobname_areallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongexample_com_stuff:
             {
               enabled: true,
+              frequency: BASIC_PING_CHECK.frequency,
               job: 'a really really really really really really really really really long jobname',
               labels: {
                 [BASIC_PING_CHECK.labels[0].name]: BASIC_PING_CHECK.labels[0].value,
@@ -137,6 +140,7 @@ describe('terraform config generation', () => {
                 },
               },
               target: 'areallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallyreallylongexample.com/stuff',
+              timeout: BASIC_PING_CHECK.timeout
             },
         },
         grafana_synthetic_monitoring_probe: TERRAFORM_PRIVATE_PROBES,
@@ -204,6 +208,7 @@ describe('terraform config generation', () => {
         grafana_synthetic_monitoring_check: {
           'stuff_https___www_grafana-dev_com': {
             enabled: true,
+            frequency: 120000,
             job: 'stuff',
             labels: {},
             probes: [1, 2],
@@ -267,6 +272,7 @@ describe('terraform config generation', () => {
               },
             },
             target: 'https://www.grafana-dev.com',
+            timeout: 17000,
           },
         },
         grafana_synthetic_monitoring_probe: TERRAFORM_PRIVATE_PROBES,

--- a/src/test/fixtures/terraform.ts
+++ b/src/test/fixtures/terraform.ts
@@ -16,7 +16,8 @@ export const TERRAFORM_PRIVATE_PROBES = {
     name: PRIVATE_PROBE.name,
     public: PRIVATE_PROBE.public,
     region: PRIVATE_PROBE.region,
-    capabilities: PRIVATE_PROBE.capabilities,
+    disable_browser_checks: PRIVATE_PROBE.capabilities.disableBrowserChecks,
+    disable_scripted_checks: PRIVATE_PROBE.capabilities.disableScriptedChecks,
   },
   [UNSELECTED_PRIVATE_PROBE.name]: {
     labels: {
@@ -27,7 +28,8 @@ export const TERRAFORM_PRIVATE_PROBES = {
     name: UNSELECTED_PRIVATE_PROBE.name,
     public: UNSELECTED_PRIVATE_PROBE.public,
     region: UNSELECTED_PRIVATE_PROBE.region,
-    capabilities: UNSELECTED_PRIVATE_PROBE.capabilities,
+    disable_browser_checks: UNSELECTED_PRIVATE_PROBE.capabilities.disableBrowserChecks,
+    disable_scripted_checks: UNSELECTED_PRIVATE_PROBE.capabilities.disableScriptedChecks,
   },
 };
 
@@ -46,6 +48,7 @@ export const TERRAFORM_BASIC_PING_CHECK = {
     grafana_synthetic_monitoring_check: {
       [nameKey]: {
         enabled: true,
+        frequency: BASIC_PING_CHECK.frequency,
         job: BASIC_PING_CHECK.job,
         labels: {
           [BASIC_PING_CHECK.labels[0].name]: BASIC_PING_CHECK.labels[0].value,
@@ -58,6 +61,7 @@ export const TERRAFORM_BASIC_PING_CHECK = {
           },
         },
         target: BASIC_PING_CHECK.target,
+        timeout: BASIC_PING_CHECK.timeout,
       },
     },
     grafana_synthetic_monitoring_probe: TERRAFORM_PRIVATE_PROBES,


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-app/issues/1033, https://github.com/grafana/synthetic-monitoring-app/issues/1028, https://github.com/grafana/synthetic-monitoring-app/issues/1032.

Fixes the export code for terraform to address:
- Adjust check capabilities format
- Include check frequency and timeout
- Omit dns validate fields when empty.
