### PR TITLE
fix: promote alerting package imports to stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@emotion/css": "11.10.6",
-    "@grafana/alerting": "12.3.0-18685446948",
+    "@grafana/alerting": "12.3.0-18779941398",
     "@grafana/data": "^12.1.0",
     "@grafana/faro-web-sdk": "1.19.0",
     "@grafana/runtime": "^12.1.0",

--- a/src/components/CheckForm/AlertsPerCheck/AlertLabelsDisplay.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertLabelsDisplay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { type LabelMatcher } from '@grafana/alerting/unstable';
+import { type LabelMatcher } from '@grafana/alerting';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Text, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';

--- a/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useMatchInstancesToRouteTrees } from '@grafana/alerting/unstable';
+import { useMatchInstancesToRouteTrees } from '@grafana/alerting';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Icon, LoadingPlaceholder, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';

--- a/src/components/CheckForm/AlertsPerCheck/RouteTreeDisplay.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/RouteTreeDisplay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { type InstanceMatchResult, type Route } from '@grafana/alerting/unstable';
+import { type InstanceMatchResult, type Route } from '@grafana/alerting';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Text, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';

--- a/src/components/CheckForm/AlertsPerCheck/alertRoutingUtils.ts
+++ b/src/components/CheckForm/AlertsPerCheck/alertRoutingUtils.ts
@@ -1,11 +1,11 @@
-import { RouteMatchInfo } from '@grafana/alerting/dist/types/grafana/notificationPolicies/utils';
 import {
   type InstanceMatchResult,
   type Label as AlertingLabel,
   type LabelMatcher,
   type Route,
   RouteWithID,
-} from '@grafana/alerting/unstable';
+} from '@grafana/alerting';
+import { RouteMatchInfo } from '@grafana/alerting/dist/types/grafana/notificationPolicies/utils';
 
 import { CheckAlertType, CheckType, Label } from 'types';
 

--- a/src/test/fixtures/alerting.ts
+++ b/src/test/fixtures/alerting.ts
@@ -1,4 +1,4 @@
-import { type InstanceMatchResult } from '@grafana/alerting/unstable';
+import { type InstanceMatchResult } from '@grafana/alerting';
 
 import { ListPrometheusAlertsResponse } from 'datasource/responses.types';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -923,14 +923,14 @@
     qs "^6.10.1"
     xcase "^2.0.1"
 
-"@grafana/alerting@12.3.0-18685446948":
-  version "12.3.0-18685446948"
-  resolved "https://registry.yarnpkg.com/@grafana/alerting/-/alerting-12.3.0-18685446948.tgz#73c19c61ec31ce9106125204d019994194c8fdf1"
-  integrity sha512-0wiXZg6QbsOEMJGod4P5E9hoeu0cc1mQzscfpoTj9KdrlaxOm8FW4trSykbR3OnXNXfSkyw19eEZt4EghRVxIg==
+"@grafana/alerting@12.3.0-18779941398":
+  version "12.3.0-18779941398"
+  resolved "https://registry.yarnpkg.com/@grafana/alerting/-/alerting-12.3.0-18779941398.tgz#fb128b96bb4f9a279b27f528b83b9d81d9b4cbc0"
+  integrity sha512-RSLwMkiM/v0We6Lze/TfeGdHP78X02AzKzEeyj9KFZ2lXEiZWpuXItSextu+x/2FbY5mHREfwOJAAQ2LaZcqBQ==
   dependencies:
     "@emotion/css" "11.13.5"
     "@faker-js/faker" "^9.8.0"
-    "@grafana/i18n" "12.3.0-18685446948"
+    "@grafana/i18n" "12.3.0-18779941398"
     "@reduxjs/toolkit" "^2.9.0"
     fishery "^2.3.1"
     lodash "^4.17.21"
@@ -1014,10 +1014,10 @@
     micro-memoize "^4.1.2"
     react-i18next "^15.0.0"
 
-"@grafana/i18n@12.3.0-18685446948":
-  version "12.3.0-18685446948"
-  resolved "https://registry.yarnpkg.com/@grafana/i18n/-/i18n-12.3.0-18685446948.tgz#312dc7da91ac1f86edfa9bd1d43648aea8a39504"
-  integrity sha512-bnJzIM5rrX7rt59KeGrIJSfGv9GHwvyPMuFOrALiF4OberHzORcN1tZ2bTgSmu4j3etCYd2MPTrVmq0oPlbgRQ==
+"@grafana/i18n@12.3.0-18779941398":
+  version "12.3.0-18779941398"
+  resolved "https://registry.yarnpkg.com/@grafana/i18n/-/i18n-12.3.0-18779941398.tgz#b38f632e0bfa77d5243b6045f6bc4f92d45ef0eb"
+  integrity sha512-TuBM8cmKHxDgUQM3niILAH9kLQ4/qoNsijFhP2Bo4In6Vj9VbIl2wlxINRouj7vAJGXtKQkJsJ12mKFJtzZpZg==
   dependencies:
     "@formatjs/intl-durationformat" "^0.7.0"
     "@typescript-eslint/utils" "^8.33.1"


### PR DESCRIPTION
As per https://github.com/grafana/grafana/pull/112931, the imports from `@grafana/alerting` can be consumed from the stable export.

This PR updates the dependency to `12.3.0-18779941398` and updates the imports.