### PR TITLE
fix: convert secrets management creation date to millis

### DIFF
--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.tsx
@@ -70,7 +70,7 @@ export function SecretCard({ secret, onEdit, onDelete }: SecretCardProps) {
         <strong>Description:</strong> {secret.description}
       </div>
       <div className={styles.keyValue}>
-        <strong>Created:</strong> {formatDate(secret.created_at)} ({secret.created_by})
+        <strong>Created:</strong> {formatDate(secret.created_at * 1000)} ({secret.created_by})
       </div>
       {/* Currently there is no modified_at returned by the API(???) */}
       {/*<div className={styles.keyValue}>*/}


### PR DESCRIPTION
The secrets list is showing created dates in 1970.  This is because the private preview secrets manager backend returned milliseconds since epoch,  but the public preview backend now returns **seconds** since epoch. 

This PR converts back to millis on the frontend

<img width="1233" height="570" alt="image" src="https://github.com/user-attachments/assets/6c2e31c9-387d-4a79-ac07-25786ddd2e63" />
