### PR TITLE
Per-check alerts: add link to notification policies

### DIFF
--- a/src/components/CheckForm/AlertsPerCheck/AlertsPerCheck.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertsPerCheck.tsx
@@ -62,8 +62,12 @@ export const AlertsPerCheck = () => {
             Enable and configure thresholds for common alerting scenarios. Use Grafana Alerting to{' '}
             <TextLink href="alerting/new/alerting" external={true}>
               create a custom alert rule
-            </TextLink>
-            .
+            </TextLink>{' '}
+            and view{' '}
+            <TextLink href="alerting/routes" external={true}>
+              notification policies
+            </TextLink>{' '}
+            to see where your alerts will be routed.
           </p>
         </div>
 


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring/issues/316

![image](https://github.com/user-attachments/assets/9c96ec54-c872-4c6d-9814-a00baaff57b1)

Adds a link to notification polices so users can configure where their alerts will be routed.