### PR TITLE
fix: handle both seconds and milliseconds in created_at response

### DIFF
--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.test.tsx
@@ -84,6 +84,42 @@ describe('SecretCard', () => {
     expect(screen.getByText(formatDate(MOCKED_SECRETS[0].created_at), { exact: false })).toBeInTheDocument();
   });
 
+  describe('timestamp format handling', () => {
+    it('should display correct date for seconds-based timestamps (new backend)', () => {
+      const secretWithSecondsTimestamp = {
+        ...MOCKED_SECRETS[0],
+        created_at: 1672574400, // Jan 1, 2023 in seconds
+      };
+
+      render(<SecretCard {...defaultProps} secret={secretWithSecondsTimestamp} />);
+
+      expect(screen.getByText(/January.*2023/)).toBeInTheDocument();
+    });
+
+    it('should display correct date for milliseconds-based timestamps (old backend)', () => {
+      const secretWithMillisecondsTimestamp = {
+        ...MOCKED_SECRETS[0],
+        created_at: 1672574400000, // Jan 1, 2023 in milliseconds
+      };
+
+      render(<SecretCard {...defaultProps} secret={secretWithMillisecondsTimestamp} />);
+
+      expect(screen.getByText(/January.*2023/)).toBeInTheDocument();
+    });
+
+    it('should not display 1970 dates for seconds timestamps', () => {
+      const secretWithRecentTimestamp = {
+        ...MOCKED_SECRETS[0],
+        created_at: 1672574400, // Jan 1, 2023 in seconds (should not be interpreted as 1970)
+      };
+
+      render(<SecretCard {...defaultProps} secret={secretWithRecentTimestamp} />);
+
+      expect(screen.queryByText(/1970/)).not.toBeInTheDocument();
+      expect(screen.getByText(/2023/)).toBeInTheDocument();
+    });
+  });
+
   it('should render a clipboard button for the secret UUID', () => {
     render(<SecretCard {...defaultProps} />);
 

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.tsx
@@ -4,7 +4,7 @@ import { Button, ClipboardButton, Icon, Tag, Text, useStyles2 } from '@grafana/u
 import { css } from '@emotion/css';
 
 import { SecretWithMetadata } from './types';
-import { formatDate } from 'utils';
+import { formatDate, normalizeTimestamp } from 'utils';
 
 interface SecretCardProps {
   secret: SecretWithMetadata;
@@ -70,7 +70,7 @@ export function SecretCard({ secret, onEdit, onDelete }: SecretCardProps) {
         <strong>Description:</strong> {secret.description}
       </div>
       <div className={styles.keyValue}>
-        <strong>Created:</strong> {formatDate(secret.created_at * 1000)} ({secret.created_by})
+        <strong>Created:</strong> {formatDate(normalizeTimestamp(secret.created_at))} ({secret.created_by})
       </div>
       {/* Currently there is no modified_at returned by the API(???) */}
       {/*<div className={styles.keyValue}>*/}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -274,6 +274,12 @@ export function formatDate(number: number) {
   });
 }
 
+// Helper function to normalize timestamps to milliseconds
+export function normalizeTimestamp(timestamp: number): number {
+  // Assume it's seconds if timestamp is less than Jan 1, 2000 in milliseconds
+  return timestamp < 946684800000 ? timestamp * 1000 : timestamp;
+}
+
 export function checkToUsageCalcValues(check: Check): CalculateUsageValues {
   const { basicMetricsOnly, settings, frequency, probes } = check;
   const checkType = getCheckType(check.settings);


### PR DESCRIPTION
Suggestion for https://github.com/grafana/synthetic-monitoring-app/pull/1210 to handle both seconds and milliseconds when displaying the `created_at` time for secrets.

<img width="854" height="306" alt="image" src="https://github.com/user-attachments/assets/39d89a13-971f-457f-82e2-f4df2541eeed" />
