### PR TITLE
chore: add canvas mock to feature complete renovate list

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,14 +19,15 @@
     // packages which we consider feature complete but if they ever do receive updates we should review them
     {
       "matchPackageNames": [
-        "dorny/paths-filter",
         "acorn-walk",
         "css-loader",
+        "dorny/paths-filter",
         "eslint-plugin-simple-import-sort",
         "identity-obj-proxy",
         "imports-loader",
         "ip-address",
         "is-base64",
+        "jest-canvas-mock",
         "pluralize",
         "punycode",
         "raw-loader",


### PR DESCRIPTION
Adding canvas-mock so renovate doesn't complain about it in the dashboard.