### PR TITLE
chore: add packages to ignore or have a long shelf life

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,5 +3,42 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   // https://github.com/grafana/deployment_tools/blob/master/docs/platform/renovate/FAQ.md#can-i-opt-inopt-out-of-the-global-configuration
   "extends": ["github>grafana/grafana-renovate-config//presets/base"],
-  "ignorePaths": [".config/Dockerfile"]
+  "ignorePaths": [".config/Dockerfile"],
+  "packageRules": [
+    // we can never update the React packages until grafana does
+    {
+      "matchPackageNames": ["react", "react-dom", "eslint-plugin-react-hooks"],
+      "enabled": false
+    },
+    // packages which we consider feature complete but if they ever do receive updates we should review them
+    {
+      "matchPackageNames": [
+        "dorny/paths-filter",
+        "acorn-walk",
+        "css-loader",
+        "eslint-plugin-simple-import-sort",
+        "identity-obj-proxy",
+        "imports-loader",
+        "ip-address",
+        "is-base64",
+        "pluralize",
+        "punycode",
+        "raw-loader",
+        "react-async-hook",
+        "react-popper",
+        "replace-in-file-webpack-plugin",
+        "style-loader",
+        "swc-loader",
+        "use-konami",
+        "valid-url",
+        "webpack-bundle-analyzer",
+        "webpack-livereload-plugin",
+        "webpack-merge",
+        "webpack-subresource-integrity",
+        "webpack-virtual-modules"
+      ],
+      "enabled": true,
+      "abandonmentThreshold": "15 years"
+    }
+  ]
 }


### PR DESCRIPTION
Updating the renovate configuration based off the report in the [Renovate Dashboard](https://github.com/grafana/synthetic-monitoring-app/issues/1296).

I've added an entry where we never update dependencies which come from Grafana: `"react", "react-dom", "eslint-plugin-react-hooks"` and an entry where we consider packages feature complete for our needs as they breach the abandonmentThreshold but we still need them. I've taken this approach so if they ever do receive updates renovate will notify us rather than us being none-the-wiser they were updated.

Our CVE scanning from ops should notify us if these packages ever have an issue.