### PR TITLE
fix: make totalChecksPerPeriod calculation equal to backend

### DIFF
--- a/src/checkUsageCalc.test.ts
+++ b/src/checkUsageCalc.test.ts
@@ -1,7 +1,7 @@
 import { UsageValues } from 'types';
 import { ONE_SECOND_IN_MS } from 'utils.constants';
 
-import { calculateMultiHTTPUsage, calculateUsage, getTotalChecksPerMonth } from './checkUsageCalc';
+import { calculateMultiHTTPUsage, calculateUsage, getTotalChecksPerMonth, getTotalChecksPerPeriod } from './checkUsageCalc';
 
 describe('checkUsageCalc', () => {
   describe('getTotalChecksPerMonth', () => {
@@ -23,6 +23,52 @@ describe('checkUsageCalc', () => {
       const probeCount = 0;
       const frequency = 300 * ONE_SECOND_IN_MS;
       const result = getTotalChecksPerMonth(probeCount, frequency);
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('getTotalChecksPerPeriod', () => {
+    it('should calculate correct executions for the reported issue case (6m frequency, 10m period)', () => {
+      const probeCount = 1;
+      const frequency = 6 * 60 * ONE_SECOND_IN_MS; // 6 minutes
+      const period = 10 * 60 * ONE_SECOND_IN_MS; // 10 minutes
+      const result = getTotalChecksPerPeriod(probeCount, frequency, period);
+      // floor(10m / 6m) * 1 = floor(1.667) * 1 = 1
+      expect(result).toBe(1);
+    });
+
+    it('should calculate correct executions when period is exactly divisible by frequency', () => {
+      const probeCount = 1;
+      const frequency = 5 * 60 * ONE_SECOND_IN_MS; // 5 minutes
+      const period = 10 * 60 * ONE_SECOND_IN_MS; // 10 minutes
+      const result = getTotalChecksPerPeriod(probeCount, frequency, period);
+      // floor(10m / 5m) * 1 = floor(2) * 1 = 2
+      expect(result).toBe(2);
+    });
+
+    it('should calculate correct executions with multiple probes', () => {
+      const probeCount = 3;
+      const frequency = 2 * 60 * ONE_SECOND_IN_MS; // 2 minutes
+      const period = 5 * 60 * ONE_SECOND_IN_MS; // 5 minutes
+      const result = getTotalChecksPerPeriod(probeCount, frequency, period);
+      // floor(5m / 2m) * 3 = floor(2.5) * 3 = 2 * 3 = 6
+      expect(result).toBe(6);
+    });
+
+    it('should return 0 when period is shorter than frequency', () => {
+      const probeCount = 1;
+      const frequency = 10 * 60 * ONE_SECOND_IN_MS; // 10 minutes
+      const period = 5 * 60 * ONE_SECOND_IN_MS; // 5 minutes
+      const result = getTotalChecksPerPeriod(probeCount, frequency, period);
+      // floor(5m / 10m) * 1 = floor(0.5) * 1 = 0
+      expect(result).toBe(0);
+    });
+
+    it('should return 0 when probe count is 0', () => {
+      const probeCount = 0;
+      const frequency = 5 * 60 * ONE_SECOND_IN_MS;
+      const period = 10 * 60 * ONE_SECOND_IN_MS;
+      const result = getTotalChecksPerPeriod(probeCount, frequency, period);
       expect(result).toBe(0);
     });
   });

--- a/src/checkUsageCalc.ts
+++ b/src/checkUsageCalc.ts
@@ -31,11 +31,11 @@ export const getTotalChecksPerMonth = (probeCount: number, frequency: number) =>
 };
 
 export const getTotalChecksPerPeriod = (probeCount: number, frequency: number, period: number) => {
-  const frequencyInSeconds = frequency / ONE_SECOND_IN_MS;
-  const checksPerMinute = SECONDS_IN_MINUTE / frequencyInSeconds;
-  const checksPerPeriod = checksPerMinute * (period / ONE_SECOND_IN_MS / 60) * probeCount;
-
-  return Math.round(checksPerPeriod);
+  // Use same logic as backend: floor(period / frequency) * probeCount
+  // This counts only complete executions that can finish within the period
+  // https://github.com/grafana/synthetic-monitoring-api/blob/410d4c402829df22f3d6adf4d00fa0146ebe01ad/internal/alerts/rules.go#L235-L239
+  const maxExecutions = Math.floor(period / frequency);
+  return maxExecutions * probeCount;
 };
 
 const getLogsGbPerMonth = (probeCount: number, frequency: number) => {


### PR DESCRIPTION
## Fix alert execution count calculation to align with backend

There was a discrepancy between the frontend and backend calculations for determining the total number of probe executions within an alert period for "failed executions" alerts. This caused the backend to reject valid alerts that the frontend incorrectly showed as acceptable.

### Example of the issue:
- Check frequency: 6 minutes
- Alert period: 10 minutes  
- Number of probes: 1
- **Frontend showed**: 2 executions (incorrect)
- **Backend calculated**: 1 execution (correct)
- **Result**: Backend rejected the alert when threshold was set to 2/2


The frontend was using `Math.round()` which could round up fractional executions.

<img width="1290" height="494" alt="image" src="https://github.com/user-attachments/assets/74d0af2e-5ad8-4e7c-93ae-912f3f55b877" />
<img width="939" height="581" alt="image" src="https://github.com/user-attachments/assets/298315de-b617-4956-9735-3d9750126940" />


### References
Backend implementation: https://github.com/grafana/synthetic-monitoring-api/blob/410d4c402829df22f3d6adf4d00fa0146ebe01ad/internal/alerts/rules.go#L235-L239
