### PR TITLE
fix: restrict secrets tab usage to admin users

### DIFF
--- a/src/data/permissions.ts
+++ b/src/data/permissions.ts
@@ -53,4 +53,6 @@ export const getUserPermissions = () => ({
   canWritePlugin: isUserActionAllowed('grafana-synthetic-monitoring-app.plugin:write', OrgRole.Admin),
 
   canWriteSM: isUserActionAllowed('grafana-synthetic-monitoring-app:write', OrgRole.Editor),
+
+  isAdmin: hasMinFallbackRole(OrgRole.Admin),
 });

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.test.tsx
@@ -4,13 +4,19 @@ import { DataTestIds } from 'test/dataTestIds';
 import { apiRoute } from 'test/handlers';
 import { render } from 'test/render';
 import { server } from 'test/server';
+import { runTestAsSMAdmin, runTestAsSMEditor, runTestAsViewer } from 'test/utils';
 
 import { SecretsManagementTab } from './SecretsManagementTab';
 
 describe('SecretsManagementTab', () => {
+  const contactAdminMessage = 'Contact an admin: currently only admins are able to add, view, or remove secrets';
+
   it('should render the fallback UI when an error occurs', async () => {
+    runTestAsSMAdmin();
+
     server.use(apiRoute('listSecrets', { result: () => ({ status: 500, body: 'Error message' }) }));
     render(<SecretsManagementTab />);
+
     await waitFor(() => expect(screen.queryByTestId(DataTestIds.CENTERED_SPINNER)).not.toBeInTheDocument(), {
       timeout: 3000,
     });
@@ -18,5 +24,34 @@ describe('SecretsManagementTab', () => {
     expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
     expect(screen.getByText(/An error has occurred/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  test.each([
+    ['viewer', runTestAsViewer],
+    ['editor', runTestAsSMEditor],
+  ])('displays contact admin message for %s users', async (_, setupFunction) => {
+    setupFunction();
+
+    render(<SecretsManagementTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText(contactAdminMessage)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId(DataTestIds.CENTERED_SPINNER)).not.toBeInTheDocument();
+  });
+
+  it('shows secrets management UI for admin users', async () => {
+    runTestAsSMAdmin();
+    server.use(apiRoute('listSecrets', { result: () => ({ status: 200, json: { secrets: [] } }) }));
+
+    render(<SecretsManagementTab />);
+
+    expect(screen.queryByText(contactAdminMessage)).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create secret/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("You don't have any secrets yet.")).toBeInTheDocument();
+    expect(screen.getByText(/You can use secrets to store private information/)).toBeInTheDocument();
   });
 });

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
 
+import { getUserPermissions } from 'data/permissions';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
+import { ContactAdminAlert } from 'page/ContactAdminAlert';
 
 import { SecretsManagementUI } from './SecretsManagementUI';
 
 export function SecretsManagementTab() {
+  const { isAdmin } = getUserPermissions();
+
+  if (!isAdmin) {
+    return (
+      <ContactAdminAlert 
+        title="Contact an admin: currently only admins are able to add, view, or remove secrets"
+        missingPermissions={['Admin role']}
+      />
+    );
+  }
+
   return (
     <QueryErrorBoundary>
       <SecretsManagementUI />

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -109,6 +109,19 @@ export function runTestAsSMEditor() {
   });
 }
 
+export function runTestAsSMAdmin() {
+  const runtime = require('@grafana/runtime');
+  jest.replaceProperty(runtime, `config`, {
+    ...config,
+    bootData: {
+      user: {
+        ...config.bootData.user,
+        orgRole: OrgRole.Admin,
+      },
+    },
+  });
+}
+
 export function runTestAsLogsViewer() {
   server.use(
     apiRoute(`getLogsDS`, {


### PR DESCRIPTION
From https://raintank-corp.slack.com/archives/C07D9QWFTQ8/p1753822656278269?thread_ts=1753720623.506399&cid=C07D9QWFTQ8

As a first stage, we need to restrict the content of the Secrets tab to just Admins.

**Viewer/Editor**
<img width="1483" height="602" alt="image" src="https://github.com/user-attachments/assets/7990a3fa-0c54-4825-80d3-e8626aa6de6e" />

**Admin**
<img width="1209" height="709" alt="image" src="https://github.com/user-attachments/assets/04e231e2-feca-4e7b-94ec-f0992bd03fc6" />

I reused the `ContactAdminAlert` but I'm open to changing it to other UI if preferred.

At a later stage, we'll focus on adding more granular permissions, but it's out of the scope of this PR.
