### PR TITLE
fix: include body and headers in HTTP check Terraform export

### DIFF
--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -60,6 +60,8 @@ const settingsToTF = (check: Check): TFCheckSettings => {
     return {
       http: {
         method: check.settings.http.method,
+        body: check.settings.http.body,
+        headers: check.settings.http.headers,
         compression: check.settings.http.compression,
         basic_auth: check.settings.http.basicAuth,
         bearer_token: check.settings.http.bearerToken,


### PR DESCRIPTION
HTTP checks with request body and/or custom headers were missing these fields in the exported Terraform configuration, preventing accurate roundtrip provisioning.

- Add missing body and headers fields to settingsToTF function
- Add regression test to verify body and headers are included in export

Fixes [#17216](https://github.com/grafana/support-escalations/issues/17216)
Closes https://github.com/grafana/synthetic-monitoring-app/issues/1181