### PR TITLE
fix: pass in logs datasource

### DIFF
--- a/src/components/Checkster/feature/adhoc-check/useAdHocLogs.ts
+++ b/src/components/Checkster/feature/adhoc-check/useAdHocLogs.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import { DataFrameJSON } from '@grafana/data';
 
 import { AdHocResponseResults } from './types.adhoc-check';
-import { useLogsDS } from 'hooks/useLogsDS';
 import { useSMDS } from 'hooks/useSMDS';
 
 export interface LokiQueryResults<RefId extends keyof any = 'A'> {
@@ -86,12 +85,11 @@ export function useAdHocLogs(
   poll = true
 ) {
   const dataSource = useSMDS();
-  const logsDS = useLogsDS();
 
   return useQuery<AdHocResponseResults>({
-    queryKey: ['logs', 'ad-hoc', { expr, from, to, logsDS }],
+    queryKey: ['logs', 'ad-hoc', { expr, from, to }],
     queryFn: async () => {
-      return loggify(await dataSource.queryLogsV2(expr!, from, to, `adhoc-logs`, logsDS));
+      return loggify(await dataSource.queryLogsV2(expr!, from, to));
     },
     enabled: !!expr,
     refetchInterval: poll ? 3000 : 0,

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -228,7 +228,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
             refId: 'A',
             expr,
             queryType: 'range',
-            datasource: this.instanceSettings.jsonData.logs,
+            datasource: this.getLogsDS(),
             intervalMs: 2000,
             maxDataPoints: 1779,
           },
@@ -243,8 +243,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
     expr: string,
     from: number | string = 'now-15m',
     to: number | string = 'now',
-    refId?: RefId,
-    datasource?: DataSourceInstanceSettings
+    refId?: RefId
   ) {
     return this.fetchAPI<LokiQueryResults<RefId>>(`/api/ds/query`, {
       method: 'POST',
@@ -255,7 +254,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
             expr,
             queryType: 'range',
             // direction: 'backwards',
-            datasource,
+            datasource: this.getLogsDS(),
             intervalMs: 2000,
             maxDataPoints: 1779,
           },


### PR DESCRIPTION
Related escalation: https://github.com/grafana/support-escalations/issues/19348

## Problem

The `queryLogsV2` method on the datasource currently uses `this.instance.jsonData.logs` as its datasource reference for the query. This is a somewhat opaque method as the app isn't responsible for how it gets initiated. In the escalation above, the customer's datasource reference isn't fully formed so when looking for the logs that the ad hoc check generated it receives a 400 in the response: 

```
message: "Query does not contain a valid data source identifier"
messageId: "query.invalidDatasourceId"
statusCode: 400
```

The payload for the datasource reference in the query is:

```
grafanaName: "grafanacloud-{customer}-logs"
hostedId: <redacted>
```

When we compare this to any of the customer's log requests on their dashboards (who use our useLogsDS hook), we can see the requests complete successfully:

```
{
    "id":<redacted>,
    "uid": "grafanacloud-logs",
    "type": "loki",
    "name": "grafanacloud-{customer}-logs",
}
```

## Solution

As this is intended to be a quick solution to unblock the customer, I've called the same `useLogsDS` hook and passed the result in as an argument to `queryLogsV2`.

The longer term fix is to migrate the ad hoc checks to using the `queryLoki` method which the check dashboards use.
