### PR TITLE
fix: change CODEOWNERS to match actual files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,4 +10,4 @@
 # used, so we need to keep the * pattern above this one.
 /CHANGELOG.md @grafana/synthetic-monitoring-fe @grafana/synthetic-monitoring-dev
 /package.json @grafana/synthetic-monitoring-fe @grafana/synthetic-monitoring-dev
-/.github/release-please/release-please-config.json @grafana/synthetic-monitoring-fe @grafana/synthetic-monitoring-dev
+/.github/release-please/.release-please-manifest.json @grafana/synthetic-monitoring-fe @grafana/synthetic-monitoring-dev


### PR DESCRIPTION
The actual file created by release please is
`/.github/release-please/.release-please-manifest.json`, which doesn't match the current CODEOWNERS.

The intention here is still to allow people not part of the frontend team to approve release PRs.