### PR TITLE
feat: add indicator when there is an error with per-check alerts

### DIFF
--- a/src/components/AlertStatus/AlertStatus.tsx
+++ b/src/components/AlertStatus/AlertStatus.tsx
@@ -138,6 +138,7 @@ const TooltipContent = ({
         {({ isEnabled }) =>
           isEnabled ? (
             <PerCheckAlertGroups
+              alerts={check.Alerts}
               groups={perCheckGroups}
               loading={perCheckGroupsLoading}
               isError={perCheckGroupsError}

--- a/src/components/AlertStatus/GrafanaNamespaceAlertRuleDisplay.tsx
+++ b/src/components/AlertStatus/GrafanaNamespaceAlertRuleDisplay.tsx
@@ -39,14 +39,14 @@ export const GrafanaNamespaceAlertRuleDisplay = ({ group, alerts }: AlertRuleDis
               <Stack gap={1} alignItems="center" justifyContent="space-between">
                 <Icon name="corner-down-right-alt" />
                 <span>{rule.name}</span>
-                <LinkButton
+                {rule.uid && <LinkButton
                   href={`/alerting/grafana/${rule.uid}/view`}
                   target="_blank"
                   icon="eye"
                   fill="text"
                   tooltip="View rule in Alerting"
                   size="sm"
-                />
+                />}
                 {alert?.status && alert.status !== 'OK' && (
                   <NotOkStatusInfo status={alert.status} error={alert?.error} />
                 )}

--- a/src/components/AlertStatus/GrafanaNamespaceAlertRuleDisplay.tsx
+++ b/src/components/AlertStatus/GrafanaNamespaceAlertRuleDisplay.tsx
@@ -64,14 +64,14 @@ export const NotOkStatusInfo = ({ status, error }: { status: string; error?: Che
     return (
       <Stack direction="column" gap={1}>
         <span>Status: {status}</span>
-        <span>Error: {error}</span>
+        {error && <span>Error: {error}</span>}
       </Stack>
     );
   }, [status, error]);
 
-  return error ? (
+  return status !== 'OK' ? (
     <Tooltip content={tooltipContent()}>
-      <Icon name="exclamation-triangle" color={config.theme2.colors.error.text} cursor={'pointer'} />
+      <Icon name="exclamation-circle" color={config.theme2.colors.error.text} cursor={'pointer'} />
     </Tooltip>
   ) : null;
 };

--- a/src/components/AlertStatus/GrafanaNamespaceAlertRuleDisplay.tsx
+++ b/src/components/AlertStatus/GrafanaNamespaceAlertRuleDisplay.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback } from 'react';
-import { config } from '@grafana/runtime';
-import { Icon, LinkButton, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import React from 'react';
+import { Icon, LinkButton, Stack, useStyles2 } from '@grafana/ui';
 
-import { Check, CheckAlertError, PrometheusAlertsGroup } from 'types';
+import { Check, PrometheusAlertsGroup } from 'types';
 
 import { getStyles } from './AlertStatus';
+import { NotOkStatusInfo } from './NotOkStatusInfo';
 
 interface AlertRuleDisplayProps {
   group: PrometheusAlertsGroup;
@@ -57,21 +57,4 @@ export const GrafanaNamespaceAlertRuleDisplay = ({ group, alerts }: AlertRuleDis
       </ul>
     </Stack>
   );
-};
-
-export const NotOkStatusInfo = ({ status, error }: { status: string; error?: CheckAlertError }) => {
-  const tooltipContent = useCallback(() => {
-    return (
-      <Stack direction="column" gap={1}>
-        <span>Status: {status}</span>
-        {error && <span>Error: {error}</span>}
-      </Stack>
-    );
-  }, [status, error]);
-
-  return status !== 'OK' ? (
-    <Tooltip content={tooltipContent()}>
-      <Icon name="exclamation-circle" color={config.theme2.colors.error.text} cursor={'pointer'} />
-    </Tooltip>
-  ) : null;
 };

--- a/src/components/AlertStatus/GrafanaNamespaceAlertRuleDisplay.tsx
+++ b/src/components/AlertStatus/GrafanaNamespaceAlertRuleDisplay.tsx
@@ -1,15 +1,17 @@
-import React from 'react';
-import { Icon, LinkButton, Stack, useStyles2 } from '@grafana/ui';
+import React, { useCallback } from 'react';
+import { config } from '@grafana/runtime';
+import { Icon, LinkButton, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
-import { PrometheusAlertsGroup } from 'types';
+import { Check, CheckAlertError, PrometheusAlertsGroup } from 'types';
 
 import { getStyles } from './AlertStatus';
 
 interface AlertRuleDisplayProps {
   group: PrometheusAlertsGroup;
+  alerts: Check['Alerts'];
 }
 
-export const GrafanaNamespaceAlertRuleDisplay = ({ group }: AlertRuleDisplayProps) => {
+export const GrafanaNamespaceAlertRuleDisplay = ({ group, alerts }: AlertRuleDisplayProps) => {
   const styles = useStyles2(getStyles);
   const { file, name, rules } = group;
   const filteredRules = rules.filter((record) => record.type === `alerting`);
@@ -29,23 +31,47 @@ export const GrafanaNamespaceAlertRuleDisplay = ({ group }: AlertRuleDisplayProp
         </div>
       </Stack>
       <ul className={styles.list}>
-        {filteredRules.map((rule) => (
-          <li key={rule.name}>
-            <Stack gap={1} alignItems="center" justifyContent="space-between">
-              <Icon name="corner-down-right-alt" />
-              <span>{rule.name}</span>
-              <LinkButton
-                href={`/alerting/grafana/${rule.uid}/view`}
-                target="_blank"
-                icon="eye"
-                fill="text"
-                tooltip="View rule in Alerting"
-                size="sm"
-              />
-            </Stack>
-          </li>
-        ))}
+        {filteredRules.map((rule) => {
+          const alert = alerts?.find((alert) => rule.name.includes(alert.name));
+
+          return (
+            <li key={rule.name}>
+              <Stack gap={1} alignItems="center" justifyContent="space-between">
+                <Icon name="corner-down-right-alt" />
+                <span>{rule.name}</span>
+                <LinkButton
+                  href={`/alerting/grafana/${rule.uid}/view`}
+                  target="_blank"
+                  icon="eye"
+                  fill="text"
+                  tooltip="View rule in Alerting"
+                  size="sm"
+                />
+                {alert?.status && alert.status !== 'OK' && (
+                  <NotOkStatusInfo status={alert.status} error={alert?.error} />
+                )}
+              </Stack>
+            </li>
+          );
+        })}
       </ul>
     </Stack>
   );
+};
+
+export const NotOkStatusInfo = ({ status, error }: { status: string; error?: CheckAlertError }) => {
+  const tooltipContent = useCallback(() => {
+    return (
+      <Stack direction="column" gap={1}>
+        <span>Status: {status}</span>
+        <span>Error: {error}</span>
+      </Stack>
+    );
+  }, [status, error]);
+
+  return error ? (
+    <Tooltip content={tooltipContent()}>
+      <Icon name="exclamation-triangle" color={config.theme2.colors.error.text} cursor={'pointer'} />
+    </Tooltip>
+  ) : null;
 };

--- a/src/components/AlertStatus/NotOkStatusInfo.tsx
+++ b/src/components/AlertStatus/NotOkStatusInfo.tsx
@@ -1,0 +1,22 @@
+import React, { useCallback } from 'react';
+import { config } from '@grafana/runtime';
+import { Icon, Stack, Tooltip } from '@grafana/ui';
+
+import { CheckAlertError } from 'types';
+
+export const NotOkStatusInfo = ({ status, error }: { status: string; error?: CheckAlertError }) => {
+  const tooltipContent = useCallback(() => {
+    return (
+      <Stack direction="column" gap={1}>
+        <span>Status: {status}</span>
+        {error && <span>Error: {error}</span>}
+      </Stack>
+    );
+  }, [status, error]);
+
+  return status !== 'OK' ? (
+    <Tooltip content={tooltipContent()}>
+      <Icon name="exclamation-circle" color={config.theme2.colors.error.text} cursor={'pointer'} />
+    </Tooltip>
+  ) : null;
+}; 

--- a/src/components/AlertStatus/PerCheckAlertsGroups.tsx
+++ b/src/components/AlertStatus/PerCheckAlertsGroups.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Stack, Text } from '@grafana/ui';
 
-import { PrometheusAlertsGroup } from 'types';
+import { Check, PrometheusAlertsGroup } from 'types';
 
 import { AlertGroupStates } from './AlertGroupStates';
 import { GrafanaNamespaceAlertRuleDisplay } from './GrafanaNamespaceAlertRuleDisplay';
@@ -11,9 +11,10 @@ interface PerCheckAlertGroupsProps {
   loading: boolean;
   isError: boolean;
   refetch: () => void;
+  alerts: Check['Alerts'];
 }
 
-export const PerCheckAlertGroups = ({ groups, loading, isError, refetch }: PerCheckAlertGroupsProps) => {
+export const PerCheckAlertGroups = ({ groups, loading, isError, refetch, alerts }: PerCheckAlertGroupsProps) => {
   return (
     <Stack direction="column" gap={2}>
       <Stack direction="row" gap={1} alignItems="center">
@@ -25,7 +26,7 @@ export const PerCheckAlertGroups = ({ groups, loading, isError, refetch }: PerCh
         groups.length > 0 &&
         groups.map((group) => {
           const id = `${group.file}-${group.name}`;
-          return <GrafanaNamespaceAlertRuleDisplay key={id} group={group} />;
+          return <GrafanaNamespaceAlertRuleDisplay key={id} group={group} alerts={alerts} />;
         })}
       {!loading && !isError && groups.length === 0 && <>No per-check alerts defined for this check</>}
     </Stack>

--- a/src/components/CheckEditor/transformations/toFormValues.alerts.ts
+++ b/src/components/CheckEditor/transformations/toFormValues.alerts.ts
@@ -8,6 +8,8 @@ export function getCheckAlertsFormValues(alerts: CheckAlertPublished[]): CheckAl
       threshold: alert.threshold,
       period: alert.period,
       isSelected: true,
+      status: alert.status,
+      creationError: alert.error,
     };
   });
 

--- a/src/components/CheckForm/AlertsPerCheck/AlertItem.test.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertItem.test.tsx
@@ -1,0 +1,33 @@
+import { config } from '@grafana/runtime';
+import { screen } from '@testing-library/react';
+import { BASIC_HTTP_CHECK } from 'test/fixtures/checks';
+
+import { CheckAlertType, FeatureName } from 'types';
+import { goToSection, renderEditForm } from 'page/__testHelpers__/checkForm';
+
+describe('AlertItem', () => {
+  beforeEach(() => {
+    jest.replaceProperty(config, 'featureToggles', {
+      // @ts-expect-error
+      [FeatureName.AlertsPerCheck]: true,
+    });
+  });
+
+  it('shows NotOkStatusInfo when status is not OK and error is present for an existing alert', async () => {
+    const { user } = await renderEditForm(BASIC_HTTP_CHECK.id);
+    await goToSection(user, 5);
+
+    const alertStatus = await screen.findByTestId(
+      `alert-error-status-${CheckAlertType.TLSTargetCertificateCloseToExpiring}`
+    );
+    expect(alertStatus).toBeInTheDocument();
+  });
+
+  it('Does not show NotOkStatusInfo when status is OK', async () => {
+    const { user } = await renderEditForm(BASIC_HTTP_CHECK.id);
+    await goToSection(user, 5);
+
+    const alertStatus = await screen.queryByTestId(`alert-error-status-${CheckAlertType.ProbeFailedExecutionsTooHigh}`);
+    expect(alertStatus).not.toBeInTheDocument();
+  });
+});

--- a/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
@@ -6,7 +6,7 @@ import { css } from '@emotion/css';
 
 import { CheckAlertType, CheckFormValues } from 'types';
 import { useMetricsDS } from 'hooks/useMetricsDS';
-import { NotOkStatusInfo } from 'components/AlertStatus/GrafanaNamespaceAlertRuleDisplay';
+import { NotOkStatusInfo } from 'components/AlertStatus/NotOkStatusInfo';
 
 import { PredefinedAlertInterface } from './AlertsPerCheck.constants';
 import { FailedExecutionsAlert } from './FailedExecutionsAlert';

--- a/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
@@ -6,6 +6,7 @@ import { css } from '@emotion/css';
 
 import { CheckAlertType, CheckFormValues } from 'types';
 import { useMetricsDS } from 'hooks/useMetricsDS';
+import { NotOkStatusInfo } from 'components/AlertStatus/GrafanaNamespaceAlertRuleDisplay';
 
 import { PredefinedAlertInterface } from './AlertsPerCheck.constants';
 import { FailedExecutionsAlert } from './FailedExecutionsAlert';
@@ -40,6 +41,8 @@ export const AlertItem = ({
   const instance = getValues('target');
   const threshold = getValues(`alerts.${alert.type}.threshold`);
   const period = getValues(`alerts.${alert.type}.period`);
+  const status = getValues(`alerts.${alert.type}.status`);
+  const creationError = getValues(`alerts.${alert.type}.creationError`);
 
   const query = alert.query
     .replace(/\$instance/g, instance)
@@ -80,6 +83,9 @@ export const AlertItem = ({
           tooltipContent={tooltipContent}
         />
       )}
+      <div className={styles.alertStatus}>
+        <NotOkStatusInfo status={status ?? 'OK'} error={creationError} />
+      </div>
     </div>
   );
 };
@@ -91,8 +97,11 @@ export const getAlertItemStyles = (theme: GrafanaTheme2) => ({
     marginLeft: theme.spacing(1),
     minHeight: '40px',
     paddingTop: theme.spacing(1),
+    justifyContent: 'space-between',
   }),
-
+  alertStatus: css({
+    marginLeft: 'auto',
+  }),
   alertRow: css({
     gap: theme.spacing(1),
     alignItems: 'flex-start',

--- a/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
@@ -83,9 +83,11 @@ export const AlertItem = ({
           tooltipContent={tooltipContent}
         />
       )}
-      <div className={styles.alertStatus}>
-        <NotOkStatusInfo status={status ?? 'OK'} error={creationError} />
-      </div>
+      {status !== 'OK' && (
+        <div className={styles.alertStatus} data-testid={`alert-error-status-${alert.type}`}>
+          <NotOkStatusInfo status={status} error={creationError} />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/data/useGMAlerts.test.ts
+++ b/src/data/useGMAlerts.test.ts
@@ -1,0 +1,67 @@
+import { CheckAlertCategory,CheckAlertPublished,CheckAlertType,PrometheusAlertingRule, PrometheusAlertsGroup } from 'types';
+import { ALL_PREDEFINED_ALERTS } from 'components/CheckForm/AlertsPerCheck/AlertsPerCheck.constants';
+
+import { findRelevantAlertGroups } from './useGMAlerts';
+
+describe('findRelevantAlertGroups', () => {
+  const ALERT_NAME = CheckAlertType.ProbeFailedExecutionsTooHigh;
+  const CATEGORY = ALL_PREDEFINED_ALERTS.find(a => a.type === ALERT_NAME)?.category || CheckAlertCategory.FailedChecks;
+
+  const MATCHING_RULE: PrometheusAlertingRule = {
+    query: 'some_query',
+    evaluationTime: 1,
+    duration: 300,
+    labels: {},
+    annotations: { description: 'desc', summary: 'sum' },
+    health: 'ok',
+    lastEvaluation: 'now',
+    state: 'inactive',
+    type: 'alerting',
+    name: ALERT_NAME,
+  };
+
+  const NON_MATCHING_RULE: PrometheusAlertingRule = {
+    ...MATCHING_RULE,
+    name: 'OtherAlert',
+  };
+
+  const GROUP: PrometheusAlertsGroup = {
+    evaulationTime: 1,
+    file: 'file',
+    folderUid: 'grafana-synthetic-monitoring-app',
+    interval: 300,
+    lastEvaluation: 'now',
+    name: 'group',
+    rules: [MATCHING_RULE, NON_MATCHING_RULE],
+    totals: null,
+  };
+
+  const baseAlert = { threshold: 1, created: 1, modified: 1, status: 'ok' };
+
+  test('returns group with only matching rules', () => {
+    const alerts: CheckAlertPublished[] = [{ name: ALERT_NAME, ...baseAlert }];
+    const result = findRelevantAlertGroups([GROUP], alerts);
+    expect(result).toStrictEqual([
+      {
+        ...GROUP,
+        rules: [MATCHING_RULE],
+      },
+    ]);
+  });
+
+  test('returns constructed group with correct category if alert is not in any group', () => {
+    const alerts = [{ name: ALERT_NAME, ...baseAlert }];
+    const result = findRelevantAlertGroups([], alerts);
+    expect(result).toStrictEqual([
+      expect.objectContaining({
+        name: CATEGORY,
+        rules: [expect.objectContaining({ name: ALERT_NAME })],
+      }),
+    ]);
+  });
+
+  test('returns empty array if alerts is empty', () => {
+    const result = findRelevantAlertGroups([GROUP], []);
+    expect(result).toStrictEqual([]);
+  });
+}); 

--- a/src/data/useGMAlerts.ts
+++ b/src/data/useGMAlerts.ts
@@ -4,8 +4,11 @@ import { firstValueFrom } from 'rxjs';
 
 import { Check, PrometheusAlertsGroup } from 'types';
 import { ListPrometheusAlertsResponse } from 'datasource/responses.types';
+import { ALL_PREDEFINED_ALERTS } from 'components/CheckForm/AlertsPerCheck/AlertsPerCheck.constants';
 
 import { constructError, showAlert } from './utils';
+
+const GRAFANA_SM_FOLDER_UID = 'grafana-synthetic-monitoring-app';
 
 export const queryKeys: Record<'list', QueryKey> = {
   list: ['alerts'],
@@ -38,20 +41,62 @@ function queryAlertApi() {
     });
 }
 
-export function findRelevantAlertGroups(groups: PrometheusAlertsGroup[], alerts: Check['Alerts']) {
-  const alertNames = alerts?.map((alert: { name: string }) => alert.name);
+function findGroupWithMatchingRule(groups: PrometheusAlertsGroup[], alertName: string): PrometheusAlertsGroup | undefined {
+  return groups.find((group) =>
+    group.rules.some((rule) => rule.name.includes(alertName))
+  );
+}
 
-  return groups
-    .filter((group) => group.folderUid === 'grafana-synthetic-monitoring-app')
-    .reduce<PrometheusAlertsGroup[]>((acc, current) => {
-      const relevantRules = current.rules.filter((rule) =>
-        alertNames?.some((alertName) => rule.name.includes(alertName))
-      );
+function extractMatchingRules(group: PrometheusAlertsGroup, alertName: string) {
+  return group.rules.filter((rule) => rule.name.includes(alertName));
+}
 
-      if (relevantRules.length) {
-        return [...acc, { ...current, rules: relevantRules }];
-      }
+function constructDummyGroup(alertName: string): PrometheusAlertsGroup {
+  const predefined = ALL_PREDEFINED_ALERTS.find((a) => a.type === alertName);
+  const category = predefined?.category || '';
+  return {
+    evaulationTime: 0,
+    file: 'Grafana Synthetic Monitoring',
+    folderUid: 'grafana-synthetic-monitoring-app',
+    interval: 0,
+    lastEvaluation: '',
+    name: category,
+    rules: [
+      {
+        annotations: { description: '', summary: '' },
+        duration: 0,
+        evaluationTime: 0,
+        health: 'ok',
+        labels: {},
+        lastEvaluation: '',
+        name: alertName,
+        query: '',
+        state: 'inactive',
+        type: 'alerting',
+      },
+    ],
+    totals: null,
+  };
+}
 
-      return acc;
-    }, []);
+export function findRelevantAlertGroups(groups: PrometheusAlertsGroup[], alerts: Check['Alerts']): PrometheusAlertsGroup[] {
+  if (!alerts) {
+    return [];
+  }
+
+  // Only consider groups with the correct folderUid
+  const grafanaGroups = groups.filter(
+    (group) => group.folderUid === GRAFANA_SM_FOLDER_UID
+  );
+
+  return alerts.map((alert) => {
+    const groupWithRule = findGroupWithMatchingRule(grafanaGroups, alert.name);
+    if (groupWithRule) {
+      return {
+        ...groupWithRule,
+        rules: extractMatchingRules(groupWithRule, alert.name),
+      };
+    }
+    return constructDummyGroup(alert.name);
+  });
 }

--- a/src/datasource/__mocks__/checkAlerts.ts
+++ b/src/datasource/__mocks__/checkAlerts.ts
@@ -14,12 +14,14 @@ export const alertsFromApi: CheckAlertsResponse = {
       threshold: 90,
       created: 1724854935,
       modified: 1724854935,
+      status: 'OK',
     },
     {
       name: CheckAlertType['ProbeFailedExecutionsTooHigh'],
       threshold: 20,
       created: 1724854935,
-      modified: 1724854935,
+      modified: 17,
+      status: 'OK',
     },
   ],
 };

--- a/src/test/db.ts
+++ b/src/test/db.ts
@@ -259,5 +259,6 @@ export const db = {
     threshold: faker.number.int({ min: 50, max: 500 }),
     created: Math.floor(faker.date.past().getTime() / 1000),
     modified: Math.floor(faker.date.recent().getTime() / 1000),
+    status: "OK",
   })),
 };

--- a/src/test/fixtures/alerting.ts
+++ b/src/test/fixtures/alerting.ts
@@ -105,7 +105,7 @@ export const GRAFANA_ALERTING_RULES: ListPrometheusAlertsResponse = {
         lastEvaluation: '2025-05-09T20:10:50Z',
         evaulationTime: 0.410487404,
       },
-      {
+      /*{
         name: 'TLS Certificate',
         file: 'Grafana Synthetic Monitoring',
         folderUid: 'grafana-synthetic-monitoring-app',
@@ -136,7 +136,7 @@ export const GRAFANA_ALERTING_RULES: ListPrometheusAlertsResponse = {
         interval: 60,
         lastEvaluation: '2025-05-09T20:10:30Z',
         evaulationTime: 0.480036517,
-      },
+      },*/
     ],
   },
   status: `success`,

--- a/src/test/fixtures/checkAlerts.ts
+++ b/src/test/fixtures/checkAlerts.ts
@@ -7,8 +7,6 @@ export const BASIC_CHECK_ALERTS: CheckAlertsResponse = {
   alerts: [
     db.alert.build({
       name: CheckAlertType.ProbeFailedExecutionsTooHigh,
-      status: 'PENDING_CREATE',
-      error: CheckAlertError.QuotaLimitReached,
     }),
     db.alert.build({
       name: CheckAlertType.TLSTargetCertificateCloseToExpiring,

--- a/src/test/fixtures/checkAlerts.ts
+++ b/src/test/fixtures/checkAlerts.ts
@@ -7,11 +7,13 @@ export const BASIC_CHECK_ALERTS: CheckAlertsResponse = {
   alerts: [
     db.alert.build({
       name: CheckAlertType.ProbeFailedExecutionsTooHigh,
+      status: 'PENDING_CREATE',
+      error: CheckAlertError.QuotaLimitReached,
     }),
     db.alert.build({
       name: CheckAlertType.TLSTargetCertificateCloseToExpiring,
       status: 'PENDING_CREATE',
-      error: CheckAlertError.QuotaLimitReached,
+      error: CheckAlertError.HostedGrafanaInstanceLoading,
     }),
   ],
 };

--- a/src/test/fixtures/checkAlerts.ts
+++ b/src/test/fixtures/checkAlerts.ts
@@ -1,11 +1,17 @@
 import { db } from 'test/db';
 
-import { CheckAlertType } from 'types';
+import { CheckAlertError, CheckAlertType } from 'types';
 import { CheckAlertsResponse } from 'datasource/responses.types';
 
 export const BASIC_CHECK_ALERTS: CheckAlertsResponse = {
   alerts: [
-    CheckAlertType.TLSTargetCertificateCloseToExpiring,
-    CheckAlertType.ProbeFailedExecutionsTooHigh,
-  ].map((name) => db.alert.build({ name })),
+    db.alert.build({
+      name: CheckAlertType.ProbeFailedExecutionsTooHigh,
+    }),
+    db.alert.build({
+      name: CheckAlertType.TLSTargetCertificateCloseToExpiring,
+      status: 'PENDING_CREATE',
+      error: CheckAlertError.QuotaLimitReached,
+    }),
+  ],
 };

--- a/src/test/fixtures/checks.ts
+++ b/src/test/fixtures/checks.ts
@@ -3,7 +3,6 @@ import { db } from 'test/db';
 import {
   AlertSensitivity,
   Check,
-  CheckAlertType,
   CheckType,
   DNSCheck,
   HTTPCheck,
@@ -20,6 +19,7 @@ import {
 } from 'types';
 import { AdHocCheckResponse } from 'datasource/responses.types';
 
+import { BASIC_CHECK_ALERTS } from './checkAlerts';
 import { PRIVATE_PROBE, PUBLIC_PROBE } from './probes';
 
 export const VALID_CERT = `-----BEGIN CERTIFICATE-----
@@ -87,22 +87,7 @@ export const BASIC_HTTP_CHECK: HTTPCheck = db.check.build(
         value: 'httpLabelValue',
       },
     ],
-    Alerts: [
-      {
-        name: CheckAlertType.ProbeFailedExecutionsTooHigh,
-        threshold: 1,
-        period: '5m',
-        created: 1746629887,
-        modified: 1746629887,
-      },
-      {
-        name: CheckAlertType.TLSTargetCertificateCloseToExpiring,
-        threshold: 12,
-        period: '',
-        created: 1746629887,
-        modified: 1746629887,
-      },
-    ],
+    Alerts: [...BASIC_CHECK_ALERTS.alerts],
     probes: [PRIVATE_PROBE.id, PUBLIC_PROBE.id] as number[],
   },
   { transient: { type: CheckType.HTTP } }

--- a/src/types.ts
+++ b/src/types.ts
@@ -325,6 +325,8 @@ export interface CheckAlertFormValues {
   threshold?: number;
   period?: string;
   isSelected?: boolean;
+  status?: string;
+  creationError?: CheckAlertError;
 }
 
 export type CheckAlertFormRecord = Partial<Record<CheckAlertType, CheckAlertFormValues>>;
@@ -664,6 +666,12 @@ export enum CheckAlertCategory {
   FailedChecks = 'Failed Checks',
 }
 
+export enum CheckAlertError {
+  HostedGrafanaInstanceLoading = 'hosted grafana instance loading',
+  QuotaLimitReached = 'quota limit reached',
+  InternalError = 'internal error',
+}
+
 export type CheckAlertDraft = {
   name: CheckAlertType;
   threshold: number;
@@ -673,6 +681,8 @@ export type CheckAlertDraft = {
 export type CheckAlertPublished = CheckAlertDraft & {
   created: number;
   modified: number;
+  status: string;
+  error?: CheckAlertError;
 };
 
 export type ThresholdUnit = 'ms' | 's' | 'd' | '%' | 'no.';


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-app/issues/1131

With the new per-check alerts, the creation request can be successful but there can still be asynchronous errors that need to be displayed to the user. This PR addresses this requirement. 

From https://github.com/grafana/synthetic-monitoring/issues/266:

>Alert rules creation process is performed asynchronously from the HTTP request that triggers its creation. This means that the user might have received a successful response (202 HTTP Accepted), but the rule itself might not end up being created (for example due to quota limits or other possible errors).
>The backend registers the possible errors returned from Hosted Grafana. We should expose these errors to the plugin, so the plugin can take different actions in order to try to provide feedback to the user on that situation. Possible methods discussed are:

- Error indication on the check list:
<img width="530" alt="image" src="https://github.com/user-attachments/assets/dfa44d20-01ee-4c8e-96ae-e3974ffaaa91" />

- Error indication in the check form - Alerting section:
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/6802dd34-2f53-4511-8afb-470cc804d03c" />


NOTE: in order to see the error messages, the app can be started using `yarn dev:msw` where there is a check (`Job name for http`) that provides an error for the `TLSTargetCertificateCloseToExpiring` alert
