### PR TITLE
fix: display latency visualization units in milliseconds

### DIFF
--- a/src/scenes/Common/AvgLatencyViz.tsx
+++ b/src/scenes/Common/AvgLatencyViz.tsx
@@ -87,10 +87,10 @@ export const AvgLatency = () => {
 
   const viz = VizConfigBuilders.stat()
     .setOption('graphMode', BigValueGraphMode.None)
-    .setUnit('s')
-    .setDecimals(2)
+    .setUnit('ms')
+    .setDecimals(0)
     .setMin(0)
-    .setMax(1)
+    .setMax(5000)
     .setNoValue('N/A')
     .setThresholds({
       mode: ThresholdsMode.Absolute,
@@ -101,11 +101,11 @@ export const AvgLatency = () => {
         },
         {
           color: 'yellow',
-          value: 1,
+          value: 1000,
         },
         {
           color: 'red',
-          value: 2,
+          value: 2000,
         },
       ],
     })

--- a/src/scenes/Common/ResponseLatencyByProbe.tsx
+++ b/src/scenes/Common/ResponseLatencyByProbe.tsx
@@ -39,7 +39,7 @@ export const ResponseLatencyByProbe = () => {
   });
 
   const viz = VizConfigBuilders.timeseries()
-    .setUnit('s')
+    .setUnit('ms')
 
     .setCustomFieldConfig('drawStyle', GraphDrawStyle.Points)
     .setCustomFieldConfig('lineInterpolation', LineInterpolation.Linear)
@@ -90,7 +90,7 @@ export const ResponseLatencyByProbe = () => {
           color: 'green',
         },
         {
-          value: 80,
+          value: 800,
           color: 'red',
         },
       ],


### PR DESCRIPTION
Closes https://github.com/grafana/support-escalations/issues/18505

### Problem
Latency visualizations were displaying inconsistent units:
- `AvgLatencyViz` showed seconds with unrealistic 1s max and 2s red threshold
- `ResponseLatencyByProbe` showed seconds with 80s red threshold 
- Other components use milliseconds

### Solution
- Changed both components to use `ms` unit 
- Updated thresholds to realistic millisecond values:
  - AvgLatency: 1000ms yellow, 2000ms red, 5000ms max
  - ResponseLatencyByProbe: 800ms red (aligns with TTFB standards)

