### PR TITLE
chore: remove unnecessary console eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,7 +25,6 @@ const config = defineConfig([
     },
     rules: {
       'custom-plugin/tracking-event-creation': 'error',
-      'no-console': ['error', { allow: [''] }],
       'no-redeclare': 'off', // we use typescript's 'no-redeclare' rule instead
       '@typescript-eslint/no-redeclare': ['error'],
       '@typescript-eslint/no-deprecated': 'error',


### PR DESCRIPTION
1. Meant to do this a while ago when I discovered that webpack strips console log statements when compiling
2. Excuse to trigger CI/CD