### PR TITLE
fix: add existing secret names to client validation

### DIFF
--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.test.tsx
@@ -274,4 +274,24 @@ describe('SecretEditModal', () => {
 
     expect(body.plaintext).toBe(newSecretValue);
   });
+
+  it('should show error message when secret name is already taken', async () => {
+    const secretMock = MOCKED_SECRETS_API_RESPONSE.secrets[0];
+    const inputValues = {
+      name: secretMock.name, // should be transformed to 'new-secret'
+      description: 'My short description',
+      plaintext: 'secret-value',
+    };
+
+    await render(<SecretEditModal {...defaultProps} existingNames={[secretMock.name]} />);
+
+    await userEvent.type(screen.getByLabelText(/Name/), inputValues.name); // Should be transformed to 'new-secret'
+    await userEvent.type(screen.getByLabelText(/Description/), inputValues.description);
+    await userEvent.type(screen.getByLabelText(/Value/), inputValues.plaintext);
+
+    const submitButton = screen.getByText('Save');
+    await userEvent.click(submitButton);
+
+    expect(screen.getByText('A secret with this name already exists')).toBeInTheDocument();
+  });
 });

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.tsx
@@ -17,6 +17,7 @@ interface SecretEditModalProps {
   id: string;
   onDismiss: () => void;
   open?: boolean;
+  existingNames?: string[];
 }
 
 function getDefaultValues(isNew = true): SecretFormValues & { plaintext?: string } {
@@ -71,7 +72,7 @@ function getErrorMessage(error: unknown): string {
   return 'An unknown error occurred';
 }
 
-export function SecretEditModal({ open, id, onDismiss }: SecretEditModalProps) {
+export function SecretEditModal({ open, id, onDismiss, existingNames = [] }: SecretEditModalProps) {
   const { data: secret, isLoading, isError: hasFetchError, error: fetchError } = useSecret(id);
   const saveSecret = useSaveSecret();
   const isNewSecret = id === SECRETS_EDIT_MODE_ADD;
@@ -95,7 +96,7 @@ export function SecretEditModal({ open, id, onDismiss }: SecretEditModalProps) {
   } = useForm<SecretFormValues & { plaintext?: string }>({
     defaultValues,
     disabled: isLoading || saveSecret.isPending,
-    resolver: zodResolver(secretSchemaFactory(isNewSecret)),
+    resolver: zodResolver(secretSchemaFactory(isNewSecret, existingNames)),
   });
 
   // Set the default value for plaintext to empty string when secret is reset (for validation to work)

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
@@ -18,6 +18,8 @@ export function SecretsManagementUI() {
   const deleteSecret = useDeleteSecret();
   const emptyState = secrets?.length === 0;
 
+  const existingNames = secrets?.map((secret) => secret.name) ?? [];
+
   const handleAddSecret = () => {
     setEditMode(SECRETS_EDIT_MODE_ADD);
   };
@@ -78,7 +80,9 @@ export function SecretsManagementUI() {
         </ConfigContent>
       )}
 
-      {editMode && <SecretEditModal id={editMode} open onDismiss={() => handleEditSecret()} />}
+      {editMode && (
+        <SecretEditModal id={editMode} existingNames={existingNames} open onDismiss={() => handleEditSecret()} />
+      )}
 
       <ConfirmModal
         isOpen={!!deleteMode}

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/secretSchema.test.ts
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/secretSchema.test.ts
@@ -9,7 +9,7 @@ describe('secretSchema', () => {
       labels: [{ name: 'env', value: 'prod' }],
     };
 
-    const secretSchema = secretSchemaFactory(true);
+    const secretSchema = secretSchemaFactory(true, ['existing-secret-name']);
 
     it('should validate a valid secret', () => {
       expect(() => secretSchema.parse(validSecret)).not.toThrow();
@@ -42,6 +42,11 @@ describe('secretSchema', () => {
       it('should fail if name is too long', () => {
         const invalidSecret = { ...validSecret, name: 'a'.repeat(256) };
         expect(() => secretSchema.parse(invalidSecret)).toThrow(/name cannot be more than 253 characters/i);
+      });
+
+      it('should fail if name is not unique', () => {
+        const invalidSecret = { ...validSecret, name: 'existing-secret-name' };
+        expect(() => secretSchema.parse(invalidSecret)).toThrow(/A secret with this name already exists/i);
       });
     });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

![image](https://github.com/user-attachments/assets/444e5fd5-ed67-426f-b671-51c6c6b70f9e)

**What this PR does / why we need it**: Adds name uniqueness to client validation

**Which issue(s) this PR fixes**: #1136

**How to test**:
1. Create a secret with the name my-secret, save.
2. Create another secret with the same name (my-secret)
3. Notice how it looks like everything went OK, but no secret was saved.
