### PR TITLE
fix: add sequence number to deduplicate probes made by the fixture fa…

### DIFF
--- a/src/test/db.ts
+++ b/src/test/db.ts
@@ -34,7 +34,7 @@ const baseCheckModel = ({ sequence }: { sequence: number }) => ({
 
 const baseProbeModel = ({ sequence }: { sequence: number }) => ({
   id: sequence,
-  name: faker.lorem.word(),
+  name: `${faker.lorem.word()}_${sequence}`,
   public: faker.datatype.boolean(),
   latitude: faker.location.latitude(),
   longitude: faker.location.longitude(),


### PR DESCRIPTION
## Problem

We sometimes have flaky tests because the probe fixtures factory makes probe duplicates, which the UI integration tests don't expect and error out on.

## Solution

Add the `sequence` argument to the probe name - sequence is an incremental ID for the factory so this will ensure no probes have identical names.