### PR TITLE
fix: validation logic for DNS targets and add appropriate tests

### DIFF
--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -21,6 +21,7 @@ describe('http', () => {
     expect(validateHttpTarget('https://hostname/')).toEqual('Target must have a valid hostname');
     expect(validateHttpTarget('https://suraj/dev')).toEqual('Target must have a valid hostname');
   });
+
   it('should reject URLs without schema', () => {
     const testcases: string[] = ['example.org'];
     testcases.forEach((testcase: string) => {
@@ -133,7 +134,7 @@ describe('DNS', () => {
 
   it('should reject dns targets with invalid characters', async () => {
     expect(validateDomain('x=y.org')).toBe(
-      'Invalid character in domain name. Only letters, numbers and "-" are allowed'
+      'Invalid character in domain name. Only letters, numbers, underscores and "-" are allowed'
     );
   });
 
@@ -151,6 +152,23 @@ describe('DNS', () => {
 
   it('should accept valid hostnames', () => {
     expect(validateDomain('grafana.com')).toBe(undefined);
+  });
+
+  it(`should accept valid hostnames that start with an underscore`, () => {
+    expect(validateDomain('hello._grafana.com')).toBe(undefined);
+  });
+
+  it(`should reject hostnames that end or start with a hyphen`, () => {
+    expect(validateDomain('-hello.com')).toBe('A domain element must begin with a letter, number or underscore');
+    expect(validateDomain('hello-.com')).toBe('A domain element must end with a letter, number or underscore');
+  });
+
+  it(`should accept hostnames that contain hyphens`, () => {
+    expect(validateDomain('hello-world.com')).toBe(undefined);
+  });
+
+  it(`should accept hostnames that contain underscores`, () => {
+    expect(validateDomain('hello_world.com')).toBe(undefined);
   });
 });
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -183,7 +183,7 @@ function isCharacterLetter(character: string): boolean {
 }
 
 function isValidDomainCharacter(character: string): boolean {
-  const regex = new RegExp(/[-A-Za-z0-9.]/);
+  const regex = new RegExp(/^[A-Za-z0-9_-]+$/);
   return Boolean(!character.match(regex)?.length);
 }
 
@@ -199,12 +199,12 @@ function validateDomainElement(element: string, isLast: boolean): string | undef
 
   const first = element[0];
   const last = element[element.length - 1];
-  if (!isCharacterLetter(first) && !isCharacterNumber(first)) {
-    return 'A domain element must begin with a letter or number';
+  if (!isCharacterLetter(first) && !isCharacterNumber(first) && first !== '_') {
+    return 'A domain element must begin with a letter, number or underscore';
   }
 
-  if (!isCharacterNumber(last) && !isCharacterLetter(last)) {
-    return 'A domain element must end with a letter or number';
+  if (!isCharacterNumber(last) && !isCharacterLetter(last) && last !== '_') {
+    return 'A domain element must end with a letter, number or underscore';
   }
 
   if (isLast) {
@@ -216,7 +216,7 @@ function validateDomainElement(element: string, isLast: boolean): string | undef
 
   const hasInvalidCharacter = element.split('').some((character) => isValidDomainCharacter(character));
   if (hasInvalidCharacter) {
-    return 'Invalid character in domain name. Only letters, numbers and "-" are allowed';
+    return 'Invalid character in domain name. Only letters, numbers, underscores and "-" are allowed';
   }
 
   return undefined;


### PR DESCRIPTION
Closes: https://github.com/grafana/synthetic-monitoring-app/issues/1182

## Problem

Our DNS validation logic didn't take into account a few peculiarities for DNS domain names. This includes allowing underscores as the starting or final character in part of the domain element.

## Solution

Expand our validation logic so it allows underscores.