### PR TITLE
chore: decrease time for running all tests

### DIFF
--- a/src/test/mocks/@grafana/ui.tsx
+++ b/src/test/mocks/@grafana/ui.tsx
@@ -42,7 +42,6 @@ jest.mock('@grafana/ui', () => {
           <svg data-testid={`emptyState ${variant}`} />
           <div>
             <span>{message}</span>
-            <span>{}</span>
           </div>
           {!!button && button}
           <div>{children}</div>


### PR DESCRIPTION
When adding duplicating tests for Checkster, I noticed that the Checkster tests were running significantly slower than the old check editor tests, despite testing the same stuff.

This observation was true for all check types except for `traceroute`, which does not have the adhoc check UI.

Apparently, the `EmptyState` component from `@grafana/ui` is adding a lot of execution time when running tests were it is rendered.

With the `EmptyState` component mocked, I managed to shave off 18s (from 45s to 27s) from the total execution time when running all tests.

### Before
<img width="360" height="100" alt="image" src="https://github.com/user-attachments/assets/a9789a17-edb1-4bf1-adaa-980825278dcc" />

### After
<img width="360" height="100" alt="image" src="https://github.com/user-attachments/assets/e478b759-545b-46bb-bf48-92caec99b8cc" />

