### PR TITLE
feat: add renovate config to ignore local dev dockerfile

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,7 @@
+{
+  // https://docs.renovatebot.com/config-overview/
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  // https://github.com/grafana/deployment_tools/blob/master/docs/platform/renovate/FAQ.md#can-i-opt-inopt-out-of-the-global-configuration
+  "extends": ["github>grafana/grafana-renovate-config//presets/base"],
+  "ignorePaths": [".config/Dockerfile"]
+}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,15 @@
 module.exports = {
   // Prettier configuration provided by Grafana scaffolding
   ...require('./.config/.prettierrc.js'),
+  overrides: [
+    {
+      files: '*.json5',
+      options: {
+        quoteProps: 'preserve',
+        parser: 'json5',
+        singleQuote: false,
+        trailingComma: 'none',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
Renovate has been activated on all our PRs and currently it is pinning all of our versions across the whole codebase.

This is undesirable for our local dev env for docker ([like this example](https://github.com/grafana/synthetic-monitoring-app/blob/f6c1d6f83c41fb233e52b64c9c03597da74707ae/.config/Dockerfile#L1)) so this PR is to set up so renovate ignores this Dockerfile specifically.

I've extended the prettier config so IDE's format on save correctly parses .json5 files (json5 is supported by renovate and we can add inline comments 🎉 )