### PR TITLE
fix: update return type of update alerts PUT request

### DIFF
--- a/src/data/useCheckAlerts.ts
+++ b/src/data/useCheckAlerts.ts
@@ -27,10 +27,10 @@ export function useListAlertsForCheck(checkId?: number) {
   return useQuery(alertsForCheckQuery(smDS, checkId));
 }
 
-export function useUpdateAlertsForCheck({ eventInfo, onError, onSuccess }: MutationProps<CheckAlertsResponse> = {}) {
+export function useUpdateAlertsForCheck({ eventInfo, onError, onSuccess }: MutationProps<null> = {}) {
   const smDS = useSMDS();
 
-  return useMutation<CheckAlertsResponse, Error, { alerts: CheckAlertDraft[]; checkId: number }>({
+  return useMutation<null, Error, { alerts: CheckAlertDraft[]; checkId: number }>({
     mutationFn: async ({ alerts, checkId }) => {
       try {
         return await smDS.updateAlertsForCheck(alerts, checkId);

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -357,7 +357,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   }
 
   async updateAlertsForCheck(alerts: CheckAlertDraft[], checkId: number) {
-    return this.fetchAPI<CheckAlertsResponse>(`${this.instanceSettings.url}/sm/check/${checkId}/alerts`, {
+    return this.fetchAPI<null>(`${this.instanceSettings.url}/sm/check/${checkId}/alerts`, {
       method: 'PUT',
       data: { alerts },
     });

--- a/src/test/handlers/alerts.ts
+++ b/src/test/handlers/alerts.ts
@@ -13,12 +13,12 @@ export const listAlertsForCheck: ApiEntry<CheckAlertsResponse> = {
   },
 };
 
-export const updateAlertsForCheck: ApiEntry<CheckAlertsResponse> = {
+export const updateAlertsForCheck: ApiEntry<null> = {
   route: `/sm/check/\\d+/alerts`,
   method: `put`,
   result: () => {
     return {
-      json: BASIC_CHECK_ALERTS,
+      json: null,
     };
   },
 };


### PR DESCRIPTION
After a conversation with @ka3de, we agreed the response for the `PUT /check/:id/alerts` endpoint should not return the list of alerts in the response body, as this is consumed from the `GET` endpoint already.
This PR addresses the frontend portion of the changes, while it is also going to be removed on the API side.
