### PR TITLE
chore: fix release-please commit message format

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -15,5 +15,6 @@
     }
   },
   "draft-pull-request": true,
+  "pull-request-title-pattern": "chore: release ${version}",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the release-please commit message in order to comply with the repository configuration which requires commit messages to match the regex:
```
(feat|fix|chore|docs): .+
```