### PR TITLE
fix: show breadcrumbs for `Home`

### DIFF
--- a/src/page/SceneHomepage.tsx
+++ b/src/page/SceneHomepage.tsx
@@ -30,9 +30,10 @@ function SceneHomepageComponent() {
     return new SceneApp({
       pages: [
         new SceneAppPage({
-          title: 'Home',
+          title: 'Synthetics',
+          renderTitle: () => <h1>Home</h1>,
           url: `${PLUGIN_URL_PATH}${AppRoutes.Home}`,
-          hideFromBreadcrumbs: true,
+          hideFromBreadcrumbs: false,
           getScene: getSummaryScene(config, checks, true),
         }),
       ],


### PR DESCRIPTION
This PR enables breadcrumbs for the "Synthetic" route.

<img width="719" height="261" alt="image" src="https://github.com/user-attachments/assets/89d9f411-f766-461b-9143-0699cb57b3ec" />

Resolves https://github.com/grafana/synthetic-monitoring-app/issues/1427

Draft reason: We've (Thomas, Chris & Vesna) have decided to change the h1 to "Synthetic" instead of "Home, and remove the redirect to `/home` and instead serve the "home" dashboard on `/`
