### PR TITLE
chore: remove public preview badge for Browser checks GA

### DIFF
--- a/src/hooks/useCheckTypeOptions.ts
+++ b/src/hooks/useCheckTypeOptions.ts
@@ -61,12 +61,6 @@ export const CHECK_TYPE_OPTIONS = [
     label: 'Browser',
     value: CheckType.Browser,
     description: 'Leverage k6 browser module to run checks in a browser.',
-    status: {
-      value: CheckStatus.PUBLIC_PREVIEW,
-      description: `Browser checks are in public preview. During the preview they are free to use: test executions will not be billed.`,
-      docsLink:
-        'https://grafana.com/docs/grafana-cloud/cost-management-and-billing/understand-your-invoice/synthetic-monitoring-invoice/',
-    },
     featureToggle: FeatureName.BrowserChecks,
     group: CheckTypeGroup.Browser,
   },


### PR DESCRIPTION
Before:
<img width="490" alt="image" src="https://github.com/user-attachments/assets/127f2151-16ec-473c-9e4c-5b1282b441fd" />

After:
<img width="581" alt="image" src="https://github.com/user-attachments/assets/ac955e7d-542a-4a42-89dd-5b5ef081d794" />

Before:
<img width="743" alt="image" src="https://github.com/user-attachments/assets/772fe9ec-5f11-434d-ad45-0763f0829024" />

After:
<img width="656" alt="image" src="https://github.com/user-attachments/assets/68d51570-9e8c-488f-84de-d649ee39709d" />

