### PR TITLE
fix: Fix list check alerts case

### DIFF
--- a/src/components/AlertStatus/AlertStatus.tsx
+++ b/src/components/AlertStatus/AlertStatus.tsx
@@ -19,7 +19,7 @@ interface AlertStatusProps {
 
 export const AlertStatus = ({ check, compact }: AlertStatusProps) => {
   const hasAlertSensitivity = check.alertSensitivity !== undefined && check.alertSensitivity !== AlertSensitivity.None;
-  const hasPerCheckAlerts = (check.Alerts?.length ?? 0) > 0;
+  const hasPerCheckAlerts = (check.alerts?.length ?? 0) > 0;
 
   const metricsDS = useMetricsDS();
 
@@ -52,7 +52,7 @@ export const AlertStatusContent = ({ check, compact, metricsDSName, hasAlertSens
     isLoading: perCheckGroupsLoading,
     isError: perCheckGroupsError,
     refetch: perCheckGroupsRefetch,
-  } = useGMAlertRules(check.Alerts);
+  } = useGMAlertRules(check.alerts);
 
   const perCheckGroupsResponse = {
     perCheckGroups,

--- a/src/components/CheckEditor/transformations/toFormValues.http.ts
+++ b/src/components/CheckEditor/transformations/toFormValues.http.ts
@@ -29,7 +29,7 @@ export function getHTTPCheckFormValues(check: HTTPCheck): CheckFormValuesHttp {
     },
     alerts: {
       ...base.alerts,
-      ...predefinedAlertsToFormValues(HTTP_PREDEFINED_ALERTS, check.Alerts || []),
+      ...predefinedAlertsToFormValues(HTTP_PREDEFINED_ALERTS, check.alerts || []),
     },
   };
 }

--- a/src/components/CheckEditor/transformations/toFormValues.utils.ts
+++ b/src/components/CheckEditor/transformations/toFormValues.utils.ts
@@ -52,7 +52,7 @@ export function getBaseFormValuesFromCheck(check: Check): Omit<CheckFormValues, 
     probes: check.probes,
     target: check.target,
     timeout: check.timeout,
-    alerts: predefinedAlertsToFormValues(GLOBAL_PREDEFINED_ALERTS, check.Alerts || []),
+    alerts: predefinedAlertsToFormValues(GLOBAL_PREDEFINED_ALERTS, check.alerts || []),
   };
 }
 

--- a/src/components/CheckForm/checkForm.hooks.ts
+++ b/src/components/CheckForm/checkForm.hooks.ts
@@ -65,7 +65,7 @@ export function useCheckForm({ check, checkType, checkState, onTestSuccess }: Us
   const alertsEnabled = useFeatureFlag(FeatureName.AlertsPerCheck).isEnabled;
 
   const { mutateAsync: updateAlertsForCheck } = useUpdateAlertsForCheck({
-    prevAlerts: check?.Alerts,
+    prevAlerts: check?.alerts,
   });
 
   const handleAlertsAndNavigate = useCallback(

--- a/src/data/useGMAlerts.ts
+++ b/src/data/useGMAlerts.ts
@@ -38,7 +38,7 @@ function queryAlertApi() {
     });
 }
 
-export function findRelevantAlertGroups(groups: PrometheusAlertsGroup[], alerts: Check['Alerts']) {
+export function findRelevantAlertGroups(groups: PrometheusAlertsGroup[], alerts: Check['alerts']) {
   const alertNames = alerts?.map((alert: { name: string }) => alert.name);
 
   return groups

--- a/src/hooks/useAlertRules.ts
+++ b/src/hooks/useAlertRules.ts
@@ -27,7 +27,7 @@ export function useAlertRules(alertSensitivity: Check['alertSensitivity']) {
   }, [data, isError, isLoading, alertFilter, refetch]);
 }
 
-export function useGMAlertRules(alerts: Check['Alerts']) {
+export function useGMAlertRules(alerts: Check['alerts']) {
   const { data, isLoading, isError, refetch } = useGMAlerts();
 
   return useMemo(() => {

--- a/src/hooks/useTerraformConfig.test.tsx
+++ b/src/hooks/useTerraformConfig.test.tsx
@@ -401,13 +401,13 @@ describe('terraform config generation', () => {
     ]);
   });
 
-  test('generates grafana_synthetic_monitoring_check_alerts resources for checks with Alerts', async () => {
+  test('generates grafana_synthetic_monitoring_check_alerts resources for checks with alerts', async () => {
     const result = await renderTerraformHook([BASIC_HTTP_CHECK], [PRIVATE_PROBE]);
     const resourceName = sanitizeName(`${BASIC_HTTP_CHECK.job}_${BASIC_HTTP_CHECK.target}`);
     expect(result.current.config.resource.grafana_synthetic_monitoring_check_alerts).toEqual({
       [resourceName]: {
         check_id: String(BASIC_HTTP_CHECK.id),
-        alerts: (BASIC_HTTP_CHECK.Alerts!).map(alert => ({
+        alerts: (BASIC_HTTP_CHECK.alerts!).map(alert => ({
           name: alert.name,
           threshold: alert.threshold,
           period: alert.period,

--- a/src/hooks/useTerraformConfig.ts
+++ b/src/hooks/useTerraformConfig.ts
@@ -65,12 +65,12 @@ function generateTerraformConfig(probes: Probe[], checks: Check[], apiHost?: str
   }
 
   const checkAlertsConfig = checks
-    .filter((check) => check.Alerts && check.Alerts.length > 0)
+    .filter((check) => check.alerts && check.alerts.length > 0)
     .reduce((acc: TFCheckAlertsConfig, check) => {
       const resourceName = sanitizeName(`${check.job}_${check.target}`);
       acc[resourceName] = {
         check_id: String(check.id),
-        alerts: (check.Alerts!).map((alert) => ({
+        alerts: (check.alerts!).map((alert) => ({
           name: alert.name,
           threshold: alert.threshold,
           period: alert.period,
@@ -90,7 +90,7 @@ function generateTerraformConfig(probes: Probe[], checks: Check[], apiHost?: str
   });
 
   const checkAlertsCommands = checks
-    .filter((check) => check.Alerts && check.Alerts.length > 0)
+    .filter((check) => check.alerts && check.alerts.length > 0)
     .map((check) => {
       return `terraform import grafana_synthetic_monitoring_check_alerts.${sanitizeName(
         `${check.job}_${check.target}`

--- a/src/test/db.ts
+++ b/src/test/db.ts
@@ -25,7 +25,7 @@ const baseCheckModel = ({ sequence }: { sequence: number }) => ({
   timeout: faker.number.int({ min: 30, max: 60 * 1000 }),
   enabled: true,
   alertSensitivity: faker.helpers.arrayElement(Object.values(AlertSensitivity)),
-  Alerts: [],
+  alerts: [],
   basicMetricsOnly: faker.datatype.boolean(),
   labels: [{ name: faker.animal.petName(), value: faker.color.human() }],
   probes: [],

--- a/src/test/fixtures/checks.ts
+++ b/src/test/fixtures/checks.ts
@@ -87,7 +87,7 @@ export const BASIC_HTTP_CHECK: HTTPCheck = db.check.build(
         value: 'httpLabelValue',
       },
     ],
-    Alerts: [
+    alerts: [
       {
         name: CheckAlertType.ProbeFailedExecutionsTooHigh,
         threshold: 1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -407,7 +407,7 @@ export interface CheckBase {
   basicMetricsOnly: boolean;
   labels: Label[]; // Currently list of [name:value]... can it be Labels?
   probes: number[];
-  Alerts?: CheckAlertPublished[];
+  alerts?: CheckAlertPublished[];
 }
 
 export type Check =


### PR DESCRIPTION
Fixes the case for alerts field as included in the list checks endpoint response.

Related grafana/synthetic-monitoring-api/pull/1387