### PR TITLE
fix: change reachability description for probes view

### DIFF
--- a/src/components/Gauges/Gauge.tsx
+++ b/src/components/Gauges/Gauge.tsx
@@ -17,14 +17,15 @@ interface Props {
   unit: `%` | `ms`;
   value: number | null;
   width: number;
+  description?: string;
 }
 
-export const Gauge = ({ fetching, loading, height, width, onClick, type, value, unit }: Props) => {
+export const Gauge = ({ fetching, loading, height, width, onClick, type, value, unit, description }: Props) => {
   const { data: threshold } = useThreshold(type);
   const parsedValue = parseValue(value, unit);
   const comparer = comparisonMap[type];
   const color = threshold && parsedValue !== null ? comparer(threshold, parsedValue) : undefined;
-  const infoText = infoMap[type];
+  const infoText = description || infoMap[type];
   const title = titleMap[type];
   const text = formatValue(parsedValue, unit, loading);
 

--- a/src/components/Gauges/SuccessRateGaugeProbe.tsx
+++ b/src/components/Gauges/SuccessRateGaugeProbe.tsx
@@ -10,9 +10,10 @@ type SuccessRateGaugeProbeProps = {
   height: number;
   width: number;
   onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  description?: string;
 };
 
-export const SuccessRateGaugeProbe = ({ probeName, height, width, onClick }: SuccessRateGaugeProbeProps) => {
+export const SuccessRateGaugeProbe = ({ probeName, height, width, onClick, description }: SuccessRateGaugeProbeProps) => {
   const metricsDS = useMetricsDS();
   const { data, isLoading, isFetching } = useProbeReachabilitySuccessRate(probeName);
   const value = data?.value[1] ?? null;
@@ -31,6 +32,7 @@ export const SuccessRateGaugeProbe = ({ probeName, height, width, onClick }: Suc
       type={`reachability`}
       value={value}
       unit="%"
+      description={description}
     />
   );
 };

--- a/src/components/ProbeCard/ProbeCard.tsx
+++ b/src/components/ProbeCard/ProbeCard.tsx
@@ -7,6 +7,7 @@ import { type ExtendedProbe, type Label } from 'types';
 import { AppRoutes } from 'routing/types';
 import { generateRoutePath } from 'routing/utils';
 import { useCanEditProbe } from 'hooks/useCanEditProbe';
+import { PROBE_REACHABILITY_DESCRIPTION } from 'components/constants';
 import { DeprecationNotice } from 'components/DeprecationNotice/DeprecationNotice';
 import { SuccessRateGaugeProbe } from 'components/Gauges';
 
@@ -69,7 +70,12 @@ export const ProbeCard = ({ probe }: { probe: ExtendedProbe }) => {
           <ProbeUsageLink probe={probe} />
         </div>
         <div className={styles.gaugeContainer}>
-          <SuccessRateGaugeProbe probeName={probe.name} height={60} width={150} />
+          <SuccessRateGaugeProbe
+            probeName={probe.name}
+            height={60}
+            width={150}
+            description={PROBE_REACHABILITY_DESCRIPTION}
+          />
         </div>
       </Card.Description>
 

--- a/src/components/ProbeStatus/ProbeStatus.tsx
+++ b/src/components/ProbeStatus/ProbeStatus.tsx
@@ -21,6 +21,7 @@ import { DeprecationNotice } from 'components/DeprecationNotice/DeprecationNotic
 import { SuccessRateGaugeProbe } from 'components/Gauges';
 
 import { ProbeUsageLink } from '../ProbeUsageLink';
+import { PROBE_REACHABILITY_DESCRIPTION } from 'components/constants';
 
 interface ProbeStatusProps {
   probe: ExtendedProbe;
@@ -94,7 +95,7 @@ export const ProbeStatus = ({ probe, onReset, readOnly }: ProbeStatusProps) => {
           </Container>
         )}
       </div>
-      <SuccessRateGaugeProbe probeName={probe.name} height={200} width={300} />
+      <SuccessRateGaugeProbe probeName={probe.name} height={200} width={300} description={PROBE_REACHABILITY_DESCRIPTION} />
       <div className={styles.metaWrapper}>
         <Meta title="Version:" value={probe.version} />
         <Meta

--- a/src/components/ProbeStatus/ProbeStatus.tsx
+++ b/src/components/ProbeStatus/ProbeStatus.tsx
@@ -17,11 +17,11 @@ import { type ExtendedProbe } from 'types';
 import { formatDate } from 'utils';
 import { useResetProbeToken } from 'data/useProbes';
 import { useCanEditProbe } from 'hooks/useCanEditProbe';
+import { PROBE_REACHABILITY_DESCRIPTION } from 'components/constants';
 import { DeprecationNotice } from 'components/DeprecationNotice/DeprecationNotice';
 import { SuccessRateGaugeProbe } from 'components/Gauges';
 
 import { ProbeUsageLink } from '../ProbeUsageLink';
-import { PROBE_REACHABILITY_DESCRIPTION } from 'components/constants';
 
 interface ProbeStatusProps {
   probe: ExtendedProbe;

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -514,7 +514,7 @@ export const UPTIME_DESCRIPTION =
   'Whether any of the probes could reach the target. Uptime decreases when all the probes fail simultaneously.';
 export const REACHABILITY_DESCRIPTION =
   'The success rate of all the probes. Reachability decreases when any probe fails.';
-export const PROBE_REACHABILITY_DESCRIPTION = 'The success rate of all synthetic checks run by this probe.';
+export const PROBE_REACHABILITY_DESCRIPTION = 'The success percentage of all checks performed by this probe.';
 export const LATENCY_DESCRIPTION =
   'The average time to receive an answer across all the checks during the whole time period.';
 

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -514,6 +514,7 @@ export const UPTIME_DESCRIPTION =
   'Whether any of the probes could reach the target. Uptime decreases when all the probes fail simultaneously.';
 export const REACHABILITY_DESCRIPTION =
   'The success rate of all the probes. Reachability decreases when any probe fails.';
+export const PROBE_REACHABILITY_DESCRIPTION = 'The success rate of all synthetic checks run by this probe.';
 export const LATENCY_DESCRIPTION =
   'The average time to receive an answer across all the checks during the whole time period.';
 


### PR DESCRIPTION
For probe-related components, the reachability description we are currently displaying can be confusing (see this [Slack](https://raintank-corp.slack.com/archives/C0162C1K9E1/p1750087772831939) conversation):
> The reachability info popup states "The success rate of all the probes. Reachability decreases when any probe fails.", which is a little misleading when viewed in context of the probe list. "The success rate of all synthetic checks run by this probe" might be a little more clear, since the language implies the probe is failing and not the checks.

In this PR, I made the following changes:

- Added a new `PROBE_REACHABILITY_DESCRIPTION` constant with the wording "The success rate of all synthetic checks run by this probe."
- Updated the probe-related components (ProbeCard, ProbeStatus) to use this new description for the reachability gauge, making the meaning clearer in the context of individual probes.

<img width="1214" alt="image" src="https://github.com/user-attachments/assets/43072d1a-fcbc-4ff9-9f18-07e192e2fa78" />
<img width="913" alt="image" src="https://github.com/user-attachments/assets/210bb140-760f-45b2-9283-76b79938a129" />



The original `REACHABILITY_DESCRIPTION` remains unchanged and is still used in other contexts where it refers to all probes.

<img width="1073" alt="image" src="https://github.com/user-attachments/assets/0da3d272-786b-494e-b7a7-f35b6c51703f" />
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/5cc6a0aa-cf46-4b75-b717-b3a660590ea6" />

This approach ensures the description is accurate and context-specific without affecting other parts of the app that use the original description.


