### PR TITLE
fix: update probe mappings

### DIFF
--- a/src/data/probeAPIServerMappings.json
+++ b/src/data/probeAPIServerMappings.json
@@ -96,6 +96,12 @@
     "backendAddress": "synthetic-monitoring-api-eu-north-0.grafana.net"
   },
   {
+    "region": "Switzerland",
+    "provider": "AWS",
+    "apiServerURL": "synthetic-monitoring-grpc-eu-central-0.grafana.net:443",
+    "backendAddress": "synthetic-monitoring-api-eu-central-0.grafana.net"
+  },
+  {
     "region": "UAE",
     "provider": "AWS",
     "apiServerURL": "synthetic-monitoring-grpc-me-central-1.grafana.net:443",


### PR DESCRIPTION
## Problem

Switzerland was recently added as a new region and the app is lacking the hard-coded mapping: https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/#add-a-new-probe-in-your-grafana-instance

## Solution

Ran the script to update the mapping 😄 