### PR TITLE
chore: remove bail flag for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "server": "docker compose up --build",
     "sign": "npx --yes @grafana/sign-plugin@latest",
     "test:changed": "jest --watch --onlyChanged",
-    "test:ci": "jest --passWithNoTests --maxWorkers 4 --bail",
+    "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "test": "jest --all",
     "verify:probe-api-mappings": "yarn ts-node scripts/probe-api-mappings/verify-probe-api-mappings.ts",
     "verify:terraform-test-config": "./scripts/terraform-validation/verify-terraform-test-config.sh",


### PR DESCRIPTION
## Problem

In our CI/CD pipeline when one test fails it aborts all the tests. This can make fixing tests tedious as you might have multiple failures that you are only aware of once you keep pushing your changes.

## Solution

Remove the `--bail` flag in our test CI/CD command.