### PR TITLE
fix: duplicate job name can now be edited

### DIFF
--- a/src/components/Checkster/contexts/ChecksterContext.tsx
+++ b/src/components/Checkster/contexts/ChecksterContext.tsx
@@ -218,7 +218,9 @@ export function ChecksterProvider({
       formMethods.setValue('job', `${check?.job} (Copy)`, { shouldDirty: true });
       formNavigation.completeAllSteps();
     }
-  }, [formMethods, check, isDuplicate, formNavigation]);
+    // only do this on mount so it doesn't trigger when the check is updated
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const value: ChecksterContextValue = useMemo(() => {
     return {

--- a/src/page/NewCheck/__tests__/DuplicateCheck.test.tsx
+++ b/src/page/NewCheck/__tests__/DuplicateCheck.test.tsx
@@ -1,0 +1,29 @@
+import { screen } from '@testing-library/dom';
+import { BASIC_SCRIPTED_CHECK } from 'test/fixtures/checks';
+
+import { CheckType } from 'types';
+import { submitForm } from 'components/Checkster/__testHelpers__/formHelpers';
+import { renderDuplicateFormV2 } from 'page/__testHelpers__/checkForm';
+
+async function renderDuplicateCheck() {
+  return renderDuplicateFormV2(BASIC_SCRIPTED_CHECK, CheckType.HTTP);
+}
+
+describe('DuplicateCheck', () => {
+  it('should be able to change the job name', async () => {
+    const { read, user } = await renderDuplicateCheck();
+    const JOB_NAME = 'JOB NAME';
+
+    const jobField = screen.getByLabelText(/Job name/);
+    expect(jobField).toHaveValue(`${BASIC_SCRIPTED_CHECK.job} (Copy)`);
+    await user.clear(jobField);
+    await user.type(jobField, JOB_NAME);
+    await submitForm(user);
+
+    const { body } = await read();
+
+    const { alerts, id, created, modified, ...rest } = BASIC_SCRIPTED_CHECK;
+
+    expect(body).toEqual({ ...rest, job: JOB_NAME });
+  });
+});

--- a/src/page/__testHelpers__/checkForm.tsx
+++ b/src/page/__testHelpers__/checkForm.tsx
@@ -32,14 +32,32 @@ export function renderNewFormV2(checkType: CheckType) {
   return renderNewForm(checkType, NewCheckV2);
 }
 
-export async function renderNewForm(checkType: CheckType, CheckComponent = NewCheck) {
+export function renderDuplicateFormV2(duplicateCheck: Check, checkType: CheckType) {
+  server.use(
+    apiRoute(`listChecks`, {
+      result: () => {
+        return {
+          json: [duplicateCheck],
+        };
+      },
+    })
+  );
+
+  return renderNewForm(checkType, NewCheckV2, duplicateCheck.id);
+}
+
+export async function renderNewForm(
+  checkType: CheckType,
+  CheckComponent = NewCheck,
+  duplicateId: number | null = null
+) {
   const { record, read } = getServerRequests();
   server.use(apiRoute(`addCheck`, {}, record));
   server.use(apiRoute(`updateAlertsForCheck`, { method: 'put' }, record));
   const checkTypeGroup = getCheckTypeGroup(checkType);
 
   const res = render(<CheckComponent />, {
-    path: `${generateRoutePath(AppRoutes.NewCheck)}/${checkTypeGroup}?checkType=${checkType}`,
+    path: `${generateRoutePath(AppRoutes.NewCheck)}/${checkTypeGroup}?checkType=${checkType}${duplicateId ? `&duplicateId=${duplicateId}` : ''}`,
     route: `${getRoute(AppRoutes.NewCheck)}/:checkTypeGroup`,
   });
 


### PR DESCRIPTION
## Problem

When duplicating a check, the job name is automatically set to "{original job name} (Copy)" to help users distinguish the duplicate. However, users were unable to edit this job name after duplication because the useEffect hook that sets the initial job name had dependencies that caused it to re-run whenever the check data was updated, resetting the job name back to the default "(Copy)" suffix.

## Solution

The useEffect hook that sets the duplicate job name now only runs on component mount by using an empty dependency array. This ensures the job name is set once when the duplicate form is first rendered, allowing users to freely edit the job name afterward without it being reset. An integration test has been added to verify that users can successfully change the job name when duplicating a check.