### PR TITLE
fix: explicit logs panel rendering height and width with new logs pan…

### DIFF
--- a/src/components/CheckTestResult.tsx
+++ b/src/components/CheckTestResult.tsx
@@ -11,8 +11,11 @@ interface Props {
   logs: DataFrame;
 }
 
+const LOGS_HEIGHT = 300;
+
 export function CheckTestResult({ probeName, success, loading, logs }: Props) {
   const [isOpen, setIsOpen] = useState(false);
+  const [width, setWidth] = useState(0);
   const styles = useStyles2(getStyles);
   const header = (
     <div className={styles.header}>
@@ -43,12 +46,21 @@ export function CheckTestResult({ probeName, success, loading, logs }: Props) {
       }}
     >
       {!loading && logs ? (
-        <div>
+        <div
+          ref={(el) => {
+            if (el) {
+              setWidth(el.clientWidth);
+            }
+          }}
+          style={{
+            height: `${LOGS_HEIGHT}px`,
+          }}
+        >
           <PanelRenderer
             title="Logs"
             pluginId="logs"
-            width={658}
-            height={300}
+            width={width}
+            height={LOGS_HEIGHT}
             data={{
               state: LoadingState.Done,
               series: [logs],
@@ -60,6 +72,9 @@ export function CheckTestResult({ probeName, success, loading, logs }: Props) {
                   to: 'now',
                 },
               },
+            }}
+            options={{
+              detailsMode: `inline`,
             }}
           />
         </div>


### PR DESCRIPTION
## Problem

A new Logs Panel has been enabled for core Grafana and it is no longer showing in the adhoc test modal on the check creation / check editing page.

<img width="811" height="260" alt="image" src="https://github.com/user-attachments/assets/e78b5ef6-54e1-42c4-8d51-022ab65c2d7b" />


## Solution

Added a container that measures the width and sets the height explicitly for the logs panel to grow into. Changed the default logs detail to render inline

<img width="850" height="552" alt="image" src="https://github.com/user-attachments/assets/03af0e10-ee7c-437d-a735-26a0a41ea8ce" />
