### PR TITLE
chore: add whatwg-fetch to silence test warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "webpack-livereload-plugin": "3.0.2",
     "webpack-merge": "6.0.1",
     "webpack-subresource-integrity": "5.1.0",
-    "webpack-virtual-modules": "0.6.2"
+    "webpack-virtual-modules": "0.6.2",
+    "whatwg-fetch": "3.6.20"
   },
   "dependencies": {
     "@emotion/css": "11.13.5",

--- a/src/test/jest-setup.tsx
+++ b/src/test/jest-setup.tsx
@@ -4,6 +4,7 @@ import '../../.config/jest-setup';
 import { server } from './server';
 import 'test/silenceErrors';
 import 'jest-canvas-mock';
+import 'whatwg-fetch';
 // have to reimport this despite it is included in the ./config/jest-setup.JSfile
 // so the types also get imported
 import '@testing-library/jest-dom';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10157,6 +10157,11 @@ whatwg-encoding@^2.0.0:
   dependencies:
     iconv-lite "0.6.3"
 
+whatwg-fetch@3.6.20:
+  version "3.6.20"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz#580ce6d791facec91d37c72890995a0b48d31c70"
+  integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==
+
 whatwg-mimetype@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"


### PR DESCRIPTION
The @grafana/alerting package uses `fetch` which we hadn't mocked for our tests so it generated noise whilst they ran. This adds `whatwg-fetch` so fetch is available and the tests stop complaining.