### PR TITLE
chore: update dev catalog version instead of version

### DIFF
--- a/scripts/deployment/create-dev-deployment-pr.sh
+++ b/scripts/deployment/create-dev-deployment-pr.sh
@@ -27,7 +27,7 @@ cat << EOF > config.json
   "update_jsonnet_attribute_configs": [
     {
       "file_path": "ksonnet/environments/hosted-grafana/waves/provisioned-plugins/grafana-synthetic-monitoring-app/dev.libsonnet",
-      "jsonnet_key": "version",
+      "jsonnet_key": "_catalog_version",
       "jsonnet_value_file": "plugin_version.txt"
     }
   ]


### PR DESCRIPTION
Ref https://github.com/grafana/synthetic-monitoring-app/issues/1219

In order to change DEV `deployment_tools` to read from the catalog, we need to update the `_catalog_version` in `ksonnet/environments/hosted-grafana/waves/provisioned-plugins/grafana-synthetic-monitoring-app/dev.libsonnet` when creating the deployment_tools PR.

See https://github.com/grafana/deployment_tools/pull/320254 