### PR TITLE
fix: always use latest terraform provider version for validation check

### DIFF
--- a/.github/workflows/call_validate-terraform.yml
+++ b/.github/workflows/call_validate-terraform.yml
@@ -32,6 +32,29 @@ jobs:
         continue-on-error: true
         run: |
           echo "🔍 Validating generated Terraform configuration..."
+          echo "📦 Checking Grafana provider version..."
+          
+          # Extract provider version constraint from generated config
+          if [ -f "artifacts/terraform-validation/testTerraformConfig.tf.json" ]; then
+            PROVIDER_CONSTRAINT=$(cat artifacts/terraform-validation/testTerraformConfig.tf.json | grep -A 10 '"required_providers"' | grep -A 5 '"grafana"' | grep '"version"' | sed 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' | head -1)
+            if [ ! -z "$PROVIDER_CONSTRAINT" ]; then
+              echo "📋 Provider version constraint: $PROVIDER_CONSTRAINT"
+            fi
+          fi
+          
+          # Get the actual resolved provider version from terraform
+          cd artifacts/terraform-validation
+          if terraform version > /tmp/tf_version.txt 2>&1; then
+            # Extract grafana provider version from terraform version output
+            RESOLVED_VERSION=$(cat /tmp/tf_version.txt | grep -i "provider.*grafana" | sed 's/.*v\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/' | head -1)
+            if [ ! -z "$RESOLVED_VERSION" ]; then
+              echo "🎯 Resolved Grafana provider version: v$RESOLVED_VERSION"
+            else
+              echo "⚠️  Could not determine resolved provider version"
+            fi
+          fi
+          cd ../..
+          
           if yarn verify:terraform-test-config > /tmp/terraform_output.txt 2>&1; then
             echo "validation_result=success" >> $GITHUB_OUTPUT
             echo "✅ Terraform configuration validation succeeded!"
@@ -212,12 +235,22 @@ jobs:
         run: |
           echo ""
           echo "================================================"
-          echo "🏁 TERRAFORM VALIDATION SUMMARY"
+          echo "TERRAFORM VALIDATION SUMMARY"
           echo "================================================"
           if [ "${{ steps.terraform-validate.outputs.validation_result }}" = "success" ]; then
             echo "✅ Status: PASSED"
             echo "🎉 All generated terraform configurations are valid!"
             echo ""
+            # Show resolved provider version info
+            cd artifacts/terraform-validation
+            if terraform version > /tmp/tf_version_summary.txt 2>&1; then
+              RESOLVED_VERSION=$(cat /tmp/tf_version_summary.txt | grep -i "provider.*grafana" | sed 's/.*v\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/' | head -1)
+              if [ ! -z "$RESOLVED_VERSION" ]; then
+                echo "📦 Grafana Provider Version: v$RESOLVED_VERSION"
+                echo ""
+              fi
+            fi
+            cd ../..
             echo "📋 Validated Resources:"
             echo "  • grafana_synthetic_monitoring_check (HTTP, DNS, TCP, Ping, MultiHTTP, Scripted, Traceroute)"
             echo "  • grafana_synthetic_monitoring_probe (Public, Private, Online, Offline)"  
@@ -228,11 +261,41 @@ jobs:
             echo "❌ Status: FAILED"
             echo "💥 Generated terraform configurations have schema compatibility issues!"
             echo ""
+            # Show resolved provider version info
+            cd artifacts/terraform-validation
+            if terraform version > /tmp/tf_version_summary.txt 2>&1; then
+              RESOLVED_VERSION=$(cat /tmp/tf_version_summary.txt | grep -i "provider.*grafana" | sed 's/.*v\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/' | head -1)
+              if [ ! -z "$RESOLVED_VERSION" ]; then
+                echo "📦 Grafana Provider Version: v$RESOLVED_VERSION"
+                echo ""
+              fi
+            fi
+            cd ../..
             echo "⚠️  These issues would cause terraform operations to fail in production."
             echo ""
+            echo "VALIDATION ERRORS:"
+            echo "────────────────────────────────────────────────"
+            
+            # Extract and display the terraform errors in a clean format
+            if [ -f /tmp/terraform_output.txt ]; then
+              # Clean up terraform output and show all validation errors
+              cat /tmp/terraform_output.txt | \
+                sed 's/\x1b\[[0-9;]*m//g' | \
+                sed 's/[[:cntrl:]]//g' | \
+                grep -v "Terraform has been successfully initialized" | \
+                grep -v "^$" | \
+                grep -v "^Initializing" | \
+                grep -v "^- " | \
+                head -30
+            else
+              echo "Unable to read terraform validation output"
+            fi
+            
+            echo "────────────────────────────────────────────────"
+            echo ""
             echo "🔧 Next steps:"
-            echo "  1. Check the validation errors above"
-            echo "  2. Review the Grafana Terraform Provider documentation"
+            echo "  1. Review the errors above"
+            echo "  2. Check the Grafana Terraform Provider documentation"
             echo "  3. Update transformation functions in src/components/TerraformConfig/"
             echo "  4. Test locally: yarn build:generate-terraform-test-config && yarn verify:terraform-test-config"
           fi

--- a/.github/workflows/call_validate-terraform.yml
+++ b/.github/workflows/call_validate-terraform.yml
@@ -108,7 +108,6 @@ jobs:
                   
                   errors.forEach((error, index) => {
                     if (error.includes('Error:')) {
-                      message += `### Error ${index + 1}\n\n`;
                       
                       // Clean up the error text by removing box-drawing characters and formatting properly
                       const cleanError = error
@@ -276,17 +275,9 @@ jobs:
             echo "VALIDATION ERRORS:"
             echo "────────────────────────────────────────────────"
             
-            # Extract and display the terraform errors in a clean format
+            # Show the terraform validation output
             if [ -f /tmp/terraform_output.txt ]; then
-              # Clean up terraform output and show all validation errors
-              cat /tmp/terraform_output.txt | \
-                sed 's/\x1b\[[0-9;]*m//g' | \
-                sed 's/[[:cntrl:]]//g' | \
-                grep -v "Terraform has been successfully initialized" | \
-                grep -v "^$" | \
-                grep -v "^Initializing" | \
-                grep -v "^- " | \
-                head -30
+              cat /tmp/terraform_output.txt
             else
               echo "Unable to read terraform validation output"
             fi

--- a/.github/workflows/call_validate-terraform.yml
+++ b/.github/workflows/call_validate-terraform.yml
@@ -22,16 +22,29 @@ jobs:
           terraform_version: "~1.0"
       
       - name: Generate test Terraform configs
-        run: yarn build:generate-terraform-test-config
+        run: |
+          echo "🔧 Generating terraform test configurations..."
+          yarn build:generate-terraform-test-config
+          echo "✅ Test configuration generation completed"
       
       - name: Validate generated Terraform
         id: terraform-validate
         continue-on-error: true
         run: |
+          echo "🔍 Validating generated Terraform configuration..."
           if yarn verify:terraform-test-config > /tmp/terraform_output.txt 2>&1; then
             echo "validation_result=success" >> $GITHUB_OUTPUT
+            echo "✅ Terraform configuration validation succeeded!"
+            echo ""
+            echo "📋 Validation output:"
+            cat /tmp/terraform_output.txt
           else
             echo "validation_result=failed" >> $GITHUB_OUTPUT
+            echo "❌ Terraform configuration validation failed!"
+            echo ""
+            echo "📋 Validation errors:"
+            cat /tmp/terraform_output.txt
+            echo ""
             # Store the output using base64 encoding to avoid issues with special characters
             OUTPUT_BASE64=$(cat /tmp/terraform_output.txt | base64 -w 0)
             echo "TERRAFORM_OUTPUT_BASE64=$OUTPUT_BASE64" >> $GITHUB_OUTPUT
@@ -195,8 +208,38 @@ jobs:
               console.log('No previous terraform validation comment found, skipping success comment creation');
             }
       
+      - name: Log validation summary
+        run: |
+          echo ""
+          echo "================================================"
+          echo "🏁 TERRAFORM VALIDATION SUMMARY"
+          echo "================================================"
+          if [ "${{ steps.terraform-validate.outputs.validation_result }}" = "success" ]; then
+            echo "✅ Status: PASSED"
+            echo "🎉 All generated terraform configurations are valid!"
+            echo ""
+            echo "📋 Validated Resources:"
+            echo "  • grafana_synthetic_monitoring_check (HTTP, DNS, TCP, Ping, MultiHTTP, Scripted, Traceroute)"
+            echo "  • grafana_synthetic_monitoring_probe (Public, Private, Online, Offline)"  
+            echo "  • grafana_synthetic_monitoring_check_alerts (Alert configurations)"
+            echo ""
+            echo "✨ The terraform export functionality will work correctly."
+          else
+            echo "❌ Status: FAILED"
+            echo "💥 Generated terraform configurations have schema compatibility issues!"
+            echo ""
+            echo "⚠️  These issues would cause terraform operations to fail in production."
+            echo ""
+            echo "🔧 Next steps:"
+            echo "  1. Check the validation errors above"
+            echo "  2. Review the Grafana Terraform Provider documentation"
+            echo "  3. Update transformation functions in src/components/TerraformConfig/"
+            echo "  4. Test locally: yarn build:generate-terraform-test-config && yarn verify:terraform-test-config"
+          fi
+          echo "================================================"
+
       - name: Fail job if validation failed
         if: steps.terraform-validate.outputs.validation_result == 'failed'
         run: |
-          echo "Terraform configuration validation failed!"
+          echo "Failing job due to terraform validation errors"
           exit 1 

--- a/scripts/terraform-validation/generate-test-configs.ts
+++ b/scripts/terraform-validation/generate-test-configs.ts
@@ -26,12 +26,6 @@ async function generateConfigs() {
         check: fixtures.FULL_HTTP_CHECK,
         probe: probeFixtures.PRIVATE_PROBE,
       },
-      // TEMPORARY: Invalid alert check to test failure logging
-      {
-        name: 'invalid-alert-http',
-        check: fixtures.INVALID_ALERT_CHECK,
-        probe: probeFixtures.PRIVATE_PROBE,
-      },
       // DNS Check
       {
         name: 'basic-dns',

--- a/scripts/terraform-validation/generate-test-configs.ts
+++ b/scripts/terraform-validation/generate-test-configs.ts
@@ -26,6 +26,12 @@ async function generateConfigs() {
         check: fixtures.FULL_HTTP_CHECK,
         probe: probeFixtures.PRIVATE_PROBE,
       },
+      // TEMPORARY: Invalid alert check to test failure logging
+      {
+        name: 'invalid-alert-http',
+        check: fixtures.INVALID_ALERT_CHECK,
+        probe: probeFixtures.PRIVATE_PROBE,
+      },
       // DNS Check
       {
         name: 'basic-dns',

--- a/scripts/terraform-validation/generate-test-configs.ts
+++ b/scripts/terraform-validation/generate-test-configs.ts
@@ -107,7 +107,7 @@ async function generateConfigs() {
         required_providers: {
           grafana: {
             source: "grafana/grafana",
-            version: "~> 3.0"
+            version: ">= 4.3.0"
           }
         }
       },

--- a/src/test/fixtures/checks.ts
+++ b/src/test/fixtures/checks.ts
@@ -271,6 +271,52 @@ export const CUSTOM_ALERT_SENSITIVITY_CHECK: DNSCheck = db.check.build(
   { transient: { type: CheckType.DNS } }
 ) as DNSCheck;
 
+// TEMPORARY: Check with invalid configuration to test failure logging
+export const INVALID_ALERT_CHECK: HTTPCheck = {
+  ...db.check.build(
+    {
+      job: 'test-invalid-alerts',
+      target: 'https://invalid-alert-test.com',
+      labels: [
+        {
+          name: 'testLabel',
+          value: 'invalidAlertTest',
+        },
+      ],
+      probes: [PRIVATE_PROBE.id] as number[],
+      settings: {
+        http: {
+          method: HttpMethod.GET,
+        },
+      },
+    },
+    { transient: { type: CheckType.HTTP } }
+  ),
+  // TEMPORARY: Adding alerts with missing required fields
+  alerts: [
+    {
+      name: 'InvalidAlertName', // This is not a valid alert name
+      threshold: 95,
+      // Missing required 'period' field - this will cause validation to fail
+    } as any,
+    {
+      name: 'ProbeFailedExecutionsTooHigh',
+      threshold: 291,
+      period: '1m',
+      invalid_field: true, // This field doesn't exist in the schema
+    } as any,
+  ],
+  // TEMPORARY: Override settings with invalid HTTP properties
+  settings: {
+    http: {
+      method: HttpMethod.GET,
+      // TEMPORARY: Adding invalid HTTP settings
+      invalid_http_setting: 'will_cause_error', // This doesn't exist in HTTP settings schema
+      fake_validation_field: 123, // Another invalid field
+    } as any,
+  },
+} as HTTPCheck;
+
 export const BASIC_CHECK_LIST: Check[] = [
   BASIC_DNS_CHECK,
   BASIC_HTTP_CHECK,
@@ -281,6 +327,7 @@ export const BASIC_CHECK_LIST: Check[] = [
   BASIC_TRACEROUTE_CHECK,
   FULL_HTTP_CHECK,
   CUSTOM_ALERT_SENSITIVITY_CHECK,
+  INVALID_ALERT_CHECK, // TEMPORARY: Adding invalid check to test failure
 ];
 
 export const CheckInfo = {

--- a/src/test/fixtures/checks.ts
+++ b/src/test/fixtures/checks.ts
@@ -271,51 +271,7 @@ export const CUSTOM_ALERT_SENSITIVITY_CHECK: DNSCheck = db.check.build(
   { transient: { type: CheckType.DNS } }
 ) as DNSCheck;
 
-// TEMPORARY: Check with invalid configuration to test failure logging
-export const INVALID_ALERT_CHECK: HTTPCheck = {
-  ...db.check.build(
-    {
-      job: 'test-invalid-alerts',
-      target: 'https://invalid-alert-test.com',
-      labels: [
-        {
-          name: 'testLabel',
-          value: 'invalidAlertTest',
-        },
-      ],
-      probes: [PRIVATE_PROBE.id] as number[],
-      settings: {
-        http: {
-          method: HttpMethod.GET,
-        },
-      },
-    },
-    { transient: { type: CheckType.HTTP } }
-  ),
-  // TEMPORARY: Adding alerts with missing required fields
-  alerts: [
-    {
-      name: 'InvalidAlertName', // This is not a valid alert name
-      threshold: 95,
-      // Missing required 'period' field - this will cause validation to fail
-    } as any,
-    {
-      name: 'ProbeFailedExecutionsTooHigh',
-      threshold: 291,
-      period: '1m',
-      invalid_field: true, // This field doesn't exist in the schema
-    } as any,
-  ],
-  // TEMPORARY: Override settings with invalid HTTP properties
-  settings: {
-    http: {
-      method: HttpMethod.GET,
-      // TEMPORARY: Adding invalid HTTP settings
-      invalid_http_setting: 'will_cause_error', // This doesn't exist in HTTP settings schema
-      fake_validation_field: 123, // Another invalid field
-    } as any,
-  },
-} as HTTPCheck;
+
 
 export const BASIC_CHECK_LIST: Check[] = [
   BASIC_DNS_CHECK,
@@ -327,7 +283,6 @@ export const BASIC_CHECK_LIST: Check[] = [
   BASIC_TRACEROUTE_CHECK,
   FULL_HTTP_CHECK,
   CUSTOM_ALERT_SENSITIVITY_CHECK,
-  INVALID_ALERT_CHECK, // TEMPORARY: Adding invalid check to test failure
 ];
 
 export const CheckInfo = {

--- a/src/test/fixtures/checks.ts
+++ b/src/test/fixtures/checks.ts
@@ -87,15 +87,7 @@ export const BASIC_HTTP_CHECK: HTTPCheck = db.check.build(
         value: 'httpLabelValue',
       },
     ],
-    alerts: [
-      ...BASIC_CHECK_ALERTS.alerts,
-      // TEMPORARY: Add invalid alert to cause validation failure  
-      {
-        name: 'InvalidAlert',
-        threshold: 95,
-        // Missing required 'period' field - this should fail on any provider version
-      } as any,
-    ],
+    alerts: [...BASIC_CHECK_ALERTS.alerts],
     probes: [PRIVATE_PROBE.id, PUBLIC_PROBE.id] as number[],
   },
   { transient: { type: CheckType.HTTP } }

--- a/src/test/fixtures/checks.ts
+++ b/src/test/fixtures/checks.ts
@@ -87,7 +87,15 @@ export const BASIC_HTTP_CHECK: HTTPCheck = db.check.build(
         value: 'httpLabelValue',
       },
     ],
-    alerts: [...BASIC_CHECK_ALERTS.alerts],
+    alerts: [
+      ...BASIC_CHECK_ALERTS.alerts,
+      // TEMPORARY: Add invalid alert to cause validation failure  
+      {
+        name: 'InvalidAlert',
+        threshold: 95,
+        // Missing required 'period' field - this should fail on any provider version
+      } as any,
+    ],
     probes: [PRIVATE_PROBE.id, PUBLIC_PROBE.id] as number[],
   },
   { transient: { type: CheckType.HTTP } }


### PR DESCRIPTION
Changes the CI Terraform Validation job to run with the latest terraform provider version.  
Also modifies the GHA logs to be more explicit about errors in failures, and display the terraform provider version used.

Failure from https://github.com/grafana/synthetic-monitoring-app/actions/runs/16815040949/job/47629666992?pr=1220
<img width="1865" height="1244" alt="image" src="https://github.com/user-attachments/assets/93bb8204-3f11-41bb-acc4-9a3a92dd36a3" />

Success from https://github.com/grafana/synthetic-monitoring-app/actions/runs/16815086056/job/47629821209?pr=1220
<img width="1207" height="419" alt="image" src="https://github.com/user-attachments/assets/60c7d39f-0d11-4a04-bc0b-641a72dd4112" />


