### PR TITLE
chore: bump k6 typings to v0.57.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/ip-address": "^7.0.0",
     "@types/is-base64": "^1.1.0",
     "@types/jest": "^29.5.0",
-    "@types/k6": "0.53.0",
+    "@types/k6": "0.57.1",
     "@types/lodash": "^4.14.194",
     "@types/node": "^20.8.7",
     "@types/prismjs": "1.26.3",

--- a/src/components/CodeEditor/k6.types.ts
+++ b/src/components/CodeEditor/k6.types.ts
@@ -1,34 +1,66 @@
-// @ts-nocheck
+/* eslint-disable simple-import-sort/imports */
 // Need to import all type declarations by one, monaco ignores import inside declaration files
-import k6Browser from '!raw-loader!@types/k6/browser.d.ts';
-import k6Crypto from '!raw-loader!@types/k6/crypto.d.ts';
-import k6Data from '!raw-loader!@types/k6/data.d.ts';
-import k6Encoding from '!raw-loader!@types/k6/encoding.d.ts';
-import k6Exec from '!raw-loader!@types/k6/execution.d.ts';
-import k6BrowserDeprecated from '!raw-loader!@types/k6/experimental/browser.d.ts';
-import k6ExperimentalTracing from '!raw-loader!@types/k6/experimental/tracing.d.ts';
-import k6Html from '!raw-loader!@types/k6/html.d.ts';
-import k6Http from '!raw-loader!@types/k6/http.d.ts';
-import k6Types from '!raw-loader!@types/k6/index.d.ts';
-import k6Metrics from '!raw-loader!@types/k6/metrics.d.ts';
-import k6Options from '!raw-loader!@types/k6/options.d.ts';
-import k6Ws from '!raw-loader!@types/k6/ws.d.ts';
 
-export { default as k6GlobalTypes } from '!raw-loader!@types/k6/global.d.ts';
+// imports and object same order as defined in @types/k6/package.json
+
+// @ts-expect-error
+import k6 from '!raw-loader!@types/k6';
+// @ts-expect-error
+import k6Options from '!raw-loader!@types/k6/options';
+// @ts-expect-error
+import k6Ws from '!raw-loader!@types/k6/ws';
+// @ts-expect-error
+import k6Http from '!raw-loader!@types/k6/http';
+// @ts-expect-error
+import k6NetgRPC from '!raw-loader!@types/k6/net/grpc';
+// @ts-expect-error
+import k6Html from '!raw-loader!@types/k6/html';
+// @ts-expect-error
+import k6Metrics from '!raw-loader!@types/k6/metrics';
+// @ts-expect-error
+import k6Timers from '!raw-loader!@types/k6/timers';
+// @ts-expect-error
+import k6Execution from '!raw-loader!@types/k6/execution';
+// @ts-expect-error
+import k6Encoding from '!raw-loader!@types/k6/encoding';
+// @ts-expect-error
+import k6Data from '!raw-loader!@types/k6/data';
+// @ts-expect-error
+import k6Crypto from '!raw-loader!@types/k6/crypto';
+// @ts-expect-error
+import k6Browser from '!raw-loader!@types/k6/browser';
+// @ts-expect-error
+import k6ExperimentalCSV from '!raw-loader!@types/k6/experimental/csv';
+// @ts-expect-error
+import k6ExperimentalFS from '!raw-loader!@types/k6/experimental/fs';
+// @ts-expect-error
+import k6ExperimentalRedis from '!raw-loader!@types/k6/experimental/redis';
+// @ts-expect-error
+import k6ExperimentalWebcrypto from '!raw-loader!@types/k6/experimental/webcrypto';
+// @ts-expect-error
+import k6ExperimentalStreams from '!raw-loader!@types/k6/experimental/streams';
+// @ts-expect-error
+import k6ExperimentalWebsockets from '!raw-loader!@types/k6/experimental/websockets';
 
 // eslint-disable-next-line no-restricted-syntax
 export default {
-  k6: k6Types,
-  'k6/browser': k6Browser,
-  'k6/crypto': k6Crypto,
-  'k6/data': k6Data,
-  'k6/encoding': k6Encoding,
-  'k6/execution': k6Exec,
-  'k6/experimental/browser': k6BrowserDeprecated,
-  'k6/experimental/tracing': k6ExperimentalTracing,
-  'k6/html': k6Html,
-  'k6/http': k6Http,
-  'k6/metrics': k6Metrics,
+  k6,
   'k6/options': k6Options,
   'k6/ws': k6Ws,
+  'k6/http': k6Http,
+  'k6/net/grpc': k6NetgRPC,
+  'k6/html': k6Html,
+  'k6/metrics': k6Metrics,
+  'k6/timers': k6Timers,
+  'k6/execution': k6Execution,
+  'k6/encoding': k6Encoding,
+  'k6/data': k6Data,
+  'k6/crypto': k6Crypto,
+  'k6/browser': k6Browser,
+  'k6/experimental/csv': k6ExperimentalCSV,
+  'k6/experimental/fs': k6ExperimentalFS,
+  'k6/experimental/redis': k6ExperimentalRedis,
+  'k6/experimental/webcrypto': k6ExperimentalWebcrypto,
+  'k6/experimental/streams': k6ExperimentalStreams,
+  'k6/experimental/websockets': k6ExperimentalWebsockets,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,10 +2746,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/k6@0.53.0":
-  version "0.53.0"
-  resolved "https://registry.yarnpkg.com/@types/k6/-/k6-0.53.0.tgz#2bba27db67a40bc0b6392cf3753f51cd2495c28b"
-  integrity sha512-5gvPxn4I7b08AS0UZPjYALg4rg4rslSNVfHPiZ1ta0EEwsJOd+uKMkvwGkQOKy0a/8HAfthxD61Qci1kXcJOjg==
+"@types/k6@0.57.1":
+  version "0.57.1"
+  resolved "https://registry.yarnpkg.com/@types/k6/-/k6-0.57.1.tgz#d32221f94e4e27198c2bdb327c7428d581ae18ce"
+  integrity sha512-S/p2RQAYUBXyYROkR2fgeON/LaxJ0YR+KIlnPQW/TOeLBXD7tX4RfDSWaIecuDTWKblmc6UwANyP0e5QDZPhMw==
 
 "@types/lodash@4.17.14":
   version "4.17.14"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps k6 types. To have the correct types for the current k6 version