### PR TITLE
feat: add data-fs-element to feedback button and fix toggletip floating

### DIFF
--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -102,12 +102,10 @@ const FeedbackButton = ({ feature, isActive, onClick, onClose, reaction, tooltip
           handleSaveFeedback={setSavedFeedback}
         />
       }
+      contentClassName={styles.content}
       onClose={onClose}
       placement="bottom"
       show={isActive}
-      style={{
-        width: `384px`,
-      }}
     >
       {/* Need to wrap in a div to prevent the toggletip from cloning the button and removing the onClick handler */}
       <div>
@@ -191,6 +189,9 @@ const FeedbackForm = ({ feature, reaction, savedFeedback, handleSaveFeedback }: 
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
+    content: css`
+      width: calc(400px - ${theme.spacing(2)});
+    `,
     container: css`
       contain: layout;
       z-index: 2;

--- a/src/components/Toggletip/Toggletip.tsx
+++ b/src/components/Toggletip/Toggletip.tsx
@@ -1,17 +1,17 @@
 import React, { ComponentProps, ReactElement, ReactNode } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Toggletip as GrafanaToggletip, useStyles2 } from '@grafana/ui';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 
 interface ToggletipProps extends Omit<ComponentProps<typeof GrafanaToggletip>, 'content'> {
   content: ReactNode;
+  contentClassName?: string;
   children: ReactElement;
-  style?: React.CSSProperties;
 }
 
-export const Toggletip = ({ children, content, style, ...props }: ToggletipProps) => {
+export const Toggletip = ({ children, content, contentClassName, ...props }: ToggletipProps) => {
   return (
-    <GrafanaToggletip content={<ContentWrapper style={style}>{content}</ContentWrapper>} {...props}>
+    <GrafanaToggletip content={<ContentWrapper className={contentClassName}>{content}</ContentWrapper>} {...props}>
       {children}
     </GrafanaToggletip>
   );
@@ -19,17 +19,13 @@ export const Toggletip = ({ children, content, style, ...props }: ToggletipProps
 
 type ContentWrapperProps = {
   children: ReactNode;
-  style?: React.CSSProperties;
+  className?: string;
 };
 
-const ContentWrapper = ({ children, style }: ContentWrapperProps) => {
+const ContentWrapper = ({ children, className }: ContentWrapperProps) => {
   const styles = useStyles2(getStyles);
 
-  return (
-    <div className={styles.toggletipCard} style={style}>
-      {children}
-    </div>
-  );
+  return <div className={cx(styles.toggletipCard, className)}>{children}</div>;
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({


### PR DESCRIPTION
## Problem

When trying to correlate bad reactions in the feedback widget to our sessions in Full Story it is difficult task right now and requires a lot of manual searching.

## Solution

Add a `data-fs-element` attribute to the feedback widget so we can easily watch sessions that led to the user clicking it.

Whilst I was there I fixed the issue with the toggletip floating in the wrong position.