### PR TITLE
fix: correct danger js PR stats

### DIFF
--- a/.github/workflows/call_dangerJS.yml
+++ b/.github/workflows/call_dangerJS.yml
@@ -28,10 +28,8 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Download currentBundleSize
-        uses: dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # v7
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          workflow: on-pr-creation.yml
-          commit: ${{ github.sha }}
           name: currentBundleSize
           path: artifacts
 

--- a/.github/workflows/call_dangerJS.yml
+++ b/.github/workflows/call_dangerJS.yml
@@ -31,6 +31,7 @@ jobs:
         uses: dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # v7
         with:
           workflow: on-pr-creation.yml
+          commit: ${{ github.sha }}
           name: currentBundleSize
           path: artifacts
 

--- a/.github/workflows/call_dangerJS.yml
+++ b/.github/workflows/call_dangerJS.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Download currentBundleSize
         uses: dawidd6/action-download-artifact@80620a5d27ce0ae443b965134db88467fc607b43 # v7
         with:
+          workflow: on-pr-creation.yml
           name: currentBundleSize
           path: artifacts
 


### PR DESCRIPTION
## Fix DangerJS bundle size reporting by specifying correct artifact source

DangerJS has been reporting inaccurate bundle size changes for recent PRs (see https://raintank-corp.slack.com/archives/C098DB0038C/p1756367397330709). 

The issue was that the `currentBundleSize` artifact download was using `dawidd6/action-download-artifact` without proper parameters, causing it to download artifacts from the most recent successfully completed workflow run instead of the current PR's build. However, since the `currentBundleSize` artifact is generated within the same workflow run as DangerJS (both are part of on-pr-creation.yml), the correct solution is to use `actions/download-artifact` which downloads from the current workflow run.

The fix changes the `currentBundleSize` download to use `actions/download-artifact` instead of `dawidd6/action-download-artifact`, ensuring it pulls the artifact from the current workflow run. The `mainBundleSize` download continues to use `dawidd6/action-download-artifact` with workflow: `on-push-to-main.yml `since it needs to download from a different workflow.

Now DangerJS will properly compare the current PR's actual bundle size against the main branch baseline instead of comparing against stale data from previous runs.

## Documentation Reference:
According to the `dawidd6/action-download-artifact` [README](https://github.com/dawidd6/action-download-artifact/blob/master/README.md):
> "If commit or pr or branch or run_id or workflow_conclusion is not specified then the artifact from the most recent successfully completed workflow run will be downloaded."
