### PR TITLE
chore: update api mappings file

### DIFF
--- a/src/data/probeAPIServerMappings.json
+++ b/src/data/probeAPIServerMappings.json
@@ -127,6 +127,12 @@
   },
   {
     "region": "United States East",
+    "provider": "AWS",
+    "apiServerURL": "synthetic-monitoring-grpc-us-east-3.grafana.net:443",
+    "backendAddress": "synthetic-monitoring-api-us-east-3.grafana.net"
+  },
+  {
+    "region": "United States East",
     "provider": "GCP",
     "apiServerURL": "synthetic-monitoring-grpc-us-east-1.grafana.net:443",
     "backendAddress": "synthetic-monitoring-api-us-east-1.grafana.net"


### PR DESCRIPTION

**What this PR does / why we need it**:

The api mappings file must be regenerated now that a new region has been released to production. This file was generated with `yarn build:probe-api-mappings`.
