### PR TITLE
fix: edit check button disabled issue

### DIFF
--- a/src/scenes/BROWSER/browserScene.ts
+++ b/src/scenes/BROWSER/browserScene.ts
@@ -45,7 +45,7 @@ export function getBrowserScene({ metrics, logs }: DashboardSceneAppConfig, chec
 
     const distinctTargets = getDistinctTargets(metrics);
     const probeDuration = getProbeDuration(metrics);
-    const editButton = getEditButton({ job, instance });
+    const editButton = getEditButton({ id: check.id });
     const annotations = getAlertAnnotations(metrics);
 
     const webVitals = getWebVitals(metrics);

--- a/src/scenes/Common/editButton.tsx
+++ b/src/scenes/Common/editButton.tsx
@@ -1,51 +1,34 @@
 import React from 'react';
-import { SceneReactObject, SceneVariable, VariableValue } from '@grafana/scenes';
+import { SceneReactObject } from '@grafana/scenes';
 import { LinkButton } from '@grafana/ui';
 
 import { Check } from 'types';
 import { ROUTES } from 'routing/types';
 import { generateRoutePath } from 'routing/utils';
 import { getUserPermissions } from 'data/permissions';
-import { useChecks } from 'data/useChecks';
 
 interface Props {
-  job: SceneVariable;
-  instance: SceneVariable;
+  id: Check['id'];
 }
 
-function EditCheckButton({ job, instance }: Props) {
-  const { data: checks = [], isLoading } = useChecks();
-  const url = getUrl(checks, instance.getValue(), job.getValue());
+function EditCheckButton({ id }: Props) {
   const { canWriteChecks } = getUserPermissions();
+  const url = id ? `${generateRoutePath(ROUTES.EditCheck, { id })}` : undefined;
+
+  const disabled = !url || !canWriteChecks;
 
   return (
-    <LinkButton
-      variant="secondary"
-      href={url}
-      disabled={isLoading || !url || !canWriteChecks}
-      icon={isLoading ? 'fa fa-spinner' : 'edit'}
-    >
+    <LinkButton variant="secondary" href={url} disabled={disabled} icon="edit">
       Edit check
     </LinkButton>
   );
 }
 
-function getUrl(checks: Check[], target?: VariableValue | null, job?: VariableValue | null) {
-  const check = checks.find((check) => check.target === target && check.job === job);
-
-  if (!check) {
-    return undefined;
-  }
-
-  return `${generateRoutePath(ROUTES.EditCheck, { id: check.id ?? 'new' })}`;
-}
-
-export function getEditButton({ job, instance }: Props) {
+export function getEditButton({ id }: Props) {
   return new SceneReactObject({
     component: EditCheckButton,
     props: {
-      job,
-      instance,
+      id,
     },
   });
 }

--- a/src/scenes/DNS/dnsScene.ts
+++ b/src/scenes/DNS/dnsScene.ts
@@ -76,7 +76,7 @@ export function getDNSScene({ metrics, logs }: DashboardSceneAppConfig, check: C
       children: [new SceneFlexItem({ height: 500, body: getErrorLogs(logs) })],
     });
 
-    const editButton = getEditButton({ job, instance });
+    const editButton = getEditButton({ id: check.id });
 
     const annotations = getAlertAnnotations(metrics);
 

--- a/src/scenes/GRPC/getGRPCScene.ts
+++ b/src/scenes/GRPC/getGRPCScene.ts
@@ -73,7 +73,7 @@ export function getGRPCScene({ metrics, logs }: DashboardSceneAppConfig, check: 
       children: [new SceneFlexItem({ height: 500, body: getErrorLogs(logs) })],
     });
 
-    const editButton = getEditButton({ job, instance });
+    const editButton = getEditButton({ id: check.id });
 
     const annotations = getAlertAnnotations(metrics);
     return new EmbeddedScene({

--- a/src/scenes/HTTP/httpScene.ts
+++ b/src/scenes/HTTP/httpScene.ts
@@ -81,7 +81,7 @@ export function getHTTPScene({ metrics, logs }: DashboardSceneAppConfig, check: 
       children: [new SceneFlexItem({ height: 500, body: errorLogs })],
     });
 
-    const editButton = getEditButton({ job, instance });
+    const editButton = getEditButton({ id: check.id });
 
     const annotations = getAlertAnnotations(metrics);
 

--- a/src/scenes/PING/pingScene.ts
+++ b/src/scenes/PING/pingScene.ts
@@ -75,7 +75,7 @@ export function getPingScene({ metrics, logs }: DashboardSceneAppConfig, check: 
       children: [new SceneFlexItem({ height: 500, body: getErrorLogs(logs) })],
     });
 
-    const editButton = getEditButton({ job, instance });
+    const editButton = getEditButton({ id: check.id });
 
     const annotations = getAlertAnnotations(metrics);
 

--- a/src/scenes/SCRIPTED/scriptedScene.ts
+++ b/src/scenes/SCRIPTED/scriptedScene.ts
@@ -41,7 +41,7 @@ export function getScriptedScene({ metrics, logs }: DashboardSceneAppConfig, che
 
     const distinctTargets = getDistinctTargets(metrics);
     const probeDuration = getProbeDuration(metrics);
-    const editButton = getEditButton({ job, instance });
+    const editButton = getEditButton({ id: check.id });
 
     const annotations = getAlertAnnotations(metrics);
     return new EmbeddedScene({

--- a/src/scenes/TCP/getTcpScene.ts
+++ b/src/scenes/TCP/getTcpScene.ts
@@ -73,7 +73,7 @@ export function getTcpScene({ metrics, logs }: DashboardSceneAppConfig, check: C
       children: [new SceneFlexItem({ height: 500, body: getErrorLogs(logs) })],
     });
 
-    const editButton = getEditButton({ job, instance });
+    const editButton = getEditButton({ id: check.id });
 
     const annotations = getAlertAnnotations(metrics);
     return new EmbeddedScene({

--- a/src/scenes/Traceroute/getTracerouteScene.ts
+++ b/src/scenes/Traceroute/getTracerouteScene.ts
@@ -54,7 +54,7 @@ export function getTracerouteScene({ metrics, logs, sm }: DashboardSceneAppConfi
     const logsPanel = getLogsPanel(logs);
     const logsRow = new SceneFlexItem({ height: 400, body: logsPanel });
 
-    const editButton = getEditButton({ job, instance });
+    const editButton = getEditButton({ id: check.id });
 
     const annotations = getAlertAnnotations(metrics);
 


### PR DESCRIPTION

**Before**
![image](https://github.com/user-attachments/assets/ccc88a65-2426-4287-aee7-a88c36ce9184)


**After**
![image](https://github.com/user-attachments/assets/7568c88a-8446-42f6-8b7a-d69f0b314061)

**What this PR does / why we need it**:
When an `instance` value includes a comma, we cannot enable the "Edit Check" button on the dashboard page for an affected check. The reason is that we take the `job` and `target|instance` value from the check object (which includes the `id`), then parse both values with `CustomVariable`, then use the parsed values to find an item in an array, that matches `job` and `target|instace`, to get the `id`

This PR takes the `id` directly and uses the `id` to create the route for the Edit Button

**Which issue(s) this PR fixes**:
Resolves [1090](https://github.com/grafana/synthetic-monitoring-app/issues/1090)
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
