### PR TITLE
fix: handle fractional "check result" logs

### DIFF
--- a/src/scenes/Common/AssertionsTable/AssertionsTable.tsx
+++ b/src/scenes/Common/AssertionsTable/AssertionsTable.tsx
@@ -36,7 +36,7 @@ function getQueryRunner(logs: DataSourceRef) {
           | keep check
           [$__range]
         )
-        / 
+        /
         count_over_time (
             {job="$job", instance="$instance", probe=~"$probe"}
             | logfmt check, msg
@@ -69,7 +69,7 @@ function getQueryRunner(logs: DataSourceRef) {
           | logfmt check, value, msg
           | __error__ = ""
           | msg = "check result"
-          | value = "0"
+          | value != "1"
           | keep check
           [$__range]
         )


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:

When https://github.com/grafana/xk6-sm/pull/34 is merged, it will be possible for `check result` logs to have fractional values, if the same check name is used twice. For example, the following snippet:
```js
  check(res, {
      'is 200': () => true,
    }
  );
  check(res, {
      'is 200': () => false,
    }
  );
```

Currently yields:
```
time="2025-01-14T17:32:54+01:00" level=info msg="check result" check="is 200" metric=checks_total scenario=default source=sm value=1
time="2025-01-14T17:32:55+01:00" level=info msg="check result" check="is 200" metric=checks_total scenario=default source=sm value=0
```

After https://github.com/grafana/xk6-sm/pull/34 is merged, it will yield
```
time="2025-01-14T17:32:54+01:00" level=info msg="check result" check="is 200" metric=checks_total scenario=default source=sm value=0.5
```

In terms of reporting, and given this will only happen if two `check`s with the same name are defined, I think it is okay to simplify and assume that if not 100% of the `check`s with the same name are okay, the check has failed. So this PR changes the query to look for `!= 1` instead of `= 0`. Other queries already look for `= 1`, so those shouldn't need changing.