### PR TITLE
fix: change user permissions for secrets endpoints

### DIFF
--- a/src/datasource/plugin.json
+++ b/src/datasource/plugin.json
@@ -93,7 +93,7 @@
       "path": "api/v1alpha1/",
       "method": "PUT",
       "url": "{{.JsonData.apiHost}}/api/v1alpha1/",
-      "reqAction": "grafana-synthetic-monitoring-app:write",
+      "reqAction": "grafana-synthetic-monitoring-app:read",
       "headers": [
         {
           "name": "Authorization",
@@ -105,7 +105,7 @@
       "path": "api/v1alpha1/",
       "method": "POST",
       "url": "{{.JsonData.apiHost}}/api/v1alpha1/",
-      "reqAction": "grafana-synthetic-monitoring-app:write",
+      "reqAction": "grafana-synthetic-monitoring-app:read",
       "headers": [
         {
           "name": "Authorization",
@@ -117,7 +117,7 @@
       "path": "api/v1alpha1/",
       "method": "DELETE",
       "url": "{{.JsonData.apiHost}}/api/v1alpha1/",
-      "reqAction": "grafana-synthetic-monitoring-app:write",
+      "reqAction": "grafana-synthetic-monitoring-app:read",
       "headers": [
         {
           "name": "Authorization",


### PR DESCRIPTION
Changes the datasource's plugin configuration so SM Viewer users with Secrets Management appropriate permissions can now perform Create/Delete/Edit operations in the UI:

https://github.com/user-attachments/assets/9288c9ce-4591-40c8-b699-8de41b6d2ca8


<img width="1596" height="192" alt="image" src="https://github.com/user-attachments/assets/69e1db73-a036-4472-9b85-1658620bb369" />
