### PR TITLE
chore: add packagerule for github action semantic scope suffix

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,6 +70,11 @@
       "description": "Label digest updates",
       "matchUpdateTypes": ["digest"],
       "labels": ["automerge-digest"]
+    },
+    // Override base preset for GitHub Actions to remove (deps) scope
+    {
+      "matchManagers": ["github-actions"],
+      "semanticCommitScope": null
     }
   ]
 }


### PR DESCRIPTION
This [PR](https://github.com/grafana/synthetic-monitoring-app/pull/1448) kept the (deps) suffix on the commit. Trying this config so it is removed in the future.