### PR TITLE
fix: probe api mappings

### DIFF
--- a/src/data/probeAPIServerMappings.json
+++ b/src/data/probeAPIServerMappings.json
@@ -140,8 +140,8 @@
   {
     "region": "United States",
     "provider": "Azure",
-    "apiServerURL": "synthetic-monitoring-grpc-us-central2.grafana.net:443",
-    "backendAddress": "synthetic-monitoring-api-us-central2.grafana.net"
+    "apiServerURL": "synthetic-monitoring-grpc-us-central-7.grafana.net:443",
+    "backendAddress": "synthetic-monitoring-api-us-central-7.grafana.net"
   },
   {
     "region": "United States",


### PR DESCRIPTION
Fixes Probe API Server Mappings as flagged by https://github.com/grafana/synthetic-monitoring-app/pull/1269#issuecomment-3325321510

<img width="845" height="671" alt="image" src="https://github.com/user-attachments/assets/d3d59310-24d8-4b51-88d3-11816be36014" />
