### PR TITLE
feat: change browser, scripted and multihttp timeouts up to 180s

### DIFF
--- a/src/components/CheckForm/CheckForm.constants.tsx
+++ b/src/components/CheckForm/CheckForm.constants.tsx
@@ -7,9 +7,9 @@ const CheckTimeoutValues = {
   [CheckType.DNS]: { min: 1, max: 60 },
   [CheckType.GRPC]: { min: 1, max: 60 },
   [CheckType.HTTP]: { min: 1, max: 60 },
-  [CheckType.MULTI_HTTP]: { min: 5, max: 120 },
-  [CheckType.Scripted]: { min: 5, max: 120 },
-  [CheckType.Browser]: { min: 5, max: 120 },
+  [CheckType.MULTI_HTTP]: { min: 5, max: 180 },
+  [CheckType.Scripted]: { min: 5, max: 180 },
+  [CheckType.Browser]: { min: 5, max: 180 },
 };
 
 export { CheckTimeoutValues };

--- a/src/page/NewCheck/__tests__/BrowserChecks/Scripted/5-execution.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/BrowserChecks/Scripted/5-execution.payload.test.tsx
@@ -39,8 +39,8 @@ describe(`BrowserCheck - Section 5 (Execution) payload`, () => {
     expect(body.frequency).toBe(ONE_MINUTE_IN_MS);
   });
 
-    it(`can add timeout up to 120 seconds`, async () => {
-      const MAX_TIMEOUT_MS = 120000;
+    it(`can add timeout up to 180 seconds`, async () => {
+      const MAX_TIMEOUT_MS = 180000;
   
       const { user, read } = await renderNewForm(checkType);
       await fillMandatoryFields({ user, checkType });

--- a/src/page/NewCheck/__tests__/MultiStepChecks/MultiHTTP/5-execution.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/MultiStepChecks/MultiHTTP/5-execution.payload.test.tsx
@@ -39,8 +39,8 @@ describe(`MultiHTTPCheck - Section 5 (Execution) payload`, () => {
     expect(body.frequency).toBe(ONE_MINUTE_IN_MS);
   });
 
-    it(`can add timeout up to 120 seconds`, async () => {
-      const MAX_TIMEOUT_MS = 120000;
+    it(`can add timeout up to 180 seconds`, async () => {
+      const MAX_TIMEOUT_MS = 180000;
   
       const { user, read } = await renderNewForm(checkType);
       await fillMandatoryFields({ user, checkType });

--- a/src/page/NewCheck/__tests__/NewCheck.journey.test.tsx
+++ b/src/page/NewCheck/__tests__/NewCheck.journey.test.tsx
@@ -246,7 +246,7 @@ describe(`<NewCheck /> journey`, () => {
 
     const errorMsg = await screen.findByRole('alert');
     expect(errorMsg).toBeInTheDocument();
-    expect(errorMsg).toHaveTextContent(/Frequency must be greater than or equal to timeout \(120 seconds\)/);
+    expect(errorMsg).toHaveTextContent(/Frequency must be greater than or equal to timeout \(180 seconds\)/);
   });
 
   // jsdom doesn't give us back the submitter of the form, so we can't test this

--- a/src/page/NewCheck/__tests__/ScriptedChecks/Scripted/5-execution.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/ScriptedChecks/Scripted/5-execution.payload.test.tsx
@@ -39,8 +39,8 @@ describe(`ScriptedCheck - Section 5 (Execution) payload`, () => {
     expect(body.frequency).toBe(ONE_MINUTE_IN_MS);
   });
 
-  it(`can add timeout up to 120 seconds`, async () => {
-    const MAX_TIMEOUT_MS = 120000;
+  it(`can add timeout up to 180 seconds`, async () => {
+    const MAX_TIMEOUT_MS = 180000;
 
     const { user, read } = await renderNewForm(checkType);
     await fillMandatoryFields({ user, checkType });


### PR DESCRIPTION
Related to https://github.com/grafana/synthetic-monitoring-app/issues/1048 and https://github.com/grafana/synthetic-monitoring-app/pull/1065

Allows a timeout of 190 seconds for `browser`, `scripted` and `multihttp` checks.