### PR TITLE
fix: use secret name, not UUID, to interact with the API

### DIFF
--- a/src/data/useSecrets.ts
+++ b/src/data/useSecrets.ts
@@ -14,7 +14,7 @@ export interface SecretsResponse {
 
 export const queryKeys = {
   list: ['secrets'],
-  byId: (id: string) => ['secrets', id],
+  byName: (name: string) => ['secrets', name],
 };
 
 function secretsQuery(api: SMDataSource) {
@@ -40,17 +40,17 @@ export function useSecrets() {
 }
 
 /**
- * Hook to fetch a secret by id
- * @param {number} id
+ * Hook to fetch a secret by name
+ * @param {string} name
  * @throws {Error} If the query fails - Use ErrorBoundary to catch errors
  */
-export function useSecret(id?: string) {
+export function useSecret(name?: string) {
   const smDS = useSMDS();
 
   return useQuery<SecretWithMetadata, unknown, SecretWithMetadata>({
-    queryKey: queryKeys.byId(id!),
-    queryFn: () => smDS.getSecret(id!),
-    enabled: !!id && id !== SECRETS_EDIT_MODE_ADD,
+    queryKey: queryKeys.byName(name!),
+    queryFn: () => smDS.getSecret(name!),
+    enabled: !!name && name !== SECRETS_EDIT_MODE_ADD,
   });
 }
 
@@ -67,7 +67,7 @@ export function useSaveSecret() {
     },
     onSuccess: async (_data, secret) => {
       const { name, ...updatedData } = secret; // name cannot be changed
-      await queryClient.setQueryData(queryKeys.byId(secret.uuid!), updatedData);
+      await queryClient.setQueryData(queryKeys.byName(secret.name!), updatedData);
       await queryClient.invalidateQueries({ queryKey: queryKeys.list });
     },
   });
@@ -81,7 +81,7 @@ export function useDeleteSecret() {
   const smDS = useSMDS();
 
   return useMutation<unknown, unknown, string>({
-    mutationFn: (id) => smDS.deleteSecret(id),
+    mutationFn: (name) => smDS.deleteSecret(name),
     onSuccess: async (_data) => {
       await queryClient.invalidateQueries({ queryKey: queryKeys.list });
     },

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -431,15 +431,15 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
     });
   }
 
-  async getSecret(id: string | number): Promise<SecretWithMetadata> {
-    return this.fetchAPI<SecretWithMetadata>(`${this.instanceSettings.url}/api/v1alpha1/secrets/${id}`, {
+  async getSecret(name: string): Promise<SecretWithMetadata> {
+    return this.fetchAPI<SecretWithMetadata>(`${this.instanceSettings.url}/api/v1alpha1/secrets/${name}`, {
       method: 'GET',
     });
   }
 
   async saveSecret(secret: SecretFormValues & { uuid?: string }): Promise<SecretWithMetadata> {
     if (secret.uuid) {
-      return this.fetchAPI<SecretWithMetadata>(`${this.instanceSettings.url}/api/v1alpha1/secrets/${secret.uuid}`, {
+      return this.fetchAPI<SecretWithMetadata>(`${this.instanceSettings.url}/api/v1alpha1/secrets/${secret.name}`, {
         method: 'PUT',
         data: secret,
       });
@@ -450,8 +450,8 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
     });
   }
 
-  async deleteSecret(id: string | number): Promise<unknown> {
-    return this.fetchAPI<SecretWithMetadata>(`${this.instanceSettings.url}/api/v1alpha1/secrets/${id}`, {
+  async deleteSecret(name: string): Promise<unknown> {
+    return this.fetchAPI<SecretWithMetadata>(`${this.instanceSettings.url}/api/v1alpha1/secrets/${name}`, {
       method: 'DELETE',
     });
   }

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.test.tsx
@@ -53,7 +53,7 @@ describe('SecretCard', () => {
     const user = userEvent.setup();
     await user.click(editButton);
 
-    expect(defaultProps.onEdit).toHaveBeenCalledWith(MOCKED_SECRETS[0].uuid);
+    expect(defaultProps.onEdit).toHaveBeenCalledWith(MOCKED_SECRETS[0].name);
   });
 
   it('should call onDelete when delete button is clicked', async () => {
@@ -63,7 +63,7 @@ describe('SecretCard', () => {
     const user = userEvent.setup();
     await user.click(deleteButton);
 
-    expect(defaultProps.onDelete).toHaveBeenCalledWith(MOCKED_SECRETS[0].uuid);
+    expect(defaultProps.onDelete).toHaveBeenCalledWith(MOCKED_SECRETS[0].name);
   });
 
   it('should render without labels when none are provided', () => {

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.tsx
@@ -8,18 +8,18 @@ import { formatDate } from 'utils';
 
 interface SecretCardProps {
   secret: SecretWithMetadata;
-  onEdit: (id?: SecretWithMetadata['uuid']) => void;
-  onDelete: (id: SecretWithMetadata['uuid']) => void;
+  onEdit: (name?: SecretWithMetadata['name']) => void;
+  onDelete: (name: SecretWithMetadata['name']) => void;
 }
 
 export function SecretCard({ secret, onEdit, onDelete }: SecretCardProps) {
   const styles = useStyles2(getStyles);
   const handleEdit = () => {
-    onEdit(secret.uuid);
+    onEdit(secret.name);
   };
 
   const handleDelete = () => {
-    onDelete(secret.uuid);
+    onDelete(secret.name);
   };
 
   return (

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.test.tsx
@@ -21,7 +21,7 @@ async function render(element: React.ReactElement) {
 
 describe('SecretEditModal', () => {
   const defaultProps = {
-    id: SECRETS_EDIT_MODE_ADD,
+    name: SECRETS_EDIT_MODE_ADD,
     onDismiss: jest.fn(),
     open: true,
   };
@@ -42,7 +42,7 @@ describe('SecretEditModal', () => {
 
   it('should render edit secret form for existing secret', async () => {
     const [secret1] = MOCKED_SECRETS_API_RESPONSE.secrets; // getSecret returns first secret, this must be the same as secret1
-    await render(<SecretEditModal {...defaultProps} id={secret1.uuid} />);
+    await render(<SecretEditModal {...defaultProps} name={secret1.name} />);
 
     expect(screen.getByText('Edit secret')).toBeInTheDocument();
     await waitFor(() => expect(screen.getByDisplayValue(secret1.description)).toBeInTheDocument(), { timeout: 3000 });
@@ -85,7 +85,7 @@ describe('SecretEditModal', () => {
     );
 
     const [secret1] = MOCKED_SECRETS_API_RESPONSE.secrets; // getSecret returns first secret, this must be the same as secret1
-    await render(<SecretEditModal {...defaultProps} id={secret1.uuid} />);
+    await render(<SecretEditModal {...defaultProps} name={secret1.name} />);
 
     expect(screen.getByText('Unable to fetch secret')).toBeInTheDocument();
     expect(screen.getByText(/request failed with status code 500/i)).toBeInTheDocument();
@@ -202,7 +202,7 @@ describe('SecretEditModal', () => {
 
     const { record, read } = getServerRequests();
     server.use(apiRoute('updateSecret', {}, record));
-    await render(<SecretEditModal {...defaultProps} id={secretMock.uuid} />);
+    await render(<SecretEditModal {...defaultProps} name={secretMock.name} />);
 
     await userEvent.type(screen.getByLabelText(/Name/), inputValues.name); // Should be transformed to 'new-secret'
     await userEvent.type(screen.getByLabelText(/Description/), inputValues.description);
@@ -228,7 +228,7 @@ describe('SecretEditModal', () => {
     };
     const { record, read } = getServerRequests();
     server.use(apiRoute('updateSecret', {}, record));
-    await render(<SecretEditModal {...defaultProps} id={secretMock.uuid} />);
+    await render(<SecretEditModal {...defaultProps} name={secretMock.name} />);
 
     expect(screen.getByLabelText(/Name/)).toBeDisabled();
 
@@ -245,7 +245,7 @@ describe('SecretEditModal', () => {
     const { record, read } = getServerRequests();
     server.use(apiRoute('updateSecret', {}, record));
     const secretMock = MOCKED_SECRETS_API_RESPONSE.secrets[0];
-    await render(<SecretEditModal {...defaultProps} id={secretMock.uuid} />);
+    await render(<SecretEditModal {...defaultProps} name={secretMock.name} />);
 
     const valueInput = screen.getByLabelText(/value/i);
     expect(valueInput).toBeDisabled();
@@ -263,7 +263,7 @@ describe('SecretEditModal', () => {
     const { record, read } = getServerRequests();
     server.use(apiRoute('updateSecret', {}, record));
     const secretMock = MOCKED_SECRETS_API_RESPONSE.secrets[0];
-    await render(<SecretEditModal {...defaultProps} id={secretMock.uuid} />);
+    await render(<SecretEditModal {...defaultProps} name={secretMock.name} />);
 
     await userEvent.click(screen.getByRole('button', { name: 'Reset' }));
     await userEvent.type(screen.getByLabelText(/value/i), newSecretValue);

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.tsx
@@ -14,7 +14,7 @@ import { secretSchemaFactory } from './secretSchema';
 import { SecretFormValues, secretToFormValues } from './SecretsManagementTab.utils';
 
 interface SecretEditModalProps {
-  id: string;
+  name: string;
   onDismiss: () => void;
   open?: boolean;
   existingNames?: string[];
@@ -72,11 +72,11 @@ function getErrorMessage(error: unknown): string {
   return 'An unknown error occurred';
 }
 
-export function SecretEditModal({ open, id, onDismiss, existingNames = [] }: SecretEditModalProps) {
-  const { data: secret, isLoading, isError: hasFetchError, error: fetchError } = useSecret(id);
+export function SecretEditModal({ open, name, onDismiss, existingNames = [] }: SecretEditModalProps) {
+  const { data: secret, isLoading, isError: hasFetchError, error: fetchError } = useSecret(name);
   const saveSecret = useSaveSecret();
-  const isNewSecret = id === SECRETS_EDIT_MODE_ADD;
-  const [isConfigured, setIsConfigured] = useState(id !== '' && !isNewSecret);
+  const isNewSecret = name === SECRETS_EDIT_MODE_ADD;
+  const [isConfigured, setIsConfigured] = useState(name !== '' && !isNewSecret);
   const [saveError, setSaveError] = useState<unknown>(null);
   const hasError = hasFetchError || !!saveError;
   const styles = useStyles2(getStyles);
@@ -157,7 +157,7 @@ export function SecretEditModal({ open, id, onDismiss, existingNames = [] }: Sec
       <form onSubmit={handleSubmit(onSubmit)}>
         {hasError && (
           <Alert title={`Unable to ${hasFetchError ? 'fetch' : 'save'} secret`} severity="error">
-            An error occurred while trying to {hasFetchError ? <>fetch secret (id: {id})</> : <>save secret</>}. If the
+            An error occurred while trying to {hasFetchError ? <>fetch secret (name: {name})</> : <>save secret</>}. If the
             problem persists, seek help from an admin or{' '}
             <TextLink href="https://grafana.com/contact" external>
               contact support

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.test.tsx
@@ -10,14 +10,14 @@ import { SecretsManagementTab } from './SecretsManagementTab';
 import { SecretsManagementUI } from './SecretsManagementUI';
 
 jest.mock('./SecretEditModal', () => ({
-  SecretEditModal: ({ onDismiss, open, id }: { onDismiss?: () => void; id: string; open?: boolean }) => {
+  SecretEditModal: ({ onDismiss, open, name }: { onDismiss?: () => void; name: string; open?: boolean }) => {
     if (!open) {
       return null;
     }
 
     return (
       <div role="dialog" aria-label="Create secret">
-        <span data-testid="modal-id">{id}</span>
+        <span data-testid="modal-id">{name}</span>
         <button onClick={onDismiss}>Close</button>
       </div>
     );
@@ -99,7 +99,7 @@ describe('SecretsManagementUI', () => {
     render(<SecretsManagementTab />);
     const editButton = screen.getAllByRole('button', { name: /edit/i })[0];
     await userEvent.click(editButton);
-    expect(screen.getByTestId('modal-id')).toHaveTextContent(MOCKED_SECRETS[0].uuid);
+    expect(screen.getByTestId('modal-id')).toHaveTextContent(MOCKED_SECRETS[0].name);
   });
 
   it('should open delete secret modal', async () => {

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
@@ -24,12 +24,12 @@ export function SecretsManagementUI() {
     setEditMode(SECRETS_EDIT_MODE_ADD);
   };
 
-  const handleEditSecret = (id?: string) => {
-    setEditMode(id ?? false);
+  const handleEditSecret = (name?: string) => {
+    setEditMode(name ?? false);
   };
 
-  const handleDeleteSecret = (id: string) => {
-    const secret = secrets?.find((s) => s.uuid === id);
+  const handleDeleteSecret = (name: string) => {
+    const secret = secrets?.find((s) => s.name === name);
     if (secret) {
       setDeleteMode(secret);
     }
@@ -81,7 +81,7 @@ export function SecretsManagementUI() {
       )}
 
       {editMode && (
-        <SecretEditModal id={editMode} existingNames={existingNames} open onDismiss={() => handleEditSecret()} />
+        <SecretEditModal name={editMode} existingNames={existingNames} open onDismiss={() => handleEditSecret()} />
       )}
 
       <ConfirmModal
@@ -101,7 +101,7 @@ export function SecretsManagementUI() {
           </div>
         }
         onConfirm={() => {
-          deleteMode && deleteSecret.mutate(deleteMode.uuid);
+          deleteMode && deleteSecret.mutate(deleteMode.name);
           setDeleteMode(undefined);
         }}
         onDismiss={() => setDeleteMode(undefined)}

--- a/src/test/handlers/index.ts
+++ b/src/test/handlers/index.ts
@@ -11,7 +11,7 @@ import { createAccessToken } from 'test/handlers/tokens';
 import { ApiEntry, RequestRes } from 'test/handlers/types';
 
 import { listAlertsForCheck, updateAlertsForCheck } from './alerts';
-import { createSecret, getSecret, listSecrets, updateSecret } from './secrets';
+import { createSecret, deleteSecret, getSecret, listSecrets, updateSecret } from './secrets';
 
 const apiRoutes = {
   addCheck,
@@ -42,6 +42,7 @@ const apiRoutes = {
   getSecret,
   createSecret,
   updateSecret,
+  deleteSecret,
 };
 
 export type ApiRoutes = typeof apiRoutes;
@@ -74,7 +75,9 @@ export function apiRoute<K extends keyof ApiRoutes>(
 }
 
 function toRestMethod({ route, method, result }: ApiEntry) {
-  const urlPattern = new RegExp(`^http://localhost.*${route}$`);
+  // Convert route patterns like /api/v1alpha1/secrets/:name to regex patterns
+  const patternRoute = route.replace(/:[^/]+/g, '[^/]+');
+  const urlPattern = new RegExp(`^http://localhost.*${patternRoute}$`);
 
   return rest[method](urlPattern, async (req, res, ctx) => {
     const { status = 200, json } = await result(req);

--- a/src/test/handlers/secrets.ts
+++ b/src/test/handlers/secrets.ts
@@ -44,7 +44,7 @@ export const listSecrets: ApiEntry<SecretsResponse> = {
  * - `result`: A function representing the response handler, returning a mock JSON payload containing the secret data.
  */
 export const getSecret: ApiEntry<SecretWithMetadata> = {
-  route: `/api/v1alpha1/secrets/${MOCKED_SECRETS_API_RESPONSE.secrets[0].uuid}`,
+  route: `/api/v1alpha1/secrets/:name`,
   method: `get`,
   result: () => {
     return {
@@ -84,8 +84,28 @@ export const createSecret: ApiEntry<SecretFormValues> = {
  * - `result`: A function that returns the expected result of the API call, which is a JSON response with a value of `null`.
  */
 export const updateSecret: ApiEntry<SecretFormValues> = {
-  route: `/api/v1alpha1/secrets/${MOCKED_SECRETS_API_RESPONSE.secrets[0].uuid}`,
+  route: `/api/v1alpha1/secrets/:name`,
   method: `put`,
+  result: () => {
+    return {
+      json: null,
+    };
+  },
+};
+
+/**
+ * Represents the API endpoint for deleting a secret.
+ *
+ * This configuration includes the API route, HTTP method, and the expected result.
+ *
+ * Properties:
+ * - `route`: The API endpoint for deleting a secret.
+ * - `method`: The HTTP method used for the request, which is "delete" in this case.
+ * - `result`: A function that returns the expected result of the API call, which is a JSON response with a value of `null`.
+ */
+export const deleteSecret: ApiEntry<unknown> = {
+  route: `/api/v1alpha1/secrets/:name`,
+  method: `delete`,
   result: () => {
     return {
       json: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,69 +1444,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@octokit/app@^14.0.2":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/app/-/app-14.1.0.tgz#2d491dc70746773b83f61edf5c56817dd7d3854b"
-  integrity sha512-g3uEsGOQCBl1+W1rgfwoRFUIR6PtvB2T1E4RpygeUU5LrLvlOqcxrt5lfykIeRpUPpupreGJUYl70fqMDXdTpw==
-  dependencies:
-    "@octokit/auth-app" "^6.0.0"
-    "@octokit/auth-unauthenticated" "^5.0.0"
-    "@octokit/core" "^5.0.0"
-    "@octokit/oauth-app" "^6.0.0"
-    "@octokit/plugin-paginate-rest" "^9.0.0"
-    "@octokit/types" "^12.0.0"
-    "@octokit/webhooks" "^12.0.4"
-
-"@octokit/auth-app@^6.0.0":
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-app/-/auth-app-6.1.3.tgz#68372159aa7b3c80d0c2319f96e1d93e2e5614d2"
-  integrity sha512-dcaiteA6Y/beAlDLZOPNReN3FGHu+pARD6OHfh3T9f3EO09++ec+5wt3KtGGSSs2Mp5tI8fQwdMOEnrzBLfgUA==
-  dependencies:
-    "@octokit/auth-oauth-app" "^7.1.0"
-    "@octokit/auth-oauth-user" "^4.1.0"
-    "@octokit/request" "^8.3.1"
-    "@octokit/request-error" "^5.1.0"
-    "@octokit/types" "^13.1.0"
-    deprecation "^2.3.1"
-    lru-cache "npm:@wolfy1339/lru-cache@^11.0.2-patch.1"
-    universal-github-app-jwt "^1.1.2"
-    universal-user-agent "^6.0.0"
-
-"@octokit/auth-oauth-app@^7.0.0", "@octokit/auth-oauth-app@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-app/-/auth-oauth-app-7.1.0.tgz#d0f74e19ebd5a4829cb780c107cedd6c894f20fc"
-  integrity sha512-w+SyJN/b0l/HEb4EOPRudo7uUOSW51jcK1jwLa+4r7PA8FPFpoxEnHBHMITqCsc/3Vo2qqFjgQfz/xUUvsSQnA==
-  dependencies:
-    "@octokit/auth-oauth-device" "^6.1.0"
-    "@octokit/auth-oauth-user" "^4.1.0"
-    "@octokit/request" "^8.3.1"
-    "@octokit/types" "^13.0.0"
-    "@types/btoa-lite" "^1.0.0"
-    btoa-lite "^1.0.0"
-    universal-user-agent "^6.0.0"
-
-"@octokit/auth-oauth-device@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-device/-/auth-oauth-device-6.1.0.tgz#f868213a3db05fe27e68d1fc607502a322379dd9"
-  integrity sha512-FNQ7cb8kASufd6Ej4gnJ3f1QB5vJitkoV1O0/g6e6lUsQ7+VsSNRHRmFScN2tV4IgKA12frrr/cegUs0t+0/Lw==
-  dependencies:
-    "@octokit/oauth-methods" "^4.1.0"
-    "@octokit/request" "^8.3.1"
-    "@octokit/types" "^13.0.0"
-    universal-user-agent "^6.0.0"
-
-"@octokit/auth-oauth-user@^4.0.0", "@octokit/auth-oauth-user@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-user/-/auth-oauth-user-4.1.0.tgz#32e5529f8bd961af9839a1f8c6ab0c8ad2184eee"
-  integrity sha512-FrEp8mtFuS/BrJyjpur+4GARteUCrPeR/tZJzD8YourzoVhRics7u7we/aDcKv+yywRNwNi/P4fRi631rG/OyQ==
-  dependencies:
-    "@octokit/auth-oauth-device" "^6.1.0"
-    "@octokit/oauth-methods" "^4.1.0"
-    "@octokit/request" "^8.3.1"
-    "@octokit/types" "^13.0.0"
-    btoa-lite "^1.0.0"
-    universal-user-agent "^6.0.0"
-
 "@octokit/auth-token@^2.4.4":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.5.0.tgz#27c37ea26c205f28443402477ffd261311f21e36"
@@ -1514,23 +1451,10 @@
   dependencies:
     "@octokit/types" "^6.0.3"
 
-"@octokit/auth-token@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-4.0.0.tgz#40d203ea827b9f17f42a29c6afb93b7745ef80c7"
-  integrity sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==
-
 "@octokit/auth-token@^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-5.1.2.tgz#68a486714d7a7fd1df56cb9bc89a860a0de866de"
   integrity sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==
-
-"@octokit/auth-unauthenticated@^5.0.0":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz#d8032211728333068b2e07b53997c29e59a03507"
-  integrity sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==
-  dependencies:
-    "@octokit/request-error" "^5.0.0"
-    "@octokit/types" "^12.0.0"
 
 "@octokit/core@^3.5.1":
   version "3.6.0"
@@ -1542,19 +1466,6 @@
     "@octokit/request" "^5.6.3"
     "@octokit/request-error" "^2.0.5"
     "@octokit/types" "^6.0.3"
-    before-after-hook "^2.2.0"
-    universal-user-agent "^6.0.0"
-
-"@octokit/core@^5.0.0":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-5.2.1.tgz#58c21a5f689ee81e0b883b5aa77573a7ff1b4ea1"
-  integrity sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==
-  dependencies:
-    "@octokit/auth-token" "^4.0.0"
-    "@octokit/graphql" "^7.1.0"
-    "@octokit/request" "^8.4.1"
-    "@octokit/request-error" "^5.1.1"
-    "@octokit/types" "^13.0.0"
     before-after-hook "^2.2.0"
     universal-user-agent "^6.0.0"
 
@@ -1588,14 +1499,6 @@
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/endpoint@^9.0.6":
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-9.0.6.tgz#114d912108fe692d8b139cfe7fc0846dfd11b6c0"
-  integrity sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==
-  dependencies:
-    "@octokit/types" "^13.1.0"
-    universal-user-agent "^6.0.0"
-
 "@octokit/graphql@^4.5.8":
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
@@ -1603,15 +1506,6 @@
   dependencies:
     "@octokit/request" "^5.6.0"
     "@octokit/types" "^6.0.3"
-    universal-user-agent "^6.0.0"
-
-"@octokit/graphql@^7.1.0":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-7.1.1.tgz#79d9f3d0c96a8fd13d64186fe5c33606d48b79cc"
-  integrity sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==
-  dependencies:
-    "@octokit/request" "^8.4.1"
-    "@octokit/types" "^13.0.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/graphql@^8.2.2":
@@ -1623,45 +1517,10 @@
     "@octokit/types" "^14.0.0"
     universal-user-agent "^7.0.0"
 
-"@octokit/oauth-app@^6.0.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/oauth-app/-/oauth-app-6.1.0.tgz#22c276f6ad2364c6999837bfdd5d9c1092838726"
-  integrity sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==
-  dependencies:
-    "@octokit/auth-oauth-app" "^7.0.0"
-    "@octokit/auth-oauth-user" "^4.0.0"
-    "@octokit/auth-unauthenticated" "^5.0.0"
-    "@octokit/core" "^5.0.0"
-    "@octokit/oauth-authorization-url" "^6.0.2"
-    "@octokit/oauth-methods" "^4.0.0"
-    "@types/aws-lambda" "^8.10.83"
-    universal-user-agent "^6.0.0"
-
-"@octokit/oauth-authorization-url@^6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz#cc82ca29cc5e339c9921672f39f2b3f5c8eb6ef2"
-  integrity sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==
-
-"@octokit/oauth-methods@^4.0.0", "@octokit/oauth-methods@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/oauth-methods/-/oauth-methods-4.1.0.tgz#1403ac9c4d4e277922fddc4c89fa8a782f8f791b"
-  integrity sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw==
-  dependencies:
-    "@octokit/oauth-authorization-url" "^6.0.2"
-    "@octokit/request" "^8.3.1"
-    "@octokit/request-error" "^5.1.0"
-    "@octokit/types" "^13.0.0"
-    btoa-lite "^1.0.0"
-
 "@octokit/openapi-types@^12.11.0":
   version "12.11.0"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-12.11.0.tgz#da5638d64f2b919bca89ce6602d059f1b52d3ef0"
   integrity sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==
-
-"@octokit/openapi-types@^20.0.0":
-  version "20.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-20.0.0.tgz#9ec2daa0090eeb865ee147636e0c00f73790c6e5"
-  integrity sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==
 
 "@octokit/openapi-types@^24.2.0":
   version "24.2.0"
@@ -1672,18 +1531,6 @@
   version "25.0.0"
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-25.0.0.tgz#adeead36992abf966e89dcd53518d8b0dc910e0d"
   integrity sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw==
-
-"@octokit/plugin-paginate-graphql@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.1.tgz#9c0b1145b93a2b8635943f497c127969d54512fc"
-  integrity sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==
-
-"@octokit/plugin-paginate-rest@11.3.1":
-  version "11.3.1"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.1.tgz#fe92d04b49f134165d6fbb716e765c2f313ad364"
-  integrity sha512-ryqobs26cLtM1kQxqeZui4v8FeznirUsksiA+RYemMPJ7Micju0WSkv50dBksTuZks9O5cg4wp+t8fZ/cLY56g==
-  dependencies:
-    "@octokit/types" "^13.5.0"
 
 "@octokit/plugin-paginate-rest@^11.4.2":
   version "11.6.0"
@@ -1699,13 +1546,6 @@
   dependencies:
     "@octokit/types" "^6.40.0"
 
-"@octokit/plugin-paginate-rest@^9.0.0":
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz#c516bc498736bcdaa9095b9a1d10d9d0501ae831"
-  integrity sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==
-  dependencies:
-    "@octokit/types" "^12.6.0"
-
 "@octokit/plugin-request-log@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
@@ -1715,13 +1555,6 @@
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz#ccb75d9705de769b2aa82bcd105cc96eb0c00f69"
   integrity sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==
-
-"@octokit/plugin-rest-endpoint-methods@13.2.2":
-  version "13.2.2"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.2.tgz#af8e5dd2cddfea576f92ffaf9cb84659f302a638"
-  integrity sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==
-  dependencies:
-    "@octokit/types" "^13.5.0"
 
 "@octokit/plugin-rest-endpoint-methods@^13.3.0":
   version "13.5.0"
@@ -1738,38 +1571,12 @@
     "@octokit/types" "^6.39.0"
     deprecation "^2.3.1"
 
-"@octokit/plugin-retry@^6.0.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-6.1.0.tgz#cf5b92223246327ca9c7e17262b93ffde028ab0a"
-  integrity sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==
-  dependencies:
-    "@octokit/request-error" "^5.0.0"
-    "@octokit/types" "^13.0.0"
-    bottleneck "^2.15.3"
-
-"@octokit/plugin-throttling@^8.0.0":
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz#9ec3ea2e37b92fac63f06911d0c8141b46dc4941"
-  integrity sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==
-  dependencies:
-    "@octokit/types" "^12.2.0"
-    bottleneck "^2.15.3"
-
 "@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
   integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
   dependencies:
     "@octokit/types" "^6.0.3"
-    deprecation "^2.0.0"
-    once "^1.4.0"
-
-"@octokit/request-error@^5.0.0", "@octokit/request-error@^5.1.0", "@octokit/request-error@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-5.1.1.tgz#b9218f9c1166e68bb4d0c89b638edc62c9334805"
-  integrity sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==
-  dependencies:
-    "@octokit/types" "^13.1.0"
     deprecation "^2.0.0"
     once "^1.4.0"
 
@@ -1790,16 +1597,6 @@
     "@octokit/types" "^6.16.1"
     is-plain-object "^5.0.0"
     node-fetch "^2.6.7"
-    universal-user-agent "^6.0.0"
-
-"@octokit/request@^8.3.1", "@octokit/request@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-8.4.1.tgz#715a015ccf993087977ea4365c44791fc4572486"
-  integrity sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==
-  dependencies:
-    "@octokit/endpoint" "^9.0.6"
-    "@octokit/request-error" "^5.1.1"
-    "@octokit/types" "^13.1.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/request@^9.2.3":
@@ -1833,14 +1630,7 @@
     "@octokit/plugin-request-log" "^1.0.4"
     "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
 
-"@octokit/types@^12.0.0", "@octokit/types@^12.2.0", "@octokit/types@^12.6.0":
-  version "12.6.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-12.6.0.tgz#8100fb9eeedfe083aae66473bd97b15b62aedcb2"
-  integrity sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==
-  dependencies:
-    "@octokit/openapi-types" "^20.0.0"
-
-"@octokit/types@^13.0.0", "@octokit/types@^13.1.0", "@octokit/types@^13.10.0", "@octokit/types@^13.5.0":
+"@octokit/types@^13.10.0":
   version "13.10.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-13.10.0.tgz#3e7c6b19c0236c270656e4ea666148c2b51fd1a3"
   integrity sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==
@@ -1860,26 +1650,6 @@
   integrity sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==
   dependencies:
     "@octokit/openapi-types" "^12.11.0"
-
-"@octokit/webhooks-methods@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz#681a6c86c9b21d4ec9e29108fb053ae7512be033"
-  integrity sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==
-
-"@octokit/webhooks-types@7.6.1":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz#bc96371057c2d54c982c9f8f642655b26cd588eb"
-  integrity sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==
-
-"@octokit/webhooks@^12.0.4":
-  version "12.3.1"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-12.3.1.tgz#fd4de89ccb0560475411503951ce6469488c63a7"
-  integrity sha512-BVwtWE3rRXB9IugmQTfKspqjNa8q+ab73ddkV9k1Zok3XbuOxJUi4lTYk5zBZDhfWb/Y2H+RO9Iggm25gsqeow==
-  dependencies:
-    "@octokit/request-error" "^5.0.0"
-    "@octokit/webhooks-methods" "^4.1.0"
-    "@octokit/webhooks-types" "7.6.1"
-    aggregate-error "^3.1.0"
 
 "@open-draft/until@^1.0.3":
   version "1.0.3"
@@ -2536,11 +2306,6 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
   integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
-"@types/aws-lambda@^8.10.83":
-  version "8.10.149"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.149.tgz#77c7bde809425546d03626e51bab8181bc5d24c9"
-  integrity sha512-NXSZIhfJjnXqJgtS7IwutqIF/SOy1Wz5Px4gUY1RWITp3AYTyuJS4xaXr/bIJY1v15XMzrJ5soGnPM+7uigZjA==
-
 "@types/babel__core@^7.1.14":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -2573,11 +2338,6 @@
   integrity sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==
   dependencies:
     "@babel/types" "^7.20.7"
-
-"@types/btoa-lite@^1.0.0":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@types/btoa-lite/-/btoa-lite-1.0.2.tgz#82bb6aab00abf7cff3ca2825abe010c0cd536ae5"
-  integrity sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==
 
 "@types/cacheable-request@^6.0.1":
   version "6.0.3"
@@ -2772,14 +2532,6 @@
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
-
-"@types/jsonwebtoken@^9.0.0":
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz#a4c3a446c0ebaaf467a58398382616f416345fb3"
-  integrity sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==
-  dependencies:
-    "@types/ms" "*"
-    "@types/node" "*"
 
 "@types/k6@0.57.1":
   version "0.57.1"
@@ -3394,14 +3146,6 @@ agent-base@6, agent-base@^6.0.0, agent-base@^6.0.2:
   dependencies:
     debug "4"
 
-aggregate-error@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
-  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
-  dependencies:
-    clean-stack "^2.0.0"
-    indent-string "^4.0.0"
-
 ajv-formats@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
@@ -3821,11 +3565,6 @@ body@^5.1.0:
     raw-body "~1.1.0"
     safe-json-parse "~1.0.1"
 
-bottleneck@^2.15.3:
-  version "2.19.5"
-  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
-  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
-
 boxen@^5.0.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.1.2.tgz#788cb686fc83c1f486dfa8a40c68fc2b831d2b50"
@@ -3878,11 +3617,6 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
-
-btoa-lite@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
-  integrity sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
@@ -4087,11 +3821,6 @@ classnames@2.5.1, classnames@2.x, classnames@^2.2.1, classnames@^2.2.5, classnam
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
-
-clean-stack@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
-  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 cli-boxes@^2.2.1:
   version "2.2.1"
@@ -8123,7 +7852,7 @@ jsonpointer@^5.0.0:
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.1.tgz#2110e0af0900fd37467b5907ecd13a7884a1b559"
   integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
 
-jsonwebtoken@^9.0.0, jsonwebtoken@^9.0.2:
+jsonwebtoken@^9.0.0:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#65ff91f4abef1784697d40952bb1998c504caaf3"
   integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
@@ -8459,11 +8188,6 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
-
-"lru-cache@npm:@wolfy1339/lru-cache@^11.0.2-patch.1":
-  version "11.0.2-patch.1"
-  resolved "https://registry.yarnpkg.com/@wolfy1339/lru-cache/-/lru-cache-11.0.2-patch.1.tgz#bb648b660478099c9022ee71a00b80603daf7294"
-  integrity sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==
 
 lz-string@^1.5.0:
   version "1.5.0"
@@ -8946,22 +8670,6 @@ object.values@^1.1.6, object.values@^1.2.1:
     call-bound "^1.0.3"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
-
-octokit@^3.1.2:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/octokit/-/octokit-3.2.1.tgz#d376ca3b12a61c58da02a93c491d2e627069b194"
-  integrity sha512-u+XuSejhe3NdIvty3Jod00JvTdAE/0/+XbhIDhefHbu+2OcTRHd80aCiH6TX19ZybJmwPQBKFQmHGxp0i9mJrg==
-  dependencies:
-    "@octokit/app" "^14.0.2"
-    "@octokit/core" "^5.0.0"
-    "@octokit/oauth-app" "^6.0.0"
-    "@octokit/plugin-paginate-graphql" "^4.0.0"
-    "@octokit/plugin-paginate-rest" "11.3.1"
-    "@octokit/plugin-rest-endpoint-methods" "13.2.2"
-    "@octokit/plugin-retry" "^6.0.0"
-    "@octokit/plugin-throttling" "^8.0.0"
-    "@octokit/request-error" "^5.0.0"
-    "@octokit/types" "^13.0.0"
 
 ol-mapbox-style@^10.1.0:
   version "10.7.0"
@@ -11330,16 +11038,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11435,14 +11134,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12042,14 +11734,6 @@ unique-string@^2.0.0:
   dependencies:
     crypto-random-string "^2.0.0"
 
-universal-github-app-jwt@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/universal-github-app-jwt/-/universal-github-app-jwt-1.2.0.tgz#1314cf2b2aff69d7ae998e8bff90d55a651d2949"
-  integrity sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g==
-  dependencies:
-    "@types/jsonwebtoken" "^9.0.0"
-    jsonwebtoken "^9.0.2"
-
 universal-user-agent@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.1.tgz#15f20f55da3c930c57bddbf1734c6654d5fd35aa"
@@ -12556,7 +12240,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12569,15 +12253,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
The API accepts UUIDs, but the downstream service doesn't. Instead of trying to convert on the fly (which is expensive) make the plugin send names.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
