### PR TITLE
fix: Timepoint Explorer xaxis and check creation rounding

### DIFF
--- a/src/scenes/components/TimepointExplorer/TimepointExplorer.context.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointExplorer.context.tsx
@@ -109,7 +109,7 @@ interface TimepointExplorerProviderProps extends PropsWithChildren {
 }
 
 export const TimepointExplorerProvider = ({ children, check }: TimepointExplorerProviderProps) => {
-  const checkCreation = Math.round(check.created! * 1000);
+  const checkCreation = Math.ceil(check.created!) * 1000;
   const [timeRange] = useTimeRange();
   const timeRangeRef = useRef<TimeRange>(timeRange);
   const logsRetentionPeriod = useLogsRetentionPeriod(timeRange.from.valueOf());

--- a/src/scenes/components/TimepointExplorer/XAxis.tsx
+++ b/src/scenes/components/TimepointExplorer/XAxis.tsx
@@ -40,8 +40,8 @@ const XAxisContent = ({ timepoints }: XAxisProps) => {
   const [dashboardTimeRange] = useTimeRange();
   const crossesDays = doesTimeRangeCrossDays(dashboardTimeRange.from.toDate(), dashboardTimeRange.to.toDate());
   const points = useMemo(
-    () => buildXAxisPoints({ timepoints, crossesDays, timepointWidth }),
-    [timepoints, crossesDays, timepointWidth]
+    () => buildXAxisPoints({ timepoints, crossesDays, timepointWidth, renderingStrategy }),
+    [timepoints, crossesDays, timepointWidth, renderingStrategy]
   );
 
   return (

--- a/src/scenes/components/TimepointExplorer/XAxis.utils.test.ts
+++ b/src/scenes/components/TimepointExplorer/XAxis.utils.test.ts
@@ -57,7 +57,7 @@ describe('buildXAxisPoints', () => {
       checkConfigs: [{ frequency: 1, from: 0, to: 1 }],
     });
 
-    const result = buildXAxisPoints({ timepoints, crossesDays: false, timepointWidth: 20 });
+    const result = buildXAxisPoints({ timepoints, crossesDays: false, timepointWidth: 20, renderingStrategy: 'end' });
     expect(result.length).toBe(1);
   });
 
@@ -66,7 +66,7 @@ describe('buildXAxisPoints', () => {
       checkConfigs: [{ frequency: 1, from: 0, to: 2 }],
     });
 
-    const result = buildXAxisPoints({ timepoints, crossesDays: false, timepointWidth: 20 });
+    const result = buildXAxisPoints({ timepoints, crossesDays: false, timepointWidth: 20, renderingStrategy: 'end' });
     expect(result.length).toBe(1);
   });
 
@@ -75,7 +75,7 @@ describe('buildXAxisPoints', () => {
       checkConfigs: [{ frequency: 1, from: 0, to: 10 }],
     });
 
-    const result = buildXAxisPoints({ timepoints, crossesDays: false, timepointWidth: 20 });
+    const result = buildXAxisPoints({ timepoints, crossesDays: false, timepointWidth: 20, renderingStrategy: 'end' });
     expect(result.length).toBe(2);
   });
 
@@ -84,7 +84,7 @@ describe('buildXAxisPoints', () => {
       checkConfigs: [{ frequency: 1, from: 0, to: 20 }],
     });
 
-    const result = buildXAxisPoints({ timepoints, crossesDays: true, timepointWidth: 20 });
+    const result = buildXAxisPoints({ timepoints, crossesDays: true, timepointWidth: 20, renderingStrategy: 'end' });
     expect(result.length).toBe(3);
   });
 
@@ -98,7 +98,7 @@ describe('buildXAxisPoints', () => {
       checkConfigs: [{ frequency, from: fromTime, to: toTime }],
     });
 
-    const result = buildXAxisPoints({ timepoints, crossesDays: true, timepointWidth: 20 });
+    const result = buildXAxisPoints({ timepoints, crossesDays: true, timepointWidth: 20, renderingStrategy: 'end' });
     expect(result[0].label).toBe(`1/1, 00:00:00`);
   });
 
@@ -112,7 +112,25 @@ describe('buildXAxisPoints', () => {
       checkConfigs: [{ frequency, from: fromTime, to: toTime }],
     });
 
-    const result = buildXAxisPoints({ timepoints, crossesDays: false, timepointWidth: 20 });
+    const result = buildXAxisPoints({ timepoints, crossesDays: false, timepointWidth: 20, renderingStrategy: 'end' });
     expect(result[0].label).toBe(`00:00:00`);
+  });
+
+  it(`should add the correct index when renderingStrategy is start`, () => {
+    const timepoints = buildTimepoints({
+      checkConfigs: [{ frequency: 1, from: 0, to: 20 }],
+    });
+
+    const result = buildXAxisPoints({ timepoints, crossesDays: true, timepointWidth: 20, renderingStrategy: 'start' });
+    expect(result[0].index).toBe(0);
+  });
+
+  it(`should add the correct index when renderingStrategy is end`, () => {
+    const timepoints = buildTimepoints({
+      checkConfigs: [{ frequency: 1, from: 0, to: 20 }],
+    });
+
+    const result = buildXAxisPoints({ timepoints, crossesDays: true, timepointWidth: 20, renderingStrategy: 'end' });
+    expect(result[0].index).toBe(19);
   });
 });

--- a/src/scenes/components/TimepointExplorer/XAxis.utils.ts
+++ b/src/scenes/components/TimepointExplorer/XAxis.utils.ts
@@ -9,9 +9,15 @@ interface BuildXAxisPointsProps {
   timepoints: StatelessTimepoint[];
   crossesDays: boolean;
   timepointWidth: number;
+  renderingStrategy: 'start' | 'end';
 }
 
-export function buildXAxisPoints({ timepoints, crossesDays, timepointWidth }: BuildXAxisPointsProps) {
+export function buildXAxisPoints({
+  timepoints,
+  crossesDays,
+  timepointWidth,
+  renderingStrategy,
+}: BuildXAxisPointsProps) {
   const timepointCount = timepoints.length;
 
   if (timepointCount === 0) {
@@ -34,7 +40,7 @@ export function buildXAxisPoints({ timepoints, crossesDays, timepointWidth }: Bu
 
     build.push({
       label: firstTimepoint.adjustedTime,
-      index: timepointCount - 1, // Reversed index
+      index: renderingStrategy === 'end' ? timepointCount - 1 : 0, // Reversed index
     });
   }
   // If we need 2 points, show first and last
@@ -44,7 +50,7 @@ export function buildXAxisPoints({ timepoints, crossesDays, timepointWidth }: Bu
 
     build.push({
       label: firstTimepoint.adjustedTime,
-      index: timepointCount - 1, // Reversed index
+      index: renderingStrategy === 'end' ? timepointCount - 1 : 0, // Reversed index
     });
 
     // Last point
@@ -52,7 +58,7 @@ export function buildXAxisPoints({ timepoints, crossesDays, timepointWidth }: Bu
 
     build.push({
       label: lastTimepoint.adjustedTime,
-      index: 0, // Reversed index
+      index: renderingStrategy === 'end' ? 0 : timepointCount - 1, // Reversed index
     });
   } else {
     // Calculate evenly spaced indices
@@ -64,7 +70,7 @@ export function buildXAxisPoints({ timepoints, crossesDays, timepointWidth }: Bu
 
       build.push({
         label: timepoint.adjustedTime,
-        index: timepointCount - 1 - index, // Reversed index for rendering
+        index: renderingStrategy === 'end' ? timepointCount - 1 - index : index, // Reversed index for rendering
       });
     }
   }


### PR DESCRIPTION
## Problem

When the `renderingStrategy` is `start` the xaxis is rendering incorrectly -- the time values are displaying from latest to oldest.

There is also a problem where the check creation is being rounded using `Math.round` and not `Math.ceil` like all the other event updates now.

<img width="1613" height="974" alt="image" src="https://github.com/user-attachments/assets/03471673-3d03-4af3-b94f-2c2c2302859d" />


## Solution

1. Change the xaxis indices depending on the `renderingStrategy`.
2. Use `Math.ceil` instead of `Math.round` for check creation.

<img width="1611" height="978" alt="image" src="https://github.com/user-attachments/assets/0963e383-3d07-4df7-88ab-f094a4dbf2fc" />
