### PR TITLE
fix: add check timeout to adhoc check timeout

### DIFF
--- a/src/components/Checkster/feature/adhoc-check/AdhocCheckPanel.tsx
+++ b/src/components/Checkster/feature/adhoc-check/AdhocCheckPanel.tsx
@@ -57,7 +57,10 @@ export function AdhocCheckPanel() {
         const now = dateTime();
         setLogState((prevState) => {
           return pendingIds.reduce<AdHocCheckStateMap>((acc, id) => {
-            if (acc[id] && now.diff(acc[id].created, 'seconds') > DEFAULT_TIMEOUT_IN_SECONDS) {
+            if (
+              acc[id] &&
+              now.diff(acc[id].created, 'seconds') > DEFAULT_TIMEOUT_IN_SECONDS + acc[id].checkTimeoutInSeconds
+            ) {
               return {
                 ...acc,
                 [id]: {
@@ -111,6 +114,7 @@ export function AdhocCheckPanel() {
         return acc;
       }, {}),
       created: dateTime(),
+      checkTimeoutInSeconds: newHocCheckRequest.timeout / 1000,
     };
     setLogState((prevState) => {
       return {

--- a/src/components/Checkster/feature/adhoc-check/types.adhoc-check.ts
+++ b/src/components/Checkster/feature/adhoc-check/types.adhoc-check.ts
@@ -20,6 +20,7 @@ export interface AdHocCheckState {
   id: string;
   probeState: Record<string, ProbeState>;
   created: DateTime;
+  checkTimeoutInSeconds: number;
 }
 
 interface LogBase {


### PR DESCRIPTION
# adhoc check timeout too short

The new check editor is not including the `check.timeout` when waiting for adhoc check to timeout. Instead it uses a hardcoded value of `30s`.

<img width="1351" height="863" alt="image" src="https://github.com/user-attachments/assets/e2dca52c-abae-4440-9313-77f8b3d3dd59" />

This PR will mimic the old way of timing out adhoc checks (`check.timeout` + `30s`).

[Issue described here](https://grafanalabs.enterprise.slack.com/archives/C06T9S2ST63/p1762431560818229)