### PR TITLE
chore: publish to dev catalog

### DIFF
--- a/.github/workflows/call_build-sign-upload-plugin.yml
+++ b/.github/workflows/call_build-sign-upload-plugin.yml
@@ -46,14 +46,26 @@ jobs:
           common_secrets: |
             GRAFANA_ACCESS_POLICY_TOKEN=plugins/sign-plugin-access-policy-token:token
 
+      - name: Replace plugin version with suffix
+        if: ${{ inputs.environment == 'dev' }}
+        run: |
+          package_json_path="package.json"
+          version=$(jq -r .version "$package_json_path")
+          commit_sha=$(git rev-parse --short=8 HEAD)
+          pr_version="$version+$commit_sha"
+          
+          echo "Replacing plugin version \"$version\" with \"$pr_version\" in $package_json_path"
+          jq --arg pr_version "$pr_version" '.version = $pr_version' "$package_json_path" > /tmp/package.json
+          mv /tmp/package.json "$package_json_path"
+
       - name: Build, Sign and Zip Plugin
         env:
           ENVIRONMENT: ${{ inputs.environment }}
         run: |
           case "$ENVIRONMENT" in
             "dev")
-              echo "Building for development with git hash versioning"
-              make build sign package-latest generate-version
+              echo "Building for development"
+              make build sign package-latest
               ;;
             "prod")
               echo "Building for production/staging with semantic versioning"
@@ -66,10 +78,21 @@ jobs:
               ;;
           esac
 
+      - name: Update dist/plugin.json with suffixed version
+        if: ${{ inputs.environment == 'dev' }}
+        run: |
+          # Get the suffixed version from package.json and apply it to dist/plugin.json
+          suffixed_version=$(jq -r .version package.json)
+          echo "Updating dist/plugin.json version to: $suffixed_version"
+          jq --arg version "$suffixed_version" '.info.version = $version' dist/plugin.json > /tmp/plugin.json
+          mv /tmp/plugin.json dist/plugin.json
+          echo "Updated dist/plugin.json version to: $(jq -r .info.version dist/plugin.json)"
+
       - name: Read plugin version
         id: read-version
         run: |
-          PLUGIN_VERSION=$(cat plugin_version.txt)
+          # Read version from the built plugin.json
+          PLUGIN_VERSION=$(jq -r .info.version dist/plugin.json)
           echo "plugin_version=${PLUGIN_VERSION}" >> "${GITHUB_OUTPUT}"
           echo "Plugin version: ${PLUGIN_VERSION}"
 

--- a/.github/workflows/call_deploy-plugin.yml
+++ b/.github/workflows/call_deploy-plugin.yml
@@ -32,7 +32,7 @@ jobs:
       plugin_version: ${{ needs.build-sign-zip-upload.outputs.plugin_version }}
 
   publish-to-grafana-com:
-    name: Publish to grafana.com
+    name: Publish to grafana.com (prod catalog)
     needs: build-sign-zip-upload
     runs-on: ubuntu-latest
     if: inputs.environment == 'production'
@@ -50,9 +50,58 @@ jobs:
           common_secrets: |
             GRAFANA_ACCESS_POLICY_TOKEN=plugins/sign-plugin-access-policy-token:token
 
-      - name: Publish plugin to grafana.com
+      - name: Publish plugin to grafana.com (prod catalog)
         env:
           GRAFANA_API_KEY: ${{ env.GRAFANA_ACCESS_POLICY_TOKEN }}
         run: |
           echo "Publishing plugin to grafana.com with version: ${{ needs.build-sign-zip-upload.outputs.plugin_version }}"
           ./scripts/publish-gcom.sh
+
+  publish-to-grafana-dev:
+    name: Publish to grafana-dev.com (dev catalog)
+    needs: build-sign-zip-upload
+    runs-on: ubuntu-latest
+    if: inputs.environment == 'dev'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Get dev catalog token from Vault
+        uses: grafana/shared-workflows/actions/get-vault-secrets@75804962c1ba608148988c1e2dc35fbb0ee21746
+        with:
+          common_secrets: |
+            GCOM_PUBLISH_TOKEN_DEV=plugins/gcom-publish-token:dev
+
+      - name: Show version being published
+        run: |
+          echo "=== Publishing version: ${{ needs.build-sign-zip-upload.outputs.plugin_version }} ==="
+          echo "Plugin version from build job: ${{ needs.build-sign-zip-upload.outputs.plugin_version }}"
+
+      - name: authenticate to gcp
+        id: gcloud
+        uses: google-github-actions/auth@b7593ed2efd1c1617e1b0254da33b86225adb2a5 # v2.1.12
+        with:
+          workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+          service_account: github-plugin-ci-workflows@grafanalabs-workload-identity.iam.gserviceaccount.com
+          token_format: id_token
+          id_token_audience: 194555723165-aftshfqa32nig79trcrh96ha94ta46jd.apps.googleusercontent.com
+          id_token_include_email: true
+          create_credentials_file: false
+          export_environment_variables: false
+
+      - name: publish to catalog
+        env:
+          GCOM_PUBLISH_TOKEN_DEV: ${{ env.GCOM_PUBLISH_TOKEN_DEV }}
+          GCLOUD_AUTH_TOKEN: ${{ steps.gcloud.outputs.id_token }}
+        uses: grafana/plugin-ci-workflows/actions/plugins/publish/publish@5c3428a6a5aca68e5292bd33829d676f84da9f33
+        with:
+          zips: '["https://storage.googleapis.com/grafanalabs-synthetic-monitoring-app-dev/builds/grafana-synthetic-monitoring-app-latest.zip"]'
+          environment: dev
+          scopes: universal
+          gcom-publish-token: ${{ env.GCOM_PUBLISH_TOKEN_DEV }}
+          gcloud-auth-token: ${{ steps.gcloud.outputs.id_token }}
+          ignore-conflicts: true


### PR DESCRIPTION
Ref https://github.com/grafana/synthetic-monitoring-app/issues/1219

Publish sm-app versions to the [dev](https://grafana-dev.com/grafana/plugins/grafana-synthetic-monitoring-app/?pg=plugins&plcmt=featured4) catalog using the shared `grafana/plugin-ci-workflows/actions/plugins/publish/publish` github action.

Action: https://github.com/grafana/synthetic-monitoring-app/actions/runs/16914595115

<img width="1253" height="812" alt="image" src="https://github.com/user-attachments/assets/449f49bd-75d6-4a02-8dd8-eeb0476214b8" />
<img width="1339" height="595" alt="image" src="https://github.com/user-attachments/assets/74543514-de6c-47c9-add7-d235c9cd37a0" />


This required for https://github.com/grafana/deployment_tools/pull/320254

Note:

The version in the dev catalog is taken from the version in `plugin.json`, so we need to append the suffix there. This is done in the same way as https://github.com/grafana/plugin-ci-workflows/blob/main/.github/workflows/cd.yml#L184