### PR TITLE
feat: apply granular secrets permissions

### DIFF
--- a/src/data/permissions.ts
+++ b/src/data/permissions.ts
@@ -1,7 +1,7 @@
 import { OrgRole } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
-import { FeatureName, PluginPermissions } from 'types';
+import { FeatureName, FixedSecretPermission, PluginPermissions } from 'types';
 import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 
 const roleHierarchy: Record<OrgRole, OrgRole[]> = {
@@ -21,7 +21,10 @@ const hasMinFallbackRole = (fallbackOrgRole: OrgRole) => {
   return roleHierarchy[fallbackOrgRole]?.includes(orgRole) || false;
 };
 
-const isUserActionAllowed = (permission: PluginPermissions, fallbackOrgRole: OrgRole): boolean => {
+const isUserActionAllowed = (
+  permission: PluginPermissions | FixedSecretPermission,
+  fallbackOrgRole: OrgRole
+): boolean => {
   const { permissions: userPermissions } = config.bootData.user;
 
   const rbacEnabled = isFeatureEnabled(FeatureName.RBAC);
@@ -53,6 +56,11 @@ export const getUserPermissions = () => ({
   canWritePlugin: isUserActionAllowed('grafana-synthetic-monitoring-app.plugin:write', OrgRole.Admin),
 
   canWriteSM: isUserActionAllowed('grafana-synthetic-monitoring-app:write', OrgRole.Editor),
+
+  canCreateSecrets: isUserActionAllowed('secret.securevalues:create', OrgRole.Admin),
+  canReadSecrets: isUserActionAllowed('secret.securevalues:read', OrgRole.Admin),
+  canUpdateSecrets: isUserActionAllowed('secret.securevalues:update', OrgRole.Admin),
+  canDeleteSecrets: isUserActionAllowed('secret.securevalues:delete', OrgRole.Admin),
 
   isAdmin: hasMinFallbackRole(OrgRole.Admin),
 });

--- a/src/data/permissions.ts
+++ b/src/data/permissions.ts
@@ -59,7 +59,7 @@ export const getUserPermissions = () => ({
 
   canCreateSecrets: isUserActionAllowed('secret.securevalues:create', OrgRole.Admin),
   canReadSecrets: isUserActionAllowed('secret.securevalues:read', OrgRole.Admin),
-  canUpdateSecrets: isUserActionAllowed('secret.securevalues:update', OrgRole.Admin),
+  canUpdateSecrets: isUserActionAllowed('secret.securevalues:write', OrgRole.Admin),
   canDeleteSecrets: isUserActionAllowed('secret.securevalues:delete', OrgRole.Admin),
 
   isAdmin: hasMinFallbackRole(OrgRole.Admin),

--- a/src/data/useSecrets.ts
+++ b/src/data/useSecrets.ts
@@ -31,12 +31,16 @@ function secretsQuery(api: SMDataSource) {
 /**
  * Hook to fetch secrets
  *
+ * @param {boolean} enabled - Whether the query should be enabled
  * @throws {Error} If the query fails - Use ErrorBoundary to catch errors
  */
-export function useSecrets() {
+export function useSecrets(enabled: boolean) {
   const smDS = useSMDS();
 
-  return useQuery<SecretsResponse, unknown, SecretWithMetadata[]>(secretsQuery(smDS));
+  return useQuery<SecretsResponse, unknown, SecretWithMetadata[]>({
+    ...secretsQuery(smDS),
+    enabled,
+  });
 }
 
 /**

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.tsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/css';
 
 import { SecretWithMetadata } from './types';
 import { formatDate } from 'utils';
+import { getUserPermissions } from 'data/permissions';
 
 interface SecretCardProps {
   secret: SecretWithMetadata;
@@ -14,6 +15,8 @@ interface SecretCardProps {
 
 export function SecretCard({ secret, onEdit, onDelete }: SecretCardProps) {
   const styles = useStyles2(getStyles);
+  const { canUpdateSecrets, canDeleteSecrets } = getUserPermissions();
+
   const handleEdit = () => {
     onEdit(secret.name);
   };
@@ -21,6 +24,8 @@ export function SecretCard({ secret, onEdit, onDelete }: SecretCardProps) {
   const handleDelete = () => {
     onDelete(secret.name);
   };
+
+  const hasAnyActions = canUpdateSecrets || canDeleteSecrets;
 
   return (
     <div className={styles.card}>
@@ -33,25 +38,31 @@ export function SecretCard({ secret, onEdit, onDelete }: SecretCardProps) {
             <Tag key={label.name} colorIndex={3} name={`${label.name}: ${label.value}`} />
           ))}
         </div>
-        <div className={styles.actions}>
-          <Button
-            aria-label={`Edit ${secret.name}`}
-            size="sm"
-            icon="edit"
-            fill="outline"
-            variant="secondary"
-            onClick={handleEdit}
-          >
-            Edit
-          </Button>
-          <Button
-            aria-label={`Delete ${secret.name}`}
-            size="sm"
-            icon="trash-alt"
-            variant="secondary"
-            onClick={handleDelete}
-          />
-        </div>
+        {hasAnyActions && (
+          <div className={styles.actions}>
+            {canUpdateSecrets && (
+              <Button
+                aria-label={`Edit ${secret.name}`}
+                size="sm"
+                icon="edit"
+                fill="outline"
+                variant="secondary"
+                onClick={handleEdit}
+              >
+                Edit
+              </Button>
+            )}
+            {canDeleteSecrets && (
+              <Button
+                aria-label={`Delete ${secret.name}`}
+                size="sm"
+                icon="trash-alt"
+                variant="secondary"
+                onClick={handleDelete}
+              />
+            )}
+          </div>
+        )}
       </div>
       <div className={styles.keyValue}>
         <strong>ID:</strong> {secret.uuid}{' '}

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.test.tsx
@@ -4,54 +4,135 @@ import { DataTestIds } from 'test/dataTestIds';
 import { apiRoute } from 'test/handlers';
 import { render } from 'test/render';
 import { server } from 'test/server';
-import { runTestAsSMAdmin, runTestAsSMEditor, runTestAsViewer } from 'test/utils';
+import { 
+  runTestAsSecretsCreator,
+  runTestAsSecretsEditor,
+  runTestAsSecretsFullAccess,
+  runTestAsSecretsNoAccess,
+  runTestAsSecretsReadOnly,
+  runTestAsSMAdmin, 
+  runTestAsSMEditor, 
+  runTestAsViewer} from 'test/utils';
 
 import { SecretsManagementTab } from './SecretsManagementTab';
 
 describe('SecretsManagementTab', () => {
-  const contactAdminMessage = 'Contact an admin: currently only admins are able to add, view, or remove secrets';
+  describe('Admin/Editor/Viewer permissions (no RBAC)', () => {
+    it('should render the fallback UI when an error occurs', async () => {
+      runTestAsSMAdmin();
 
-  it('should render the fallback UI when an error occurs', async () => {
-    runTestAsSMAdmin();
+      server.use(apiRoute('listSecrets', { result: () => ({ status: 500, body: 'Error message' }) }));
+      render(<SecretsManagementTab />);
 
-    server.use(apiRoute('listSecrets', { result: () => ({ status: 500, body: 'Error message' }) }));
-    render(<SecretsManagementTab />);
+      await waitFor(() => expect(screen.queryByTestId(DataTestIds.CENTERED_SPINNER)).not.toBeInTheDocument(), {
+        timeout: 3000,
+      });
 
-    await waitFor(() => expect(screen.queryByTestId(DataTestIds.CENTERED_SPINNER)).not.toBeInTheDocument(), {
-      timeout: 3000,
+      expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+      expect(screen.getByText(/An error has occurred/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
-    expect(screen.getByText(/An error has occurred/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    it.each([
+      ['viewer', runTestAsViewer],
+      ['editor', runTestAsSMEditor],
+    ])('displays contact admin message for %s users without secrets access', async (_, setupFunction) => {
+      setupFunction();
+
+      render(<SecretsManagementTab />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Contact an admin: you don't have permissions to view secrets/)).toBeInTheDocument();
+      });
+      expect(screen.getByText('secret.securevalues:read')).toBeInTheDocument();
+      expect(screen.queryByTestId(DataTestIds.CENTERED_SPINNER)).not.toBeInTheDocument();
+    });
+
+    it('shows secrets management UI for admin users', async () => {
+      runTestAsSMAdmin();
+      server.use(apiRoute('listSecrets', { result: () => ({ status: 200, json: { secrets: [] } }) }));
+
+      render(<SecretsManagementTab />);
+
+      expect(screen.queryByText(/Contact an admin/)).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create secret/i })).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("You don't have any secrets yet.")).toBeInTheDocument();
+      expect(screen.getByText(/You can use secrets to store private information/)).toBeInTheDocument();
+    });
   });
 
-  test.each([
-    ['viewer', runTestAsViewer],
-    ['editor', runTestAsSMEditor],
-  ])('displays contact admin message for %s users', async (_, setupFunction) => {
-    setupFunction();
-
-    render(<SecretsManagementTab />);
-
-    await waitFor(() => {
-      expect(screen.getByText(contactAdminMessage)).toBeInTheDocument();
-    });
-    expect(screen.queryByTestId(DataTestIds.CENTERED_SPINNER)).not.toBeInTheDocument();
-  });
-
-  it('shows secrets management UI for admin users', async () => {
-    runTestAsSMAdmin();
-    server.use(apiRoute('listSecrets', { result: () => ({ status: 200, json: { secrets: [] } }) }));
-
-    render(<SecretsManagementTab />);
-
-    expect(screen.queryByText(contactAdminMessage)).not.toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /create secret/i })).toBeInTheDocument();
+  describe('RBAC permissions', () => {
+    beforeEach(() => {
+      server.use(apiRoute('listSecrets', { result: () => ({ status: 200, json: { secrets: [] } }) }));
     });
 
-    expect(screen.getByText("You don't have any secrets yet.")).toBeInTheDocument();
-    expect(screen.getByText(/You can use secrets to store private information/)).toBeInTheDocument();
+    it('allows full access for users with all secret permissions', async () => {
+      runTestAsSecretsFullAccess();
+
+      render(<SecretsManagementTab />);
+
+      expect(screen.queryByText(/Contact an admin/)).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create secret/i })).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("You don't have any secrets yet.")).toBeInTheDocument();
+    });
+
+    it('allows access for users with read-only permissions', async () => {
+      runTestAsSecretsReadOnly();
+
+      render(<SecretsManagementTab />);
+
+      expect(screen.queryByText(/Contact an admin/)).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText("You don't have any secrets yet.")).toBeInTheDocument();
+      });
+
+      // Should not show create button for read-only users
+      expect(screen.queryByRole('button', { name: /create secret/i })).not.toBeInTheDocument();
+    });
+
+    it('allows access for users with creator permissions', async () => {
+      runTestAsSecretsCreator();
+
+      render(<SecretsManagementTab />);
+
+      expect(screen.queryByText(/Contact an admin/)).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create secret/i })).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("You don't have any secrets yet.")).toBeInTheDocument();
+    });
+
+    it('allows access for users with editor permissions', async () => {
+      runTestAsSecretsEditor();
+
+      render(<SecretsManagementTab />);
+
+      expect(screen.queryByText(/Contact an admin/)).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText("You don't have any secrets yet.")).toBeInTheDocument();
+      });
+
+      // Should not show create button for editor-only users (they can only edit existing secrets)
+      expect(screen.queryByRole('button', { name: /create secret/i })).not.toBeInTheDocument();
+    });
+
+    it('denies access for users with no secret permissions', async () => {
+      runTestAsSecretsNoAccess();
+
+      render(<SecretsManagementTab />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Contact an admin: you don't have permissions to view secrets/)).toBeInTheDocument();
+      });
+      expect(screen.getByText('secret.securevalues:read')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /create secret/i })).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.test.tsx
@@ -42,9 +42,10 @@ describe('SecretsManagementTab', () => {
       render(<SecretsManagementTab />);
 
       await waitFor(() => {
-        expect(screen.getByText(/Contact an admin: you don't have permissions to view secrets/)).toBeInTheDocument();
+        expect(screen.getByText(/Contact an admin: you need either read or create permissions for secrets/)).toBeInTheDocument();
       });
       expect(screen.getByText('secret.securevalues:read')).toBeInTheDocument();
+      expect(screen.getByText('secret.securevalues:create')).toBeInTheDocument();
       expect(screen.queryByTestId(DataTestIds.CENTERED_SPINNER)).not.toBeInTheDocument();
     });
 
@@ -129,9 +130,10 @@ describe('SecretsManagementTab', () => {
       render(<SecretsManagementTab />);
 
       await waitFor(() => {
-        expect(screen.getByText(/Contact an admin: you don't have permissions to view secrets/)).toBeInTheDocument();
+        expect(screen.getByText(/Contact an admin: you need either read or create permissions for secrets/)).toBeInTheDocument();
       });
       expect(screen.getByText('secret.securevalues:read')).toBeInTheDocument();
+      expect(screen.getByText('secret.securevalues:create')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /create secret/i })).not.toBeInTheDocument();
     });
   });

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.tsx
@@ -7,13 +7,13 @@ import { ContactAdminAlert } from 'page/ContactAdminAlert';
 import { SecretsManagementUI } from './SecretsManagementUI';
 
 export function SecretsManagementTab() {
-  const { isAdmin } = getUserPermissions();
+  const { canReadSecrets } = getUserPermissions();
 
-  if (!isAdmin) {
+  if (!canReadSecrets) {
     return (
-      <ContactAdminAlert 
-        title="Contact an admin: currently only admins are able to add, view, or remove secrets"
-        missingPermissions={['Admin role']}
+      <ContactAdminAlert
+        title="Contact an admin: you don't have permissions to view secrets"
+        missingPermissions={['secret.securevalues:read']}
       />
     );
   }

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.tsx
@@ -7,13 +7,13 @@ import { ContactAdminAlert } from 'page/ContactAdminAlert';
 import { SecretsManagementUI } from './SecretsManagementUI';
 
 export function SecretsManagementTab() {
-  const { canReadSecrets } = getUserPermissions();
+  const { canReadSecrets, canCreateSecrets } = getUserPermissions();
 
-  if (!canReadSecrets) {
+  if (!canReadSecrets && !canCreateSecrets) {
     return (
       <ContactAdminAlert
-        title="Contact an admin: you don't have permissions to view secrets"
-        missingPermissions={['secret.securevalues:read']}
+        title="Contact an admin: you need either read or create permissions for secrets"
+        missingPermissions={['secret.securevalues:read', 'secret.securevalues:create']}
       />
     );
   }

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {
+  runTestAsSecretsCreator,
+  runTestAsSecretsEditor,
+  runTestAsSecretsFullAccess,
+  runTestAsSecretsReadOnly,
+} from 'test/utils';
 
 import { useDeleteSecret, useSecrets } from 'data/useSecrets';
 
@@ -63,68 +69,166 @@ describe('SecretsManagementUI', () => {
     });
 
     it('should render empty state when no secrets exist', async () => {
+      runTestAsSecretsFullAccess();
       render(<SecretsManagementUI />);
 
       expect(screen.getByText(/you don't have any secrets yet/i)).toBeInTheDocument();
     });
 
-    it('should have create button', async () => {
+    it('should have create button for users with create permissions', async () => {
+      runTestAsSecretsFullAccess();
       render(<SecretsManagementUI />);
+
       const addButton = screen.getByRole('button', { name: /create secret/i });
       await userEvent.click(addButton);
 
       expect(screen.getByRole('dialog', { name: /create secret/i })).toBeInTheDocument();
       expect(screen.getByTestId('modal-id')).toHaveTextContent(SECRETS_EDIT_MODE_ADD);
     });
+
+    it('should have create button for users with creator permissions', async () => {
+      runTestAsSecretsCreator();
+      render(<SecretsManagementUI />);
+
+      expect(screen.getByRole('button', { name: /create secret/i })).toBeInTheDocument();
+    });
+
+    it('should not have create button for read-only users', async () => {
+      runTestAsSecretsReadOnly();
+      render(<SecretsManagementUI />);
+
+      expect(screen.queryByRole('button', { name: /create secret/i })).not.toBeInTheDocument();
+      expect(screen.getByText(/Contact an admin to create secrets/)).toBeInTheDocument();
+    });
+
+    it('should not have create button for editor-only users', async () => {
+      runTestAsSecretsEditor();
+      render(<SecretsManagementUI />);
+
+      expect(screen.queryByRole('button', { name: /create secret/i })).not.toBeInTheDocument();
+      expect(screen.getByText(/Contact an admin to create secrets/)).toBeInTheDocument();
+    });
   });
 
-  it('should display loading state', async () => {
-    (useSecrets as jest.Mock).mockReturnValue({ isLoading: true });
-    render(<SecretsManagementTab />);
-    expect(screen.getByLabelText('Loading secrets')).toBeInTheDocument();
-  });
-
-  it.each(MOCKED_SECRETS.map((secret) => [secret.name, secret.uuid, secret.description]))(
-    'should render %s (%s) (incl description)',
-    async (name, uuid) => {
+  describe('Secrets list with permission-based actions', () => {
+    it('should display loading state', async () => {
+      (useSecrets as jest.Mock).mockReturnValue({ isLoading: true });
       render(<SecretsManagementTab />);
+      expect(screen.getByLabelText('Loading secrets')).toBeInTheDocument();
+    });
+
+    it.each(MOCKED_SECRETS.map((secret) => [secret.name, secret.uuid, secret.description]))(
+      'should render %s (%s) (incl description)',
+      async (name, uuid) => {
+        runTestAsSecretsFullAccess();
+        render(<SecretsManagementTab />);
+        await waitFor(() => {
+          expect(screen.getByText(name)).toBeInTheDocument();
+          expect(screen.getByText(uuid)).toBeInTheDocument();
+        });
+      }
+    );
+
+    it('should show both edit and delete buttons for users with full access', async () => {
+      runTestAsSecretsFullAccess();
+      render(<SecretsManagementTab />);
+
       await waitFor(() => {
-        expect(screen.getByText(name)).toBeInTheDocument();
-        expect(screen.getByText(uuid)).toBeInTheDocument();
+        expect(screen.getAllByRole('button', { name: /edit/i })).toHaveLength(MOCKED_SECRETS.length);
+        expect(screen.getAllByRole('button', { name: /delete/i })).toHaveLength(MOCKED_SECRETS.length);
       });
-    }
-  );
+    });
 
-  it('should open edit secret modal', async () => {
-    render(<SecretsManagementTab />);
-    const editButton = screen.getAllByRole('button', { name: /edit/i })[0];
-    await userEvent.click(editButton);
-    expect(screen.getByTestId('modal-id')).toHaveTextContent(MOCKED_SECRETS[0].name);
-  });
+    it('should show no action buttons for read-only users', async () => {
+      runTestAsSecretsReadOnly();
+      render(<SecretsManagementTab />);
 
-  it('should open delete secret modal', async () => {
-    render(<SecretsManagementTab />);
-    const deleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
-    await userEvent.click(deleteButton);
-    expect(screen.getByTestId('data-testid Confirm Modal Danger Button')).toBeInTheDocument();
-  });
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+      });
+    });
 
-  it('should require "delete" input text to delete', async () => {
-    render(<SecretsManagementTab />);
-    const deleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
-    await userEvent.click(deleteButton);
-    const confirmButton = screen.getByTestId('data-testid Confirm Modal Danger Button');
-    await userEvent.click(confirmButton);
-    expect(mockDeleteMutation.mutate).toHaveBeenCalledTimes(0);
+    it('should show only edit buttons for users with update permissions', async () => {
+      runTestAsSecretsEditor();
+      render(<SecretsManagementTab />);
 
-    const inputWrapper = screen.getByTestId('input-wrapper');
-    const input = within(inputWrapper).getByPlaceholderText(/type "delete" to confirm/i);
-    await userEvent.type(input, 'wrong text');
-    await userEvent.click(confirmButton);
-    expect(mockDeleteMutation.mutate).toHaveBeenCalledTimes(0);
-    await userEvent.clear(input); // reset input
-    await userEvent.type(input, 'delete');
-    await userEvent.click(confirmButton);
-    expect(mockDeleteMutation.mutate).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(screen.getAllByRole('button', { name: /edit/i })).toHaveLength(MOCKED_SECRETS.length);
+        expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show main create button for users with create permissions when secrets exist', async () => {
+      runTestAsSecretsFullAccess();
+      render(<SecretsManagementTab />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /create secret/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should not show main create button for read-only users when secrets exist', async () => {
+      runTestAsSecretsReadOnly();
+      render(<SecretsManagementTab />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /create secret/i })).not.toBeInTheDocument();
+      });
+    });
+
+    it('should open edit secret modal when user has update permissions', async () => {
+      runTestAsSecretsEditor();
+      render(<SecretsManagementTab />);
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('button', { name: /edit/i })).toHaveLength(MOCKED_SECRETS.length);
+      });
+
+      const editButtons = screen.getAllByRole('button', { name: /edit/i });
+      await userEvent.click(editButtons[0]);
+
+      expect(screen.getByTestId('modal-id')).toHaveTextContent(MOCKED_SECRETS[0].name);
+    });
+
+    it('should open delete secret modal when user has delete permissions', async () => {
+      runTestAsSecretsFullAccess();
+      render(<SecretsManagementTab />);
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('button', { name: /delete/i })).toHaveLength(MOCKED_SECRETS.length);
+      });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      await userEvent.click(deleteButtons[0]);
+
+      expect(screen.getByTestId('data-testid Confirm Modal Danger Button')).toBeInTheDocument();
+    });
+
+    it('should require "delete" input text to delete when user has delete permissions', async () => {
+      runTestAsSecretsFullAccess();
+      render(<SecretsManagementTab />);
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('button', { name: /delete/i })).toHaveLength(MOCKED_SECRETS.length);
+      });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      await userEvent.click(deleteButtons[0]);
+
+      const confirmButton = screen.getByTestId('data-testid Confirm Modal Danger Button');
+      await userEvent.click(confirmButton);
+      expect(mockDeleteMutation.mutate).toHaveBeenCalledTimes(0);
+
+      const inputWrapper = screen.getByTestId('input-wrapper');
+      const input = within(inputWrapper).getByPlaceholderText(/type "delete" to confirm/i);
+      await userEvent.type(input, 'wrong text');
+      await userEvent.click(confirmButton);
+      expect(mockDeleteMutation.mutate).toHaveBeenCalledTimes(0);
+      await userEvent.clear(input); // reset input
+      await userEvent.type(input, 'delete');
+      await userEvent.click(confirmButton);
+      expect(mockDeleteMutation.mutate).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
@@ -16,7 +16,7 @@ export function SecretsManagementUI() {
   const [editMode, setEditMode] = useState<string | false>(false);
   const [deleteMode, setDeleteMode] = useState<SecretWithUuid | undefined>();
   const { canCreateSecrets, canReadSecrets } = getUserPermissions();
-  const { data: secrets, isLoading, isFetching } = useSecrets();
+  const { data: secrets, isLoading, isFetching } = useSecrets(canReadSecrets);
   const deleteSecret = useDeleteSecret();
   const emptyState = (canReadSecrets && secrets?.length === 0) || (!canReadSecrets && canCreateSecrets);
 

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
@@ -15,10 +15,10 @@ import { SecretEditModal } from './SecretEditModal';
 export function SecretsManagementUI() {
   const [editMode, setEditMode] = useState<string | false>(false);
   const [deleteMode, setDeleteMode] = useState<SecretWithUuid | undefined>();
+  const { canCreateSecrets, canReadSecrets } = getUserPermissions();
   const { data: secrets, isLoading, isFetching } = useSecrets();
   const deleteSecret = useDeleteSecret();
-  const { canCreateSecrets } = getUserPermissions();
-  const emptyState = secrets?.length === 0;
+  const emptyState = (canReadSecrets && secrets?.length === 0) || (!canReadSecrets && canCreateSecrets);
 
   const existingNames = secrets?.map((secret) => secret.name) ?? [];
 
@@ -37,7 +37,7 @@ export function SecretsManagementUI() {
     }
   };
 
-  if (isLoading) {
+  if (isLoading && canReadSecrets) {
     return <ConfigContent loading ariaLoadingLabel="Loading secrets" />;
   }
 
@@ -83,11 +83,13 @@ export function SecretsManagementUI() {
               information such as passwords, API keys, and other sensitive data.
             </p>
           </div>
-          <ConfigContent.Section>
-            {secrets?.map((secret) => (
-              <SecretCard key={secret.uuid} secret={secret} onEdit={handleEditSecret} onDelete={handleDeleteSecret} />
-            ))}
-          </ConfigContent.Section>
+          {canReadSecrets && (
+            <ConfigContent.Section>
+              {secrets?.map((secret) => (
+                <SecretCard key={secret.uuid} secret={secret} onEdit={handleEditSecret} onDelete={handleDeleteSecret} />
+              ))}
+            </ConfigContent.Section>
+          )}
         </ConfigContent>
       )}
 

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
@@ -3,6 +3,7 @@ import { Button, ConfirmModal, EmptyState } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { SecretWithUuid } from './types';
+import { getUserPermissions } from 'data/permissions';
 import { useDeleteSecret, useSecrets } from 'data/useSecrets';
 import { CenteredSpinner } from 'components/CenteredSpinner';
 
@@ -16,6 +17,7 @@ export function SecretsManagementUI() {
   const [deleteMode, setDeleteMode] = useState<SecretWithUuid | undefined>();
   const { data: secrets, isLoading, isFetching } = useSecrets();
   const deleteSecret = useDeleteSecret();
+  const { canCreateSecrets } = getUserPermissions();
   const emptyState = secrets?.length === 0;
 
   const existingNames = secrets?.map((secret) => secret.name) ?? [];
@@ -47,23 +49,32 @@ export function SecretsManagementUI() {
             variant="call-to-action"
             message="You don't have any secrets yet."
             button={
-              <Button onClick={handleAddSecret} icon="plus">
-                Create secret
-              </Button>
+              canCreateSecrets ? (
+                <Button onClick={handleAddSecret} icon="plus">
+                  Create secret
+                </Button>
+              ) : undefined
             }
           >
             You can use secrets to store private information such as passwords, API keys, and other sensitive data.
+            {!canCreateSecrets && (
+              <div style={{ marginTop: '16px', fontSize: '14px', color: '#6c757d' }}>
+                Contact an admin to create secrets.
+              </div>
+            )}
           </EmptyState>
         </ConfigContent>
       ) : (
         <ConfigContent
           title="Secrets management"
           actions={
-            <div>
-              <Button size="sm" icon="plus" onClick={handleAddSecret}>
-                Create secret
-              </Button>
-            </div>
+            canCreateSecrets ? (
+              <div>
+                <Button size="sm" icon="plus" onClick={handleAddSecret}>
+                  Create secret
+                </Button>
+              </div>
+            ) : undefined
           }
         >
           <div>

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -70,7 +70,7 @@
       "type": "page",
       "name": "Config",
       "path": "/a/grafana-synthetic-monitoring-app/config",
-      "action": "grafana-synthetic-monitoring-app:write",
+      "action": "grafana-synthetic-monitoring-app:read",
       "addToNav": true
     },
     {

--- a/src/test/fixtures/rbacPermissions.ts
+++ b/src/test/fixtures/rbacPermissions.ts
@@ -15,6 +15,10 @@ export const FULL_ADMIN_ACCESS = {
   'grafana-synthetic-monitoring-app.probes:delete': true,
   'grafana-synthetic-monitoring-app.alerts:delete': true,
   'grafana-synthetic-monitoring-app.thresholds:delete': true,
+  'secret.securevalues:create': true,
+  'secret.securevalues:read': true,
+  'secret.securevalues:write': true,
+  'secret.securevalues:delete': true,
 };
 
 export const FULL_WRITER_ACCESS = {
@@ -42,3 +46,26 @@ export const FULL_READONLY_ACCESS = {
   'grafana-synthetic-monitoring-app.alerts:read': true,
   'grafana-synthetic-monitoring-app.thresholds:read': true,
 };
+
+export const SECRETS_FULL_ACCESS = {
+  'secret.securevalues:create': true,
+  'secret.securevalues:read': true,
+  'secret.securevalues:write': true,
+  'secret.securevalues:delete': true,
+};
+
+export const SECRETS_READ_ONLY_ACCESS = {
+  'secret.securevalues:read': true,
+};
+
+export const SECRETS_CREATOR_ACCESS = {
+  'secret.securevalues:create': true,
+  'secret.securevalues:read': true,
+};
+
+export const SECRETS_EDITOR_ACCESS = {
+  'secret.securevalues:read': true,
+  'secret.securevalues:write': true,
+};
+
+export const SECRETS_NO_ACCESS = {};

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -11,7 +11,15 @@ import {
 import { ExtendedProbe, FeatureName, type Probe, ProbeProvider, ProbeWithMetadata } from 'types';
 import { pascalCaseToSentence } from 'utils';
 
-import { FULL_ADMIN_ACCESS, FULL_READONLY_ACCESS, FULL_WRITER_ACCESS } from './fixtures/rbacPermissions';
+import { 
+  FULL_ADMIN_ACCESS, 
+  FULL_READONLY_ACCESS, 
+  FULL_WRITER_ACCESS, 
+  SECRETS_CREATOR_ACCESS, 
+  SECRETS_EDITOR_ACCESS, 
+  SECRETS_FULL_ACCESS, 
+  SECRETS_NO_ACCESS, 
+  SECRETS_READ_ONLY_ACCESS} from './fixtures/rbacPermissions';
 import { apiRoute } from './handlers';
 import { server } from './server';
 
@@ -244,6 +252,45 @@ export function runTestAsRBACAdmin() {
       },
     },
   });
+}
+
+function runTestAsSecretsWithPermissions(permissions: Record<string, boolean>) {
+  const runtime = require('@grafana/runtime');
+  jest.replaceProperty(runtime, `config`, {
+    ...config,
+    featureToggles: {
+      ...runtime.config.featureToggles,
+      accessControlOnCall: true,
+      [FeatureName.RBAC]: true,
+    },
+
+    bootData: {
+      ...runtime.config.bootData,
+      user: {
+        permissions,
+      },
+    },
+  });
+}
+
+export function runTestAsSecretsFullAccess() {
+  runTestAsSecretsWithPermissions(SECRETS_FULL_ACCESS);
+}
+
+export function runTestAsSecretsReadOnly() {
+  runTestAsSecretsWithPermissions(SECRETS_READ_ONLY_ACCESS);
+}
+
+export function runTestAsSecretsCreator() {
+  runTestAsSecretsWithPermissions(SECRETS_CREATOR_ACCESS);
+}
+
+export function runTestAsSecretsEditor() {
+  runTestAsSecretsWithPermissions(SECRETS_EDITOR_ACCESS);
+}
+
+export function runTestAsSecretsNoAccess() {
+  runTestAsSecretsWithPermissions(SECRETS_NO_ACCESS);
 }
 
 export function runTestAsHGFreeUserOverLimit() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -881,6 +881,6 @@ export type PluginPermissions =
   | `${PermissionBase}.access-tokens:${'write'}`
   | `${PermissionBase}.plugin:${'write'}`;
 
-export type FixedSecretPermission = `secret.securevalues:${'create' | 'read' | 'update' | 'delete'}`;
+export type FixedSecretPermission = `secret.securevalues:${'create' | 'read' | 'write' | 'delete'}`;
 
 export type AlertingType = 'alerting' | 'sensitivity';

--- a/src/types.ts
+++ b/src/types.ts
@@ -881,4 +881,6 @@ export type PluginPermissions =
   | `${PermissionBase}.access-tokens:${'write'}`
   | `${PermissionBase}.plugin:${'write'}`;
 
+export type FixedSecretPermission = `secret.securevalues:${'create' | 'read' | 'update' | 'delete'}`;
+
 export type AlertingType = 'alerting' | 'sensitivity';


### PR DESCRIPTION
Implements granular restrictions on the secrets UI consuming the following fixed permissions:

```
'secret.securevalues:create',
'secret.securevalues:read'
'secret.securevalues:write'
'secret.securevalues:delete'
  ```
  
**Editor with no secrets permissions assigned:**
<img width="1466" height="817" alt="image" src="https://github.com/user-attachments/assets/17d82275-cd4d-410f-9575-4250b4db4b74" />

**Editor with read permissions assigned:**
- with no secrets
<img width="1504" height="822" alt="image" src="https://github.com/user-attachments/assets/ec508f30-538e-485f-9fa0-0ca10ba0feb6" />

- with secrets
<img width="1509" height="815" alt="image" src="https://github.com/user-attachments/assets/533c4978-424b-42b7-94cb-eb9472303530" />


**Editor with read+create permissions assigned:**
- with no secrets
<img width="1500" height="802" alt="image" src="https://github.com/user-attachments/assets/bbaae6c3-96c5-4df3-b352-24aeee40c7af" />
- with secrets
<img width="1509" height="822" alt="image" src="https://github.com/user-attachments/assets/f977b25a-1bee-4951-af8e-f2232edeba03" />

**Editor with read+update permissions assigned:**
<img width="1494" height="742" alt="image" src="https://github.com/user-attachments/assets/695ab030-c5f5-4d60-8140-30731337f27a" />
<img width="1506" height="754" alt="image" src="https://github.com/user-attachments/assets/90058b39-9736-4514-a2cf-7ad0a5d1b4e8" />

**Editor with read+delete permissions assigned:**
<img width="1512" height="694" alt="image" src="https://github.com/user-attachments/assets/24bdde7f-712e-4f14-910d-2d49ea9886ee" />

**Editor with read+create+update+delete permissions assigned:**
<img width="1479" height="813" alt="image" src="https://github.com/user-attachments/assets/29c578ae-d336-4d45-8db5-76465b9d3eeb" />
<img width="1494" height="738" alt="image" src="https://github.com/user-attachments/assets/b6f769bf-3bd8-45fe-912e-8b71ff217a9c" />

