### PR TITLE
chore: renamed all schemas to camelcase

### DIFF
--- a/src/components/CheckForm/checkForm.hooks.ts
+++ b/src/components/CheckForm/checkForm.hooks.ts
@@ -1,14 +1,14 @@
 import { BaseSyntheticEvent, useCallback, useRef, useState } from 'react';
 import { FieldErrors } from 'react-hook-form';
-import { BrowserCheckSchema } from 'schemas/forms/BrowserCheckSchema';
-import { DNSCheckSchema } from 'schemas/forms/DNSCheckSchema';
-import { GRPCCheckSchema } from 'schemas/forms/GRPCCheckSchema';
-import { HttpCheckSchema } from 'schemas/forms/HttpCheckSchema';
-import { MultiHttpCheckSchema } from 'schemas/forms/MultiHttpCheckSchema';
-import { PingCheckSchema } from 'schemas/forms/PingCheckSchema';
-import { ScriptedCheckSchema } from 'schemas/forms/ScriptedCheckSchema';
-import { TCPCheckSchema } from 'schemas/forms/TCPCheckSchema';
-import { TracerouteCheckSchema } from 'schemas/forms/TracerouteCheckSchema';
+import { browserCheckSchema } from 'schemas/forms/BrowserCheckSchema';
+import { dnsCheckSchema } from 'schemas/forms/DNSCheckSchema';
+import { grpcCheckSchema } from 'schemas/forms/GRPCCheckSchema';
+import { httpCheckSchema } from 'schemas/forms/HttpCheckSchema';
+import { multiHttpCheckSchema } from 'schemas/forms/MultiHttpCheckSchema';
+import { pingCheckSchema } from 'schemas/forms/PingCheckSchema';
+import { scriptedCheckSchema } from 'schemas/forms/ScriptedCheckSchema';
+import { tcpCheckSchema } from 'schemas/forms/TCPCheckSchema';
+import { tracerouteCheckSchema } from 'schemas/forms/TracerouteCheckSchema';
 
 import { Check, CheckAlertDraft, CheckAlertFormRecord, CheckFormValues, CheckType, FeatureName } from 'types';
 import { ROUTES } from 'routing/types';
@@ -24,15 +24,15 @@ import { broadcastFailedSubmission, findFieldToFocus } from './checkForm.utils';
 import { useFormCheckType } from './useCheckType';
 
 const schemaMap = {
-  [CheckType.Browser]: BrowserCheckSchema,
-  [CheckType.DNS]: DNSCheckSchema,
-  [CheckType.GRPC]: GRPCCheckSchema,
-  [CheckType.HTTP]: HttpCheckSchema,
-  [CheckType.MULTI_HTTP]: MultiHttpCheckSchema,
-  [CheckType.PING]: PingCheckSchema,
-  [CheckType.Scripted]: ScriptedCheckSchema,
-  [CheckType.TCP]: TCPCheckSchema,
-  [CheckType.Traceroute]: TracerouteCheckSchema,
+  [CheckType.Browser]: browserCheckSchema,
+  [CheckType.DNS]: dnsCheckSchema,
+  [CheckType.GRPC]: grpcCheckSchema,
+  [CheckType.HTTP]: httpCheckSchema,
+  [CheckType.MULTI_HTTP]: multiHttpCheckSchema,
+  [CheckType.PING]: pingCheckSchema,
+  [CheckType.Scripted]: scriptedCheckSchema,
+  [CheckType.TCP]: tcpCheckSchema,
+  [CheckType.Traceroute]: tracerouteCheckSchema,
 };
 
 export function useCheckFormSchema(check?: Check) {

--- a/src/components/ProbeEditor/ProbeEditor.tsx
+++ b/src/components/ProbeEditor/ProbeEditor.tsx
@@ -4,7 +4,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, Field, Input, Label, Legend, LinkButton, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ProbeSchema } from 'schemas/forms/ProbeSchema';
+import { probeSchema } from 'schemas/forms/ProbeSchema';
 
 import { ExtendedProbe, FeatureName, Probe } from 'types';
 import { ROUTES } from 'routing/types';
@@ -38,7 +38,7 @@ export const ProbeEditor = ({
   const styles = useStyles2(getStyles);
   const { canWriteProbes } = useCanEditProbe(probe);
   const writeMode = canWriteProbes && !forceViewMode;
-  const form = useForm<Probe>({ defaultValues: probe, resolver: zodResolver(ProbeSchema) });
+  const form = useForm<Probe>({ defaultValues: probe, resolver: zodResolver(probeSchema) });
   const { latitude, longitude } = form.watch();
   const handleSubmit = form.handleSubmit((formValues: Probe) => onSubmit(formValues));
   const { errors, isSubmitting } = form.formState;

--- a/src/schemas/forms/BaseCheckSchema.ts
+++ b/src/schemas/forms/BaseCheckSchema.ts
@@ -1,25 +1,25 @@
-import { checkAlertsRefinement, CheckAlertsSchema } from 'schemas/general/CheckAlerts';
-import { CheckProbesSchema } from 'schemas/general/CheckProbes';
-import { FrequencySchema } from 'schemas/general/Frequency';
-import { JobSchema } from 'schemas/general/Job';
-import { LabelsSchema } from 'schemas/general/Label';
+import { checkAlertsRefinement, checkAlertsSchema } from 'schemas/general/CheckAlerts';
+import { checkProbesSchema } from 'schemas/general/CheckProbes';
+import { frequencySchema } from 'schemas/general/Frequency';
+import { jobSchema } from 'schemas/general/Job';
+import { labelsSchema } from 'schemas/general/Label';
 import { z, ZodType } from 'zod';
 
 import { AlertSensitivity, CheckFormValuesBase } from 'types';
 
-export const BaseCheckSchema: ZodType<CheckFormValuesBase> = z
+export const baseCheckSchema: ZodType<CheckFormValuesBase> = z
   .object({
-    job: JobSchema,
+    job: jobSchema,
     target: z.string(),
-    frequency: FrequencySchema,
+    frequency: frequencySchema,
     id: z.number().optional(),
     timeout: z.number(),
     enabled: z.boolean(),
-    probes: CheckProbesSchema,
+    probes: checkProbesSchema,
     alertSensitivity: z.nativeEnum(AlertSensitivity),
-    labels: LabelsSchema,
+    labels: labelsSchema,
     publishAdvancedMetrics: z.boolean(),
-    alerts: CheckAlertsSchema.optional(),
+    alerts: checkAlertsSchema.optional(),
   })
   .superRefine((data, ctx) => {
     const { frequency, timeout } = data;

--- a/src/schemas/forms/BrowserCheckSchema.ts
+++ b/src/schemas/forms/BrowserCheckSchema.ts
@@ -3,18 +3,18 @@ import { z, ZodType } from 'zod';
 import { BrowserSettings, CheckFormValuesBrowser, CheckType } from 'types';
 
 import { maxSizeValidation, validateBrowserScript } from './script/validation';
-import { BaseCheckSchema } from './BaseCheckSchema';
+import { baseCheckSchema } from './BaseCheckSchema';
 
-const BrowserSettingsSchema: ZodType<BrowserSettings> = z.object({
+const browserSettingsSchema: ZodType<BrowserSettings> = z.object({
   script: z.string().min(1, `Script is required.`).superRefine(maxSizeValidation).superRefine(validateBrowserScript),
 });
 
-const BrowserSchemaValues = z.object({
+const browserSchemaValues = z.object({
   target: z.string().min(3, `Instance must be at least 3 characters long.`),
   checkType: z.literal(CheckType.Browser),
   settings: z.object({
-    browser: BrowserSettingsSchema,
+    browser: browserSettingsSchema,
   }),
 });
 
-export const BrowserCheckSchema: ZodType<CheckFormValuesBrowser> = BaseCheckSchema.and(BrowserSchemaValues);
+export const browserCheckSchema: ZodType<CheckFormValuesBrowser> = baseCheckSchema.and(browserSchemaValues);

--- a/src/schemas/forms/DNSCheckSchema.ts
+++ b/src/schemas/forms/DNSCheckSchema.ts
@@ -1,4 +1,4 @@
-import { DomainNameTarget } from 'schemas/general/DomainNameTarget';
+import { domainNameTargetSchema } from 'schemas/general/DomainNameTarget';
 import { z, ZodType } from 'zod';
 
 import {
@@ -12,9 +12,9 @@ import {
   ResponseMatchType,
 } from 'types';
 
-import { BaseCheckSchema } from './BaseCheckSchema';
+import { baseCheckSchema } from './BaseCheckSchema';
 
-const DNSSettingsSchema: ZodType<DnsSettingsFormValues> = z.object({
+const dnsSettingsSchema: ZodType<DnsSettingsFormValues> = z.object({
   recordType: z.nativeEnum(DnsRecordType),
   server: z
     .string({
@@ -40,12 +40,12 @@ const DNSSettingsSchema: ZodType<DnsSettingsFormValues> = z.object({
   ),
 });
 
-const DNSSchemaValues = z.object({
-  target: DomainNameTarget,
+const dnsSchemaValues = z.object({
+  target: domainNameTargetSchema,
   checkType: z.literal(CheckType.DNS),
   settings: z.object({
-    dns: DNSSettingsSchema,
+    dns: dnsSettingsSchema,
   }),
 });
 
-export const DNSCheckSchema: ZodType<CheckFormValuesDns> = BaseCheckSchema.and(DNSSchemaValues);
+export const dnsCheckSchema: ZodType<CheckFormValuesDns> = baseCheckSchema.and(dnsSchemaValues);

--- a/src/schemas/forms/GRPCCheckSchema.ts
+++ b/src/schemas/forms/GRPCCheckSchema.ts
@@ -1,24 +1,24 @@
-import { HostPortTarget } from 'schemas/general/HostPortTarget';
-import { TLSConfigSchema } from 'schemas/general/TLSConfig';
+import { hostPortTargetSchema } from 'schemas/general/HostPortTarget';
+import { tlsConfigSchema } from 'schemas/general/TLSConfig';
 import { z, ZodType } from 'zod';
 
 import { CheckFormValuesGRPC, CheckType, GRPCSettingsFormValues, IpVersion } from 'types';
 
-import { BaseCheckSchema } from './BaseCheckSchema';
+import { baseCheckSchema } from './BaseCheckSchema';
 
-const GRPCSettingsSchema: ZodType<GRPCSettingsFormValues> = z.object({
+const grpcSettingsSchema: ZodType<GRPCSettingsFormValues> = z.object({
   ipVersion: z.nativeEnum(IpVersion),
   service: z.string().optional(),
   tls: z.boolean().optional(),
-  tlsConfig: TLSConfigSchema,
+  tlsConfig: tlsConfigSchema,
 });
 
-const GRPCSchemaValues = z.object({
-  target: HostPortTarget,
+const grpcSchemaValues = z.object({
+  target: hostPortTargetSchema,
   checkType: z.literal(CheckType.GRPC),
   settings: z.object({
-    grpc: GRPCSettingsSchema,
+    grpc: grpcSettingsSchema,
   }),
 });
 
-export const GRPCCheckSchema: ZodType<CheckFormValuesGRPC> = BaseCheckSchema.and(GRPCSchemaValues);
+export const grpcCheckSchema: ZodType<CheckFormValuesGRPC> = baseCheckSchema.and(grpcSchemaValues);

--- a/src/schemas/forms/HttpCheckSchema.ts
+++ b/src/schemas/forms/HttpCheckSchema.ts
@@ -1,6 +1,6 @@
-import { HeadersSchema } from 'schemas/general/Header';
-import { HttpTargetSchema } from 'schemas/general/HttpTarget';
-import { TLSConfigSchema } from 'schemas/general/TLSConfig';
+import { headersSchema } from 'schemas/general/Header';
+import { httpTargetSchema } from 'schemas/general/HttpTarget';
+import { tlsConfigSchema } from 'schemas/general/TLSConfig';
 import { z, ZodType } from 'zod';
 
 import {
@@ -18,15 +18,15 @@ import {
   IpVersion,
 } from 'types';
 
-import { BaseCheckSchema } from './BaseCheckSchema';
+import { baseCheckSchema } from './BaseCheckSchema';
 
-const HttpRegexBodyValidationSchema: ZodType<HttpRegexBodyValidationFormValue> = z.object({
+const httpRegexBodyValidationSchema: ZodType<HttpRegexBodyValidationFormValue> = z.object({
   matchType: z.literal(HttpRegexValidationType.Body),
   expression: z.string().min(1, 'Expression is required'),
   inverted: z.boolean(),
 });
 
-const HttpRegexHeaderValidationSchema: ZodType<HttpRegexHeaderValidationFormValue> = z.object({
+const httpRegexHeaderValidationSchema: ZodType<HttpRegexHeaderValidationFormValue> = z.object({
   matchType: z.literal(HttpRegexValidationType.Header),
   expression: z.string().min(1, 'Expression is required'),
   inverted: z.boolean(),
@@ -34,15 +34,15 @@ const HttpRegexHeaderValidationSchema: ZodType<HttpRegexHeaderValidationFormValu
   allowMissing: z.boolean(),
 });
 
-const HttpRegexValidationSchema: ZodType<HttpRegexValidationFormValue> = HttpRegexBodyValidationSchema.or(
-  HttpRegexHeaderValidationSchema
+const httpRegexValidationSchema: ZodType<HttpRegexValidationFormValue> = httpRegexBodyValidationSchema.or(
+  httpRegexHeaderValidationSchema
 );
 
-const HttpSettingsSchema: ZodType<HttpSettingsFormValues> = z.object({
+const httpSettingsSchema: ZodType<HttpSettingsFormValues> = z.object({
   sslOptions: z.nativeEnum(HttpSslOption),
-  headers: HeadersSchema,
-  proxyConnectHeaders: HeadersSchema,
-  regexValidations: z.array(HttpRegexValidationSchema),
+  headers: headersSchema,
+  proxyConnectHeaders: headersSchema,
+  regexValidations: z.array(httpRegexValidationSchema),
   followRedirects: z.boolean(),
   compression: z.nativeEnum(HTTPCompressionAlgo),
   proxyURL: z.string().optional(),
@@ -77,16 +77,16 @@ const HttpSettingsSchema: ZodType<HttpSettingsFormValues> = z.object({
         });
       }
     }),
-  tlsConfig: TLSConfigSchema,
+  tlsConfig: tlsConfigSchema,
   cacheBustingQueryParamName: z.string().optional(),
 });
 
-const HttpSchemaValues = z.object({
-  target: HttpTargetSchema,
+const httpSchemaValues = z.object({
+  target: httpTargetSchema,
   checkType: z.literal(CheckType.HTTP),
   settings: z.object({
-    http: HttpSettingsSchema,
+    http: httpSettingsSchema,
   }),
 });
 
-export const HttpCheckSchema: ZodType<CheckFormValuesHttp> = BaseCheckSchema.and(HttpSchemaValues);
+export const httpCheckSchema: ZodType<CheckFormValuesHttp> = baseCheckSchema.and(httpSchemaValues);

--- a/src/schemas/forms/MultiHttpCheckSchema.ts
+++ b/src/schemas/forms/MultiHttpCheckSchema.ts
@@ -1,6 +1,6 @@
-import { HeadersSchema } from 'schemas/general/Header';
-import { HttpTargetSchema } from 'schemas/general/HttpTarget';
-import { QueryParamsSchema } from 'schemas/general/QueryParam';
+import { headersSchema } from 'schemas/general/Header';
+import { httpTargetSchema } from 'schemas/general/HttpTarget';
+import { queryParamsSchema } from 'schemas/general/QueryParam';
 import { z, ZodType } from 'zod';
 
 import {
@@ -23,11 +23,11 @@ import {
   RequestProps,
 } from 'components/MultiHttp/MultiHttpTypes';
 
-import { BaseCheckSchema } from './BaseCheckSchema';
+import { baseCheckSchema } from './BaseCheckSchema';
 
-const MultiHttpRequestSchema: ZodType<RequestProps> = z.object({
+const multiHttpRequestSchema: ZodType<RequestProps> = z.object({
   method: z.nativeEnum(HttpMethod),
-  url: HttpTargetSchema,
+  url: httpTargetSchema,
   body: z
     .object({
       contentType: z.string(),
@@ -35,8 +35,8 @@ const MultiHttpRequestSchema: ZodType<RequestProps> = z.object({
       payload: z.string(),
     })
     .optional(),
-  headers: HeadersSchema,
-  queryFields: QueryParamsSchema.optional(),
+  headers: headersSchema,
+  queryFields: queryParamsSchema.optional(),
   postData: z
     .object({
       mimeType: z.string(),
@@ -45,72 +45,72 @@ const MultiHttpRequestSchema: ZodType<RequestProps> = z.object({
     .optional(),
 });
 
-const AssertionValueSchema = z
+const assertionValueSchema = z
   .string({
     required_error: 'Value is required',
   })
   .min(1, { message: 'Value is required' });
 
-const AssertionExpressionSchema = z
+const assertionExpressionSchema = z
   .string({
     required_error: 'Expression is required',
   })
   .min(1, { message: 'Expression is required' });
 
-const MultiHttpAssertionTextSchema: ZodType<AssertionText> = z.object({
+const multiHttpAssertionTextSchema: ZodType<AssertionText> = z.object({
   condition: z.nativeEnum(AssertionConditionVariant),
   subject: z.nativeEnum(AssertionSubjectVariant),
   type: z.literal(MultiHttpAssertionType.Text),
-  value: AssertionValueSchema,
+  value: assertionValueSchema,
 });
 
-const MultiHttpAssertionJsonPathValueSchema: ZodType<AssertionJsonPathValue> = z.object({
+const multiHttpAssertionJsonPathValueSchema: ZodType<AssertionJsonPathValue> = z.object({
   condition: z.nativeEnum(AssertionConditionVariant),
-  expression: AssertionExpressionSchema,
+  expression: assertionExpressionSchema,
   type: z.literal(MultiHttpAssertionType.JSONPathValue),
-  value: AssertionValueSchema,
+  value: assertionValueSchema,
 });
 
-const MultiHttpAssertionJsonPathSchema: ZodType<AssertionJsonPath> = z.object({
-  expression: AssertionExpressionSchema,
+const multiHttpAssertionJsonPathSchema: ZodType<AssertionJsonPath> = z.object({
+  expression: assertionExpressionSchema,
   type: z.literal(MultiHttpAssertionType.JSONPath),
 });
 
-const MultiHttpAssertionRegexSchema: ZodType<AssertionRegex> = z.object({
-  expression: AssertionExpressionSchema,
+const multiHttpAssertionRegexSchema: ZodType<AssertionRegex> = z.object({
+  expression: assertionExpressionSchema,
   subject: z.nativeEnum(AssertionSubjectVariant),
   type: z.literal(MultiHttpAssertionType.Regex),
 });
 
-const MultiHttpAssertionSchema: ZodType<Assertion> = z.union([
-  MultiHttpAssertionTextSchema,
-  MultiHttpAssertionJsonPathValueSchema,
-  MultiHttpAssertionJsonPathSchema,
-  MultiHttpAssertionRegexSchema,
+const multiHttpAssertionSchema: ZodType<Assertion> = z.union([
+  multiHttpAssertionTextSchema,
+  multiHttpAssertionJsonPathValueSchema,
+  multiHttpAssertionJsonPathSchema,
+  multiHttpAssertionRegexSchema,
 ]);
 
-const MultiHttpVariablesSchema: ZodType<MultiHttpVariable> = z.object({
+const multiHttpVariablesSchema: ZodType<MultiHttpVariable> = z.object({
   attribute: z.string().optional(),
   expression: z.string().min(1, { message: 'Expression is required' }),
   name: z.string().min(1, { message: 'Name is required' }),
   type: z.number(),
 });
 
-const MultiHttpEntriesSchema: ZodType<MultiHttpEntryFormValues> = z.object({
-  checks: z.array(MultiHttpAssertionSchema).optional(),
-  request: MultiHttpRequestSchema,
-  variables: z.array(MultiHttpVariablesSchema).optional(),
+const multiHttpEntriesSchema: ZodType<MultiHttpEntryFormValues> = z.object({
+  checks: z.array(multiHttpAssertionSchema).optional(),
+  request: multiHttpRequestSchema,
+  variables: z.array(multiHttpVariablesSchema).optional(),
 });
 
-const MultiHttpSettingsSchema: ZodType<MultiHttpSettingsFormValues> = z.object({
-  entries: z.array(MultiHttpEntriesSchema),
+const multiHttpSettingsSchema: ZodType<MultiHttpSettingsFormValues> = z.object({
+  entries: z.array(multiHttpEntriesSchema),
 });
 
-const MultiHttpSchemaValues = z.object({
+const multiHttpSchemaValues = z.object({
   checkType: z.literal(CheckType.MULTI_HTTP),
   settings: z.object({
-    multihttp: MultiHttpSettingsSchema,
+    multihttp: multiHttpSettingsSchema,
   }),
 });
 
-export const MultiHttpCheckSchema: ZodType<CheckFormValuesMultiHttp> = BaseCheckSchema.and(MultiHttpSchemaValues);
+export const multiHttpCheckSchema: ZodType<CheckFormValuesMultiHttp> = baseCheckSchema.and(multiHttpSchemaValues);

--- a/src/schemas/forms/PingCheckSchema.ts
+++ b/src/schemas/forms/PingCheckSchema.ts
@@ -1,21 +1,21 @@
-import { HostNameTargetSchema } from 'schemas/general/HostNameTarget';
+import { hostNameTargetSchema } from 'schemas/general/HostNameTarget';
 import { z, ZodType } from 'zod';
 
 import { CheckFormValuesPing, CheckType, IpVersion, PingSettingsFormValues } from 'types';
 
-import { BaseCheckSchema } from './BaseCheckSchema';
+import { baseCheckSchema } from './BaseCheckSchema';
 
-const PingSettingsSchema: ZodType<PingSettingsFormValues> = z.object({
+const pingSettingsSchema: ZodType<PingSettingsFormValues> = z.object({
   ipVersion: z.nativeEnum(IpVersion),
   dontFragment: z.boolean(),
 });
 
-const PingSchemaValues = z.object({
-  target: HostNameTargetSchema,
+const pingSchemaValues = z.object({
+  target: hostNameTargetSchema,
   checkType: z.literal(CheckType.PING),
   settings: z.object({
-    ping: PingSettingsSchema,
+    ping: pingSettingsSchema,
   }),
 });
 
-export const PingCheckSchema: ZodType<CheckFormValuesPing> = BaseCheckSchema.and(PingSchemaValues);
+export const pingCheckSchema: ZodType<CheckFormValuesPing> = baseCheckSchema.and(pingSchemaValues);

--- a/src/schemas/forms/ProbeSchema.ts
+++ b/src/schemas/forms/ProbeSchema.ts
@@ -1,4 +1,4 @@
-import { LabelsSchema } from 'schemas/general/Label';
+import { labelsSchema } from 'schemas/general/Label';
 import { z, ZodType } from 'zod';
 
 import { Probe } from 'types';
@@ -11,7 +11,7 @@ const LATITUDE_MAX = 90;
 const LONGITUDE_MIN = -180;
 const LONGITUDE_MAX = 180;
 
-export const ProbeSchema: ZodType<Probe> = z.object({
+export const probeSchema: ZodType<Probe> = z.object({
   created: z.number().optional(),
   id: z.number().optional(),
   modified: z.number().optional(),
@@ -45,7 +45,7 @@ export const ProbeSchema: ZodType<Probe> = z.object({
   }),
   online: z.boolean(),
   onlineChange: z.number(),
-  labels: LabelsSchema,
+  labels: labelsSchema,
   version: z.string(),
   deprecated: z.boolean(),
   capabilities: z.object({

--- a/src/schemas/forms/ScriptedCheckSchema.ts
+++ b/src/schemas/forms/ScriptedCheckSchema.ts
@@ -3,18 +3,18 @@ import { z, ZodType } from 'zod';
 import { CheckFormValuesScripted, CheckType, ScriptedSettings } from 'types';
 
 import { maxSizeValidation, validateNonBrowserScript } from './script/validation';
-import { BaseCheckSchema } from './BaseCheckSchema';
+import { baseCheckSchema } from './BaseCheckSchema';
 
-export const ScriptedSettingsSchema: ZodType<ScriptedSettings> = z.object({
+export const scriptedSettingsSchema: ZodType<ScriptedSettings> = z.object({
   script: z.string().min(1, `Script is required.`).superRefine(maxSizeValidation).superRefine(validateNonBrowserScript),
 });
 
-const ScriptedSchemaValues = z.object({
+const scriptedSchemaValues = z.object({
   target: z.string().min(3, `Instance must be at least 3 characters long.`),
   checkType: z.literal(CheckType.Scripted),
   settings: z.object({
-    scripted: ScriptedSettingsSchema,
+    scripted: scriptedSettingsSchema,
   }),
 });
 
-export const ScriptedCheckSchema: ZodType<CheckFormValuesScripted> = BaseCheckSchema.and(ScriptedSchemaValues);
+export const scriptedCheckSchema: ZodType<CheckFormValuesScripted> = baseCheckSchema.and(scriptedSchemaValues);

--- a/src/schemas/forms/TCPCheckSchema.ts
+++ b/src/schemas/forms/TCPCheckSchema.ts
@@ -1,15 +1,15 @@
-import { HostPortTarget } from 'schemas/general/HostPortTarget';
-import { TLSConfigSchema } from 'schemas/general/TLSConfig';
+import { hostPortTargetSchema } from 'schemas/general/HostPortTarget';
+import { tlsConfigSchema } from 'schemas/general/TLSConfig';
 import { z, ZodType } from 'zod';
 
 import { CheckFormValuesTcp, CheckType, IpVersion, TcpSettingsFormValues } from 'types';
 
-import { BaseCheckSchema } from './BaseCheckSchema';
+import { baseCheckSchema } from './BaseCheckSchema';
 
-const TCPSettingsSchema: ZodType<TcpSettingsFormValues> = z.object({
+const tcpSettingsSchema: ZodType<TcpSettingsFormValues> = z.object({
   ipVersion: z.nativeEnum(IpVersion),
   tls: z.boolean().optional(),
-  tlsConfig: TLSConfigSchema,
+  tlsConfig: tlsConfigSchema,
   queryResponse: z.array(
     z.object({
       send: z.string(),
@@ -19,12 +19,12 @@ const TCPSettingsSchema: ZodType<TcpSettingsFormValues> = z.object({
   ),
 });
 
-const TCPSchemaValues = z.object({
-  target: HostPortTarget,
+const tcpSchemaValues = z.object({
+  target: hostPortTargetSchema,
   checkType: z.literal(CheckType.TCP),
   settings: z.object({
-    tcp: TCPSettingsSchema,
+    tcp: tcpSettingsSchema,
   }),
 });
 
-export const TCPCheckSchema: ZodType<CheckFormValuesTcp> = BaseCheckSchema.and(TCPSchemaValues);
+export const tcpCheckSchema: ZodType<CheckFormValuesTcp> = baseCheckSchema.and(tcpSchemaValues);

--- a/src/schemas/forms/TracerouteCheckSchema.ts
+++ b/src/schemas/forms/TracerouteCheckSchema.ts
@@ -1,14 +1,14 @@
-import { HostNameTargetSchema } from 'schemas/general/HostNameTarget';
+import { hostNameTargetSchema } from 'schemas/general/HostNameTarget';
 import { z, ZodType } from 'zod';
 
 import { CheckFormValuesTraceroute, CheckType, TracerouteSettingsFormValues } from 'types';
 
-import { BaseCheckSchema } from './BaseCheckSchema';
+import { baseCheckSchema } from './BaseCheckSchema';
 
 const MAX_HOPS = 64;
 const MAX_UNKNOWN_HOPS = 20;
 
-const TracerouteSettingsSchema: ZodType<TracerouteSettingsFormValues> = z.object({
+const tracerouteSettingsSchema: ZodType<TracerouteSettingsFormValues> = z.object({
   maxHops: z
     .number({
       required_error: `Must be a number (0-${MAX_HOPS})`,
@@ -27,12 +27,12 @@ const TracerouteSettingsSchema: ZodType<TracerouteSettingsFormValues> = z.object
   hopTimeout: z.number(),
 });
 
-const TracerouteSchemaValues = z.object({
-  target: HostNameTargetSchema,
+const tracerouteSchemaValues = z.object({
+  target: hostNameTargetSchema,
   checkType: z.literal(CheckType.Traceroute),
   settings: z.object({
-    traceroute: TracerouteSettingsSchema,
+    traceroute: tracerouteSettingsSchema,
   }),
 });
 
-export const TracerouteCheckSchema: ZodType<CheckFormValuesTraceroute> = BaseCheckSchema.and(TracerouteSchemaValues);
+export const tracerouteCheckSchema: ZodType<CheckFormValuesTraceroute> = baseCheckSchema.and(tracerouteSchemaValues);

--- a/src/schemas/general/CheckAlerts.ts
+++ b/src/schemas/general/CheckAlerts.ts
@@ -11,7 +11,7 @@ const isScientificNotation = (val: number) => {
 
 const invalidThreshold = 'Threshold value must be a valid integer';
 
-const CheckAlertSchema = z
+const checkAlertSchema = z
   .object({
     id: z.number().optional(),
     isSelected: z.boolean().optional(),
@@ -38,7 +38,7 @@ const CheckAlertSchema = z
     { message: invalidThreshold, path: ['threshold'] }
   );
 
-const ProbeFailedExecutionsTooHighSchema = CheckAlertSchema.refine(
+const probeFailedExecutionsTooHighSchema = checkAlertSchema.refine(
   (data) => {
     if (data.isSelected && !data.period) {
       return false;
@@ -48,9 +48,9 @@ const ProbeFailedExecutionsTooHighSchema = CheckAlertSchema.refine(
   { message: 'You need to choose a period for this alert', path: ['period'] }
 );
 
-export const CheckAlertsSchema: ZodType<CheckAlertFormRecord | undefined> = z.object({
-  ProbeFailedExecutionsTooHigh: ProbeFailedExecutionsTooHighSchema.optional(),
-  TLSTargetCertificateCloseToExpiring: CheckAlertSchema.optional(),
+export const checkAlertsSchema: ZodType<CheckAlertFormRecord | undefined> = z.object({
+  ProbeFailedExecutionsTooHigh: probeFailedExecutionsTooHighSchema.optional(),
+  TLSTargetCertificateCloseToExpiring: checkAlertSchema.optional(),
 });
 
 export function checkAlertsRefinement(data: CheckFormValuesBase, ctx: z.RefinementCtx) {

--- a/src/schemas/general/CheckProbes.ts
+++ b/src/schemas/general/CheckProbes.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 const MAX_PROBES = 64;
 
-export const CheckProbesSchema = z
+export const checkProbesSchema = z
   .array(z.number(), { required_error: 'At least one probe is required' })
   .nonempty({
     message: 'At least one probe is required',

--- a/src/schemas/general/DomainNameTarget.ts
+++ b/src/schemas/general/DomainNameTarget.ts
@@ -2,9 +2,9 @@ import { z } from 'zod';
 
 import { validateDomain } from 'validation';
 
-import { TargetSchema } from './Target';
+import { targetSchema } from './Target';
 
-export const DomainNameTarget = TargetSchema.and(z.string().superRefine(validate));
+export const domainNameTargetSchema = targetSchema.and(z.string().superRefine(validate));
 
 function validate(target: string, ctx: z.RefinementCtx) {
   const message = validateDomain(target);

--- a/src/schemas/general/Frequency.ts
+++ b/src/schemas/general/Frequency.ts
@@ -3,6 +3,6 @@ import { z } from 'zod';
 const ONE_HOUR = 60 * 60;
 export const MAX_BASE_FREQUENCY = ONE_HOUR;
 
-export const FrequencySchema = z
+export const frequencySchema = z
   .number()
   .max(MAX_BASE_FREQUENCY, { message: `Frequency cannot be greater than ${MAX_BASE_FREQUENCY} seconds` });

--- a/src/schemas/general/Header.ts
+++ b/src/schemas/general/Header.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 const NAME_REQUIRED_ERROR = '{type} name is required';
 const VALUE_REQUIRED_ERROR = '{type} value is required';
 
-const HeaderSchema = z.object({
+const headerSchema = z.object({
   name: z
     .string({
       required_error: NAME_REQUIRED_ERROR,
@@ -16,8 +16,8 @@ const HeaderSchema = z.object({
     .min(1, { message: VALUE_REQUIRED_ERROR }),
 });
 
-export const HeadersSchema = z
-  .array(HeaderSchema)
+export const headersSchema = z
+  .array(headerSchema)
   .superRefine((headers, ctx) => {
     const headerNames = headers.map((header) => header.name);
     const uniqueNames = new Set(headerNames);

--- a/src/schemas/general/HostNameTarget.ts
+++ b/src/schemas/general/HostNameTarget.ts
@@ -2,9 +2,9 @@ import { z } from 'zod';
 
 import { validateHostAddress } from 'validation';
 
-import { TargetSchema } from './Target';
+import { targetSchema } from './Target';
 
-export const HostNameTargetSchema = TargetSchema.and(z.string().superRefine(validate));
+export const hostNameTargetSchema = targetSchema.and(z.string().superRefine(validate));
 
 function validate(target: string, ctx: z.RefinementCtx) {
   const message = validateHostAddress(target);

--- a/src/schemas/general/HostPortTarget.ts
+++ b/src/schemas/general/HostPortTarget.ts
@@ -2,9 +2,9 @@ import { z } from 'zod';
 
 import { validateHostPort } from 'validation';
 
-import { TargetSchema } from './Target';
+import { targetSchema } from './Target';
 
-export const HostPortTarget = TargetSchema.and(z.string().superRefine(validate));
+export const hostPortTargetSchema = targetSchema.and(z.string().superRefine(validate));
 
 function validate(target: string, ctx: z.RefinementCtx) {
   const message = validateHostPort(target);

--- a/src/schemas/general/HttpTarget.ts
+++ b/src/schemas/general/HttpTarget.ts
@@ -2,9 +2,9 @@ import { z } from 'zod';
 
 import { validateHttpTarget } from 'validation';
 
-import { TargetSchema } from './Target';
+import { targetSchema } from './Target';
 
-export const HttpTargetSchema = TargetSchema.and(z.string().superRefine(validate));
+export const httpTargetSchema = targetSchema.and(z.string().superRefine(validate));
 
 function validate(target: string, ctx: z.RefinementCtx) {
   const message = validateHttpTarget(target);

--- a/src/schemas/general/Job.ts
+++ b/src/schemas/general/Job.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const JobSchema = z
+export const jobSchema = z
   .string({
     required_error: 'Job name is required',
   })

--- a/src/schemas/general/Label.ts
+++ b/src/schemas/general/Label.ts
@@ -6,7 +6,7 @@ const VALUE_REQUIRED_ERROR = '{type} value is required';
 const MAX_LENGTH = 128;
 const LABEL_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
-const LabelSchema = z.object({
+const labelSchema = z.object({
   name: z
     .string({
       required_error: NAME_REQUIRED_ERROR,
@@ -22,7 +22,7 @@ const LabelSchema = z.object({
     .max(MAX_LENGTH, { message: `{type} values must be ${MAX_LENGTH} characters or less` }),
 });
 
-export const LabelsSchema = z.array(LabelSchema).superRefine((labels, ctx) => {
+export const labelsSchema = z.array(labelSchema).superRefine((labels, ctx) => {
   const labelNames = labels.map((label) => label.name);
   const uniqueNames = new Set(labelNames);
 

--- a/src/schemas/general/Probes.ts
+++ b/src/schemas/general/Probes.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 const MAX_PROBES = 64;
 
-export const ProbesSchema = z
+export const probesSchema = z
   .array(z.number(), { required_error: 'At least one probe is required' })
   .nonempty({
     message: 'At least one probe is required',

--- a/src/schemas/general/QueryParam.ts
+++ b/src/schemas/general/QueryParam.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 const NAME_REQUIRED_ERROR = '{type} name is required';
 
-const QueryParam = z.object({
+const queryParamSchema = z.object({
   name: z
     .string({
       required_error: NAME_REQUIRED_ERROR,
@@ -11,7 +11,7 @@ const QueryParam = z.object({
   value: z.string(),
 });
 
-export const QueryParamsSchema = z.array(QueryParam).superRefine((queryParams, ctx) => {
+export const queryParamsSchema = z.array(queryParamSchema).superRefine((queryParams, ctx) => {
   const queryParamNames = queryParams.map((query) => query.name);
   const uniqueNames = new Set(queryParamNames);
 

--- a/src/schemas/general/TLSConfig.ts
+++ b/src/schemas/general/TLSConfig.ts
@@ -7,7 +7,7 @@ const PEM_FOOTER = '-----END CERTIFICATE-----';
 
 const CERT_ERROR_MESSAGE = 'Certificate must be in the PEM format.';
 
-export const TLSConfigSchema: ZodType<TLSConfig | undefined> = z
+export const tlsConfigSchema: ZodType<TLSConfig | undefined> = z
   .object({
     caCert: z
       .string()

--- a/src/schemas/general/Target.ts
+++ b/src/schemas/general/Target.ts
@@ -2,6 +2,6 @@ import { z } from 'zod';
 
 const MAX_CHARACTERS = 2040;
 
-export const TargetSchema = z
+export const targetSchema = z
   .string()
   .max(MAX_CHARACTERS, { message: `Target must be ${MAX_CHARACTERS} characters or less` });


### PR DESCRIPTION
We were using PascalCase schema names across the codebase, as the [zod author recommends](https://github.com/colinhacks/zod/pull/3285#issuecomment-1998639354). Upon reflection we have decided PascalCase is not a suitable naming convention as @w1kman explains:

> A schema is not a typescript type, nor is it a class constructor.
You "cannot" export Dog twice, so instead pretending that Dog is a type (when it is a schema) and making up a new name for the actual type (DogType or the schema), you could actually make sense of the exports.
import { Dog } from 'schemas'  <- importing a type
import { dog } from 'schemas' <- importing a schema
Also this
"But for utility schemas with a self-evident static type I wouldn't capitalize."
Feelings, not rules
The author of the PR is following common practice (IMO).
"I appreciate the PR, but a lot of the changes in this PR feel weird to me so I'm not going to merge. Ultimately people can do what they want and I don't think there's much value in trying to establish a dogma here."
The value is "Am I importing a type or am I importing a schema?".

Big disclaimer, I got Cursor to do this for me in the background whilst I did other work 🤐 