### PR TITLE
chore: force renovate chore titles

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,8 @@
     // This overrides the base preset's rules that add (deps) and (deps-dev) scopes
     {
       "matchManagers": ["npm", "github-actions", "dockerfile"],
-      "semanticCommitScope": null
+      "semanticCommitScope": null,
+      "semanticCommitType": "chore"
     },
     // we can never update the React packages until grafana does
     {


### PR DESCRIPTION
## Problem
Renovate PRs inherit manager-specific semantic commit types from the shared Grafana preset. For GitHub Actions updates that meant titles like `ci: update ...`, which conflicts with our expectation that all dependency-management PRs use the `chore:` prefix and no `(deps)` scope.

## Solution
Explicitly override the semantic commit type for the npm, github-actions, and dockerfile managers so Renovate always emits `chore:` PR titles (with the scope set to `null`). This keeps automation PRs consistent—for example both #1474 and #1475 will now follow the same prefix.
