### PR TITLE
fix: updated check list search

### DIFF
--- a/src/page/CheckList/CheckList.test.tsx
+++ b/src/page/CheckList/CheckList.test.tsx
@@ -52,6 +52,36 @@ const renderCheckList = async (checks = BASIC_CHECK_LIST, searchParams = '') => 
   return res;
 };
 
+// overkill, but just in case
+const SPECIAL_CHARACTERS = [
+  '*',
+  '?',
+  '!',
+  '@',
+  '#',
+  '$',
+  '%',
+  '^',
+  '&',
+  '(',
+  ')',
+  '[',
+  ']',
+  '{',
+  '}',
+  '|',
+  '\\',
+  '/',
+  ':',
+  ';',
+  '<',
+  '>',
+  ',',
+  '.',
+  '`',
+  '~',
+];
+
 describe('CheckList', () => {
   test('renders empty state', async () => {
     server.use(
@@ -138,6 +168,23 @@ describe('CheckList', () => {
     filterInput.focus();
 
     await user.paste(BASIC_DNS_CHECK.labels[0].value);
+    await waitForElementToBeRemoved(willBeRemoved, { timeout: 1500 });
+    const checks = await screen.findAllByTestId('check-card');
+    expect(checks.length).toBe(1);
+  });
+
+  test.each(SPECIAL_CHARACTERS)('search can use special character: %s', async (specialChar) => {
+    const NO_MATCH_JOB = `NOMATCHJOB`;
+    const NO_MATCH_TARGET = `NOMATCHTARGET`;
+    const { user } = await renderCheckList([
+      { ...BASIC_DNS_CHECK, job: specialChar },
+      { ...BASIC_HTTP_CHECK, job: NO_MATCH_JOB, target: NO_MATCH_TARGET },
+    ]);
+    const filterInput = await screen.findByPlaceholderText('Search by job name, endpoint, or label');
+    const willBeRemoved = screen.getByText(NO_MATCH_JOB);
+    filterInput.focus();
+
+    await user.paste(specialChar);
     await waitForElementToBeRemoved(willBeRemoved, { timeout: 1500 });
     const checks = await screen.findAllByTestId('check-card');
     expect(checks.length).toBe(1);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,7 +126,7 @@ export function enumToStringArray(enumObject: {}) {
 // Matches a string against multiple options
 export const matchStrings = (string: string, comparisons: string[]): boolean => {
   const lowerCased = string.toLowerCase();
-  return comparisons.some((comparison) => comparison.toLowerCase().match(lowerCased));
+  return comparisons.some((comparison) => comparison.toLowerCase().includes(lowerCased));
 };
 
 export function getCheckType(settings: Settings): CheckType {


### PR DESCRIPTION
Closes: https://github.com/grafana/synthetic-monitoring-app/issues/1159

## Problem

The checklist search currently crashes the page when a special character (specifically ones which are used in regex pattern matching) begins the search.

## Solution

Change the matching implementation so it is literal rather than using regex under the hood. I've added extensive tests to ensure it works correctly and doesn't regress.