### PR TITLE
fix: use configured datasource instead of default one

### DIFF
--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -101,20 +101,24 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   // see https://github.com/grafana/synthetic-monitoring-app/pull/911 for more details
   getMetricsDS() {
     const info = this.instanceSettings.jsonData.metrics;
-    const ds = findLinkedDatasource({ ...info, uid: 'grafanacloud-metrics' });
-    if (ds) {
-      return ds;
+    // First try to use the configured datasource (respects custom configurations)
+    const configuredDs = findLinkedDatasource(info);
+    if (configuredDs) {
+      return configuredDs;
     }
-    return findLinkedDatasource(info);
+    // Fall back to the default Grafana Cloud metrics datasource if configured one doesn't exist
+    return findLinkedDatasource({ ...info, uid: 'grafanacloud-metrics' });
   }
 
   getLogsDS() {
     const info = this.instanceSettings.jsonData.logs;
-    const ds = findLinkedDatasource({ ...info, uid: 'grafanacloud-logs' });
-    if (ds) {
-      return ds;
+    // First try to use the configured datasource (respects custom configurations)
+    const configuredDs = findLinkedDatasource(info);
+    if (configuredDs) {
+      return configuredDs;
     }
-    return findLinkedDatasource(this.instanceSettings.jsonData.logs);
+    // Fall back to the default Grafana Cloud logs datasource if configured one doesn't exist
+    return findLinkedDatasource({ ...info, uid: 'grafanacloud-logs' });
   }
 
   async query(options: DataQueryRequest<SMQuery>): Promise<DataQueryResponse> {

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -22,6 +22,7 @@ export const defaultQuery: SMQuery = {
 export interface ProvisioningLinkedDatasourceInfo {
   grafanaName: string;
   hostedId: number;
+  uid?: string;
 }
 
 export interface LinkedDatasourceInfo extends ProvisioningLinkedDatasourceInfo {


### PR DESCRIPTION
Ref https://github.com/grafana/support-escalations/issues/19505
Related to https://github.com/grafana/synthetic-monitoring-app/pull/911 

## Support custom Loki datasources in Synthetic Monitoring

### Problem

The Synthetic Monitoring app hardcoded fallbacks to `uid: 'grafanacloud-logs'` for log queries, preventing users from configuring alternative Loki datasources. This blocked use cases where customers need to use different Loki datasources.

**Affected areas:**
- Runtime log queries always tried `grafanacloud-logs` UID first
- Initialization logic prioritized hardcoded UIDs over provisioned configuration

### Solution

Updated the datasource resolution logic to respect the configured datasource in `jsonData.logs` before falling back to hardcoded defaults.

**Changes:**

1. **`DataSource.ts` - `getLogsDS()` and `getMetricsDS()`**
   - Now attempt to use the configured datasource from `jsonData` first
   - Only fall back to hardcoded Grafana Cloud UIDs if the configured datasource doesn't exist

2. **`useAppInitializer.ts` - `findDatasourceByNameAndUid()`**
   - Updated to try finding datasources by configured UID before falling back to default Cloud UIDs
   - Respects datasource configuration from provisioning metadata

### Testing

To test:
1. Provision SM plugin with custom Loki datasource in `jsonData.logs`
2. Verify runtime queries use the configured datasource
3. Verify fallback behavior when configured datasource doesn't exist

### Notes

**GCOM Provisioning Required:**
If the SM datasource is deleted and re-initialized, it will reset to whatever GCOM provisions (the default datasource).

**Future Enhancement:**
We may evaluate adding a UI dropdown in the plugin configuration to allow users to select from available Loki datasources, removing the dependency on GCOM provisioning for this use case.

<img width="2541" height="960" alt="image" src="https://github.com/user-attachments/assets/95f9d7b6-3392-4813-8fca-7ac88c015161" />
