### PR TITLE
chore: standardize enum naming to PascalCase

### DIFF
--- a/src/faro.ts
+++ b/src/faro.ts
@@ -22,7 +22,7 @@ export enum FaroEvent {
   UPDATE_CHECK_ALERTS = 'update_check_alerts',
 }
 
-enum FARO_ENV {
+export enum FaroEnv {
   DEV = 'development',
   STAGING = 'staging',
   PROD = 'production',
@@ -78,41 +78,41 @@ export function reportError(error: Error | Object | string, type?: FaroEvent) {
   } catch (e) {}
 }
 
-function getFaroEnv() {
+function getFaroEnv(): FaroEnv {
   const appUrl = new URL(config.appUrl).hostname;
   switch (true) {
     case appUrl.endsWith('grafana-ops.net'):
-      return FARO_ENV.STAGING;
+      return FaroEnv.STAGING;
     case appUrl.endsWith('grafana.net'):
-      return FARO_ENV.PROD;
+      return FaroEnv.PROD;
     case appUrl.endsWith('grafana-dev.net'):
     case appUrl.endsWith('localhost'):
     default:
-      return FARO_ENV.DEV;
+      return FaroEnv.DEV;
   }
 }
 
 export function getFaroConfig() {
   const env = getFaroEnv();
   switch (env) {
-    case FARO_ENV.DEV:
+    case FaroEnv.DEV:
       return {
         url: 'https://faro-collector-ops-us-east-0.grafana-ops.net/collect/769f675a8e1e8b05f05b478b7002259b',
         name: 'synthetic-monitoring-app-dev',
-        env: FARO_ENV.DEV,
+        env: FaroEnv.DEV,
       };
-    case FARO_ENV.STAGING:
+    case FaroEnv.STAGING:
       return {
         url: 'https://faro-collector-ops-us-east-0.grafana-ops.net/collect/73212b0adc2a3d002ee3befa3b48c4d9',
         name: 'synthetic-monitoring-app-staging',
-        env: FARO_ENV.STAGING,
+        env: FaroEnv.STAGING,
       };
-    case FARO_ENV.PROD:
+    case FaroEnv.PROD:
     default:
       return {
         url: 'https://faro-collector-ops-us-east-0.grafana-ops.net/collect/837791054a26c6aba5d32ece9030be32',
         name: 'synthetic-monitoring-app-prod',
-        env: FARO_ENV.PROD,
+        env: FaroEnv.PROD,
       };
   }
 }

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/ResultByTargetTable.tsx
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/ResultByTargetTable.tsx
@@ -19,7 +19,7 @@ import { Table } from 'components/Table';
 import { getTablePanelStyles } from '../getTablePanelStyles';
 import { getQueryRunner } from './resultsByTargetTableQueries';
 import { ResultsByTargetTableRow } from './ResultsByTargetTableRow';
-import { findValueByName, getValueFieldName, RESULTS_BY_TARGET_TABLE_REF_ID } from './utils';
+import { findValueByName, getValueFieldName, ResultsByTargetTableRefId } from './utils';
 
 interface ResultsByTargetTableState extends SceneObjectState {
   metrics: DataSourceRef;
@@ -116,12 +116,10 @@ const ResultsByTargetTableComponent = ({ model }: SceneComponentProps<ResultsByT
       return [];
     }
     const expectedResponseSeries = data.series.find(
-      (series) => series.refId === RESULTS_BY_TARGET_TABLE_REF_ID.EXPECTED_RESPONSE
+      (series) => series.refId === ResultsByTargetTableRefId.EXPECTED_RESPONSE
     );
-    const latencySeries = data.series.find((series) => series.refId === RESULTS_BY_TARGET_TABLE_REF_ID.LATENCY);
-    const successRateSeries = data.series.find(
-      (series) => series.refId === RESULTS_BY_TARGET_TABLE_REF_ID.SUCCESS_RATE
-    );
+    const latencySeries = data.series.find((series) => series.refId === ResultsByTargetTableRefId.LATENCY);
+    const successRateSeries = data.series.find((series) => series.refId === ResultsByTargetTableRefId.SUCCESS_RATE);
     if (!successRateSeries || !expectedResponseSeries || !latencySeries) {
       return [];
     }
@@ -140,7 +138,7 @@ const ResultsByTargetTableComponent = ({ model }: SceneComponentProps<ResultsByT
             findValueByName(
               name,
               method,
-              getValueFieldName(RESULTS_BY_TARGET_TABLE_REF_ID.SUCCESS_RATE),
+              getValueFieldName(ResultsByTargetTableRefId.SUCCESS_RATE),
               successRateSeries?.fields ?? []
             )) *
           100;
@@ -148,13 +146,13 @@ const ResultsByTargetTableComponent = ({ model }: SceneComponentProps<ResultsByT
           findValueByName(
             name,
             method,
-            getValueFieldName(RESULTS_BY_TARGET_TABLE_REF_ID.EXPECTED_RESPONSE),
+            getValueFieldName(ResultsByTargetTableRefId.EXPECTED_RESPONSE),
             expectedResponseSeries?.fields ?? []
           ) * 100;
         const latency = findValueByName(
           name,
           method,
-          getValueFieldName(RESULTS_BY_TARGET_TABLE_REF_ID.LATENCY),
+          getValueFieldName(ResultsByTargetTableRefId.LATENCY),
           latencySeries?.fields ?? []
         );
 

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/resultsByTargetTableQueries.ts
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/resultsByTargetTableQueries.ts
@@ -3,7 +3,7 @@ import { DataSourceRef } from '@grafana/schema';
 
 import { CheckType } from 'types';
 
-import { RESULTS_BY_TARGET_TABLE_REF_ID } from './utils';
+import { ResultsByTargetTableRefId } from './utils';
 
 export function getQueryRunner(metrics: DataSourceRef, checkType: CheckType) {
   const label = checkType === CheckType.Scripted ? 'name' : 'url';
@@ -26,7 +26,7 @@ export function getQueryRunner(metrics: DataSourceRef, checkType: CheckType) {
         instant: true,
         legendFormat: '__auto',
         range: false,
-        refId: RESULTS_BY_TARGET_TABLE_REF_ID.SUCCESS_RATE,
+        refId: ResultsByTargetTableRefId.SUCCESS_RATE,
       },
       {
         datasource: metrics,
@@ -44,7 +44,7 @@ export function getQueryRunner(metrics: DataSourceRef, checkType: CheckType) {
         instant: true,
         legendFormat: '__auto',
         range: false,
-        refId: RESULTS_BY_TARGET_TABLE_REF_ID.EXPECTED_RESPONSE,
+        refId: ResultsByTargetTableRefId.EXPECTED_RESPONSE,
       },
       {
         datasource: metrics,
@@ -58,7 +58,7 @@ export function getQueryRunner(metrics: DataSourceRef, checkType: CheckType) {
           )`,
         format: 'table',
         instant: true,
-        refId: RESULTS_BY_TARGET_TABLE_REF_ID.LATENCY,
+        refId: ResultsByTargetTableRefId.LATENCY,
       },
     ],
   });

--- a/src/scenes/SCRIPTED/ResultsByTargetTable/utils.ts
+++ b/src/scenes/SCRIPTED/ResultsByTargetTable/utils.ts
@@ -1,24 +1,19 @@
 import { Field } from '@grafana/data';
 
-export enum RESULTS_BY_TARGET_TABLE_REF_ID {
+export enum ResultsByTargetTableRefId {
   SUCCESS_RATE = 'successRate',
   EXPECTED_RESPONSE = 'expectedResponse',
   LATENCY = 'latency',
 }
 
-export function getValueFieldName(refId: RESULTS_BY_TARGET_TABLE_REF_ID) {
+export function getValueFieldName(refId: ResultsByTargetTableRefId) {
   return `Value #${refId}`;
 }
 
 // name is the name of the target. By default it is a url, but the end user can override that with a name specified in the k6 script.
 // method is the HTTP method (e.g. GET, POST, etc.)
 // Field name is the name of the field in the query (e.g. 'name' or 'Value #refId')
-export function findValueByName(
-  name: string,
-  method: string,
-  fieldName: string,
-  fields: Array<Field<any>>
-): any {
+export function findValueByName(name: string, method: string, fieldName: string, fields: Array<Field<any>>): any {
   const nameFieldIndex = fields.findIndex((field) => field.name === 'name' || field.name === 'url');
   if (nameFieldIndex === -1) {
     return;


### PR DESCRIPTION
This PR standardizes enum naming to follow PascalCase convention.

Changes:
- Rename `RESULTS_BY_TARGET_TABLE_REF_ID` to `ResultsByTargetTableRefId`
- Rename `FARO_ENV` to `FaroEnv`
- Update all references to use the new enum names

This change is part of our ongoing effort to maintain consistent naming conventions across the codebase.