### PR TITLE
fix: github actions staging value passthrough

### DIFF
--- a/.github/workflows/call_deploy-plugin.yml
+++ b/.github/workflows/call_deploy-plugin.yml
@@ -21,7 +21,7 @@ jobs:
   build-sign-zip-upload:
     uses: ./.github/workflows/call_build-sign-upload-plugin.yml
     with:
-      environment: ${{ inputs.environment == 'staging' ||  inputs.environment == 'production' && 'prod' || inputs.environment == 'dev' && 'dev' || inputs.environment }}
+      environment: ${{ (inputs.environment == 'production' || inputs.environment == 'staging') && 'prod' || inputs.environment }}
 
   update-deployment-tools:
     needs: build-sign-zip-upload

--- a/src/components/ProbeSetupModal/ProbeSetupModal.tsx
+++ b/src/components/ProbeSetupModal/ProbeSetupModal.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { Alert, Button, Modal, Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
@@ -73,7 +72,6 @@ const EnvsTable = ({ token }: { token: string }) => {
       pagination={false}
       id="probe-setup-modal-table"
       name="probe-setup-modal-table"
-      config={config}
     />
   );
 };


### PR DESCRIPTION
The Github action to release to staging (ops) needed some parenthesis so it passed the correct value along. [Log with error.](https://github.com/grafana/synthetic-monitoring-app/actions/runs/16565122685/job/46843271217)

Also brought along the lint error fix that made it to `main`.