### PR TITLE
feat: add GRAFANA_ALERTS to annotations for firing/pending alerts

### DIFF
--- a/src/scenes/Common/alertAnnotations.ts
+++ b/src/scenes/Common/alertAnnotations.ts
@@ -1,6 +1,9 @@
 import { dataLayers, SceneDataLayerSet } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
+const firingCondition = `{job="$job", instance="$instance", alertstate="firing"}`;
+const pendingCondition = `{job="$job", instance="$instance", alertstate="pending"}`;
+
 export function getAlertAnnotations(metrics: DataSourceRef) {
   return new SceneDataLayerSet({
     layers: [
@@ -9,7 +12,7 @@ export function getAlertAnnotations(metrics: DataSourceRef) {
         isHidden: false,
         query: {
           datasource: metrics,
-          expr: 'max(ALERTS{job="$job", instance="$instance", alertstate="firing"})',
+          expr: `max(ALERTS${firingCondition} or GRAFANA_ALERTS${firingCondition})`,
           hide: false,
           legendFormat: 'alert firing',
           refId: 'alertsAnnotation',
@@ -24,9 +27,9 @@ export function getAlertAnnotations(metrics: DataSourceRef) {
         isHidden: false,
         query: {
           datasource: metrics,
-          expr: 'max(ALERTS{job="$job", instance="$instance", alertstate="pending"})',
+          expr: `max(ALERTS${pendingCondition} or GRAFANA_ALERTS${pendingCondition})`,
           hide: false,
-          legendFormat: 'alert firing',
+          legendFormat: 'alert pending',
           refId: 'alertsAnnotation',
           enable: true,
           iconColor: 'yellow',

--- a/src/scenes/HTTP/HttpDashboard.tsx
+++ b/src/scenes/HTTP/HttpDashboard.tsx
@@ -36,10 +36,13 @@ export const HttpDashboard = ({ check }: { check: Check }) => {
   const metricsDS = useMetricsDS();
   const styles = useStyles2(getStyles);
 
+  const firingCondition = `{job="$job", instance="$instance", alertstate="firing"}`;
+  const pendingCondition = `{job="$job", instance="$instance", alertstate="pending"}`;
+
   const annotations = [
     {
       datasource: metricsDS,
-      expr: 'max(ALERTS{job="$job", instance="$instance", alertstate="firing"})',
+      expr: `max(ALERTS${firingCondition} or GRAFANA_ALERTS${firingCondition})`,
       hide: false,
       legendFormat: 'alert firing',
       refId: 'alertsAnnotation',
@@ -50,9 +53,9 @@ export const HttpDashboard = ({ check }: { check: Check }) => {
     },
     {
       datasource: metricsDS,
-      expr: 'max(ALERTS{job="$job", instance="$instance", alertstate="pending"})',
+      expr: `max(ALERTS${pendingCondition} or GRAFANA_ALERTS${pendingCondition})`,
       hide: false,
-      legendFormat: 'alert firing',
+      legendFormat: 'alert pending',
       refId: 'alertsAnnotation',
       enable: true,
       iconColor: 'yellow',


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-app/issues/1132

Since the alerting team has added the new `GRAFANA_ALERTS` metric to obtain the `alertstatus` of the alerts, we can now use it to display annotations. I've included it to the current `firing`/`pending` annotations in the checks dashboards. 

**Note:** As of today, this metric is only available in prod for _free_ users (see https://github.com/grafana/alerting-squad/issues/1024) but its absence does now cause any issue with current annotations as the queries check for `ALERTS or GRAFANA_ALERTS`

I have tested these annotations using a free account with a custom dashboard and it shows as expected:

<img width="1608" height="687" alt="image" src="https://github.com/user-attachments/assets/cab19cc5-de22-4d1b-9445-79e6936b9182" />
<img width="2217" height="1034" alt="image" src="https://github.com/user-attachments/assets/3fdf2e09-c423-4b7f-9bb4-a14520c28bda" />
<img width="2224" height="688" alt="image" src="https://github.com/user-attachments/assets/089261ec-1e95-4b9a-a2ec-f4a65ebfa873" />
<img width="601" height="643" alt="image" src="https://github.com/user-attachments/assets/27ed4d9c-68fb-479c-863f-335224604046" />
