### PR TITLE
fix: invert order between Alerting/Execution when AlertsPerCheck is e…

### DIFF
--- a/src/components/CheckForm/AlertsPerCheckSection.tsx
+++ b/src/components/CheckForm/AlertsPerCheckSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Tab, TabContent, TabsBar } from '@grafana/ui';
+import { Stack, Tab, TabContent, TabsBar } from '@grafana/ui';
 
 import { AlertingType, CheckAlertFormValues, CheckAlertType } from 'types';
 import { AlertsPerCheck } from 'components/CheckForm/AlertsPerCheck/AlertsPerCheck';
@@ -8,18 +8,16 @@ import { CheckFormAlert } from 'components/CheckFormAlert';
 interface AlertsPerCheckSectionProps {
   handleInitAlerts: (alerts: Partial<Record<CheckAlertType, CheckAlertFormValues>>) => void;
   alertsInitialized: boolean;
-  styles: { wrapper: string };
 }
 
 export const AlertsPerCheckSection: React.FC<AlertsPerCheckSectionProps> = ({
   handleInitAlerts,
   alertsInitialized,
-  styles,
 }) => {
   const [selectedAlertingTab, setSelectedAlertingTab] = useState<AlertingType>('alerting');
 
   return (
-    <>
+    <Stack direction="column" gap={2}>
       <TabsBar>
         <Tab
           label="Per-check alerts"
@@ -33,13 +31,11 @@ export const AlertsPerCheckSection: React.FC<AlertsPerCheckSectionProps> = ({
         />
       </TabsBar>
       <TabContent>
-        <div className={styles.wrapper}>
-          {selectedAlertingTab === 'alerting' && (
-            <AlertsPerCheck onInitAlerts={handleInitAlerts} isInitialized={alertsInitialized} />
-          )}
-          {selectedAlertingTab === 'sensitivity' && <CheckFormAlert />}
-        </div>
+        {selectedAlertingTab === 'alerting' && (
+          <AlertsPerCheck onInitAlerts={handleInitAlerts} isInitialized={alertsInitialized} />
+        )}
+        {selectedAlertingTab === 'sensitivity' && <CheckFormAlert />}
       </TabContent>
-    </>
+    </Stack>
   );
-}; 
+};

--- a/src/components/CheckForm/AlertsPerCheckSection.tsx
+++ b/src/components/CheckForm/AlertsPerCheckSection.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Tab, TabContent, TabsBar } from '@grafana/ui';
+
+import { AlertingType, CheckAlertFormValues, CheckAlertType } from 'types';
+import { AlertsPerCheck } from 'components/CheckForm/AlertsPerCheck/AlertsPerCheck';
+import { CheckFormAlert } from 'components/CheckFormAlert';
+
+interface AlertsPerCheckSectionProps {
+  handleInitAlerts: (alerts: Partial<Record<CheckAlertType, CheckAlertFormValues>>) => void;
+  alertsInitialized: boolean;
+  styles: { wrapper: string };
+}
+
+export const AlertsPerCheckSection: React.FC<AlertsPerCheckSectionProps> = ({
+  handleInitAlerts,
+  alertsInitialized,
+  styles,
+}) => {
+  const [selectedAlertingTab, setSelectedAlertingTab] = useState<AlertingType>('alerting');
+
+  return (
+    <>
+      <TabsBar>
+        <Tab
+          label="Per-check alerts"
+          onChangeTab={() => setSelectedAlertingTab('alerting')}
+          active={selectedAlertingTab === 'alerting'}
+        />
+        <Tab
+          label="Legacy alerts"
+          onChangeTab={() => setSelectedAlertingTab('sensitivity')}
+          active={selectedAlertingTab === 'sensitivity'}
+        />
+      </TabsBar>
+      <TabContent>
+        <div className={styles.wrapper}>
+          {selectedAlertingTab === 'alerting' && (
+            <AlertsPerCheck onInitAlerts={handleInitAlerts} isInitialized={alertsInitialized} />
+          )}
+          {selectedAlertingTab === 'sensitivity' && <CheckFormAlert />}
+        </div>
+      </TabContent>
+    </>
+  );
+}; 

--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -7,14 +7,7 @@ import { css } from '@emotion/css';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { DataTestIds } from 'test/dataTestIds';
 
-import {
-  Check,
-  CheckAlertFormValues,
-  CheckAlertType,
-  CheckFormValues,
-  CheckType,
-  FeatureName,
-} from 'types';
+import { Check, CheckAlertFormValues, CheckAlertType, CheckFormValues, CheckType, FeatureName } from 'types';
 import { createNavModel } from 'utils';
 import { AppRoutes } from 'routing/types';
 import { generateRoutePath } from 'routing/utils';
@@ -274,11 +267,7 @@ export const CheckForm = ({ check, disabled }: CheckFormProps) => {
 
               {isAlertsPerCheckOn && (
                 <FormLayout.Section label="Alerting" fields={[`alerts`, `alertSensitivity`]} status={status}>
-                  <AlertsPerCheckSection
-                    handleInitAlerts={handleInitAlerts}
-                    alertsInitialized={alertsInitialized}
-                    styles={styles}
-                  />
+                  <AlertsPerCheckSection handleInitAlerts={handleInitAlerts} alertsInitialized={alertsInitialized} />
                 </FormLayout.Section>
               )}
             </FormLayout>

--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -2,13 +2,12 @@ import React, { forwardRef, RefObject, useCallback, useMemo, useState } from 're
 import { FormProvider, SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
-import { Alert, Button, Stack, Tab, TabContent, TabsBar, Text, Tooltip, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { DataTestIds } from 'test/dataTestIds';
 
 import {
-  AlertingType,
   Check,
   CheckAlertFormValues,
   CheckAlertType,
@@ -30,7 +29,6 @@ import { toFormValues } from 'components/CheckEditor/checkFormTransformations';
 import { CheckJobName } from 'components/CheckEditor/FormComponents/CheckJobName';
 import { ChooseCheckType } from 'components/CheckEditor/FormComponents/ChooseCheckType';
 import { ProbeOptions } from 'components/CheckEditor/ProbeOptions';
-import { AlertsPerCheck } from 'components/CheckForm/AlertsPerCheck/AlertsPerCheck';
 import { checkHasChanges } from 'components/CheckForm/checkForm.utils';
 import { DNSCheckLayout } from 'components/CheckForm/FormLayouts/CheckDNSLayout';
 import { GRPCCheckLayout } from 'components/CheckForm/FormLayouts/CheckGrpcLayout';
@@ -51,6 +49,7 @@ import { OverLimitAlert } from 'components/OverLimitAlert';
 
 import { CheckFormContextProvider, useCheckFormContext } from './CheckFormContext/CheckFormContext';
 import { BrowserCheckLayout } from './FormLayouts/CheckBrowserLayout';
+import { AlertsPerCheckSection } from './AlertsPerCheckSection';
 import { useCheckForm, useCheckFormSchema } from './checkForm.hooks';
 import { FormLayout } from './FormLayout';
 import { useFormCheckType, useFormCheckTypeGroup } from './useCheckType';
@@ -214,33 +213,6 @@ export const CheckForm = ({ check, disabled }: CheckFormProps) => {
         ]);
   }, [check, checkTypeGroupOption, isExistingCheck]);
 
-  const [selectedAlertingTab, setSelectedAlertingTab] = useState<AlertingType>('alerting');
-
-  const AlertsPerCheckSection: React.FC = () => (
-    <>
-      <TabsBar>
-        <Tab
-          label="Per-check alerts"
-          onChangeTab={() => setSelectedAlertingTab('alerting')}
-          active={selectedAlertingTab === 'alerting'}
-        />
-        <Tab
-          label="Legacy alerts"
-          onChangeTab={() => setSelectedAlertingTab('sensitivity')}
-          active={selectedAlertingTab === 'sensitivity'}
-        />
-      </TabsBar>
-      <TabContent>
-        <div className={styles.wrapper}>
-          {selectedAlertingTab === 'alerting' && (
-            <AlertsPerCheck onInitAlerts={handleInitAlerts} isInitialized={alertsInitialized} />
-          )}
-          {selectedAlertingTab === 'sensitivity' && <CheckFormAlert />}
-        </div>
-      </TabContent>
-    </>
-  );
-
   const isAlertsPerCheckOn = useFeatureFlag(FeatureName.AlertsPerCheck).isEnabled;
 
   return (
@@ -302,7 +274,11 @@ export const CheckForm = ({ check, disabled }: CheckFormProps) => {
 
               {isAlertsPerCheckOn && (
                 <FormLayout.Section label="Alerting" fields={[`alerts`, `alertSensitivity`]} status={status}>
-                  <AlertsPerCheckSection />
+                  <AlertsPerCheckSection
+                    handleInitAlerts={handleInitAlerts}
+                    alertsInitialized={alertsInitialized}
+                    styles={styles}
+                  />
                 </FormLayout.Section>
               )}
             </FormLayout>

--- a/src/page/NewCheck/__tests__/ApiEndPointChecks/CommonFields.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/ApiEndPointChecks/CommonFields.payload.test.tsx
@@ -1,7 +1,7 @@
 import { config } from '@grafana/runtime';
 import { screen } from '@testing-library/react';
 import { PRIVATE_PROBE } from 'test/fixtures/probes';
-import { selectOption } from 'test/utils';
+import { probeToMetadataProbe, selectOption } from 'test/utils';
 
 import { AlertSensitivity, Check, CheckType, FeatureName } from 'types';
 import {
@@ -101,19 +101,21 @@ describe('Api endpoint checks - common fields payload', () => {
 
           const { user, read } = await renderNewForm(checkType);
 
-          await fillMandatoryFields({ user, checkType });
-
+          await fillMandatoryFields({ user, checkType, fieldsToOmit: ['probes'] });
           await goToSection(user, 4);
+          const probeCheckbox = await screen.findByLabelText(probeToMetadataProbe(PRIVATE_PROBE).displayName);
+          await user.click(probeCheckbox);
+
+          await goToSection(user, 5);
 
           expect(screen.getByText('Per-check alerts')).toBeInTheDocument();
 
           expect(screen.getByText('Failed Checks')).toBeInTheDocument();
 
-          const thresholdsInput = screen.getByTestId('alert-threshold-ProbeFailedExecutionsTooHigh');
-
           await user.click(screen.getByTestId('checkbox-alert-ProbeFailedExecutionsTooHigh'));
-          await user.clear(thresholdsInput);
-          await user.type(thresholdsInput, '1');
+          await user.clear(screen.getByTestId('alert-threshold-ProbeFailedExecutionsTooHigh'));
+
+          await user.type(screen.getByTestId('alert-threshold-ProbeFailedExecutionsTooHigh'), '1');
 
           await submitForm(user);
 
@@ -133,7 +135,6 @@ describe('Api endpoint checks - common fields payload', () => {
           const { user, read } = await renderNewForm(checkType);
 
           await fillMandatoryFields({ user, checkType });
-
           await goToSection(user, 4);
 
           expect(screen.queryByText('Predefined alerts')).not.toBeInTheDocument();

--- a/src/page/NewCheck/__tests__/ApiEndPointChecks/PingCheck/4-alerting.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/ApiEndPointChecks/PingCheck/4-alerting.payload.test.tsx
@@ -1,5 +1,7 @@
 import { config } from '@grafana/runtime';
 import { screen } from '@testing-library/react';
+import { PRIVATE_PROBE } from 'test/fixtures/probes';
+import { probeToMetadataProbe } from 'test/utils';
 
 import { CheckType, FeatureName } from 'types';
 import { goToSection, renderNewForm, submitForm } from 'page/__testHelpers__/checkForm';
@@ -26,8 +28,12 @@ describe(`PingCheck - Section 4 (Alerting) payload`, () => {
     });
 
     const { user } = await renderNewForm(checkType);
-    await fillMandatoryFields({ user, checkType });
+    await fillMandatoryFields({ user, checkType, fieldsToOmit: ['probes'] });
     await goToSection(user, 4);
+    const probeCheckbox = await screen.findByLabelText(probeToMetadataProbe(PRIVATE_PROBE).displayName);
+    await user.click(probeCheckbox);
+
+    await goToSection(user, 5);
 
     expect(screen.getByText('Per-check alerts')).toBeInTheDocument();
 

--- a/src/page/NewCheck/__tests__/NewCheck.journey.test.tsx
+++ b/src/page/NewCheck/__tests__/NewCheck.journey.test.tsx
@@ -252,20 +252,23 @@ describe(`<NewCheck /> journey`, () => {
     });
 
     const { user } = await renderNewForm(CheckType.HTTP);
-    await fillMandatoryFields({ user, checkType: CheckType.HTTP });
-
+    await fillMandatoryFields({ user, checkType: CheckType.HTTP, fieldsToOmit: ['probes'] });
     await goToSection(user, 4);
+    const probeCheckbox = await screen.findByLabelText(probeToMetadataProbe(PUBLIC_PROBE).displayName);
+    await user.click(probeCheckbox);
+
+    await goToSection(user, 5);
     await user.click(screen.getByLabelText('Enable Probe Failed Executions Too High alert'));
-    const thresholdsInput = screen.getByTestId('alert-threshold-ProbeFailedExecutionsTooHigh');
-    await user.clear(thresholdsInput);
-    await user.type(thresholdsInput, '6');
+    const thresholdsInput = 'alert-threshold-ProbeFailedExecutionsTooHigh';
+    await user.clear(screen.getByTestId(thresholdsInput));
+    await user.type(screen.getByTestId(thresholdsInput), '6');
     await submitForm(user);
     expect(screen.getByRole('alert')).toBeInTheDocument();
 
-    await goToSection(user, 5);
+    await goToSection(user, 4);
     await selectBasicFrequency(user, '10s');
 
-    await goToSection(user, 4);
+    await goToSection(user, 5);
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
This PR adjusts the order of the "Alerting" and "Execution" sections in the check form based on the state of the AlertsPerCheck feature flag. When the flag is enabled, the "Execution" section is displayed before the "Alerting" section.

This change aligns with the user flow, as customers must first configure the frequency (in the "Execution" section), which then determines the available alert periods in the "Alerting" section. 

When `AlertsPerCheck` is on:
![image](https://github.com/user-attachments/assets/d013c395-4969-4702-aae4-3ee505c191dd)

When `AlertsPerCheck` is off:
![image](https://github.com/user-attachments/assets/96e8c31f-218c-4108-a300-8a1b7e5d1fca)
