### PR TITLE
fix: update tsconfig for `monaco` 

### DIFF
--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -94,7 +94,11 @@ export const CodeEditor = forwardRef(function CodeEditor(
     const compilerOptions = monaco.languages.typescript.javascriptDefaults.getCompilerOptions();
     monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
       ...compilerOptions,
-      checkJs, // show errors for JS files, by default it check only TS
+      checkJs, // show errors for JS files; by default, it checks only TS
+
+      // To allow for top-level await (a combination of `target` and `module` options is required).
+      target: monaco.languages.typescript.ScriptTarget.ESNext, // Was ESNext by default, now it's set explicitly.
+      module: monaco.languages.typescript.ModuleKind.ESNext,
     });
 
     // Needed to make `checkJs` work and highlight errors


### PR DESCRIPTION
Adds support for [top-level `async`](https://github.com/grafana/synthetic-monitoring-app/issues/1231) in scripted/browser checks

Even though k6 doesn't support some experimental features that are currently in `ESNext`, it's still the most suitable option (of the ones that we can pick from).

Resolves: #1231
