### PR TITLE
chore: add cursor files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ temp/
 .idea/
 
 .vscode
+.cursorrules
+.cursor
 .DS_Store
 
 dev/license.jwt


### PR DESCRIPTION
Adding the cursor files to the `.gitignore` file so we can experiment locally what works for us best if using Cursor.