### PR TITLE
fix: handle undefined allowMissing in HTTP regex header validations

### DIFF
--- a/src/components/CheckEditor/transformations/toFormValues.http.ts
+++ b/src/components/CheckEditor/transformations/toFormValues.http.ts
@@ -109,7 +109,7 @@ const getHttpRegexValidationFormValues = (
           matchType: HttpRegexValidationType.Header,
           expression: headerMatch.regexp,
           header: headerMatch.header,
-          allowMissing: headerMatch.allowMissing,
+          allowMissing: headerMatch.allowMissing ?? false,
           inverted: invertedTypes.has(regexType),
         });
       }

--- a/src/components/Checkster/transformations/toFormValues.http.ts
+++ b/src/components/Checkster/transformations/toFormValues.http.ts
@@ -106,7 +106,7 @@ const getHttpRegexValidationFormValues = (
           matchType: HttpRegexValidationType.Header,
           expression: headerMatch.regexp,
           header: headerMatch.header,
-          allowMissing: headerMatch.allowMissing,
+          allowMissing: headerMatch.allowMissing ?? false,
           inverted: invertedTypes.has(regexType),
         });
       }


### PR DESCRIPTION
## Problem

Users were seeing red checkmarks (validation errors) in the Uptime section when editing HTTP checks that have Regexp Header validation configured. The error would disappear when switching between steps.

## Root Cause

The `allowMissing` field in `HeaderMatch` objects can be `undefined` when returned from the backend. However, the Zod schema validation (`httpRegexHeaderValidationSchema`) requires `allowMissing` to be a boolean, causing validation to fail.

## Solution

Added `?? false` fallback when transforming backend data to form values for HTTP regex header validations. This ensures the field is always a boolean, defaulting to `false` when undefined.

The `toPayload` transformation functions already had this safety check in place, so this change brings the `toFormValues` functions in line with existing behavior.

**Before**
https://github.com/user-attachments/assets/c0a2b46b-80e0-4e61-87cd-effab0a24132

**After**
https://github.com/user-attachments/assets/da2a5632-ae2b-404d-aaf5-b46b87d1a3d5

