### PR TITLE
feat: allow to expand/collapse editor

### DIFF
--- a/src/components/Checkster/components/form/FormInstanceField.tsx
+++ b/src/components/Checkster/components/form/FormInstanceField.tsx
@@ -37,6 +37,7 @@ export function FormInstanceField({ field }: { field: 'target' }) {
         </Stack>
       }
       required
+      grow
     />
   );
 }

--- a/src/components/Checkster/components/form/FormJobField.tsx
+++ b/src/components/Checkster/components/form/FormJobField.tsx
@@ -26,6 +26,7 @@ export function FormJobField({ field = 'job' }: FormJobFieldProps) {
       invalid={Boolean(errors.job)}
       error={errors.job?.message}
       required
+      grow
     >
       <Input
         id="check-editor-job-input"

--- a/src/components/Checkster/components/form/generic/GenericInputField.tsx
+++ b/src/components/Checkster/components/form/generic/GenericInputField.tsx
@@ -17,6 +17,7 @@ interface GenericInputFieldFormInputFieldProps {
   placeholder?: ComponentProps<typeof Input>['placeholder'];
   type?: ComponentProps<typeof Input>['type'];
   interpolationVariables?: Record<string, string>;
+  grow?: boolean;
 }
 
 export function GenericInputField({
@@ -27,6 +28,7 @@ export function GenericInputField({
   required,
   type = 'text',
   interpolationVariables,
+  grow,
   ...rest // ideally, only used for aria attributes
 }: GenericInputFieldFormInputFieldProps) {
   const {
@@ -42,6 +44,7 @@ export function GenericInputField({
       description={description}
       required={required}
       htmlFor={id}
+      grow={grow}
       {...getFieldErrorProps(errors, field, interpolationVariables)}
     >
       <Input

--- a/src/components/Checkster/components/form/generic/GenericScriptField.tsx
+++ b/src/components/Checkster/components/form/generic/GenericScriptField.tsx
@@ -12,10 +12,11 @@ import { Column } from '../../ui/Column';
 
 interface GenericScriptFieldProps {
   field: CheckFormFieldPath;
+  renderHeaderAction?: () => React.ReactNode;
 }
 
 // FIXME: Not actually a Field (no label, no description), but it has errors!
-export function GenericScriptField({ field }: GenericScriptFieldProps) {
+export function GenericScriptField({ field, renderHeaderAction }: GenericScriptFieldProps) {
   const {
     control,
     formState: { errors, disabled },
@@ -50,6 +51,7 @@ export function GenericScriptField({ field }: GenericScriptFieldProps) {
               readOnly={disabled}
               data-form-name={field}
               data-form-element-selector="textarea"
+              renderHeaderAction={renderHeaderAction}
             />
           );
         }}

--- a/src/components/Checkster/components/form/generic/GenericScriptField.tsx
+++ b/src/components/Checkster/components/form/generic/GenericScriptField.tsx
@@ -12,11 +12,12 @@ import { Column } from '../../ui/Column';
 
 interface GenericScriptFieldProps {
   field: CheckFormFieldPath;
-  renderHeaderAction?: () => React.ReactNode;
+  isExpanded?: boolean;
+  onToggleExpand?: () => void;
 }
 
 // FIXME: Not actually a Field (no label, no description), but it has errors!
-export function GenericScriptField({ field, renderHeaderAction }: GenericScriptFieldProps) {
+export function GenericScriptField({ field, isExpanded, onToggleExpand }: GenericScriptFieldProps) {
   const {
     control,
     formState: { errors, disabled },
@@ -51,7 +52,8 @@ export function GenericScriptField({ field, renderHeaderAction }: GenericScriptF
               readOnly={disabled}
               data-form-name={field}
               data-form-element-selector="textarea"
-              renderHeaderAction={renderHeaderAction}
+              isExpanded={isExpanded}
+              onToggleExpand={onToggleExpand}
             />
           );
         }}

--- a/src/components/Checkster/components/form/layouts/ScriptedCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/ScriptedCheckContent.tsx
@@ -66,9 +66,8 @@ export function ScriptedCheckContent({
           <FormTabContent label="Script" fillVertical vanilla>
             <GenericScriptField
               field={scriptField}
-              renderHeaderAction={() => (
-                <ExpandButton isExpanded={isFullSection} onToggle={() => setIsFullSection(!isFullSection)} />
-              )}
+              isExpanded={isFullSection}
+              onToggleExpand={() => setIsFullSection(!isFullSection)}
             />
           </FormTabContent>
           {hasExamples && (
@@ -81,27 +80,6 @@ export function ScriptedCheckContent({
     </SectionContent>
   );
 }
-
-interface ExpandButtonProps {
-  isExpanded: boolean;
-  onToggle: () => void;
-}
-
-const ExpandButton = ({ isExpanded, onToggle }: ExpandButtonProps) => {
-  return (
-    <Button
-      type="button"
-      onClick={onToggle}
-      variant="secondary"
-      size="sm"
-      icon={isExpanded ? 'angle-down' : 'angle-up'}
-      tooltip={isExpanded ? 'Show all fields' : 'Expand editor to full section'}
-      aria-label={isExpanded ? 'Collapse editor' : 'Expand editor'}
-    >
-      {isExpanded ? 'Show fields' : 'Expand editor'}
-    </Button>
-  );
-};
 
 const HelpButton = () => {
   const { setActive } = useFeatureTabsContext();

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -20,27 +20,38 @@ const addK6Types = (monaco: typeof monacoType) => {
   // Remove TS errors for remote libs imports
   monaco.languages.typescript.javascriptDefaults.addExtraLib("declare module 'https://*'");
 };
-const containerStyles = css`
-  height: 100%;
-  min-height: 600px;
+const getEditorStyles = () => ({
+  container: css`
+    height: 100%;
+    min-height: calc(100vh - 400px);
 
-  & > div {
-    height: inherit;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+    & > div {
+      height: inherit;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
 
-  // Background styling for editable ranges (multi)
-  .editableArea--multi-line {
-    opacity: 1;
-    background-color: rgba(255, 255, 255, 0.1);
-  }
+    // Background styling for editable ranges (multi)
+    .editableArea--multi-line {
+      opacity: 1;
+      background-color: rgba(255, 255, 255, 0.1);
+    }
 
-  > section {
-    min-height: inherit;
-  }
-`;
+    > section {
+      min-height: inherit;
+    }
+  `,
+  wrapper: css`
+    position: relative;
+  `,
+  floatingButton: css`
+    position: absolute;
+    top: 38px;
+    right: 24px;
+    z-index: 100;
+  `,
+});
 
 export const CodeEditor = forwardRef(function CodeEditor(
   {
@@ -55,6 +66,7 @@ export const CodeEditor = forwardRef(function CodeEditor(
     overlayMessage,
     readOnly,
     renderHeader,
+    renderHeaderAction,
     value,
     ...rest // Allow for custom data-attributes
   }: CodeEditorProps & ConstrainedEditorProps,
@@ -63,6 +75,7 @@ export const CodeEditor = forwardRef(function CodeEditor(
   const [editorRef, setEditorRef] = useState<null | monacoType.editor.IStandaloneCodeEditor>(null);
   const [constrainedInstance, setConstrainedInstance] = useState<null | ConstrainedEditorInstance>(null);
   const [prevValue, setPrevValue] = useState(value);
+  const styles = getEditorStyles();
 
   // GC
   useEffect(() => {
@@ -162,8 +175,9 @@ export const CodeEditor = forwardRef(function CodeEditor(
   }, [value, constrainedRanges]);
 
   return (
-    <div data-fs-element="Code editor" id={id} {...rest}>
+    <div data-fs-element="Code editor" id={id} {...rest} className={styles.wrapper}>
       {renderHeader && renderHeader({ scriptValue: value })}
+      {renderHeaderAction && <div className={styles.floatingButton}>{renderHeaderAction()}</div>}
       {/* {overlayMessage && <Overlay>{overlayMessage}</Overlay>} */}
       <GrafanaCodeEditor
         value={value}
@@ -181,7 +195,7 @@ export const CodeEditor = forwardRef(function CodeEditor(
         onBeforeEditorMount={handleBeforeEditorMount}
         onEditorDidMount={handleEditorDidMount}
         readOnly={readOnly}
-        containerStyles={containerStyles}
+        containerStyles={styles.container}
       />
     </div>
   );

--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useEffect, useState } from 'react';
-import { CodeEditor as GrafanaCodeEditor } from '@grafana/ui';
+import { Button, CodeEditor as GrafanaCodeEditor } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { ConstrainedEditorInstance } from 'constrained-editor-plugin';
 import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
@@ -20,6 +20,28 @@ const addK6Types = (monaco: typeof monacoType) => {
   // Remove TS errors for remote libs imports
   monaco.languages.typescript.javascriptDefaults.addExtraLib("declare module 'https://*'");
 };
+
+interface ExpandButtonProps {
+  isExpanded?: boolean;
+  onToggleExpand: () => void;
+}
+
+function ExpandButton({ isExpanded, onToggleExpand }: ExpandButtonProps) {
+  return (
+    <Button
+      type="button"
+      onClick={onToggleExpand}
+      variant="secondary"
+      size="sm"
+      icon={isExpanded ? 'angle-down' : 'angle-up'}
+      tooltip={isExpanded ? 'Show all fields' : 'Expand editor to full section'}
+      aria-label={isExpanded ? 'Collapse editor' : 'Expand editor'}
+    >
+      {isExpanded ? 'Show fields' : 'Expand editor'}
+    </Button>
+  );
+}
+
 const getEditorStyles = () => ({
   container: css`
     height: 100%;
@@ -66,7 +88,8 @@ export const CodeEditor = forwardRef(function CodeEditor(
     overlayMessage,
     readOnly,
     renderHeader,
-    renderHeaderAction,
+    isExpanded,
+    onToggleExpand,
     value,
     ...rest // Allow for custom data-attributes
   }: CodeEditorProps & ConstrainedEditorProps,
@@ -177,7 +200,11 @@ export const CodeEditor = forwardRef(function CodeEditor(
   return (
     <div data-fs-element="Code editor" id={id} {...rest} className={styles.wrapper}>
       {renderHeader && renderHeader({ scriptValue: value })}
-      {renderHeaderAction && <div className={styles.floatingButton}>{renderHeaderAction()}</div>}
+      {onToggleExpand && (
+        <div className={styles.floatingButton}>
+          <ExpandButton isExpanded={isExpanded} onToggleExpand={onToggleExpand} />
+        </div>
+      )}
       {/* {overlayMessage && <Overlay>{overlayMessage}</Overlay>} */}
       <GrafanaCodeEditor
         value={value}

--- a/src/components/CodeEditor/CodeEditor.types.ts
+++ b/src/components/CodeEditor/CodeEditor.types.ts
@@ -12,7 +12,8 @@ export interface CodeEditorProps {
   overlayMessage?: ReactNode;
   readOnly?: boolean;
   renderHeader?: ({ scriptValue }: { scriptValue: string }) => ReactNode;
-  renderHeaderAction?: () => ReactNode;
+  isExpanded?: boolean;
+  onToggleExpand?: () => void;
   value: string;
 }
 

--- a/src/components/CodeEditor/CodeEditor.types.ts
+++ b/src/components/CodeEditor/CodeEditor.types.ts
@@ -12,6 +12,7 @@ export interface CodeEditorProps {
   overlayMessage?: ReactNode;
   readOnly?: boolean;
   renderHeader?: ({ scriptValue }: { scriptValue: string }) => ReactNode;
+  renderHeaderAction?: () => ReactNode;
   value: string;
 }
 


### PR DESCRIPTION
From https://github.com/grafana/synthetic-monitoring-app/pull/1461#pullrequestreview-3466431816

## Improve Monaco Editor Layout for Better Screen Space Utilization

Enhanced the scripted check editor layout to maximize available screen space for the Monaco code editor, addressing concerns about limited editor space on laptop screens.

- **Horizontal Job & Instance fields:** Changed Job name and Instance fields from vertical stacking to side-by-side layout, saving vertical space
- Editor now adapts to screen size
- **New expand button:** Added a floating button in the top-right corner of the Monaco editor which adds toggle functionality:
**Collapsed state:** Shows Job and Instance fields (normal view)
**Expanded state:** Hides fields, editor occupies full section height
- When the form is submitted with errors in Job or Instance fields, editor auto-collapses to reveal error messages

https://github.com/user-attachments/assets/9aa20aef-35f8-47a7-9493-5ba57a729d9c

