### PR TITLE
fix: unsuccessful switch in logs panel

### DIFF
--- a/src/scenes/Common/ErrorLogsPanel.tsx
+++ b/src/scenes/Common/ErrorLogsPanel.tsx
@@ -26,7 +26,9 @@ export const ErrorLogs = ({ startingUnsuccessfulOnly = false }: { startingUnsucc
   const dataProvider = useQueryRunner({
     queries: [
       {
-        expr: '{probe=~"$probe", instance="$instance", job="$job"} | logfmt',
+        expr: `{probe=~"$probe", instance="$instance", job="$job", probe_success=~"${
+          unsuccessfulOnly ? '0' : '.*'
+        }"} | logfmt`,
         refId: 'Execution_Logs',
       },
     ],


### PR DESCRIPTION
The logs panel switch to change from all / unsuccessful only log entries is broken. See https://raintank-corp.slack.com/archives/C0175SS6SA3/p1757005216616369. This PR fixes it. 

Before

https://github.com/user-attachments/assets/cea44cf5-b52e-4a5a-82d6-a378bc19fb91

After 

https://github.com/user-attachments/assets/770607f6-2148-4b91-802a-923d3d2fc7ca

