### PR TITLE
feat: rename the TLS certificate expiry alert

### DIFF
--- a/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
@@ -9,7 +9,7 @@ import { useMetricsDS } from 'hooks/useMetricsDS';
 
 import { PredefinedAlertInterface } from './AlertsPerCheck.constants';
 import { FailedExecutionsAlert } from './FailedExecutionsAlert';
-import { HTTPTargetCertificateCloseToExpiringAlert } from './HTTPTargetCertificateCloseToExpiringAlert';
+import { TLSTargetCertificateCloseToExpiringAlert } from './TLSTargetCertificateCloseToExpiringAlert';
 
 function createExploreLink(dataSourceName: string, query: string) {
   return urlUtil.renderUrl(`/explore`, {
@@ -72,8 +72,8 @@ export const AlertItem = ({
         />
       )}
 
-      {alert.type === CheckAlertType.HTTPTargetCertificateCloseToExpiring && (
-        <HTTPTargetCertificateCloseToExpiringAlert
+      {alert.type === CheckAlertType.TLSTargetCertificateCloseToExpiring && (
+        <TLSTargetCertificateCloseToExpiringAlert
           alert={alert}
           selected={selected}
           onSelectionChange={handleToggleAlert}

--- a/src/components/CheckForm/AlertsPerCheck/AlertsPerCheck.constants.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertsPerCheck.constants.tsx
@@ -57,7 +57,7 @@ export const GLOBAL_PREDEFINED_ALERTS: PredefinedAlertInterface[] = [
 
 export const HTTP_PREDEFINED_ALERTS: PredefinedAlertInterface[] = [
   {
-    type: CheckAlertType.HTTPTargetCertificateCloseToExpiring,
+    type: CheckAlertType.TLSTargetCertificateCloseToExpiring,
     name: 'HTTP Target Certificate Close To Expiring',
     description: 'Trigger an alert if the target certificate will expire in less than $threshold days.',
     supportsPeriod: false,

--- a/src/components/CheckForm/AlertsPerCheck/TLSTargetCertificateCloseToExpiringAlert.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/TLSTargetCertificateCloseToExpiringAlert.tsx
@@ -18,7 +18,7 @@ import { useCheckFormContext } from '../CheckFormContext/CheckFormContext';
 import { getAlertItemStyles } from './AlertItem';
 import { PredefinedAlertInterface } from './AlertsPerCheck.constants';
 
-export const HTTPTargetCertificateCloseToExpiringAlert = ({
+export const TLSTargetCertificateCloseToExpiringAlert = ({
   alert,
   selected,
   onSelectionChange,

--- a/src/datasource/__mocks__/checkAlerts.ts
+++ b/src/datasource/__mocks__/checkAlerts.ts
@@ -10,7 +10,7 @@ export function mockAlertsForCheckData(mockData: CheckAlertsResponse = alertsFro
 export const alertsFromApi: CheckAlertsResponse = {
   alerts: [
     {
-      name: CheckAlertType['HTTPTargetCertificateCloseToExpiring'],
+      name: CheckAlertType['TLSTargetCertificateCloseToExpiring'],
       threshold: 90,
       created: 1724854935,
       modified: 1724854935,

--- a/src/page/NewCheck/__tests__/ApiEndPointChecks/HTTPCheck/4-alerting.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/ApiEndPointChecks/HTTPCheck/4-alerting.payload.test.tsx
@@ -35,9 +35,9 @@ describe(`HttpCheck - Section 4 (Alerting) payload`, () => {
 
     expect(screen.getByText(`Alert if the target's certificate expires in less than`)).toBeInTheDocument();
 
-    const thresholdsInput = screen.getByTestId('alert-threshold-HTTPTargetCertificateCloseToExpiring');
+    const thresholdsInput = screen.getByTestId('alert-threshold-TLSTargetCertificateCloseToExpiring');
 
-    await user.click(screen.getByTestId('checkbox-alert-HTTPTargetCertificateCloseToExpiring'));
+    await user.click(screen.getByTestId('checkbox-alert-TLSTargetCertificateCloseToExpiring'));
     await user.clear(thresholdsInput);
     await user.type(thresholdsInput, '1');
 
@@ -48,7 +48,7 @@ describe(`HttpCheck - Section 4 (Alerting) payload`, () => {
     expect(alertsBody).toEqual({
       alerts: [
         {
-          name: 'HTTPTargetCertificateCloseToExpiring',
+          name: 'TLSTargetCertificateCloseToExpiring',
           threshold: 1,
         },
       ],

--- a/src/schemas/general/CheckAlerts.ts
+++ b/src/schemas/general/CheckAlerts.ts
@@ -50,7 +50,7 @@ const ProbeFailedExecutionsTooHighSchema = CheckAlertSchema.refine(
 
 export const CheckAlertsSchema: ZodType<CheckAlertFormRecord | undefined> = z.object({
   ProbeFailedExecutionsTooHigh: ProbeFailedExecutionsTooHighSchema.optional(),
-  HTTPTargetCertificateCloseToExpiring: CheckAlertSchema.optional(),
+  TLSTargetCertificateCloseToExpiring: CheckAlertSchema.optional(),
 });
 
 export function checkAlertsRefinement(data: CheckFormValuesBase, ctx: z.RefinementCtx) {

--- a/src/test/fixtures/checkAlerts.ts
+++ b/src/test/fixtures/checkAlerts.ts
@@ -5,7 +5,7 @@ import { CheckAlertsResponse } from 'datasource/responses.types';
 
 export const BASIC_CHECK_ALERTS: CheckAlertsResponse = {
   alerts: [
-    CheckAlertType.HTTPTargetCertificateCloseToExpiring,
+    CheckAlertType.TLSTargetCertificateCloseToExpiring,
     CheckAlertType.ProbeFailedExecutionsTooHigh,
   ].map((name) => db.alert.build({ name })),
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -655,7 +655,7 @@ export type AlertFilter = (record: PrometheusAlertRecord) => boolean;
 
 export enum CheckAlertType {
   ProbeFailedExecutionsTooHigh = 'ProbeFailedExecutionsTooHigh',
-  HTTPTargetCertificateCloseToExpiring = 'HTTPTargetCertificateCloseToExpiring',
+  TLSTargetCertificateCloseToExpiring = 'TLSTargetCertificateCloseToExpiring',
 }
 
 export enum CheckAlertCategory {


### PR DESCRIPTION
**What this PR does / why we need it**:
The underlying metric for the alert rule is the same for multiple check types (HTTP, gRPC, TCP), therefore, since the alert can be reused for these types, replace the 'HTTP' prefix, which referenced the check type, for 'TLS'.

Related grafana/synthetic-monitoring-api/pull/1300
