### PR TITLE
Feat: add terraform config for Per-check alerts

### DIFF
--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -19,6 +19,7 @@ import {
 export interface TFOutput {
   config: TFConfig;
   checkCommands: string[];
+  checkAlertsCommands: string[];
   probeCommands: string[];
 }
 

--- a/src/components/TerraformConfig/terraformTypes.ts
+++ b/src/components/TerraformConfig/terraformTypes.ts
@@ -30,6 +30,7 @@ export interface TFConfig {
   resource: {
     grafana_synthetic_monitoring_check?: TFCheckConfig;
     grafana_synthetic_monitoring_probe?: TFProbeConfig;
+    grafana_synthetic_monitoring_check_alerts?: TFCheckAlertsConfig;
   };
 }
 
@@ -244,4 +245,17 @@ export interface TFProbe
   labels: TFLabels;
   disable_scripted_checks: boolean;
   disable_browser_checks: boolean;
+}
+
+export interface TFCheckAlertsConfig {
+  [key: string]: TFCheckAlerts;
+}
+
+export interface TFCheckAlerts {
+  check_id: string;
+  alerts: Array<{
+    name: string;
+    threshold: number;
+    period?: string;
+  }>;
 }

--- a/src/hooks/useTerraformConfig.test.tsx
+++ b/src/hooks/useTerraformConfig.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { BASIC_PING_CHECK } from 'test/fixtures/checks';
+import { BASIC_HTTP_CHECK, BASIC_PING_CHECK } from 'test/fixtures/checks';
 import { SM_DATASOURCE } from 'test/fixtures/datasources';
 import { PRIVATE_PROBE, UNSELECTED_PRIVATE_PROBE } from 'test/fixtures/probes';
 import { TERRAFORM_BASIC_PING_CHECK, TERRAFORM_PRIVATE_PROBES } from 'test/fixtures/terraform';
@@ -392,5 +392,12 @@ describe('terraform config generation', () => {
         },
       },
     });
+  });
+
+  test('generates checkAlertsCommands only for checks with Alerts', async () => {
+    const result = await renderTerraformHook([BASIC_PING_CHECK, BASIC_HTTP_CHECK], [PRIVATE_PROBE]);
+    expect(result.current.checkAlertsCommands).toEqual([
+      `terraform import grafana_synthetic_monitoring_check_alerts.${sanitizeName(`${BASIC_HTTP_CHECK.job}_${BASIC_HTTP_CHECK.target}`)} ${BASIC_HTTP_CHECK.id}`
+    ]);
   });
 });

--- a/src/hooks/useTerraformConfig.test.tsx
+++ b/src/hooks/useTerraformConfig.test.tsx
@@ -400,4 +400,19 @@ describe('terraform config generation', () => {
       `terraform import grafana_synthetic_monitoring_check_alerts.${sanitizeName(`${BASIC_HTTP_CHECK.job}_${BASIC_HTTP_CHECK.target}`)} ${BASIC_HTTP_CHECK.id}`
     ]);
   });
+
+  test('generates grafana_synthetic_monitoring_check_alerts resources for checks with Alerts', async () => {
+    const result = await renderTerraformHook([BASIC_HTTP_CHECK], [PRIVATE_PROBE]);
+    const resourceName = sanitizeName(`${BASIC_HTTP_CHECK.job}_${BASIC_HTTP_CHECK.target}`);
+    expect(result.current.config.resource.grafana_synthetic_monitoring_check_alerts).toEqual({
+      [resourceName]: {
+        check_id: String(BASIC_HTTP_CHECK.id),
+        alerts: (BASIC_HTTP_CHECK.Alerts!).map(alert => ({
+          name: alert.name,
+          threshold: alert.threshold,
+          period: alert.period,
+        })),
+      }
+    });
+  });
 });

--- a/src/hooks/useTerraformConfig.ts
+++ b/src/hooks/useTerraformConfig.ts
@@ -70,12 +70,20 @@ function generateTerraformConfig(probes: Probe[], checks: Check[], apiHost?: str
     }`;
   });
 
+  const checkAlertsCommands = checks
+    .filter((check) => check.Alerts && check.Alerts.length > 0)
+    .map((check) => {
+      return `terraform import grafana_synthetic_monitoring_check_alerts.${sanitizeName(
+        `${check.job}_${check.target}`
+      )} ${check.id}`;
+    });
+
   const probeCommands = Object.keys(probesConfig).map((probeName) => {
     const probeId = probes.find((probe) => sanitizeName(probe.name) === probeName)?.id;
     return `terraform import grafana_synthetic_monitoring_probe.${probeName} ${probeId}:<PROBE_ACCESS_TOKEN>`;
   });
 
-  return { config, checkCommands, probeCommands };
+  return { config, checkCommands, checkAlertsCommands, probeCommands };
 }
 
 export function useTerraformConfig() {

--- a/src/page/ConfigPageLayout/tabs/TerraformTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/TerraformTab.tsx
@@ -14,7 +14,7 @@ import { ContactAdminAlert } from 'page/ContactAdminAlert';
 import { ConfigContent } from '../ConfigContent';
 
 export function TerraformTab() {
-  const { config, checkCommands, probeCommands, error, isLoading } = useTerraformConfig();
+  const { config, checkCommands, probeCommands, error, isLoading, checkAlertsCommands } = useTerraformConfig();
   const styles = useStyles2(getStyles);
   const { canReadChecks, canReadProbes } = getUserPermissions();
   useEffect(() => {
@@ -93,6 +93,12 @@ export function TerraformTab() {
       {checkCommands && (
         <ConfigContent.Section title="Import existing checks into Terraform">
           <Clipboard content={checkCommands.join(' && \\\n')} className={styles.clipboard} isCode />
+        </ConfigContent.Section>
+      )}
+
+      {checkAlertsCommands && checkAlertsCommands.length > 0 && (
+        <ConfigContent.Section title="Import check alerts into Terraform">
+          <Clipboard content={checkAlertsCommands.join(' && \\\n')} className={styles.clipboard} isCode />
         </ConfigContent.Section>
       )}
 


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-app/issues/1128

## Add Terraform Support for Per-Check Alerts

This PR introduces support for exporting and importing Synthetic Monitoring check alerts as Terraform resources and commands. The changes allow users to manage per-check alert configurations via Terraform, improving automation and reproducibility for alerting setups.

### Key Changes
**1. Terraform Import Commands for Check Alerts**

New import commands for `grafana_synthetic_monitoring_check_alerts` are generated and displayed in the Config page.
Only checks with defined alerts will have corresponding import commands.
The Config page now includes a dedicated section to copy these commands for easy use.

<img width="1175" alt="image" src="https://github.com/user-attachments/assets/387cd7fa-9043-4b66-8e52-9e6b5de7e12b" />


**2. Exported Terraform Config for Check Alerts**

The exported Terraform config now includes a `grafana_synthetic_monitoring_check_alerts` resource for each check with alerts.
Each resource contains the check ID and an array of alert definitions (name, threshold, and period).

<img width="696" alt="image" src="https://github.com/user-attachments/assets/08af2329-0118-48c2-ab0a-6d9b7a34734a" />

**3. Test Updates**

Unit tests have been added and updated to cover the new functionality.

For more details on the `grafana_synthetic_monitoring_check_alerts` resource, see the official Terraform provider [documentation](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/synthetic_monitoring_check_alerts).

NOTE: this depends on https://github.com/grafana/synthetic-monitoring-app/pull/1139 where support for returning the alerts in the checks list request was introduced. 
