### PR TITLE
fix: resolve incorrect alert rule group matching

### DIFF
--- a/src/data/useGMAlerts.test.ts
+++ b/src/data/useGMAlerts.test.ts
@@ -20,6 +20,21 @@ describe('findRelevantAlertGroups', () => {
     name: ALERT_NAME,
   };
 
+  const RULE_5M: PrometheusAlertingRule = {
+    ...MATCHING_RULE,
+    name: `${ALERT_NAME} [5m]`,
+  };
+
+  const RULE_10M: PrometheusAlertingRule = {
+    ...MATCHING_RULE,
+    name: `${ALERT_NAME} [10m]`,
+  };
+
+  const RULE_30M: PrometheusAlertingRule = {
+    ...MATCHING_RULE,
+    name: `${ALERT_NAME} [30m]`,
+  };
+
   const NON_MATCHING_RULE: PrometheusAlertingRule = {
     ...MATCHING_RULE,
     name: 'OtherAlert',
@@ -81,5 +96,102 @@ describe('findRelevantAlertGroups', () => {
         rules: [expect.objectContaining({ name: alertType })],
       }),
     ]);
+  });
+
+  describe('period-based alert matching', () => {
+    const GROUP_5M: PrometheusAlertsGroup = {
+      evaulationTime: 1,
+      file: 'Grafana Synthetic Monitoring',
+      folderUid: 'grafana-synthetic-monitoring-app',
+      interval: 300,
+      lastEvaluation: 'now',
+      name: 'Failed Checks [5m]',
+      rules: [RULE_5M],
+      totals: null,
+    };
+
+    const GROUP_10M: PrometheusAlertsGroup = {
+      ...GROUP_5M,
+      name: 'Failed Checks [10m]',
+      rules: [RULE_10M],
+    };
+
+    const GROUP_30M: PrometheusAlertsGroup = {
+      ...GROUP_5M,
+      name: 'Failed Checks [30m]',
+      rules: [RULE_30M],
+    };
+
+    test('matches exact period when period is specified', () => {
+      const alerts: CheckAlertPublished[] = [{ 
+        name: ALERT_NAME, 
+        period: '5m',
+        ...baseAlert 
+      }];
+      
+      // Test the scenario from the escalation: 10m group comes first in array
+      const groups = [GROUP_10M, GROUP_30M, GROUP_5M];
+      const result = findRelevantAlertGroups(groups, alerts);
+      
+      expect(result).toStrictEqual([
+        {
+          ...GROUP_5M,
+          rules: [RULE_5M],
+        },
+      ]);
+    });
+
+    test('matches 10m period correctly even when 5m exists', () => {
+      const alerts: CheckAlertPublished[] = [{ 
+        name: ALERT_NAME, 
+        period: '10m',
+        ...baseAlert 
+      }];
+      
+      const groups = [GROUP_5M, GROUP_10M, GROUP_30M];
+      const result = findRelevantAlertGroups(groups, alerts);
+      
+      expect(result).toStrictEqual([
+        {
+          ...GROUP_10M,
+          rules: [RULE_10M],
+        },
+      ]);
+    });
+
+    test('handles alert without period (backward compatibility)', () => {
+      const alerts: CheckAlertPublished[] = [{ 
+        name: ALERT_NAME,
+        ...baseAlert 
+      }];
+      
+      const groups = [GROUP];
+      const result = findRelevantAlertGroups(groups, alerts);
+      
+      expect(result).toStrictEqual([
+        {
+          ...GROUP,
+          rules: [MATCHING_RULE],
+        },
+      ]);
+    });
+
+    test('creates dummy group when no matching period rule exists', () => {
+      const alerts: CheckAlertPublished[] = [{ 
+        name: ALERT_NAME, 
+        period: '15m', // This period doesn't exist in any group
+        ...baseAlert 
+      }];
+      
+      const groups = [GROUP_5M, GROUP_10M, GROUP_30M];
+      const result = findRelevantAlertGroups(groups, alerts);
+      
+      expect(result).toStrictEqual([
+        expect.objectContaining({
+          name: CATEGORY,
+          rules: [expect.objectContaining({ name: ALERT_NAME })],
+        }),
+      ]);
+    });
   });
 }); 

--- a/src/data/useGMAlerts.ts
+++ b/src/data/useGMAlerts.ts
@@ -43,13 +43,15 @@ function queryAlertApi() {
 
 function findGroupWithMatchingRule(
   groups: PrometheusAlertsGroup[],
-  alertName: string
+  alert: { name: string; period?: string }
 ): PrometheusAlertsGroup | undefined {
-  return groups.find((group) => group.rules.some((rule) => rule.name.includes(alertName)));
+  const fullAlertName = alert.period ? `${alert.name} [${alert.period}]` : alert.name;
+  return groups.find((group) => group.rules.some((rule) => rule.name === fullAlertName));
 }
 
-function extractMatchingRules(group: PrometheusAlertsGroup, alertName: string) {
-  return group.rules.filter((rule) => rule.name.includes(alertName));
+function extractMatchingRules(group: PrometheusAlertsGroup, alert: { name: string; period?: string }) {
+  const fullAlertName = alert.period ? `${alert.name} [${alert.period}]` : alert.name;
+  return group.rules.filter((rule) => rule.name === fullAlertName);
 }
 
 function constructDummyGroup(alertName: string): PrometheusAlertsGroup {
@@ -92,11 +94,11 @@ export function findRelevantAlertGroups(
   const grafanaGroups = groups.filter((group) => group.folderUid === GRAFANA_SM_FOLDER_UID);
 
   return alerts.map((alert) => {
-    const groupWithRule = findGroupWithMatchingRule(grafanaGroups, alert.name);
+    const groupWithRule = findGroupWithMatchingRule(grafanaGroups, alert);
     if (groupWithRule) {
       return {
         ...groupWithRule,
-        rules: extractMatchingRules(groupWithRule, alert.name),
+        rules: extractMatchingRules(groupWithRule, alert),
       };
     }
     return constructDummyGroup(alert.name);


### PR DESCRIPTION
### Fix incorrect alert rule group matching in UI

Resolves a bug where the UI was displaying the wrong alert rule group for period-based alerts. The issue occurred because `findGroupWithMatchingRule` used substring matching (`includes()`), causing situations like `ProbeFailedExecutionsTooHigh [5m]` to incorrectly match `ProbeFailedExecutionsTooHigh [10m]` when the `10m` group appeared first in the array, as it was matching by rule name.

The fix replaces substring matching with exact rule name matching by constructing the full rule name including the period (e.g., `ProbeFailedExecutionsTooHigh [5m]`). This ensures the UI displays the correct alert group that matches the check's configured period.

Fixes https://github.com/grafana/support-escalations/issues/18565

**Before**
https://github.com/user-attachments/assets/587422ef-c91a-49cb-971e-63ae85d123cd

**After**
https://github.com/user-attachments/assets/e5fa364c-1c08-4c51-954c-54598de5ac40


