### PR TITLE
fix: lint warnings

### DIFF
--- a/src/components/CheckTestResultsModal.tsx
+++ b/src/components/CheckTestResultsModal.tsx
@@ -115,7 +115,7 @@ export function CheckTestResultsModal({ testResponse, isOpen, onDismiss }: Props
           setResultsByProbe({ ...resultsByProbe, [`${info.probe}${testResponse.id}`]: info });
         }
       } catch (e) {
-        console.log('error parsing', e); // eslint-disable-line no-console
+        console.log('error parsing', e);  
       }
     });
   }

--- a/src/faro.ts
+++ b/src/faro.ts
@@ -56,7 +56,7 @@ export function reportEvent(type: FaroEvent, info: Record<string, string> = {}) 
   try {
     faro.api?.pushEvent(type, attributes);
   } catch (e) {
-    // eslint-disable-next-line no-console
+     
     console.error(`Failed to report event: ${type}`, e);
   }
 }

--- a/src/scenes/debugTransform.ts
+++ b/src/scenes/debugTransform.ts
@@ -10,7 +10,7 @@ import { map } from 'rxjs/operators';
 export const debugTransform: CustomTransformOperator = () => (source: Observable<DataFrame[]>) => {
   return source.pipe(
     map((data: DataFrame[]) => {
-      // eslint-disable-next-line no-console
+       
       console.log(data);
       return data;
     })

--- a/src/test/handlers/index.ts
+++ b/src/test/handlers/index.ts
@@ -94,7 +94,7 @@ export function getServerRequests() {
     try {
       body = await request?.json();
     } catch (e) {
-      // eslint-disable-next-line no-console
+       
       console.error(e);
     }
 

--- a/src/test/silenceErrors.ts
+++ b/src/test/silenceErrors.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 const originalConsoleError = console.error;
 
 const ignoreErrorsList = [


### PR DESCRIPTION
Fixing the lint warnings that are generated since we added back allowing `console.log` (as for production they are stripped out).