### PR TITLE
fix: add catch blocks to script examples

### DIFF
--- a/src/components/BrowserExamplesMenu/snippets/colorscheme.js
+++ b/src/components/BrowserExamplesMenu/snippets/colorscheme.js
@@ -39,6 +39,9 @@ export default async function() {
     await check(colorScheme, {
       'isDarkColorScheme': cs => cs.isDarkColorScheme
     });
+  } catch (e) {
+    console.log('Error during execution:', e);
+    throw e;
   } finally {
     await page.close();
   }

--- a/src/components/BrowserExamplesMenu/snippets/dispatch.js
+++ b/src/components/BrowserExamplesMenu/snippets/dispatch.js
@@ -30,6 +30,9 @@ export default async function () {
     await check(page.locator('h3'), {
       header: async (locator) => (await locator.textContent()) === 'Contact us',
     });
+  } catch (e) {
+    console.log('Error during execution:', e);
+    throw e;
   } finally {
     await page.close();
   }

--- a/src/components/BrowserExamplesMenu/snippets/evaluate.js
+++ b/src/components/BrowserExamplesMenu/snippets/evaluate.js
@@ -42,6 +42,9 @@ export default async function () {
     await check(result, {
       'result should be 25': (result) => result == 25,
     });
+  } catch (e) {
+    console.log('Error during execution:', e);
+    throw e;
   } finally {
     await page.close();
   }

--- a/src/components/BrowserExamplesMenu/snippets/fillform.js
+++ b/src/components/BrowserExamplesMenu/snippets/fillform.js
@@ -48,6 +48,9 @@ export default async function () {
         return cookies.find((c) => c.name == 'sid') !== undefined;
       },
     });
+  } catch (e) {
+    console.log('Error during execution:', e);
+    throw e;
   } finally {
     await page.close();
   }

--- a/src/components/BrowserExamplesMenu/snippets/getattribute.js
+++ b/src/components/BrowserExamplesMenu/snippets/getattribute.js
@@ -29,6 +29,9 @@ export default async function () {
     await check(page.locator('#dark-mode-toggle-3'), {
       "GetAttribute('mode')": async (locator) => (await locator.getAttribute('mode')) === 'light',
     });
+  } catch (e) {
+    console.log('Error during execution:', e);
+    throw e;
   } finally {
     await page.close();
   }

--- a/src/components/BrowserExamplesMenu/snippets/querying.js
+++ b/src/components/BrowserExamplesMenu/snippets/querying.js
@@ -33,6 +33,9 @@ export default async function () {
     await check(page.locator(`//header//h1[@class="title"]`), {
       'Title with XPath selector': async (locator) => (await locator.textContent()) === title,
     });
+  } catch (e) {
+    console.log('Error during execution:', e);
+    throw e;
   } finally {
     await page.close();
   }

--- a/src/components/BrowserExamplesMenu/snippets/waitForFunction.js
+++ b/src/components/BrowserExamplesMenu/snippets/waitForFunction.js
@@ -35,6 +35,9 @@ export default async function () {
       timeout: 2000,
     });
     await check(ok, { 'waitForFunction successfully resolved': ok.innerHTML() == 'Hello' });
+  } catch (e) {
+    console.log('Error during execution:', e);
+    throw e;
   } finally {
     await page.close();
   }

--- a/src/components/ScriptExamplesMenu/snippets/browser_fill_form.js
+++ b/src/components/ScriptExamplesMenu/snippets/browser_fill_form.js
@@ -1,5 +1,5 @@
-import { browser } from 'k6/experimental/browser'
-import { check } from 'k6'
+import { browser } from 'k6/experimental/browser';
+import { check } from 'k6';
 
 export const options = {
   scenarios: {
@@ -17,25 +17,28 @@ export const options = {
   thresholds: {
     checks: ['rate==1.0'],
   },
-}
+};
 
 export default async function () {
-  const page = browser.newPage()
+  const page = browser.newPage();
 
   try {
-    await page.goto('https://test.k6.io/my_messages.php')
+    await page.goto('https://test.k6.io/my_messages.php');
 
-    page.locator('input[name="login"]').type('admin')
-    page.locator('input[name="password"]').type('123')
+    page.locator('input[name="login"]').type('admin');
+    page.locator('input[name="password"]').type('123');
 
-    const submitButton = page.locator('input[type="submit"]')
+    const submitButton = page.locator('input[type="submit"]');
 
-    await Promise.all([page.waitForNavigation(), submitButton.click()])
+    await Promise.all([page.waitForNavigation(), submitButton.click()]);
 
     check(page, {
       header: (p) => p.locator('h2').textContent() === 'Welcome, admin!',
-    })
+    });
+  } catch (e) {
+    console.log('Error during execution:', e);
+    throw e;
   } finally {
-    page.close()
+    page.close();
   }
 }

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -206,6 +206,9 @@ export default async function () {
     await check(page.locator("h2"), {
       header: async (locator) => (await locator.textContent()) == "Welcome, admin!",
     });
+  } catch (e) {
+    console.log('Error during execution:', e);
+    throw e;
   } finally {
     await page.close();
   }


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring/issues/243

## Add catch blocks to browser/scripted example scripts

### Summary

This PR improves error handling in browser and scripted checks example scripts by ensuring that every `try/finally` block now includes a `catch` block. The catch block logs any errors that occur during script execution and rethrows the error for visibility and debugging.

  - The catch block logs errors using:
    ```js
    catch (e) {
      console.log('Error during execution:', e);
      throw e;
    }
    ```
- This change ensures that any runtime errors are surfaced in logs, making debugging easier for users running or adapting these examples.

![image](https://github.com/user-attachments/assets/f6020a3a-e5a5-4b07-8fcb-759f9544bce3)

