### PR TITLE
fix: add information about legacy vs per-check alerts in Alerting page

### DIFF
--- a/src/page/AlertingPage.tsx
+++ b/src/page/AlertingPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
-import { Alert, Button, Modal, Spinner, Stack, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Modal, Spinner, Stack, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { AlertFormValues, AlertRule } from 'types';
@@ -31,21 +31,38 @@ const Alerting = () => {
 
   return (
     <div>
-      <p>
-        View and edit default alerts for Synthetic Monitoring here. To tie one of these alerts to a check, you must
-        select the alert sensitivity from the Alerting section of the check form when creating a check.{' '}
-        <a
-          href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/synthetic-monitoring-alerting/"
-          className={styles.link}
-        >
-          Learn more about alerting for Synthetic Monitoring.
-        </a>
-      </p>
-      {canReadAlerts ? (
-        <AlertingPageContent />
-      ) : (
-        <ContactAdminAlert title="Insufficient Permissions" missingPermissions={['datasources:read']} />
-      )}
+      <Alert title="Legacy Alerting System" severity="info">
+        <p>
+          This page shows <strong>legacy alerts</strong> that use the alert sensitivity system (High, Medium, Low).
+          These alerts are applied globally and configured by selecting an alert sensitivity when creating or editing
+          checks.
+        </p>
+        <p>
+          We recommend using the new <strong>per-check alerts</strong> system instead. Per-check alerts allow you to set
+          specific thresholds and conditions for individual checks. You can configure per-check alerts in the
+          &ldquo;Alerting&rdquo; section when creating or editing any check.
+        </p>
+        <p>
+          <TextLink
+            href="https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/configure-per-check-alerts/"
+            external={true}
+          >
+            Learn more about alerting for Synthetic Monitoring
+          </TextLink>
+        </p>
+      </Alert>
+
+      <div className={styles.contentSection}>
+        <p>
+          View and edit default alerts for Synthetic Monitoring here. To tie one of these alerts to a check, you must
+          select the alert sensitivity from the Alerting section of the check form when creating a check.
+        </p>
+        {canReadAlerts ? (
+          <AlertingPageContent />
+        ) : (
+          <ContactAdminAlert title="Insufficient Permissions" missingPermissions={['datasources:read']} />
+        )}
+      </div>
     </div>
   );
 };
@@ -169,10 +186,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginBottom: theme.spacing(4),
     textAlign: 'center',
   }),
-  link: css({
-    textDecoration: 'underline',
-  }),
-  icon: css({
-    marginRight: theme.spacing(1),
+  contentSection: css({
+    marginTop: theme.spacing(2),
   }),
 });

--- a/src/page/pageDefinitions.ts
+++ b/src/page/pageDefinitions.ts
@@ -29,7 +29,7 @@ const pages: NavModelItem[] = [
     url: `${PLUGIN_URL_PATH}probes`,
   },
   {
-    text: 'Alerts',
+    text: 'Alerts (Legacy)',
     id: 'alerts',
     url: `${PLUGIN_URL_PATH}alerts`,
   },

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -61,7 +61,7 @@
     },
     {
       "type": "page",
-      "name": "Alerts",
+      "name": "Alerts (Legacy)",
       "path": "/a/grafana-synthetic-monitoring-app/alerts",
       "action": "grafana-synthetic-monitoring-app.alerts:read",
       "addToNav": true

--- a/src/routing/InitialisedRouter.test.tsx
+++ b/src/routing/InitialisedRouter.test.tsx
@@ -43,7 +43,7 @@ describe('Routes to pages correctly', () => {
   });
   test('Alert page renders', async () => {
     renderInitialisedRouting({ path: getRoute(AppRoutes.Alerts) });
-    const alertsText = await screen.findByText('Learn more about alerting for Synthetic Monitoring.');
+    const alertsText = await screen.findByText('Learn more about alerting for Synthetic Monitoring');
     expect(alertsText).toBeInTheDocument();
   });
   test('Config page renders', async () => {


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring/issues/317

The "Alerts" menu item takes users to the legacy alerts page, which could cause confusion since the new per-check alerting system isn't represented there. Users might expect to see their current alerts but only find legacy ones with no clear indication of where to find the new alerts.

<img width="1492" alt="image" src="https://github.com/user-attachments/assets/d255910a-279e-42bf-b38a-bb6c4a2afca4" />

- Renamed menu item from "Alerts" to "Alerts (Legacy)" for clarity
- Added prominent info alert at the top of the page explaining this page shows legacy alerts using the alert sensitivity system 
- Recommends using the new per-check alerts system instead
- Explains where to configure per-check alerts (in the "Alerting" section when creating/editing checks)
- Updated documentation link to point to per-check alerts documentation