### PR TITLE
fix: prevent adding duplicated probes when bulk editing

### DIFF
--- a/src/page/CheckList/components/BulkActionsModal.tsx
+++ b/src/page/CheckList/components/BulkActionsModal.tsx
@@ -127,7 +127,7 @@ const BulkActionsModalContent = ({ onDismiss, isOpen, checks, action }: BulkActi
 
 function getUpdatedProbes(check: Check, action: 'add' | 'remove', probeIds: number[]) {
   if (action === 'add') {
-    return [...check.probes, ...probeIds];
+    return [...new Set([...check.probes, ...probeIds])];
   }
 
   return check.probes.filter((id) => !probeIds.includes(id));


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a wrong behavior when bulk-editing checks that ended up adding duplicated probe locations to the check.

https://github.com/user-attachments/assets/edf1deba-94d3-4319-b1a7-ccfa7b4a62d2

**Which issue(s) this PR fixes**:

Closes https://github.com/grafana/synthetic-monitoring-app/issues/1071

