### PR TITLE
fix: added correctSceneVariableInterpolation function with tests

### DIFF
--- a/src/scenes/BROWSER/WebVitals/webVitalGaugeScene.tsx
+++ b/src/scenes/BROWSER/WebVitals/webVitalGaugeScene.tsx
@@ -6,6 +6,7 @@ import { css } from '@emotion/css';
 
 import { WebVitalName } from './types';
 import { DataQueryExtended } from 'scenes/ExplorablePanel';
+import { correctSceneVariableInterpolation } from 'scenes/utils';
 
 import { WebVitalGauge } from './WebVitalGauge';
 
@@ -72,7 +73,7 @@ function setExploreLink(model: WebVitalGaugeScene) {
     let queries = (newDataState.data?.request?.targets ?? []) as DataQueryExtended[];
     queries = queries.map((q) => ({
       ...q,
-      expr: sceneGraph.interpolate(model, q.expr),
+      expr: correctSceneVariableInterpolation(sceneGraph.interpolate(model, q.expr)),
     }));
 
     const datasource = queries.find((query) => !!query.datasource?.uid)?.datasource?.uid;

--- a/src/scenes/ExplorablePanel.ts
+++ b/src/scenes/ExplorablePanel.ts
@@ -3,6 +3,8 @@ import { sceneGraph, VizPanel, VizPanelMenu, VizPanelState } from '@grafana/scen
 import { DataQuery } from '@grafana/schema';
 import appEvents from 'grafana/app/core/app_events';
 
+import { correctSceneVariableInterpolation } from 'scenes/utils';
+
 export interface DataQueryExtended extends DataQuery {
   expr: string;
 }
@@ -37,7 +39,7 @@ export class ExplorablePanel extends VizPanel {
         let queries = (newDataState.data?.request?.targets ?? []) as DataQueryExtended[];
         queries = queries.map((q) => ({
           ...q,
-          expr: sceneGraph.interpolate(this, q.expr),
+          expr: correctSceneVariableInterpolation(sceneGraph.interpolate(this, q.expr)),
         }));
 
         const datasource = queries.find((query) => !!query.datasource?.uid)?.datasource?.uid;

--- a/src/scenes/HTTP/HttpDashboard.tsx
+++ b/src/scenes/HTTP/HttpDashboard.tsx
@@ -66,7 +66,10 @@ export const HttpDashboard = ({ check }: { check: Check }) => {
       <QueryVariable
         name="probe"
         isMulti={true}
-        query={{ query: `label_values(sm_check_info{check_name="${CheckType.HTTP}"},probe)`, refId: 'A' }}
+        query={{
+          query: `label_values(sm_check_info{check_name="${CheckType.HTTP}", job="$job", instance="$instance"},probe)`,
+          refId: 'A',
+        }}
         refresh={VariableRefresh.onDashboardLoad}
         datasource={{ uid: metricsDS?.uid }}
         includeAll={true}

--- a/src/scenes/HTTP/useVizPanelMenu.tsx
+++ b/src/scenes/HTTP/useVizPanelMenu.tsx
@@ -2,6 +2,8 @@ import { PanelMenuItem, TimeRange } from '@grafana/data';
 import { QueryRunnerState, SceneDataQuery, VizConfig, VizPanelMenu } from '@grafana/scenes';
 import { useVariableInterpolator } from '@grafana/scenes-react';
 
+import { correctSceneVariableInterpolation } from 'scenes/utils';
+
 interface UseVizPanelMenuProps {
   data: QueryRunnerState;
   viz: VizConfig;
@@ -17,9 +19,8 @@ export function useVizPanelMenu({ data, viz, currentTimeRange, variables }: UseV
   let queries = data.queries;
   queries = queries.map((q: SceneDataQuery) => ({
     ...q,
-    expr: interpolator(q.expr),
+    expr: correctSceneVariableInterpolation(interpolator(q.expr)),
   }));
-
   const datasource = data.datasource?.uid;
 
   const jsonDef = {

--- a/src/scenes/utils.test.ts
+++ b/src/scenes/utils.test.ts
@@ -1,0 +1,33 @@
+import { correctSceneVariableInterpolation } from './utils';
+
+describe('correctSceneVariableInterpolation', () => {
+  describe(`returns the same input if it's correct`, () => {
+    it('when there is a single probe', () => {
+      const input = `probe_success{job="some job", instance="some instance", probe=~"correct probe"}`;
+
+      expect(correctSceneVariableInterpolation(input)).toBe(input);
+    });
+
+    it('when it uses all probes', () => {
+      const input = `probe_success{job="some job", instance="some instance", probe=~".*"}`;
+
+      expect(correctSceneVariableInterpolation(input)).toBe(input);
+    });
+  });
+
+  describe(`corrects wrong interpolation`, () => {
+    it('should correct multiple probes', () => {
+      const input = `probe_success{job="some job", instance="some instance", probe=~"{incorrect probe1,incorrect probe2}"}`;
+      const output = `probe_success{job="some job", instance="some instance", probe=~"incorrect probe1|incorrect probe2"}`;
+
+      expect(correctSceneVariableInterpolation(input)).toBe(output);
+    });
+
+    it('should correct multiple jobs and probes', () => {
+      const input = `probe_success{job=~"{incorrect job1,incorrect job2}", instance="some instance", probe=~"{incorrect probe1,incorrect probe2}"}`;
+      const output = `probe_success{job=~"incorrect job1|incorrect job2", instance="some instance", probe=~"incorrect probe1|incorrect probe2"}`;
+
+      expect(correctSceneVariableInterpolation(input)).toBe(output);
+    });
+  });
+});

--- a/src/scenes/utils.ts
+++ b/src/scenes/utils.ts
@@ -6,3 +6,7 @@ export function getMinStepFromFrequency(ms?: number, incrementFactor?: number): 
   }
   return `${minStep}m`;
 }
+
+export function correctSceneVariableInterpolation(input: string) {
+  return input.replace(/(\w+)=~"\{([^}]+)\}"/g, (_, key, values) => `${key}=~"${values.split(',').join('|')}"`);
+}


### PR DESCRIPTION
Addresses: https://github.com/grafana/synthetic-monitoring-app/issues/1141

## Problem

1. The probe variable shows unrelated probes
2. When selecting multiple values for probes they don't get parsed when opened up in Explore correctly, instead of `probe=~"probe1|probe2"` we receive `probe=~"{probe1,probe2}"` which is incorrect.

## Solution
For HTTP dashboards we use React scenes and use `useVariableInterpolator` to generate the Explore query and for all the other dashboards we use vanilla scenes so use `sceneGraph.interpolate`.

Following the code in scenes we end up at `sceneInterpolator` and `formatRegistry` and it is difficult to discern if and how we pass a custom format for the variable. For the time-being I have created `correctSceneVariableInterpolation` to wrap the interpolate function and added the appropriate tests.

I'll do some investigation and raise this with the scenes team to see if we can get an upstream fix as a longer-term solution.

**Before**

<img width="1320" alt="Explore view showing a query including probe=~'{Chris Mac 2,Chris Mac}' and no data being displayed as the visualisation." src="https://github.com/user-attachments/assets/3d29370b-0b96-4e2c-9b58-5d464d15b6f5" />

**After**

<img width="1408" alt="Explore view showing a query including probe=~'Chris Mac 2|Chris Mac' and data in a time series graph being displayed as the visualisation." src="https://github.com/user-attachments/assets/0b6c3fda-abd6-4b27-8c22-a4973b52a80b" />
