### PR TITLE
GHA: a few improvements

### DIFF
--- a/.github/workflows/call_update-deployment-tools.yml
+++ b/.github/workflows/call_update-deployment-tools.yml
@@ -35,15 +35,6 @@ jobs:
             GITHUB_APP_INSTALLATION_ID=updater-app:app-installation-id
             GITHUB_APP_PRIVATE_KEY=updater-app:private-key
 
-      # needed?
-
-      # - name: Export GitHub Actions URL
-      #   id: export-gha-url
-      #   shell: bash
-      #   run: |
-      #     GHA_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-      #     echo "gha_url=${GHA_URL}" >> "${GITHUB_OUTPUT}"
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -72,8 +63,6 @@ jobs:
       # Authentification for the next step docker image usage
       - name: Authenticate with GAR
         uses: grafana/shared-workflows/actions/login-to-gar@fa48192dac470ae356b3f7007229f3ac28c48a25
-        with:
-          environment: prod
 
       - name: Create plugin version file
         env:

--- a/.github/workflows/call_update-deployment-tools.yml
+++ b/.github/workflows/call_update-deployment-tools.yml
@@ -61,8 +61,15 @@ jobs:
       #     ENVIRONMENT: ${{ inputs.environment }}
 
       # Authentification for the next step docker image usage
-      - name: Authenticate with GAR
-        uses: grafana/shared-workflows/actions/login-to-gar@fa48192dac470ae356b3f7007229f3ac28c48a25
+      - name: Authenticate with GAR (Direct WIF)
+        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193
+        with:
+          project_id: "grafanalabs-workload-identity"
+          workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+          create_credentials_file: true
+
+      - name: Configure Docker for GAR
+        run: gcloud auth configure-docker us-docker.pkg.dev
 
       - name: Create plugin version file
         env:

--- a/.github/workflows/dispatch_deploy-plugin.yml
+++ b/.github/workflows/dispatch_deploy-plugin.yml
@@ -10,10 +10,14 @@ on:
       #   default: 'latest'
       #   type: string
       environment:
-        description: Deployment environment for the plugin (dev, staging, production)
+        description: Deployment environment for the plugin
         required: true
-        type: string
-        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - staging
+          - production
+        default: dev
       autoMerge:
         description: Whether to automatically merge the PR after deployment
         required: false

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -3,7 +3,7 @@ name: On pushing to main
 on:
   push:
     branches:
-      - main
+      - chore/gh-actions-improvs #testing
 
 jobs:
   publish-techdocs:

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -3,7 +3,7 @@ name: On pushing to main
 on:
   push:
     branches:
-      - chore/gh-actions-improvs #testing
+      - main
 
 jobs:
   publish-techdocs:


### PR DESCRIPTION
**Changes GAR authentication job to prevent logging an error**

The `login-to-gar` shared action was failing with s HTTP 404 error during service account impersonation. The issue was caused by:
Missing project ID resolution (notice the `-` in `projects/-/serviceAccounts/...`)
The service account impersonation was failing during the first authentication attempt.

The action would eventually succeed via its fallback mechanism, making the job successful, but caused confusing error logs. To prevent it, I replaced the failing `login-to-gar` action with Direct Workload Identity Federation using `google-github-actions/auth` (https://github.com/grafana/deployment_tools/tree/ece2dc51a27a36d68bc75543f1e40f6e2d78667c/terraform/projects/grafanalabs-workload-identity#using-google-github-actionsauth-directly)


Also, in this PR I changed the environment input from the Deploy (dispatch) manual workflow to be a dropdown with 3 possible values: `dev`, `staging` and `production` instead of free text.

