### PR TITLE
fix: prevent loading errorRateMap when data has not finished loading

### DIFF
--- a/src/scenes/HTTP/ErrorRateMap.tsx
+++ b/src/scenes/HTTP/ErrorRateMap.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { LoadingState } from '@grafana/data';
 import { VizConfigBuilders } from '@grafana/scenes';
 import { useDataTransformer, useQueryRunner, useTimeRange, VizPanel } from '@grafana/scenes-react';
@@ -11,6 +11,7 @@ import { useVizPanelMenu } from './useVizPanelMenu';
 
 export const ErrorRateMap = ({ minStep }: { minStep: string }) => {
   const metricsDS = useMetricsDS();
+  const [hasLoaded, setHasLoaded] = useState(false);
 
   function getErrorMapQueries(minStep: string) {
     return [
@@ -160,6 +161,14 @@ export const ErrorRateMap = ({ minStep }: { minStep: string }) => {
     data: dataProvider,
   });
 
+  const data = dataProvider.useState();
+
+  useEffect(() => {
+    if (data?.data?.state === LoadingState.Done && !hasLoaded) {
+      setHasLoaded(true);
+    }
+  }, [data, hasLoaded]);
+
   const viz = VizConfigBuilders.geomap()
     .setUnit('percentunit')
     .setOption('basemap', {
@@ -249,7 +258,6 @@ export const ErrorRateMap = ({ minStep }: { minStep: string }) => {
     })
     .build();
 
-  const data = dataProvider.useState();
   const [currentTimeRange] = useTimeRange();
 
   const menu = useVizPanelMenu({
@@ -259,7 +267,7 @@ export const ErrorRateMap = ({ minStep }: { minStep: string }) => {
     variables: ['job', 'probe', 'instance'],
   });
 
-  if (data?.data?.state === LoadingState.Loading) {
+  if (!hasLoaded) {
     return <LoadingPlaceholder text="Loading..." />;
   }
 

--- a/src/scenes/HTTP/ErrorRateMap.tsx
+++ b/src/scenes/HTTP/ErrorRateMap.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { LoadingState } from '@grafana/data';
 import { VizConfigBuilders } from '@grafana/scenes';
 import { useDataTransformer, useQueryRunner, useTimeRange, VizPanel } from '@grafana/scenes-react';
 import { FrameGeometrySourceMode, ThresholdsMode } from '@grafana/schema';
@@ -259,7 +260,7 @@ export const ErrorRateMap = ({ minStep }: { minStep: string }) => {
     variables: ['job', 'probe', 'instance'],
   });
 
-  if (!dataTransformer.isDataReadyToDisplay()) {
+  if (!dataTransformer.isDataReadyToDisplay() || data?.data?.state !== LoadingState.Done) {
     return <LoadingPlaceholder text="Loading..." />;
   }
 

--- a/src/scenes/HTTP/ErrorRateMap.tsx
+++ b/src/scenes/HTTP/ErrorRateMap.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import { LoadingState } from '@grafana/data';
+import React from 'react';
 import { VizConfigBuilders } from '@grafana/scenes';
 import { useDataTransformer, useQueryRunner, useTimeRange, VizPanel } from '@grafana/scenes-react';
 import { FrameGeometrySourceMode, ThresholdsMode } from '@grafana/schema';
@@ -11,7 +10,6 @@ import { useVizPanelMenu } from './useVizPanelMenu';
 
 export const ErrorRateMap = ({ minStep }: { minStep: string }) => {
   const metricsDS = useMetricsDS();
-  const [hasLoaded, setHasLoaded] = useState(false);
 
   function getErrorMapQueries(minStep: string) {
     return [
@@ -163,12 +161,6 @@ export const ErrorRateMap = ({ minStep }: { minStep: string }) => {
 
   const data = dataProvider.useState();
 
-  useEffect(() => {
-    if (data?.data?.state === LoadingState.Done && !hasLoaded) {
-      setHasLoaded(true);
-    }
-  }, [data, hasLoaded]);
-
   const viz = VizConfigBuilders.geomap()
     .setUnit('percentunit')
     .setOption('basemap', {
@@ -267,7 +259,7 @@ export const ErrorRateMap = ({ minStep }: { minStep: string }) => {
     variables: ['job', 'probe', 'instance'],
   });
 
-  if (!hasLoaded) {
+  if (!dataTransformer.isDataReadyToDisplay()) {
     return <LoadingPlaceholder text="Loading..." />;
   }
 


### PR DESCRIPTION
## Problem Description

The ErrorRateMap component sometimes throws this error on first load, as reported in [Slack](https://raintank-corp.slack.com/archives/C0162C1K9E1/p1752663586695719):

```
TypeError: Cannot read properties of undefined (reading 'setActive')
  at GeomapPanel.tsx:367:25
 // at this.mouseWheelZoom!.setActive(Boolean(options.mouseWheelZoom));
```

<img width="2173" height="941" alt="image" src="https://github.com/user-attachments/assets/4be2b2ea-fcd7-4fe4-98d2-e23f5b2140b1" />


This typically happens on the first page load and goes away after refresh.

## Root Cause

The issue is a race condition where the geomap panel tries to initialize before the data queries complete and the expected data structure is available. The geomap attempts to call `setActive()` on undefined objects during its internal initialization.

## Fix Applied

1. **Loading state tracking** - Added `hasLoaded` state variable to track if data has loaded successfully at least once
2. **Prevent early rendering** - Only renders the geomap after data has loaded successfully 
3. **Consistent pattern** - Uses the same approach as other components like `AssertionsTable` (PR #666)

## How to reproduce

The issue can be reproduced by loading a HTTP dashboard with slow network settings (4g throttling did it for me), or forcing a delay locally after the `dataProvider` creation in `ErrorRateMap`: 
```
  useEffect(() => {
    // Force race condition by rendering the geomap before data is ready
    const timer = setTimeout(() => {
      console.log('Force error timer complete - allowing normal rendering');
    }, 5000);
    
    return () => clearTimeout(timer);
  }, []);
  ```
  
  which will output the error:
<img width="2477" height="860" alt="image" src="https://github.com/user-attachments/assets/e5959c11-3949-4f2e-b766-f14dc8c98875" />


With the fix, this doesn't happen anymore:

<img width="1527" height="681" alt="image" src="https://github.com/user-attachments/assets/cc1f5125-93d6-4d77-8b78-7ec442732262" />




