### PR TITLE
feat: add error logs only toggle to logs panel in timepoint explorer

### DIFF
--- a/src/components/PageNavigation/PageNavigation.tsx
+++ b/src/components/PageNavigation/PageNavigation.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { LinkButton, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { AppRoutes } from 'routing/types';
+import { getRoute } from 'routing/utils';
+
+export const PageNavigation = () => {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.navigationRow}>
+      <div className={styles.stack}>
+        <LinkButton variant="secondary" fill="outline" href={getRoute(AppRoutes.Home)}>
+          Home
+        </LinkButton>
+        <LinkButton variant="secondary" fill="outline" href={getRoute(AppRoutes.Checks)}>
+          Checks
+        </LinkButton>
+        <LinkButton variant="secondary" fill="outline" href={getRoute(AppRoutes.Probes)}>
+          Probes
+        </LinkButton>
+        <LinkButton variant="secondary" fill="outline" href={getRoute(AppRoutes.Config)}>
+          Config
+        </LinkButton>
+      </div>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  navigationRow: css({
+    display: `flex`,
+    justifyContent: `flex-start`,
+    alignItems: `center`,
+    marginBottom: theme.spacing(2),
+  }),
+  stack: css({
+    alignItems: `center`,
+    display: `flex`,
+    gap: theme.spacing(2),
+  }),
+});
+
+
+

--- a/src/page/CheckList/components/CheckListHeader.tsx
+++ b/src/page/CheckList/components/CheckListHeader.tsx
@@ -7,6 +7,7 @@ import { CheckFiltersType, CheckListViewType, FilterType } from 'page/CheckList/
 import { Check, CheckSort } from 'types';
 import { getUserPermissions } from 'data/permissions';
 import { AddNewCheckButton } from 'components/AddNewCheckButton';
+import { PageNavigation } from 'components/PageNavigation/PageNavigation';
 import { BulkActions } from 'page/CheckList/components/BulkActions';
 import { CheckFilters } from 'page/CheckList/components/CheckFilters';
 import { CheckListViewSwitcher } from 'page/CheckList/components/CheckListViewSwitcher';
@@ -81,6 +82,7 @@ export const CheckListHeader = ({
 
   return (
     <>
+      <PageNavigation />
       <div className={styles.row}>
         <div>
           Currently showing {currentPageChecks.length} of {checks.length} total checks

--- a/src/page/ConfigPageLayout/ConfigPageLayout.tsx
+++ b/src/page/ConfigPageLayout/ConfigPageLayout.tsx
@@ -7,6 +7,7 @@ import { FeatureName } from 'types';
 import { AppRoutes } from 'routing/types';
 import { getRoute } from 'routing/utils';
 import { useFeatureFlagContext } from 'hooks/useFeatureFlagContext';
+import { PageNavigation } from 'components/PageNavigation/PageNavigation';
 
 function getConfigTabUrl(tab = '/') {
   return `${getRoute(AppRoutes.Config)}/${tab}`.replace(/\/+/g, '/');
@@ -73,6 +74,7 @@ export function ConfigPageLayout() {
 
   return (
     <PluginPage pageNav={pageNav}>
+      <PageNavigation />
       <Outlet />
     </PluginPage>
   );

--- a/src/page/Probes/Probes.tsx
+++ b/src/page/Probes/Probes.tsx
@@ -11,6 +11,7 @@ import { getUserPermissions } from 'data/permissions';
 import { useExtendedProbes } from 'data/useProbes';
 import { CenteredSpinner } from 'components/CenteredSpinner';
 import { DocsLink } from 'components/DocsLink';
+import { PageNavigation } from 'components/PageNavigation/PageNavigation';
 import { ProbeList } from 'components/ProbeList';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
 
@@ -19,6 +20,7 @@ export const Probes = () => {
 
   return (
     <PluginPage actions={<Actions />}>
+      <PageNavigation />
       <div className={css({ maxWidth: `560px`, marginBottom: theme.spacing(4) })}>
         <p>
           Probes are the agents responsible for emulating user interactions and collecting data from your specified

--- a/src/page/SceneHomepage.tsx
+++ b/src/page/SceneHomepage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { SceneApp, SceneAppPage } from '@grafana/scenes';
 import { LoadingPlaceholder } from '@grafana/ui';
+import { PluginPage } from '@grafana/runtime';
 
 import { DashboardSceneAppConfig } from 'types';
 import { PLUGIN_URL_PATH } from 'routing/constants';
@@ -10,6 +11,7 @@ import { useLogsDS } from 'hooks/useLogsDS';
 import { useMetricsDS } from 'hooks/useMetricsDS';
 import { useSMDS } from 'hooks/useSMDS';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
+import { PageNavigation } from 'components/PageNavigation/PageNavigation';
 import { getSummaryScene } from 'scenes/Summary';
 
 function SceneHomepageComponent() {
@@ -31,7 +33,7 @@ function SceneHomepageComponent() {
       pages: [
         new SceneAppPage({
           title: 'Synthetics',
-          renderTitle: () => <h1>Home</h1>,
+          renderTitle: () => null, // Title is rendered by PluginPage instead
           url: `${PLUGIN_URL_PATH}${AppRoutes.Home}`,
           hideFromBreadcrumbs: false,
           getScene: getSummaryScene(config, checks, true),
@@ -44,7 +46,12 @@ function SceneHomepageComponent() {
     return <LoadingPlaceholder text="Loading..." />;
   }
 
-  return <scene.Component model={scene} />;
+  return (
+    <PluginPage renderTitle={() => <h1>Home</h1>}>
+      <PageNavigation />
+      <scene.Component model={scene} />
+    </PluginPage>
+  );
 }
 
 export function SceneHomepage() {

--- a/src/scenes/components/LogsRenderer/LogsRenderer.tsx
+++ b/src/scenes/components/LogsRenderer/LogsRenderer.tsx
@@ -9,17 +9,21 @@ export const LogsRenderer = <T extends UnknownParsedLokiRecord>({
   logs,
   logsView,
   mainKey,
+  errorLogsOnly,
+  onErrorLogsOnlyChange,
 }: {
   logs: T[];
   logsView: LogsView;
   mainKey: string;
+  errorLogsOnly: boolean;
+  onErrorLogsOnlyChange: (value: boolean) => void;
 }) => {
   if (logsView === 'event') {
-    return <LogsEvent<T> logs={logs} mainKey={mainKey} />;
+    return <LogsEvent<T> logs={logs} mainKey={mainKey} errorLogsOnly={errorLogsOnly} onErrorLogsOnlyChange={onErrorLogsOnlyChange} />;
   }
 
   if (logsView === 'raw-logs') {
-    return <LogsRaw<T> logs={logs} />;
+    return <LogsRaw<T> logs={logs} errorLogsOnly={errorLogsOnly} onErrorLogsOnlyChange={onErrorLogsOnlyChange} />;
   }
 
   return null;

--- a/src/scenes/components/TimepointExplorer/TimepointViewerExecutions.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointViewerExecutions.tsx
@@ -23,6 +23,8 @@ import { useTimepointViewerExecutions } from 'scenes/components/TimepointExplore
 interface TimepointViewerExecutionsProps {
   isLoading: boolean;
   logsView: LogsView;
+  errorLogsOnly: boolean;
+  onErrorLogsOnlyChange: (value: boolean) => void;
   pendingProbeNames: string[];
   probeExecutions: ProbeExecutionLogs[];
   probeNameToView?: string;
@@ -32,6 +34,8 @@ interface TimepointViewerExecutionsProps {
 export const TimepointViewerExecutions = ({
   isLoading,
   logsView,
+  errorLogsOnly,
+  onErrorLogsOnlyChange,
   pendingProbeNames,
   probeExecutions = [],
   probeNameToView,
@@ -103,7 +107,15 @@ export const TimepointViewerExecutions = ({
             }
 
             if (executions.length > 1) {
-              return <MultipleExecutions key={probeName} executions={executions} logsView={logsView} />;
+              return (
+                <MultipleExecutions
+                  key={probeName}
+                  executions={executions}
+                  logsView={logsView}
+                  errorLogsOnly={errorLogsOnly}
+                  onErrorLogsOnlyChange={onErrorLogsOnlyChange}
+                />
+              );
             }
 
             return (
@@ -115,6 +127,8 @@ export const TimepointViewerExecutions = ({
                       logs={execution}
                       logsView={logsView}
                       mainKey="msg"
+                      errorLogsOnly={errorLogsOnly}
+                      onErrorLogsOnlyChange={onErrorLogsOnlyChange}
                     />
                   );
                 })}
@@ -176,7 +190,17 @@ const ProbeNameIcon = ({ status }: { status: TimepointStatus }) => {
   return <Icon name={ICON_MAP[status]} color={vizOption.statusColor} />;
 };
 
-const MultipleExecutions = ({ executions, logsView }: { executions: ExecutionLogs[]; logsView: LogsView }) => {
+const MultipleExecutions = ({
+  executions,
+  logsView,
+  errorLogsOnly,
+  onErrorLogsOnlyChange,
+}: {
+  executions: ExecutionLogs[];
+  logsView: LogsView;
+  errorLogsOnly: boolean;
+  onErrorLogsOnlyChange: (value: boolean) => void;
+}) => {
   const styles = useStyles2(getStyles);
   const success = useTimepointVizOptions('success');
   const failure = useTimepointVizOptions('failure');
@@ -202,7 +226,13 @@ const MultipleExecutions = ({ executions, logsView }: { executions: ExecutionLog
                     color={`${probe_success === '1' ? success.statusColor : failure.statusColor}`}
                   />
                 </Stack>
-                <LogsRenderer<UnknownExecutionLog> logs={execution} logsView={logsView} mainKey="msg" />
+                <LogsRenderer<UnknownExecutionLog>
+                  logs={execution}
+                  logsView={logsView}
+                  mainKey="msg"
+                  errorLogsOnly={errorLogsOnly}
+                  onErrorLogsOnlyChange={onErrorLogsOnlyChange}
+                />
               </div>
               {index !== executions.length - 1 && <div className={styles.divider} />}
             </>


### PR DESCRIPTION


**What this PR does / why we need it**:

Introduces a toggle to only show error logs.  For checks with lots of logs, these can be hard to find/surface.

It's worth considering if we should default this to on, if there are any error logs present. We should also consider if theres potentially a better way to filter logs. this is a quick and dirty fix for users with a large number of logs lines in a check

**Which issue(s) this PR fixes**:

n/a

Fixes #

**Special notes for your reviewer**:

<img width="1846" height="353" alt="image" src="https://github.com/user-attachments/assets/2c7c359c-252f-4bae-a0e5-83ef1e2e620f" />


<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
