### PR TITLE
Fix: Terraform fixes for scripted, browser and multiHTTP checks

### DIFF
--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -10,7 +10,9 @@ import {
   isTCPCheck,
   isTracerouteCheck,
 } from 'utils.types';
+import { fromBase64 } from 'utils';
 
+import { mapAssertionsToTF, mapVariablesToTF } from './terraformMultiHTTPConfigUtils';
 import { TFCheck, TFCheckSettings, TFLabels, TFMultiHttpEntry, TFProbe, TFTlsConfig } from './terraformTypes';
 
 const labelsToTFLabels = (labels: Label[]): TFLabels =>
@@ -132,7 +134,8 @@ const settingsToTF = (check: Check): TFCheckSettings => {
         entries: escaped.entries.map((entry) => {
           const { queryFields, ...request } = entry.request;
           const transformed: TFMultiHttpEntry = {
-            ...entry,
+            variables: entry.variables?.map(mapVariablesToTF),
+            assertions: entry.checks?.map(mapAssertionsToTF),
             request: {
               ...request,
               query_fields: queryFields,
@@ -155,13 +158,17 @@ const settingsToTF = (check: Check): TFCheckSettings => {
 
   if (isScriptedCheck(check)) {
     return {
-      scripted: {},
+      scripted: {
+        script: fromBase64(check.settings.scripted.script),
+      },
     };
   }
 
   if (isBrowserCheck(check)) {
     return {
-      browser: {},
+      browser: {
+        script: fromBase64(check.settings.browser.script),
+      },
     };
   }
 

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -12,7 +12,7 @@ import {
 } from 'utils.types';
 import { fromBase64 } from 'utils';
 
-import { mapAssertionsToTF, mapVariablesToTF } from './terraformMultiHTTPConfigUtils';
+import { mapAssertionsToTF, mapRequestBodyToTF, mapVariablesToTF } from './terraformMultiHTTPConfigUtils';
 import { TFCheck, TFCheckSettings, TFLabels, TFMultiHttpEntry, TFProbe, TFTlsConfig } from './terraformTypes';
 
 const labelsToTFLabels = (labels: Label[]): TFLabels =>
@@ -139,17 +139,9 @@ const settingsToTF = (check: Check): TFCheckSettings => {
             request: {
               ...request,
               query_fields: queryFields,
-              body: {
-                content_type: entry.request.body?.contentType,
-              },
+              body: mapRequestBodyToTF(request.body),
             },
           };
-          if (entry.request.postData) {
-            transformed.request.post_data = {
-              mime_type: entry.request.postData.mimeType,
-              text: entry.request.postData.text,
-            };
-          }
           return transformed;
         }),
       },

--- a/src/components/TerraformConfig/terraformMultiHTTPConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformMultiHTTPConfigUtils.ts
@@ -1,0 +1,154 @@
+import { MultiHttpAssertionType, MultiHttpVariableType } from 'types';
+import {
+  Assertion,
+  AssertionConditionVariant,
+  AssertionJsonPath,
+  AssertionJsonPathValue,
+  AssertionRegex,
+  AssertionSubjectVariant,
+  AssertionText,
+  MultiHttpVariable,
+} from 'components/MultiHttp/MultiHttpTypes';
+
+import {
+  TFMultiHttpAssertion,
+  TFMultiHTTPAssertionCondition,
+  TFMultiHttpAssertionSubject,
+  TFMultiHTTPAssertionType,
+  TFMultiHttpVariable,
+  TFMultiHTTPVariableType,
+} from './terraformTypes';
+
+export const mapTFMultiHTTPAssertionCondition = (
+  condition: AssertionConditionVariant
+): TFMultiHTTPAssertionCondition => {
+  switch (condition) {
+    case AssertionConditionVariant.Contains:
+      return 'CONTAINS';
+    case AssertionConditionVariant.NotContains:
+      return 'NOT_CONTAINS';
+    case AssertionConditionVariant.Equals:
+      return 'EQUALS';
+    case AssertionConditionVariant.StartsWith:
+      return 'STARTS_WITH';
+    case AssertionConditionVariant.EndsWith:
+      return 'ENDS_WITH';
+    case AssertionConditionVariant.TypeOf:
+      return 'TYPE_OF';
+    default:
+      throw new Error(`Unknown condition: ${condition}`);
+  }
+};
+
+export const mapTFMultiHTTPAssertionSubject = (subject: AssertionSubjectVariant): TFMultiHttpAssertionSubject => {
+  switch (subject) {
+    case AssertionSubjectVariant.ResponseBody:
+      return 'RESPONSE_BODY';
+    case AssertionSubjectVariant.ResponseHeaders:
+      return 'RESPONSE_HEADERS';
+    case AssertionSubjectVariant.HttpStatusCode:
+      return 'HTTP_STATUS_CODE';
+    default:
+      throw new Error(`Unknown subject: ${subject}`);
+  }
+};
+
+export function mapAssertionsToTF(entryCheck: Assertion): TFMultiHttpAssertion {
+  let assertionType: TFMultiHTTPAssertionType;
+
+  switch (entryCheck.type) {
+    case MultiHttpAssertionType.Text:
+      assertionType = 'TEXT';
+      break;
+    case MultiHttpAssertionType.JSONPathValue:
+      assertionType = 'JSON_PATH_VALUE';
+      break;
+    case MultiHttpAssertionType.JSONPath:
+      assertionType = 'JSON_PATH_ASSERTION';
+      break;
+    case MultiHttpAssertionType.Regex:
+      assertionType = 'REGEX_ASSERTION';
+      break;
+    default:
+      assertionType = 'TEXT';
+  }
+
+  const assertion: TFMultiHttpAssertion = {
+    type: assertionType,
+  };
+
+  switch (assertionType) {
+    case 'TEXT': {
+      const entryCheckText = entryCheck as AssertionText;
+
+      // For TEXT assertions, we expect `condition`, `subject`, and `value`
+      if (entryCheckText.condition && entryCheckText.subject && entryCheckText.value) {
+        assertion.condition = mapTFMultiHTTPAssertionCondition(entryCheckText.condition);
+        assertion.subject = mapTFMultiHTTPAssertionSubject(entryCheckText.subject);
+        assertion.value = entryCheckText.value;
+      }
+      break;
+    }
+
+    case 'JSON_PATH_VALUE': {
+      const entryCheckJsonPathValue = entryCheck as AssertionJsonPathValue;
+
+      // For JSON_PATH_VALUE, we expect `condition`, `expression`, and `value`
+      if (entryCheckJsonPathValue.condition && entryCheckJsonPathValue.expression && entryCheckJsonPathValue.value) {
+        assertion.condition = mapTFMultiHTTPAssertionCondition(entryCheckJsonPathValue.condition);
+        assertion.expression = entryCheckJsonPathValue.expression;
+        assertion.value = entryCheckJsonPathValue.value;
+      }
+      break;
+    }
+
+    case 'JSON_PATH_ASSERTION': {
+      const entryCheckJsonPath = entryCheck as AssertionJsonPath;
+
+      // For JSON_PATH_ASSERTION, we only need the `expression`
+      if (entryCheckJsonPath.expression) {
+        assertion.expression = entryCheckJsonPath.expression;
+      }
+      break;
+    }
+
+    case 'REGEX_ASSERTION': {
+      const entryCheckRegex = entryCheck as AssertionRegex;
+
+      // For REGEX_ASSERTION, we expect `subject`, and `expression`
+      if (entryCheckRegex.subject && entryCheckRegex.expression) {
+        assertion.subject = mapTFMultiHTTPAssertionSubject(entryCheckRegex.subject);
+        assertion.expression = entryCheckRegex.expression;
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  return assertion;
+}
+
+export function mapVariablesToTF(variable: MultiHttpVariable): TFMultiHttpVariable {
+  let variableType: TFMultiHTTPVariableType;
+  switch (variable.type) {
+    case MultiHttpVariableType.CSS_SELECTOR:
+      variableType = 'CSS_SELECTOR';
+      break;
+    case MultiHttpVariableType.JSON_PATH:
+      variableType = 'JSON_PATH';
+      break;
+    case MultiHttpVariableType.REGEX:
+      variableType = 'REGEX';
+      break;
+
+    default:
+      variableType = 'JSON_PATH';
+  }
+
+  return {
+    ...variable,
+    type: variableType,
+  };
+}

--- a/src/components/TerraformConfig/terraformMultiHTTPConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformMultiHTTPConfigUtils.ts
@@ -175,18 +175,20 @@ export function mapRequestBodyToTF(body?: MultiHttpRequestBody): TFMultiHttpRequ
   };
 }
 
-// Helper function to map assertion types
-function mapAssertionType(type: MultiHttpAssertionType): TFMultiHTTPAssertionType {
-  switch (type) {
-    case MultiHttpAssertionType.Text:
-      return ASSERTION_TYPES.TEXT;
-    case MultiHttpAssertionType.JSONPathValue:
-      return ASSERTION_TYPES.JSON_PATH_VALUE;
-    case MultiHttpAssertionType.JSONPath:
-      return ASSERTION_TYPES.JSON_PATH_ASSERTION;
-    case MultiHttpAssertionType.Regex:
-      return ASSERTION_TYPES.REGEX_ASSERTION;
-    default:
-      throw new Error(`Unknown assertion type: ${type}`);
-  }
+const ASSERTION_TYPE_MAP: Record<MultiHttpAssertionType, TFMultiHTTPAssertionType> = {
+  [MultiHttpAssertionType.Text]: ASSERTION_TYPES.TEXT,
+  [MultiHttpAssertionType.JSONPathValue]: ASSERTION_TYPES.JSON_PATH_VALUE,
+  [MultiHttpAssertionType.JSONPath]: ASSERTION_TYPES.JSON_PATH_ASSERTION,
+  [MultiHttpAssertionType.Regex]: ASSERTION_TYPES.REGEX_ASSERTION,
+};
+
+/**
+ * Maps an assertion type to its Terraform configuration format
+ */
+export function mapAssertionType(type: MultiHttpAssertionType): TFMultiHTTPAssertionType {
+  return mapEnumToTerraformValue(
+    type,
+    ASSERTION_TYPE_MAP,
+    `Unknown assertion type: ${type}`
+  );
 }

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -9,7 +9,12 @@ import {
   TCPQueryResponse,
   TcpSettings,
 } from 'types';
-import { MultiHttpEntry, MultiHttpVariable, RequestProps } from 'components/MultiHttp/MultiHttpTypes';
+import {
+  MultiHttpEntry,
+  MultiHttpRequestBody,
+  MultiHttpVariable,
+  RequestProps,
+} from 'components/MultiHttp/MultiHttpTypes';
 
 export interface TFOutput {
   config: TFConfig;
@@ -186,6 +191,11 @@ export type TFMultiHttpAssertionSubject = 'RESPONSE_HEADERS' | 'HTTP_STATUS_CODE
 
 export type TFMultiHTTPVariableType = 'JSON_PATH' | 'REGEX' | 'CSS_SELECTOR';
 
+export interface TFMultiHttpRequestBody extends Omit<MultiHttpRequestBody, 'contentType' | 'contentEncoding'> {
+  content_type?: string;
+  content_encoding?: string;
+}
+
 export interface TFMultiHttpAssertion {
   type: TFMultiHTTPAssertionType;
   condition?: TFMultiHTTPAssertionCondition;
@@ -209,11 +219,7 @@ interface TFMultiHttpRequest extends Omit<RequestProps, 'queryFields' | 'postDat
     mime_type: string;
     text: string;
   };
-  body: {
-    content_type?: string;
-    content_encoding?: string;
-    payload?: string;
-  };
+  body?: TFMultiHttpRequestBody;
 }
 
 interface TFHeaderMatch extends Omit<HeaderMatch, 'allowMissing'> {

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -9,7 +9,7 @@ import {
   TCPQueryResponse,
   TcpSettings,
 } from 'types';
-import { MultiHttpEntry, RequestProps } from 'components/MultiHttp/MultiHttpTypes';
+import { MultiHttpEntry, MultiHttpVariable, RequestProps } from 'components/MultiHttp/MultiHttpTypes';
 
 export interface TFOutput {
   config: TFConfig;
@@ -174,10 +174,35 @@ interface TFMultiHTTPSettings {
   entries: TFMultiHttpEntry[];
 }
 
-export interface TFMultiHttpEntry extends Omit<MultiHttpEntry, 'request'> {
-  request: TFMultiHttpRequest;
+export type TFMultiHTTPAssertionType = 'TEXT' | 'JSON_PATH_VALUE' | 'JSON_PATH_ASSERTION' | 'REGEX_ASSERTION';
+export type TFMultiHTTPAssertionCondition =
+  | 'NOT_CONTAINS'
+  | 'EQUALS'
+  | 'STARTS_WITH'
+  | 'ENDS_WITH'
+  | 'TYPE_OF'
+  | 'CONTAINS';
+export type TFMultiHttpAssertionSubject = 'RESPONSE_HEADERS' | 'HTTP_STATUS_CODE' | 'RESPONSE_BODY';
+
+export type TFMultiHTTPVariableType = 'JSON_PATH' | 'REGEX' | 'CSS_SELECTOR';
+
+export interface TFMultiHttpAssertion {
+  type: TFMultiHTTPAssertionType;
+  condition?: TFMultiHTTPAssertionCondition;
+  subject?: TFMultiHttpAssertionSubject;
+  expression?: string;
+  value?: string;
 }
 
+export interface TFMultiHttpVariable extends Omit<MultiHttpVariable, 'type'> {
+  type: TFMultiHTTPVariableType;
+}
+
+export interface TFMultiHttpEntry extends Omit<MultiHttpEntry, 'request' | 'checks' | 'variables'> {
+  request: TFMultiHttpRequest;
+  assertions?: TFMultiHttpAssertion[];
+  variables?: TFMultiHttpVariable[];
+}
 interface TFMultiHttpRequest extends Omit<RequestProps, 'queryFields' | 'postData' | 'body'> {
   query_fields?: Label[];
   post_data?: {
@@ -207,7 +232,8 @@ export interface TFProbeConfig {
   [key: string]: TFProbe;
 }
 
-export interface TFProbe extends Omit<Probe, 'online' | 'onlineChange' | 'version' | 'deprecated' | 'labels' | 'capabilities'> {
+export interface TFProbe
+  extends Omit<Probe, 'online' | 'onlineChange' | 'version' | 'deprecated' | 'labels' | 'capabilities'> {
   labels: TFLabels;
   disable_scripted_checks: boolean;
   disable_browser_checks: boolean;


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-app/issues/1094
Closes https://github.com/grafana/synthetic-monitoring-app/issues/853

## Summary
This PR introduces a refactoring of the Terraform configuration generation, specifically focusing on `MultiHTTP` and `Scripted`/`Browser` checks to match the terraform provider expected structure, as these kind of checks are failing when trying to import them.

 The changes include:
1. Extraction of `MultiHTTP-specific` logic into a dedicated utility file
2. Improved type safety and validation for assertions and variables
3. Addition of scripted and browser check support
4. Enhanced test coverage

## Key Changes

### New MultiHTTP Configuration Utils
- Created new file `terraformMultiHTTPConfigUtils.ts` to handle MultiHTTP-specific transformations, as MultiHTTP checks can be complex due to their nested structure containing multiple assertions, variables, and request configurations
- Added proper handling of different assertion types (Text, JSON Path, Regex)
- The new structure of the generated configuration matches the official provider schema from [Grafana Synthetic Monitoring Provider](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/synthetic_monitoring_check#nested-schema-for-settingsmultihttp)

### Scripted and Browser Check Support
- Fixed a bug where scripted and browser checks were missing the `script` section in the generated Terraform configuration, causing `terraform apply` to fail
