### PR TITLE
fix: typing errors after upgrading dependencies

### DIFF
--- a/src/components/CheckEditor/FormComponents/MultiHttpCheckRequests.tsx
+++ b/src/components/CheckEditor/FormComponents/MultiHttpCheckRequests.tsx
@@ -120,7 +120,7 @@ export const MultiHttpCheckRequests = () => {
             invalid={Boolean(errors?.settings?.multihttp?.entries?.[index])}
             isOpen={collapseState[index].open}
             onToggle={() => dispatchCollapse({ type: 'toggle', index })}
-            ref={(el) => (panelRefs.current[index] = el)}
+            ref={(el) => { panelRefs.current[index] = el }}
             onRemove={onRemove}
             requestMethod={requestMethod}
           >

--- a/src/components/CheckEditor/FormComponents/RequestBodyTextArea.tsx
+++ b/src/components/CheckEditor/FormComponents/RequestBodyTextArea.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FieldError, FieldPath, useFormContext } from 'react-hook-form';
+import { FieldPath, useFormContext } from 'react-hook-form';
 import { Field, TextArea } from '@grafana/ui';
 import { get } from 'lodash';
 
@@ -15,8 +15,8 @@ export const RequestBodyTextArea = ({ disabled, name }: RequestBodyTextAreaProps
     register,
     formState: { errors },
   } = useFormContext<CheckFormValues>();
-  const fieldError = get(errors, name) as FieldError | undefined;
-  const errorMessage = fieldError?.message;
+  const fieldError = get(errors, name);
+  const errorMessage = typeof fieldError === 'string' ? fieldError : fieldError?.message;
 
   return (
     <Field

--- a/src/components/CheckEditor/FormComponents/RequestBodyTextArea.tsx
+++ b/src/components/CheckEditor/FormComponents/RequestBodyTextArea.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FieldPath, useFormContext } from 'react-hook-form';
+import { FieldError, FieldPath, useFormContext } from 'react-hook-form';
 import { Field, TextArea } from '@grafana/ui';
 import { get } from 'lodash';
 
@@ -15,14 +15,15 @@ export const RequestBodyTextArea = ({ disabled, name }: RequestBodyTextAreaProps
     register,
     formState: { errors },
   } = useFormContext<CheckFormValues>();
-  const error = get(errors, name);
+  const fieldError = get(errors, name) as FieldError | undefined;
+  const errorMessage = fieldError?.message;
 
   return (
     <Field
       description="The body of the HTTP request used in probe."
-      error={error?.message}
+      error={errorMessage}
       htmlFor={name}
-      invalid={Boolean(error)}
+      invalid={Boolean(errorMessage)}
       label="Request body"
     >
       <TextArea

--- a/src/components/CheckEditor/FormComponents/RequestHeaders.tsx
+++ b/src/components/CheckEditor/FormComponents/RequestHeaders.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FieldError, FieldPath, useFormContext } from 'react-hook-form';
+import { FieldPath, useFormContext } from 'react-hook-form';
 import { Field } from '@grafana/ui';
 import { get } from 'lodash';
 
@@ -19,8 +19,8 @@ export const RequestHeaders = ({ description, disabled, label, name, ...rest }: 
   const {
     formState: { errors },
   } = useFormContext<CheckFormValues>();
-  const fieldError = get(errors, name) as FieldError | undefined;
-  const errorMessage = fieldError?.message || fieldError?.root?.message;
+  const fieldError = get(errors, name);
+  const errorMessage = typeof fieldError === 'string' ? fieldError : fieldError?.message || fieldError?.root?.message;
 
   return (
     <Field

--- a/src/components/CheckEditor/FormComponents/RequestHeaders.tsx
+++ b/src/components/CheckEditor/FormComponents/RequestHeaders.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FieldPath, useFormContext } from 'react-hook-form';
+import { FieldError, FieldPath, useFormContext } from 'react-hook-form';
 import { Field } from '@grafana/ui';
 import { get } from 'lodash';
 
@@ -19,7 +19,7 @@ export const RequestHeaders = ({ description, disabled, label, name, ...rest }: 
   const {
     formState: { errors },
   } = useFormContext<CheckFormValues>();
-  const fieldError = get(errors, name);
+  const fieldError = get(errors, name) as FieldError | undefined;
   const errorMessage = fieldError?.message || fieldError?.root?.message;
 
   return (

--- a/src/components/CheckEditor/FormComponents/RequestQueryParams.tsx
+++ b/src/components/CheckEditor/FormComponents/RequestQueryParams.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FieldPath, useFormContext } from 'react-hook-form';
+import { FieldError, FieldPath, useFormContext } from 'react-hook-form';
 import { Field } from '@grafana/ui';
 import { get } from 'lodash';
 
@@ -16,7 +16,7 @@ export const RequestQueryParams = ({ disabled, name, ...rest }: RequestQueryPara
   const {
     formState: { errors },
   } = useFormContext<CheckFormValues>();
-  const fieldError = get(errors, name);
+  const fieldError = get(errors, name) as FieldError | undefined;
   const errorMessage = fieldError?.message || fieldError?.root?.message;
   const label = `Query parameter`;
 

--- a/src/components/CheckEditor/FormComponents/RequestQueryParams.tsx
+++ b/src/components/CheckEditor/FormComponents/RequestQueryParams.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FieldError, FieldPath, useFormContext } from 'react-hook-form';
+import { FieldPath, useFormContext } from 'react-hook-form';
 import { Field } from '@grafana/ui';
 import { get } from 'lodash';
 
@@ -16,8 +16,8 @@ export const RequestQueryParams = ({ disabled, name, ...rest }: RequestQueryPara
   const {
     formState: { errors },
   } = useFormContext<CheckFormValues>();
-  const fieldError = get(errors, name) as FieldError | undefined;
-  const errorMessage = fieldError?.message || fieldError?.root?.message;
+  const fieldError = get(errors, name);
+  const errorMessage = typeof fieldError === 'string' ? fieldError : fieldError?.message || fieldError?.root?.message;
   const label = `Query parameter`;
 
   return (

--- a/src/components/CheckForm/CheckForm.tsx
+++ b/src/components/CheckForm/CheckForm.tsx
@@ -331,7 +331,7 @@ interface ConstructActionsProps {
   checkType: CheckType;
   disabled: boolean;
   loading: boolean;
-  ref: RefObject<HTMLButtonElement>;
+  ref: RefObject<HTMLButtonElement | null>;
 }
 
 function constructActions({ checkType, ...rest }: ConstructActionsProps) {

--- a/src/components/CheckForm/FormLayout/FormLayout.tsx
+++ b/src/components/CheckForm/FormLayout/FormLayout.tsx
@@ -8,7 +8,7 @@ import { DataTestIds } from 'test/dataTestIds';
 
 import { flattenKeys } from '../checkForm.utils';
 import { normalizeFlattenedErrors, useFormLayout } from './formlayout.utils';
-import { FormSection, FormSectionInternal } from './FormSection';
+import { FormSection, FormSectionInternal, FormSectionProps } from './FormSection';
 import { FormSidebar } from './FormSidebar';
 
 type ActionNode = {
@@ -59,7 +59,9 @@ export const FormLayout = <T extends FieldValues>({
         if (child.type === FormSection) {
           index++;
 
-          return <FormSectionInternal {...child.props} index={index} activeSection={activeSection} />;
+          const sectionProps = child.props as Omit<FormSectionProps, 'index' | 'activeSection'>;
+
+          return <FormSectionInternal {...sectionProps} index={index} activeSection={activeSection} />;
         }
 
         return child;

--- a/src/components/NameValueInput/NameValueInput.tsx
+++ b/src/components/NameValueInput/NameValueInput.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useRef } from 'react';
-import { FieldErrorsImpl, useFieldArray, useFormContext, useFormState } from 'react-hook-form';
+import { FieldError, FieldErrorsImpl, Merge, useFieldArray, useFormContext, useFormState } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Button, Field, IconButton, Input, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { get } from 'lodash';
 
-import { CheckFormValues, Probe } from 'types';
+import { CheckFormValues, Label, Probe } from 'types';
 import { interpolateErrorMessage } from 'components/CheckForm/utils';
 
 export type NameValueName = 'settings.http.headers' | 'settings.http.proxyConnectHeaders' | 'labels';
@@ -18,7 +18,9 @@ interface Props {
   'data-fs-element'?: string;
 }
 
-function getErrors(errors: FieldErrorsImpl<CheckFormValues | Probe>, name: NameValueName) {
+type NameValueArrayError = Merge<FieldError, Array<Merge<FieldError, FieldErrorsImpl<Label>> | undefined>>;
+
+function getErrors(errors: FieldErrorsImpl<CheckFormValues | Probe>, name: NameValueName): NameValueArrayError | undefined {
   return get(errors, name);
 }
 

--- a/src/components/Request/RequestOptions.tsx
+++ b/src/components/Request/RequestOptions.tsx
@@ -1,11 +1,20 @@
-import React, { Children, forwardRef, Fragment, isValidElement, ReactElement, ReactNode, useImperativeHandle, useState } from 'react';
-import { Button, Stack, Tab, TabContent, TabProps,TabsBar } from '@grafana/ui';
+import React, {
+  Children,
+  forwardRef,
+  Fragment,
+  isValidElement,
+  ReactElement,
+  useImperativeHandle,
+  useState,
+} from 'react';
+import { Button, Stack, Tab, TabContent, TabProps, TabsBar } from '@grafana/ui';
 
 import { HandleErrorRef } from 'hooks/useNestedRequestErrors';
 import { Indent } from 'components/Indent';
 
+type RequestOptionsChild = ReactElement<TabProps> | undefined | null;
 interface RequestOptionsProps {
-  children: ReactNode;
+  children: RequestOptionsChild[] | RequestOptionsChild;
   open?: boolean;
 }
 
@@ -40,8 +49,8 @@ export const RequestOptions = forwardRef<HandleErrorRef, RequestOptionsProps>(({
 
                 return (
                   <Tab
-                    key={(section as ReactElement<TabProps>).props.label}
-                    label={(section as ReactElement<TabProps>).props.label}
+                    key={section.props.label}
+                    label={section.props.label}
                     onChangeTab={() => setActiveTab(i)}
                     active={activeTab === i}
                   />
@@ -54,7 +63,7 @@ export const RequestOptions = forwardRef<HandleErrorRef, RequestOptionsProps>(({
                   return null;
                 }
 
-                return activeTab === i && <Fragment key={(section as ReactElement<TabProps>).props.label}>{section}</Fragment>;
+                return activeTab === i && <Fragment key={section.props.label}>{section}</Fragment>;
               })}
             </TabContent>
           </Stack>{' '}

--- a/src/components/Request/RequestOptions.tsx
+++ b/src/components/Request/RequestOptions.tsx
@@ -1,5 +1,5 @@
-import React, { Children, forwardRef, Fragment, isValidElement, ReactNode, useImperativeHandle, useState } from 'react';
-import { Button, Stack, Tab, TabContent, TabsBar } from '@grafana/ui';
+import React, { Children, forwardRef, Fragment, isValidElement, ReactElement, ReactNode, useImperativeHandle, useState } from 'react';
+import { Button, Stack, Tab, TabContent, TabProps,TabsBar } from '@grafana/ui';
 
 import { HandleErrorRef } from 'hooks/useNestedRequestErrors';
 import { Indent } from 'components/Indent';
@@ -40,8 +40,8 @@ export const RequestOptions = forwardRef<HandleErrorRef, RequestOptionsProps>(({
 
                 return (
                   <Tab
-                    key={section.props.label}
-                    label={section.props.label}
+                    key={(section as ReactElement<TabProps>).props.label}
+                    label={(section as ReactElement<TabProps>).props.label}
                     onChangeTab={() => setActiveTab(i)}
                     active={activeTab === i}
                   />
@@ -54,7 +54,7 @@ export const RequestOptions = forwardRef<HandleErrorRef, RequestOptionsProps>(({
                   return null;
                 }
 
-                return activeTab === i && <Fragment key={section.props.label}>{section}</Fragment>;
+                return activeTab === i && <Fragment key={(section as ReactElement<TabProps>).props.label}>{section}</Fragment>;
               })}
             </TabContent>
           </Stack>{' '}

--- a/src/datasource/QueryEditor.tsx
+++ b/src/datasource/QueryEditor.tsx
@@ -11,7 +11,7 @@ import { getCheckType } from 'utils';
 
 import { SMDataSource } from './DataSource';
 
-type Props = QueryEditorProps<SMDataSource, SMQuery, SMOptions>;
+type Props = QueryEditorProps<SMDataSource, SMQuery, SMOptions, SMQuery>;
 
 interface TracerouteCheckOptionValue {
   job: string;
@@ -62,7 +62,7 @@ function getProbeOptionsForCheck(check: TracerouteCheckOptionValue | undefined, 
 }
 
 export class QueryEditor extends PureComponent<Props, State> {
-  constructor(props: Props, state: State) {
+  constructor(props: Props) {
     super(props);
     this.state = {
       tracerouteCheckOptions: [],

--- a/src/page/CheckList/components/CheckFilters.tsx
+++ b/src/page/CheckList/components/CheckFilters.tsx
@@ -39,7 +39,7 @@ export function CheckFilters({ onReset, onChange, checks, checkFilters, includeS
   const styles = useStyles2(getStyles);
   const [searchValue, setSearchValue] = useState(checkFilters.search);
   const [probes] = useExtendedProbes();
-  const debounceRef = useRef<NodeJS.Timeout>();
+  const debounceRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
   function handleSearchChange(event: ChangeEvent<HTMLInputElement>) {
     const value = event.currentTarget.value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9157,7 +9157,14 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@6.3.0, path-to-regexp@^1.7.0, path-to-regexp@^6.2.0:
+path-to-regexp@^1.7.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
+  dependencies:
+    isarray "0.0.1"
+
+path-to-regexp@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
   integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==


### PR DESCRIPTION
After recreating the `yarn.lock` file (https://github.com/grafana/synthetic-monitoring-app/pull/1105) we got some typing errors mainly related to React Hook Form upgrading from 7.51.5 to 7.55.0. This PR fixes them.

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/594d9ab0-fcd2-4627-8ed4-3f8be44c8e4e" />
