### PR TITLE
feat: make check editor features be configured with FeatureName

### DIFF
--- a/src/components/Checkster/contexts/FeatureTabsContext.tsx
+++ b/src/components/Checkster/contexts/FeatureTabsContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
 
 import { FeatureTabConfig, FeatureTabLabel } from '../types';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 
 import { FEATURE_TABS } from '../feature/config';
 import { useChecksterContext } from './ChecksterContext';
@@ -24,9 +25,13 @@ export function FeatureTabsContextProvider({ children }: PropsWithChildren) {
   const { checkType } = useChecksterContext();
 
   const tabs = useMemo(() => {
-    return FEATURE_TABS.filter(
-      ([, , checkCompatibility]) => checkCompatibility.length === 0 || checkCompatibility.includes(checkType)
-    );
+    return FEATURE_TABS.filter(([, , checkCompatibility, featureName]) => {
+      if (featureName && !isFeatureEnabled(featureName)) {
+        return false;
+      }
+
+      return checkCompatibility.length === 0 || checkCompatibility.includes(checkType);
+    });
   }, [checkType]);
 
   const activeTab = useMemo<FeatureTabConfig | typeof panicTab>(() => {

--- a/src/components/Checkster/feature/config.ts
+++ b/src/components/Checkster/feature/config.ts
@@ -1,10 +1,12 @@
 import { FeatureTabConfig } from '../types';
+import { FeatureName } from 'types';
 
 import { ADHOC_CHECK_COMPATABILITY, AdhocCheckPanel } from './adhoc-check';
 import { DOCS_CHECK_COMPATABILITY, DocsPanel } from './docs';
 import { SECRETS_CHECK_COMPATIBILITY, SecretsPanel } from './secrets';
+
 export const FEATURE_TABS: FeatureTabConfig[] = [
   ['Test', AdhocCheckPanel, ADHOC_CHECK_COMPATABILITY],
-  ['Secrets', SecretsPanel, SECRETS_CHECK_COMPATIBILITY],
+  ['Secrets', SecretsPanel, SECRETS_CHECK_COMPATIBILITY, FeatureName.SecretsManagement],
   ['Docs', DocsPanel, DOCS_CHECK_COMPATABILITY],
 ];

--- a/src/components/Checkster/types.ts
+++ b/src/components/Checkster/types.ts
@@ -68,7 +68,9 @@ export enum HTTPAuthType {
 }
 
 export type FeatureTabLabel = ComponentProps<typeof Tab>['label'];
-export type FeatureTabConfig = [FeatureTabLabel, ComponentType, CheckType[]];
+export type FeatureTabConfigAll = [FeatureTabLabel, ComponentType, CheckType[]];
+export type FeatureTabConfigFeatureToggle = [FeatureTabLabel, ComponentType, CheckType[], FeatureName];
+export type FeatureTabConfig = FeatureTabConfigAll | FeatureTabConfigFeatureToggle;
 
 export type CheckFormFieldPath = FieldPath<CheckFormValues>;
 


### PR DESCRIPTION
<img width="1342" height="865" alt="image" src="https://github.com/user-attachments/assets/62ee6649-cac8-40f2-a17a-f30c6fef4577" />

## The problem

Even if Secrets management isn't enabled, the secrets tab will be rendered.

## The solution

Make it possible to add FeatureName (that needs to be enabled) to tab config.