### PR TITLE
feat: implement POC for folders

### DIFF
--- a/src/components/Checkster/components/form/FormFolderField.tsx
+++ b/src/components/Checkster/components/form/FormFolderField.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useController, useFormContext } from 'react-hook-form';
+
+import { CheckFormValues, FeatureName } from 'types';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
+import { FolderSelector } from 'components/FolderSelector';
+
+export function FormFolderField() {
+  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
+  const { control } = useFormContext<CheckFormValues>();
+  const { field: folderField } = useController({ control, name: 'folderUid' });
+
+  if (!isFoldersEnabled) {
+    return null;
+  }
+
+  return <FolderSelector value={folderField.value} onChange={folderField.onChange} includeRoot />;
+}

--- a/src/components/Checkster/components/form/layouts/DnsCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/DnsCheckContent.tsx
@@ -8,6 +8,7 @@ import { useHasFieldsError } from '../../../hooks/useHasFieldsError';
 import { AdditionalSettings } from '../../AdditionalSettings';
 import { SectionContent } from '../../ui/SectionContent';
 import { ChooseCheckType } from '../ChooseCheckType';
+import { FormFolderField } from '../FormFolderField';
 import { FormIpVersionRadioField } from '../FormIpVersionRadioField';
 import { FormJobField } from '../FormJobField';
 import { FormTabContent, FormTabs } from '../FormTabs';
@@ -29,6 +30,7 @@ export function DnsCheckContent() {
   return (
     <SectionContent>
       <FormJobField field="job" />
+      <FormFolderField />
       <ChooseCheckType />
       <GenericInputField
         field="target"

--- a/src/components/Checkster/components/form/layouts/GrpcCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/GrpcCheckContent.tsx
@@ -6,6 +6,7 @@ import { useHasFieldsError } from '../../../hooks/useHasFieldsError';
 import { AdditionalSettings } from '../../AdditionalSettings';
 import { SectionContent } from '../../ui/SectionContent';
 import { ChooseCheckType } from '../ChooseCheckType';
+import { FormFolderField } from '../FormFolderField';
 import { FormIpVersionRadioField } from '../FormIpVersionRadioField';
 import { FormJobField } from '../FormJobField';
 import { FormTabContent, FormTabs } from '../FormTabs';
@@ -30,6 +31,7 @@ export function GrpcCheckContent() {
   return (
     <SectionContent>
       <FormJobField field="job" />
+      <FormFolderField />
 
       <ChooseCheckType />
 

--- a/src/components/Checkster/components/form/layouts/HttpCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/HttpCheckContent.tsx
@@ -6,6 +6,7 @@ import { useHasFieldsError } from '../../../hooks/useHasFieldsError';
 import { AdditionalSettings } from '../../AdditionalSettings';
 import { SectionContent } from '../../ui/SectionContent';
 import { ChooseCheckType } from '../ChooseCheckType';
+import { FormFolderField } from '../FormFolderField';
 import { FormHttpAuthenticationField } from '../FormHttpAuthenticationField';
 import { FormHttpRequestMethodTargetFields } from '../FormHttpRequestMethodTargetFields';
 import { FormIpVersionRadioField } from '../FormIpVersionRadioField';
@@ -38,7 +39,7 @@ export function HttpCheckContent() {
   return (
     <SectionContent>
       <FormJobField field="job" />
-
+      <FormFolderField />
       <ChooseCheckType />
 
       {/* TODO: Would be nice to write root fields like `.target` (instead of `target`) */}

--- a/src/components/Checkster/components/form/layouts/MultiHttpCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/MultiHttpCheckContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { SectionContent } from '../../ui/SectionContent';
+import { FormFolderField } from '../FormFolderField';
 import { FormJobField } from '../FormJobField';
 import { FormMultiHttpEntriesField } from '../FormMultiHttpEntriesField';
 
@@ -11,6 +12,7 @@ export function MultiHttpCheckContent() {
   return (
     <SectionContent>
       <FormJobField field="job" />
+      <FormFolderField />
       <FormMultiHttpEntriesField field="settings.multihttp.entries" />
     </SectionContent>
   );

--- a/src/components/Checkster/components/form/layouts/PingCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/PingCheckContent.tsx
@@ -4,6 +4,7 @@ import { DEFAULT_EXAMPLE_HOSTNAME } from '../../../constants';
 import { AdditionalSettings } from '../../AdditionalSettings';
 import { SectionContent } from '../../ui/SectionContent';
 import { ChooseCheckType } from '../ChooseCheckType';
+import { FormFolderField } from '../FormFolderField';
 import { FormIpVersionRadioField } from '../FormIpVersionRadioField';
 import { FormJobField } from '../FormJobField';
 import { FormTabContent, FormTabs } from '../FormTabs';
@@ -14,6 +15,7 @@ export function PingCheckContent() {
   return (
     <SectionContent>
       <FormJobField field="job" />
+      <FormFolderField />
       <ChooseCheckType />
       <GenericInputField
         field="target"

--- a/src/components/Checkster/components/form/layouts/ScriptedCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/ScriptedCheckContent.tsx
@@ -15,6 +15,7 @@ import { FIELD_SPACING, SECONDARY_CONTAINER_ID } from '../../../constants';
 import { ScriptExamples } from '../../ScriptExamples';
 import { Column } from '../../ui/Column';
 import { SectionContent } from '../../ui/SectionContent';
+import { FormFolderField } from '../FormFolderField';
 import { FormInstanceField } from '../FormInstanceField';
 import { FormJobField } from '../FormJobField';
 import { FormTabContent, FormTabs } from '../FormTabs';
@@ -42,6 +43,7 @@ export function ScriptedCheckContent({
     <SectionContent noWrapper>
       <Column gap={FIELD_SPACING} padding={theme.spacing(0, 2)}>
         <FormJobField field="job" />
+        <FormFolderField />
         <FormInstanceField field="target" />
         <K6ChannelSelect />
       </Column>

--- a/src/components/Checkster/components/form/layouts/TcpCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/TcpCheckContent.tsx
@@ -6,6 +6,7 @@ import { useHasFieldsError } from '../../../hooks/useHasFieldsError';
 import { AdditionalSettings } from '../../AdditionalSettings';
 import { SectionContent } from '../../ui/SectionContent';
 import { ChooseCheckType } from '../ChooseCheckType';
+import { FormFolderField } from '../FormFolderField';
 import { FormIpVersionRadioField } from '../FormIpVersionRadioField';
 import { FormJobField } from '../FormJobField';
 import { FormTabContent, FormTabs } from '../FormTabs';
@@ -30,6 +31,7 @@ export function TcpCheckContent() {
   return (
     <SectionContent>
       <FormJobField field="job" />
+      <FormFolderField />
       <ChooseCheckType />
       <GenericInputField
         field="target"

--- a/src/components/Checkster/components/form/layouts/TracerouteCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/TracerouteCheckContent.tsx
@@ -6,6 +6,7 @@ import { useHasFieldsError } from '../../../hooks/useHasFieldsError';
 import { AdditionalSettings } from '../../AdditionalSettings';
 import { SectionContent } from '../../ui/SectionContent';
 import { ChooseCheckType } from '../ChooseCheckType';
+import { FormFolderField } from '../FormFolderField';
 import { FormJobField } from '../FormJobField';
 import { FormTabContent, FormTabs } from '../FormTabs';
 import { GenericCheckboxField } from '../generic/GenericCheckboxField';
@@ -28,6 +29,7 @@ export function TracerouteCheckContent() {
   return (
     <SectionContent>
       <FormJobField field="job" />
+      <FormFolderField />
       <ChooseCheckType />
 
       <GenericInputField

--- a/src/components/Checkster/transformations/toFormValues.utils.ts
+++ b/src/components/Checkster/transformations/toFormValues.utils.ts
@@ -46,6 +46,7 @@ export function getBaseFormValuesFromCheck(check: Check): Omit<CheckFormValues, 
     target: check.target,
     timeout: check.timeout,
     alerts: predefinedAlertsToFormValues(GLOBAL_PREDEFINED_ALERTS, check.alerts || []),
+    folderUid: check.folderUid,
   };
 }
 

--- a/src/components/Checkster/transformations/toPayload.utils.ts
+++ b/src/components/Checkster/transformations/toPayload.utils.ts
@@ -15,6 +15,7 @@ export function getBasePayloadValuesFromForm(formValues: CheckFormValues): Check
     probes: formValues.probes,
     target: formValues.target,
     timeout: formValues.timeout,
+    folderUid: formValues.folderUid,
   };
 }
 

--- a/src/components/FolderSelector/FolderSelector.tsx
+++ b/src/components/FolderSelector/FolderSelector.tsx
@@ -1,0 +1,219 @@
+import React, { useState } from 'react';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Button, Field, Icon, Input, Modal, Select, Stack, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { useCreateFolder, useFolderPermissions, useFolders } from 'data/useFolders';
+
+interface FolderSelectorProps {
+  value?: string;
+  onChange: (folderUid?: string) => void;
+  required?: boolean;
+  disabled?: boolean;
+  includeRoot?: boolean;
+}
+
+export const FolderSelector = ({
+  value,
+  onChange,
+  required = false,
+  disabled = false,
+  includeRoot = true,
+}: FolderSelectorProps) => {
+  
+  const styles = useStyles2(getStyles);
+  const { data: folders = [], isLoading } = useFolders();
+  const [showCreateModal, setShowCreateModal] = useState(false);
+
+  const options: Array<SelectableValue<string>> = [
+    ...(includeRoot
+      ? [{ label: 'Root (No folder)', value: '', description: 'Check will not be in a folder' }]
+      : []
+    ),
+    ...folders.map((folder) => {
+      return {
+        label: folder.title,
+        value: folder.uid,
+        description: buildFolderDescription(folder),
+        icon: 'folder' as const,
+      };
+    }),
+  ];
+
+  const selectedOption = options.find((opt) => opt.value === value);
+
+  return (
+    <div>
+      <Field
+        label="Folder"
+        description="Organize checks into folders with RBAC permissions"
+        required={required}
+      >
+        <Stack direction="row" gap={1}>
+          <div className={styles.selectContainer}>
+            <Select //eslint-disable-line @typescript-eslint/no-deprecated
+              options={options}
+              value={selectedOption}
+              onChange={(selected) => {
+                onChange(selected?.value);
+              }}
+              placeholder={isLoading ? 'Loading folders...' : 'Select a folder'}
+              disabled={disabled || isLoading}
+              isClearable={!required && includeRoot}
+              aria-label="Select folder"
+            />
+          </div>
+          <Button
+            variant="secondary"
+            size="md"
+            onClick={() => {
+              setShowCreateModal(true);
+            }}
+            disabled={disabled}
+            tooltip="Create a new folder"
+          >
+            <Icon name="plus" />
+          </Button>
+        </Stack>
+      </Field>
+
+      {value && <FolderPermissionHint folderUid={value} />}
+
+      {showCreateModal && (
+        <CreateFolderModal
+          onClose={() => {
+            setShowCreateModal(false);
+          }}
+          onSuccess={(newFolder) => {
+            setShowCreateModal(false);
+            onChange(newFolder.uid);
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+const FolderPermissionHint = ({ folderUid }: { folderUid: string }) => {
+  const styles = useStyles2(getStyles);
+  const { folder, canWrite, canDelete, canAdmin } = useFolderPermissions(folderUid);
+
+  if (!folder) {
+    return null;
+  }
+
+  return (
+    <div className={styles.permissionHint}>
+      <Stack direction="row" gap={1}>
+        <Icon name="shield" />
+        <span>
+          You can: {[canWrite && 'edit', canDelete && 'delete', canAdmin && 'manage permissions'].filter(Boolean).join(', ')}
+        </span>
+      </Stack>
+    </div>
+  );
+};
+
+interface CreateFolderModalProps {
+  onClose: () => void;
+  onSuccess: (folder: any) => void;
+}
+
+const CreateFolderModal = ({ onClose, onSuccess }: CreateFolderModalProps) => {
+  const [title, setTitle] = useState('');
+  const [error, setError] = useState<string>();
+  const createFolder = useCreateFolder();
+
+  const handleSubmit = async () => {
+    if (!title.trim()) {
+      setError('Folder name is required');
+      return;
+    }
+
+    try {
+      const folder = await createFolder.mutateAsync({ title: title.trim() });
+      onSuccess(folder);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create folder');
+    }
+  };
+
+  return (
+    <Modal title="Create New Folder" onDismiss={onClose} isOpen>
+      <div>
+        <Field
+          label="Folder Name"
+          description="A descriptive name for organizing your checks"
+          error={error}
+          invalid={Boolean(error)}
+        >
+          <Input
+            value={title}
+            onChange={(e) => {
+              setTitle(e.currentTarget.value);
+              setError(undefined);
+            }}
+            placeholder="e.g., Production, Staging, Team ABC"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleSubmit();
+              }
+            }}
+          />
+        </Field>
+      </div>
+
+      <Modal.ButtonRow>
+        <Button variant="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button variant="primary" onClick={handleSubmit} disabled={!title.trim() || createFolder.isPending}>
+          {createFolder.isPending ? 'Creating...' : 'Create Folder'}
+        </Button>
+      </Modal.ButtonRow>
+    </Modal>
+  );
+};
+
+function buildFolderDescription(folder: any): string {
+  const parts: string[] = [];
+
+  if (folder.parents && folder.parents.length > 0) {
+    parts.push(`Path: ${folder.parents.map((p: any) => p.title).join(' > ')} > ${folder.title}`);
+  }
+
+  const permissions: string[] = [];
+  if (folder.canSave) {
+    permissions.push('create');
+  }
+  if (folder.canEdit) {
+    permissions.push('edit');
+  }
+  if (folder.canDelete) {
+    permissions.push('delete');
+  }
+
+  if (permissions.length > 0) {
+    parts.push(`Permissions: ${permissions.join(', ')}`);
+  }
+
+  return parts.join(' • ');
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    selectContainer: css({
+      flex: 1,
+    }),
+    permissionHint: css({
+      marginTop: theme.spacing(1),
+      padding: theme.spacing(1),
+      backgroundColor: theme.colors.background.secondary,
+      borderRadius: theme.shape.radius.default,
+      fontSize: theme.typography.bodySmall.fontSize,
+      color: theme.colors.text.secondary,
+    }),
+  };
+};
+

--- a/src/components/FolderSelector/index.ts
+++ b/src/components/FolderSelector/index.ts
@@ -1,0 +1,2 @@
+export { FolderSelector } from './FolderSelector';
+

--- a/src/data/useFolders.ts
+++ b/src/data/useFolders.ts
@@ -1,0 +1,117 @@
+import { useMutation, useQuery, UseQueryResult } from '@tanstack/react-query';
+import { getBackendSrv } from '@grafana/runtime';
+
+import { GrafanaFolder } from 'types';
+import { queryClient } from 'data/queryClient';
+
+export interface CreateFolderPayload {
+  title: string;
+  parentUid?: string;
+}
+
+export interface UpdateFolderPayload {
+  title: string;
+  version: number;
+}
+
+export const folderQueryKeys = {
+  all: ['folders'] as const,
+  list: () => [...folderQueryKeys.all, 'list'] as const,
+  detail: (uid: string) => [...folderQueryKeys.all, 'detail', uid] as const,
+};
+
+export function useFolders(): UseQueryResult<GrafanaFolder[], Error> {
+  return useQuery({
+    queryKey: folderQueryKeys.list(),
+    queryFn: async () => {
+      const response = await getBackendSrv().get<GrafanaFolder[]>('/api/folders');
+      return response;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useFolder(
+  uid: string | undefined,
+  enabled = true
+): UseQueryResult<GrafanaFolder, Error> {
+  return useQuery({
+    queryKey: folderQueryKeys.detail(uid!),
+    queryFn: async () => {
+      const response = await getBackendSrv().get<GrafanaFolder>(`/api/folders/${uid}`);
+      return response;
+    },
+    enabled: enabled && Boolean(uid),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useCreateFolder() {
+  return useMutation({
+    mutationFn: async (payload: CreateFolderPayload): Promise<GrafanaFolder> => {
+      const response = await getBackendSrv().post<GrafanaFolder>('/api/folders', payload);
+      return response;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: folderQueryKeys.all });
+    },
+  });
+}
+
+export function useUpdateFolder() {
+  return useMutation({
+    mutationFn: async ({
+      uid,
+      payload,
+    }: {
+      uid: string;
+      payload: UpdateFolderPayload;
+    }): Promise<GrafanaFolder> => {
+      const response = await getBackendSrv().put<GrafanaFolder>(`/api/folders/${uid}`, payload);
+      return response;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: folderQueryKeys.all });
+    },
+  });
+}
+
+export function useDeleteFolder() {
+  return useMutation({
+    mutationFn: async (uid: string): Promise<{ message: string; id: number }> => {
+      const response = await getBackendSrv().delete<{ message: string; id: number }>(`/api/folders/${uid}`);
+      return response;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: folderQueryKeys.all });
+    },
+  });
+}
+
+
+export function useWritableFolders(): UseQueryResult<GrafanaFolder[], Error> {
+  const foldersQuery = useFolders();
+
+  return {
+    ...foldersQuery,
+    // Only include folders with explicit canSave permission
+    data: foldersQuery.data?.filter((folder) => folder.canSave === true),
+  } as UseQueryResult<GrafanaFolder[], Error>;
+}
+
+/**
+ * Helper hook to get folder permissions for a specific folder
+ */
+export function useFolderPermissions(folderUid: string | undefined) {
+  const { data: folder, isLoading } = useFolder(folderUid);
+
+  return {
+    canRead: folder?.canSave ?? false,
+    canWrite: folder?.canEdit ?? false,
+    canDelete: folder?.canDelete ?? false,
+    canAdmin: folder?.canAdmin ?? false,
+    folder,
+    isLoading,
+  };
+}
+

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -330,6 +330,10 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
         return { ...check, folderUid: 'dfa2kemr3ajggd' }; //Access test folder
         //return { ...check, folderUid: '123' };
       }
+
+      if (check.id === 2499) {
+        return { ...check, folderUid: 'dfdue0tzgf4e8a' }; // Inner folder
+      }
       return check;
     });
 

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -311,7 +311,29 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   }
 
   async listChecks(includeAlerts = false) {
-    return this.fetchAPI<ListCheckResult>(`${this.instanceSettings.url}/sm/check/list?includeAlerts=${includeAlerts}`);
+    const result = await this.fetchAPI<ListCheckResult>(
+      `${this.instanceSettings.url}/sm/check/list?includeAlerts=${includeAlerts}`
+    );
+
+    // TODO: Remove this after backend implements folderUid support
+    // Temporarily add folderUid to specific check for testing
+    const modifiedChecks = result.map((check) => {
+      if (check.id === 1629348 || check.id === 1669440) {
+        return { ...check, folderUid: 'afa2p3og6h9fkd' }; // pizza checks
+      }
+
+      if (check.id === 1669439 || check.id === 1669437) {
+        return { ...check, folderUid: 'dfa2s1lbvah34b' }; // restricted checks
+      }
+
+      if (check.id === 2260) {
+        return { ...check, folderUid: 'dfa2kemr3ajggd' }; //Access test folder
+        //return { ...check, folderUid: '123' };
+      }
+      return check;
+    });
+
+    return modifiedChecks;
   }
 
   async testCheck(check: Check) {
@@ -492,7 +514,6 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       showErrorAlert: false,
     });
   }
-
 
   //--------------------------------------------------------------------------------
   // TEST

--- a/src/hooks/useAccessibleChecks.ts
+++ b/src/hooks/useAccessibleChecks.ts
@@ -2,33 +2,70 @@ import { useMemo } from 'react';
 
 import { Check, FeatureName } from 'types';
 import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
-import { useFolders } from 'data/useFolders';
+import { useCheckForbiddenFolders, useFolders } from 'data/useFolders';
 
 /**
  * Filter checks based on folder permissions
- * Only returns checks that are either:
- * 1. In folders the user has access to (if folder is in /api/folders response, user has at least View permission)
- * 2. Not in any folder (root level)
+ * 
+ * Shows checks if:
+ * - No folder (root level)
+ * - Folder in accessible list (200)
+ * - Folder deleted (404) - shows with "Folder deleted" badge
+ * 
+ * Hides checks if:
+ * - Folder exists but user has no access (403)
  *
- * See https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder_permissions/
+ * See https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder/
  */
 export function useAccessibleChecks(checks: Check[]): Check[] {
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
-  const { data: folders = [] } = useFolders();
+  const { data: folders = [], isError: foldersQueryError } = useFolders();
+
+  const accessibleFolderUids = useMemo(() => new Set(folders.map((f) => f.uid)), [folders]);
+
+  // Get list of folder UIDs that aren't in accessible list
+  const missingFolderUids = useMemo(() => {
+    const uids = new Set<string>();
+    checks.forEach((check) => {
+      if (check.folderUid && !accessibleFolderUids.has(check.folderUid)) {
+        uids.add(check.folderUid);
+      }
+    });
+    return Array.from(uids);
+  }, [checks, accessibleFolderUids]);
+
+  // Check which missing folders are forbidden (403) vs orphaned (404)
+  const { data: forbiddenFolders = {}, isLoading: isForbiddenFoldersLoading } = useCheckForbiddenFolders(
+    missingFolderUids,
+    !foldersQueryError
+  );
 
   return useMemo(() => {
     if (!isFoldersEnabled) {
       return checks;
     }
 
-    // If a folder is in the list, user has read access
-    const accessibleFolderUids = new Set(folders.map((folder) => folder.uid));
+    // If user doesn't have folders:read permission, only show root level checks
+    if (foldersQueryError) {
+      return checks.filter((check) => !check.folderUid);
+    }
 
     return checks.filter((check) => {
       if (!check.folderUid) {
-        return true;
+        return true; // Root level
       }
-      return accessibleFolderUids.has(check.folderUid);
+
+      if (accessibleFolderUids.has(check.folderUid)) {
+        return true; // In accessible list
+      }
+
+      // While loading forbidden folders data, hide checks with unknown status to prevent flicker
+      // Once loaded, hide if explicitly forbidden (403), show if orphaned (404)
+      if (isForbiddenFoldersLoading) {
+        return false;
+      }
+
+      return !forbiddenFolders[check.folderUid];
     });
-  }, [checks, folders, isFoldersEnabled]);
+  }, [checks, accessibleFolderUids, forbiddenFolders, isFoldersEnabled, foldersQueryError, isForbiddenFoldersLoading]);
 }

--- a/src/hooks/useAccessibleChecks.ts
+++ b/src/hooks/useAccessibleChecks.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+
+import { Check, FeatureName } from 'types';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
+import { useFolders } from 'data/useFolders';
+
+/**
+ * Filter checks based on folder permissions
+ * Only returns checks that are either:
+ * 1. In folders the user has access to (if folder is in /api/folders response, user has at least View permission)
+ * 2. Not in any folder (root level)
+ *
+ * See https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/folder_permissions/
+ */
+export function useAccessibleChecks(checks: Check[]): Check[] {
+  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
+  const { data: folders = [] } = useFolders();
+
+  return useMemo(() => {
+    if (!isFoldersEnabled) {
+      return checks;
+    }
+
+    // If a folder is in the list, user has read access
+    const accessibleFolderUids = new Set(folders.map((folder) => folder.uid));
+
+    return checks.filter((check) => {
+      if (!check.folderUid) {
+        return true;
+      }
+      return accessibleFolderUids.has(check.folderUid);
+    });
+  }, [checks, folders, isFoldersEnabled]);
+}

--- a/src/hooks/useCheckAccess.ts
+++ b/src/hooks/useCheckAccess.ts
@@ -2,19 +2,31 @@ import { useMemo } from 'react';
 
 import { Check, FeatureName } from 'types';
 import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
-import { useFolders } from 'data/useFolders';
+import { useFolder, useFolders } from 'data/useFolders';
 
 /**
  * Check if user has access to a specific check based on folder permissions
  *
+ * Queries the individual folder to distinguish between:
+ * - 200: Folder exists and user has access → Allow access
+ * - 404: Folder doesn't exist (orphaned) → Allow access (show with warning)
+ * - 403: Folder exists but no access → Deny access
+ * - Other errors: Deny access (safe default)
+ *
  * Returns:
- * - true: User has access (check has no folder OR user has access to the folder)
- * - false: User doesn't have access (check is in a folder user can't access)
+ * - true: User has access (accessible folder, orphaned folder, or root level)
+ * - false: No access (forbidden, unknown error, or no folders:read permission)
  * - null: Loading folder data
  */
 export function useCheckAccess(check: Check | undefined): boolean | null {
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
-  const { data: folders, isLoading } = useFolders();
+  const { data: folders, isLoading: isFoldersLoading, isError: foldersQueryError } = useFolders();
+  
+  const accessibleFolderUids = useMemo(() => new Set(folders?.map((f) => f.uid) || []), [folders]);
+  const needsFolderCheck = Boolean(check?.folderUid && !accessibleFolderUids.has(check.folderUid));
+  
+  // Query folder info only if needed
+  const folderInfo = useFolder(check?.folderUid, isFoldersEnabled && needsFolderCheck && !foldersQueryError);
 
   return useMemo(() => {
     if (!isFoldersEnabled) {
@@ -25,16 +37,41 @@ export function useCheckAccess(check: Check | undefined): boolean | null {
       return false;
     }
 
-    if (isLoading) {
+    if (isFoldersLoading) {
       return null;
     }
 
-    //root level: allow access
+    // If user doesn't have folders:read permission, only allow root level checks
+    if (foldersQueryError) {
+      return !check.folderUid;
+    }
+
+    // Root level checks are always accessible
     if (!check.folderUid) {
       return true;
     }
 
-    const hasAccess = folders?.some((folder) => folder.uid === check.folderUid);
-    return hasAccess ?? false;
-  }, [check, folders, isLoading, isFoldersEnabled]);
+    // Check is in accessible folders list
+    if (accessibleFolderUids.has(check.folderUid)) {
+      return true;
+    }
+
+    // Still loading folder info
+    if (folderInfo.isLoading) {
+      return null;
+    }
+
+    // Explicitly deny access if forbidden (403)
+    if (folderInfo.isForbidden) {
+      return false;
+    }
+
+    // Explicitly allow access if orphaned (404)
+    if (folderInfo.isOrphaned) {
+      return true;
+    }
+
+    // For other errors or unknown states, deny access to be safe
+    return false;
+  }, [check, accessibleFolderUids, isFoldersLoading, folderInfo, isFoldersEnabled, foldersQueryError]);
 }

--- a/src/hooks/useCheckAccess.ts
+++ b/src/hooks/useCheckAccess.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+
+import { Check, FeatureName } from 'types';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
+import { useFolders } from 'data/useFolders';
+
+/**
+ * Check if user has access to a specific check based on folder permissions
+ *
+ * Returns:
+ * - true: User has access (check has no folder OR user has access to the folder)
+ * - false: User doesn't have access (check is in a folder user can't access)
+ * - null: Loading folder data
+ */
+export function useCheckAccess(check: Check | undefined): boolean | null {
+  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
+  const { data: folders, isLoading } = useFolders();
+
+  return useMemo(() => {
+    if (!isFoldersEnabled) {
+      return true;
+    }
+
+    if (!check) {
+      return false;
+    }
+
+    if (isLoading) {
+      return null;
+    }
+
+    //root level: allow access
+    if (!check.folderUid) {
+      return true;
+    }
+
+    const hasAccess = folders?.some((folder) => folder.uid === check.folderUid);
+    return hasAccess ?? false;
+  }, [check, folders, isLoading, isFoldersEnabled]);
+}

--- a/src/hooks/useChecksByFolder.ts
+++ b/src/hooks/useChecksByFolder.ts
@@ -4,74 +4,109 @@ import { Check, FeatureName, GrafanaFolder } from 'types';
 import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 import { getFolderPath, useFolders } from 'data/useFolders';
 
-export interface FolderGroup {
+export interface FolderNode {
   folderUid: string;
   folder?: GrafanaFolder;
   folderPath: string;
   checks: Check[];
-  isAccessible: boolean; // Has folder in accessible list
-  isOrphaned: boolean; // Folder might be deleted (not in accessible list)
+  children: FolderNode[];
+  isAccessible: boolean;
+  isOrphaned: boolean;
 }
 
 export interface ChecksByFolder {
-  folderGroups: FolderGroup[];
-  rootChecks: Check[]; // Checks with no folder
+  folderTree: FolderNode[];
+  rootChecks: Check[];
 }
 
-/**
- * Groups checks by their folder, separating root-level checks from folder checks
- * 
- * Returns:
- * - folderGroups: Array of folders with their checks
- * - rootChecks: Checks that don't belong to any folder
- */
+export function collectAllFolderUids(nodes: FolderNode[]): string[] {
+  const uids: string[] = [];
+  const walk = (list: FolderNode[]) => {
+    list.forEach((node) => {
+      uids.push(node.folderUid);
+      walk(node.children);
+    });
+  };
+  walk(nodes);
+  return uids;
+}
+
+export function getTotalCheckCount(node: FolderNode): number {
+  let count = node.checks.length;
+  node.children.forEach((child) => {
+    count += getTotalCheckCount(child);
+  });
+  return count;
+}
+
 export function useChecksByFolder(checks: Check[]): ChecksByFolder {
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
   const { data: folders = [] } = useFolders();
 
   return useMemo(() => {
-    // If folders feature is disabled, treat all checks as root
     if (!isFoldersEnabled) {
-      return {
-        folderGroups: [],
-        rootChecks: checks,
-      };
+      return { folderTree: [], rootChecks: checks };
     }
 
-    const folderMap = new Map<string, FolderGroup>();
     const rootChecks: Check[] = [];
-
     const foldersById = new Map(folders.map((f) => [f.uid, f]));
+    const nodeMap = new Map<string, FolderNode>();
+
+    const getOrCreateNode = (uid: string): FolderNode => {
+      if (!nodeMap.has(uid)) {
+        const folder = foldersById.get(uid);
+        nodeMap.set(uid, {
+          folderUid: uid,
+          folder,
+          folderPath: folder ? getFolderPath(folder, foldersById) : uid,
+          checks: [],
+          children: [],
+          isAccessible: !!folder,
+          isOrphaned: !folder,
+        });
+      }
+      return nodeMap.get(uid)!;
+    };
 
     checks.forEach((check) => {
       if (!check.folderUid) {
         rootChecks.push(check);
         return;
       }
+      getOrCreateNode(check.folderUid).checks.push(check);
+    });
 
-      if (!folderMap.has(check.folderUid)) {
-        const folder = foldersById.get(check.folderUid);
-        folderMap.set(check.folderUid, {
-          folderUid: check.folderUid,
-          folder,
-          folderPath: folder ? getFolderPath(folder, foldersById) : check.folderUid,
-          checks: [],
-          isAccessible: !!folder,
-          isOrphaned: !folder,
-        });
+    // Ensure ancestor folders exist as nodes so the tree is connected
+    nodeMap.forEach((node) => {
+      let current = node.folder;
+      while (current?.parentUid) {
+        getOrCreateNode(current.parentUid);
+        current = foldersById.get(current.parentUid);
       }
-
-      folderMap.get(check.folderUid)!.checks.push(check);
     });
 
-    const folderGroups = Array.from(folderMap.values()).sort((a, b) => {
-      return a.folderPath.localeCompare(b.folderPath);
+    // Build the tree by linking children to parents
+    const rootNodes: FolderNode[] = [];
+    nodeMap.forEach((node) => {
+      const parentUid = node.folder?.parentUid;
+      if (parentUid && nodeMap.has(parentUid)) {
+        nodeMap.get(parentUid)!.children.push(node);
+      } else {
+        rootNodes.push(node);
+      }
     });
 
-    return {
-      folderGroups,
-      rootChecks,
+    const sortNodes = (nodes: FolderNode[]) => {
+      nodes.sort((a, b) => {
+        const titleA = a.folder?.title ?? a.folderUid;
+        const titleB = b.folder?.title ?? b.folderUid;
+        return titleA.localeCompare(titleB);
+      });
+      nodes.forEach((n) => sortNodes(n.children));
     };
+    sortNodes(rootNodes);
+
+    return { folderTree: rootNodes, rootChecks };
   }, [checks, folders, isFoldersEnabled]);
 }
 

--- a/src/hooks/useChecksByFolder.ts
+++ b/src/hooks/useChecksByFolder.ts
@@ -1,0 +1,82 @@
+import { useMemo } from 'react';
+
+import { Check, FeatureName, GrafanaFolder } from 'types';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
+import { useFolders } from 'data/useFolders';
+
+export interface FolderGroup {
+  folderUid: string;
+  folder?: GrafanaFolder;
+  checks: Check[];
+  isAccessible: boolean; // Has folder in accessible list
+  isOrphaned: boolean; // Folder might be deleted (not in accessible list)
+}
+
+export interface ChecksByFolder {
+  folderGroups: FolderGroup[];
+  rootChecks: Check[]; // Checks with no folder
+}
+
+/**
+ * Groups checks by their folder, separating root-level checks from folder checks
+ * 
+ * Returns:
+ * - folderGroups: Array of folders with their checks
+ * - rootChecks: Checks that don't belong to any folder
+ */
+export function useChecksByFolder(checks: Check[]): ChecksByFolder {
+  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
+  const { data: folders = [] } = useFolders();
+
+  return useMemo(() => {
+    // If folders feature is disabled, treat all checks as root
+    if (!isFoldersEnabled) {
+      return {
+        folderGroups: [],
+        rootChecks: checks,
+      };
+    }
+
+    const folderMap = new Map<string, FolderGroup>();
+    const rootChecks: Check[] = [];
+
+    // Create folder lookup for quick access
+    const foldersById = new Map(folders.map((f) => [f.uid, f]));
+
+    checks.forEach((check) => {
+      // Checks without folderUid go to root
+      if (!check.folderUid) {
+        rootChecks.push(check);
+        return;
+      }
+
+      // Create folder group if it doesn't exist
+      if (!folderMap.has(check.folderUid)) {
+        const folder = foldersById.get(check.folderUid);
+        folderMap.set(check.folderUid, {
+          folderUid: check.folderUid,
+          folder,
+          checks: [],
+          isAccessible: !!folder,
+          isOrphaned: !folder, // If not in accessible list, might be deleted
+        });
+      }
+
+      // Add check to its folder group
+      folderMap.get(check.folderUid)!.checks.push(check);
+    });
+
+    // Convert map to array and sort by folder title
+    const folderGroups = Array.from(folderMap.values()).sort((a, b) => {
+      const titleA = a.folder?.title || a.folderUid;
+      const titleB = b.folder?.title || b.folderUid;
+      return titleA.localeCompare(titleB);
+    });
+
+    return {
+      folderGroups,
+      rootChecks,
+    };
+  }, [checks, folders, isFoldersEnabled]);
+}
+

--- a/src/page/CheckList/CheckList.hooks.ts
+++ b/src/page/CheckList/CheckList.hooks.ts
@@ -19,6 +19,7 @@ interface CheckFiltersProps {
     state: Array<SelectableValue<ProbeFilter>>,
     update: (value: Array<SelectableValue<ProbeFilter>> | null) => void
   ];
+  folder: [state: string | undefined, update: (value: string | null | undefined) => void];
 }
 
 export function useCheckFilters() {
@@ -71,6 +72,12 @@ export function useCheckFilters() {
           .filter((probe) => labels.includes(probe.displayName))
           .map((probe) => ({ label: probe.displayName, value: probe.id } as SelectableValue<ProbeFilter>));
       },
+    }),
+    folder: useQueryParametersState<string | undefined>({
+      key: 'folder',
+      initialValue: undefined,
+      encode: (value) => value || '',
+      decode: (value) => (value || undefined),
     }),
   };
 

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -6,23 +6,24 @@ import { Pagination, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { getTotalChecksPerMonth } from 'checkUsageCalc';
 
-import { CheckFiltersType, CheckListViewType, FilterType } from 'page/CheckList/CheckList.types';
-import { Check, CheckEnabledStatus, CheckSort, CheckType, FeatureName, Label } from 'types';
-import { MetricCheckSuccess, Time } from 'datasource/responses.types';
-import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
-import { useSuspenseChecks } from 'data/useChecks';
-import { useSuspenseProbes } from 'data/useProbes';
-import { useChecksReachabilitySuccessRate } from 'data/useSuccessRates';
-import { findCheckinMetrics } from 'data/utils';
-import { useAccessibleChecks } from 'hooks/useAccessibleChecks';
-import { useQueryParametersState } from 'hooks/useQueryParametersState';
 import { ChecksEmptyState } from 'components/ChecksEmptyState';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
+import { useChecksReachabilitySuccessRate } from 'data/useSuccessRates';
+import { useSuspenseChecks } from 'data/useChecks';
+import { useSuspenseProbes } from 'data/useProbes';
+import { findCheckinMetrics } from 'data/utils';
+import { MetricCheckSuccess, Time } from 'datasource/responses.types';
+import { useAccessibleChecks } from 'hooks/useAccessibleChecks';
+import { useQueryParametersState } from 'hooks/useQueryParametersState';
 import { CHECK_LIST_STATUS_OPTIONS } from 'page/CheckList/CheckList.constants';
 import { useCheckFilters } from 'page/CheckList/CheckList.hooks';
+import { CheckFiltersType, CheckListViewType, FilterType } from 'page/CheckList/CheckList.types';
 import { matchesAllFilters } from 'page/CheckList/CheckList.utils';
+import { CheckListFolderView } from 'page/CheckList/components/CheckListFolderView';
 import { CheckListHeader } from 'page/CheckList/components/CheckListHeader';
 import { CheckListItem } from 'page/CheckList/components/CheckListItem';
+import { Check, CheckEnabledStatus, CheckSort, CheckType, FeatureName, Label } from 'types';
 
 const CHECKS_PER_PAGE_CARD = 15;
 const CHECKS_PER_PAGE_LIST = 50;
@@ -204,22 +205,33 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
         viewType={viewType}
       />
       <div>
-        <section className="card-section card-list-layout-list">
-          <div className={styles.list}>
-            {currentPageChecks.map((check, index) => (
-              <CheckListItem
-                check={check}
-                key={check.id}
-                onLabelSelect={handleLabelSelect}
-                onStatusSelect={handleStatusSelect}
-                onTypeSelect={handleTypeSelect}
-                onToggleCheckbox={handleCheckSelect}
-                selected={selectedCheckIds.has(check.id!)}
-                viewType={viewType}
-              />
-            ))}
-          </div>
-        </section>
+        {viewType === CheckListViewType.Folder ? (
+          <CheckListFolderView
+            checks={currentPageChecks}
+            onLabelSelect={handleLabelSelect}
+            onStatusSelect={handleStatusSelect}
+            onTypeSelect={handleTypeSelect}
+            onToggleCheckbox={handleCheckSelect}
+            selectedCheckIds={selectedCheckIds}
+          />
+        ) : (
+          <section className="card-section card-list-layout-list">
+            <div className={styles.list}>
+              {currentPageChecks.map((check, index) => (
+                <CheckListItem
+                  check={check}
+                  key={check.id}
+                  onLabelSelect={handleLabelSelect}
+                  onStatusSelect={handleStatusSelect}
+                  onTypeSelect={handleTypeSelect}
+                  onToggleCheckbox={handleCheckSelect}
+                  selected={selectedCheckIds.has(check.id!)}
+                  viewType={viewType}
+                />
+              ))}
+            </div>
+          </section>
+        )}
         {totalPages > 1 && (
           <Pagination
             numberOfPages={totalPages}

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -14,6 +14,7 @@ import { useSuspenseChecks } from 'data/useChecks';
 import { useSuspenseProbes } from 'data/useProbes';
 import { useChecksReachabilitySuccessRate } from 'data/useSuccessRates';
 import { findCheckinMetrics } from 'data/utils';
+import { useAccessibleChecks } from 'hooks/useAccessibleChecks';
 import { useQueryParametersState } from 'hooks/useQueryParametersState';
 import { ChecksEmptyState } from 'components/ChecksEmptyState';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
@@ -56,9 +57,11 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
   useSuspenseProbes(); // we need to block rendering until we have the probe list so not to initially render a check list that might have probe filters
   const navigate = useNavigate();
   const location = useLocation();
-  const { data: checks } = useSuspenseChecks();
+  const { data: allChecks } = useSuspenseChecks();
   const { data: reachabilitySuccessRates = [] } = useChecksReachabilitySuccessRate();
   const filters = useCheckFilters();
+  
+  const checks = useAccessibleChecks(allChecks);
 
   const [sortType, setSortType] = useQueryParametersState<CheckSort>({
     key: 'sort',

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -7,8 +7,9 @@ import { css } from '@emotion/css';
 import { getTotalChecksPerMonth } from 'checkUsageCalc';
 
 import { CheckFiltersType, CheckListViewType, FilterType } from 'page/CheckList/CheckList.types';
-import { Check, CheckEnabledStatus, CheckSort, CheckType, Label } from 'types';
+import { Check, CheckEnabledStatus, CheckSort, CheckType, FeatureName, Label } from 'types';
 import { MetricCheckSuccess, Time } from 'datasource/responses.types';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 import { useSuspenseChecks } from 'data/useChecks';
 import { useSuspenseProbes } from 'data/useProbes';
 import { useChecksReachabilitySuccessRate } from 'data/useSuccessRates';
@@ -71,10 +72,13 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
   const [type, setType] = filters.type;
   const [status, setStatus] = filters.status;
   const [probes, setProbes] = filters.probes;
+  const [folder, setFolder] = filters.folder;
+
+  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
 
   const checkFilters = useMemo(
-    () => ({ labels, search, type, status, probes }),
-    [labels, search, type, status, probes]
+    () => ({ labels, search, type, status, probes, folder: isFoldersEnabled ? folder : undefined }),
+    [labels, search, type, status, probes, folder, isFoldersEnabled]
   );
 
   const [currentPage, setCurrentPage] = useState(1);
@@ -107,6 +111,9 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
         break;
       case 'probes':
         setProbes(filters.probes);
+        break;
+      case 'folder':
+        setFolder(filters.folder);
         break;
       default:
         break;

--- a/src/page/CheckList/CheckList.types.ts
+++ b/src/page/CheckList/CheckList.types.ts
@@ -5,6 +5,7 @@ import { Check, CheckEnabledStatus, CheckType, DashboardSceneAppConfig } from 't
 export enum CheckListViewType {
   Card = 'card',
   List = 'list',
+  Folder = 'folder',
 }
 
 export type ProbeFilter = {

--- a/src/page/CheckList/CheckList.types.ts
+++ b/src/page/CheckList/CheckList.types.ts
@@ -14,7 +14,7 @@ export type ProbeFilter = {
 
 export type CheckTypeFilter = CheckType | 'all';
 
-export type FilterType = 'search' | 'labels' | 'type' | 'status' | 'probes';
+export type FilterType = 'search' | 'labels' | 'type' | 'status' | 'probes' | 'folder';
 
 export interface CheckFiltersType {
   [key: string]: any;
@@ -24,6 +24,7 @@ export interface CheckFiltersType {
   type: CheckTypeFilter;
   status: SelectableValue<CheckEnabledStatus>;
   probes: Array<SelectableValue<ProbeFilter>>;
+  folder?: string;
 }
 
 export interface VizViewSceneAppConfig extends DashboardSceneAppConfig {

--- a/src/page/CheckList/CheckList.utils.ts
+++ b/src/page/CheckList/CheckList.utils.ts
@@ -61,8 +61,23 @@ const matchesSelectedProbes = (check: Check, selectedProbes: SelectableValue[]) 
   return check.probes.some((id) => probeIds.includes(id));
 };
 
+const matchesFolderFilter = (check: Check, folderFilter?: string) => {
+  // If no folder filter is set, show all checks
+  if (folderFilter === undefined) {
+    return true;
+  }
+
+  // If folder filter is empty string, show only checks without a folder (root level)
+  if (folderFilter === '') {
+    return !check.folderUid;
+  }
+
+  // Otherwise, match the specific folder
+  return check.folderUid === folderFilter;
+};
+
 export const matchesAllFilters = (check: Check, checkFilters: CheckFiltersType) => {
-  const { type, search, labels, status, probes } = checkFilters;
+  const { type, search, labels, status, probes, folder } = checkFilters;
 
   return (
     Boolean(check.id) &&
@@ -70,7 +85,8 @@ export const matchesAllFilters = (check: Check, checkFilters: CheckFiltersType) 
     matchesSearchFilter(check, search) &&
     matchesLabelFilter(check, labels) &&
     matchesStatusFilter(check, status) &&
-    matchesSelectedProbes(check, probes)
+    matchesSelectedProbes(check, probes) &&
+    matchesFolderFilter(check, folder)
   );
 };
 

--- a/src/page/CheckList/components/CheckFolderBadge.tsx
+++ b/src/page/CheckList/components/CheckFolderBadge.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { Badge } from '@grafana/ui';
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Tag, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 
 import { Check, FeatureName } from 'types';
 import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
@@ -12,6 +15,8 @@ interface CheckFolderBadgeProps {
 export function CheckFolderBadge({ check }: CheckFolderBadgeProps) {
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
   const { data: folder, isError } = useFolder(check.folderUid, isFoldersEnabled);
+  const navigate = useNavigate();
+  const styles = useStyles2(getStyles);
 
   if (!isFoldersEnabled || !check.folderUid) {
     return null;
@@ -19,22 +24,50 @@ export function CheckFolderBadge({ check }: CheckFolderBadgeProps) {
 
   if (isError || !folder) {
     return (
-      <Badge
-        text={check.folderUid}
-        color="orange"
+      <Tag
+        name={check.folderUid}
         icon="folder"
-        tooltip={`Folder not found (${check.folderUid})`}
+        colorIndex={15}
+        className={styles.errorTag}
       />
     );
   }
 
+  const handleClick = () => {
+    navigate(`/dashboards?query=${encodeURIComponent(folder.title)}`);
+  };
+
   return (
-    <Badge
-      text={folder.title}
-      color="blue"
+    <Tag
+      name={folder.title}
       icon="folder"
-      tooltip={`This check is in the "${folder.title}" folder`}
+      onClick={handleClick}
+      className={styles.folderTag}
     />
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    folderTag: css({
+      cursor: 'pointer',
+      backgroundColor: theme.colors.primary.main,
+      color: theme.colors.primary.contrastText,
+      borderColor: theme.colors.primary.border,
+      '& svg': {
+        marginRight: theme.spacing(0.5),
+        verticalAlign: 'middle',
+      },
+    }),
+    errorTag: css({
+      backgroundColor: theme.colors.warning.main,
+      color: theme.colors.warning.contrastText,
+      borderColor: theme.colors.warning.border,
+      '& svg': {
+        marginRight: theme.spacing(0.5),
+        verticalAlign: 'middle',
+      },
+    }),
+  };
+};
 

--- a/src/page/CheckList/components/CheckFolderBadge.tsx
+++ b/src/page/CheckList/components/CheckFolderBadge.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/css';
 
 import { Check, FeatureName } from 'types';
 import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
-import { useFolder } from 'data/useFolders';
+import { getFolderPath, useFolder } from 'data/useFolders';
 
 interface CheckFolderBadgeProps {
   check: Check;
@@ -33,7 +33,9 @@ export function CheckFolderBadge({ check }: CheckFolderBadgeProps) {
       }
     };
 
-    return <Tag name={folderInfo.folder.title} icon="folder" onClick={handleClick} className={styles.folderTag} />;
+    const pathLabel = getFolderPath(folderInfo.folder);
+
+    return <Tag name={pathLabel} icon="folder" onClick={handleClick} className={styles.folderTag} />;
   }
 
   // Folder deleted/orphaned (404) or any error - assume deleted for better UX

--- a/src/page/CheckList/components/CheckFolderBadge.tsx
+++ b/src/page/CheckList/components/CheckFolderBadge.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Tag, useStyles2 } from '@grafana/ui';
+import { Tag, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { Check, FeatureName } from 'types';
@@ -13,37 +13,34 @@ interface CheckFolderBadgeProps {
 
 export function CheckFolderBadge({ check }: CheckFolderBadgeProps) {
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
-  const { data: folder, isError } = useFolder(check.folderUid, isFoldersEnabled);
+  const folderInfo = useFolder(check.folderUid, isFoldersEnabled);
   const styles = useStyles2(getStyles);
 
   if (!isFoldersEnabled || !check.folderUid) {
     return null;
   }
 
-  if (isError || !folder) {
-    return (
-      <Tag
-        name={check.folderUid}
-        icon="folder"
-        colorIndex={15}
-        className={styles.errorTag}
-      />
-    );
+  // Loading state
+  if (folderInfo.isLoading) {
+    return null;
   }
 
-  const handleClick = () => {
-    if (folder.url) {
-      window.open(folder.url, '_blank');
-    }
-  };
+  // Folder exists and accessible (200)
+  if (folderInfo.hasAccess && folderInfo.folder) {
+    const handleClick = () => {
+      if (folderInfo.folder?.url) {
+        window.open(folderInfo.folder.url, '_blank');
+      }
+    };
 
+    return <Tag name={folderInfo.folder.title} icon="folder" onClick={handleClick} className={styles.folderTag} />;
+  }
+
+  // Folder deleted/orphaned (404) or any error - assume deleted for better UX
   return (
-    <Tag
-      name={folder.title}
-      icon="folder"
-      onClick={handleClick}
-      className={styles.folderTag}
-    />
+    <Tooltip content={`Folder no longer exists: ${check.folderUid}`}>
+      <Tag name="Folder deleted" icon="folder" colorIndex={15} className={styles.errorTag} />
+    </Tooltip>
   );
 }
 
@@ -54,18 +51,20 @@ const getStyles = (theme: GrafanaTheme2) => {
       backgroundColor: theme.colors.primary.main,
       color: theme.colors.primary.contrastText,
       borderColor: theme.colors.primary.border,
+      display: 'inline-flex',
+      alignItems: 'center',
       '& svg': {
         marginRight: theme.spacing(0.5),
-        verticalAlign: 'middle',
       },
     }),
     errorTag: css({
       backgroundColor: theme.colors.warning.main,
       color: theme.colors.warning.contrastText,
       borderColor: theme.colors.warning.border,
+      display: 'inline-flex',
+      alignItems: 'center',
       '& svg': {
         marginRight: theme.spacing(0.5),
-        verticalAlign: 'middle',
       },
     }),
   };

--- a/src/page/CheckList/components/CheckFolderBadge.tsx
+++ b/src/page/CheckList/components/CheckFolderBadge.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Badge } from '@grafana/ui';
+
+import { Check, FeatureName } from 'types';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
+import { useFolder } from 'data/useFolders';
+
+interface CheckFolderBadgeProps {
+  check: Check;
+}
+
+export function CheckFolderBadge({ check }: CheckFolderBadgeProps) {
+  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
+  const { data: folder, isError } = useFolder(check.folderUid, isFoldersEnabled);
+
+  if (!isFoldersEnabled || !check.folderUid) {
+    return null;
+  }
+
+  if (isError || !folder) {
+    return (
+      <Badge
+        text={check.folderUid}
+        color="orange"
+        icon="folder"
+        tooltip={`Folder not found (${check.folderUid})`}
+      />
+    );
+  }
+
+  return (
+    <Badge
+      text={folder.title}
+      color="blue"
+      icon="folder"
+      tooltip={`This check is in the "${folder.title}" folder`}
+    />
+  );
+}
+

--- a/src/page/CheckList/components/CheckFolderBadge.tsx
+++ b/src/page/CheckList/components/CheckFolderBadge.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Tag, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -15,7 +14,6 @@ interface CheckFolderBadgeProps {
 export function CheckFolderBadge({ check }: CheckFolderBadgeProps) {
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
   const { data: folder, isError } = useFolder(check.folderUid, isFoldersEnabled);
-  const navigate = useNavigate();
   const styles = useStyles2(getStyles);
 
   if (!isFoldersEnabled || !check.folderUid) {
@@ -34,7 +32,9 @@ export function CheckFolderBadge({ check }: CheckFolderBadgeProps) {
   }
 
   const handleClick = () => {
-    navigate(`/dashboards?query=${encodeURIComponent(folder.title)}`);
+    if (folder.url) {
+      window.open(folder.url, '_blank');
+    }
   };
 
   return (

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -96,7 +96,7 @@ export function CheckListFolderView({
                     <Icon name={isExpanded ? 'angle-down' : 'angle-right'} size="lg" />
                     <Icon name="folder" />
                     <span className={styles.folderTitle}>
-                      {group.folder?.title || group.folderUid}
+                      {group.folderPath}
                       {group.isOrphaned && <span className={styles.orphanedLabel}> (Folder deleted)</span>}
                     </span>
                     <span className={styles.checkCount}>

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -1,0 +1,248 @@
+import React, { useState } from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Button, Icon, Stack, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { CheckListViewType } from '../CheckList.types';
+import { Check, Label } from 'types';
+import { useChecksByFolder } from 'hooks/useChecksByFolder';
+
+import { CheckListItem } from './CheckListItem';
+
+interface CheckListFolderViewProps {
+  checks: Check[];
+  onLabelSelect: (label: Label) => void;
+  onStatusSelect: (enabled: boolean) => void;
+  onTypeSelect: (checkType: any) => void;
+  onToggleCheckbox: (checkId: number) => void;
+  selectedCheckIds: Set<number>;
+}
+
+export function CheckListFolderView({
+  checks,
+  onLabelSelect,
+  onStatusSelect,
+  onTypeSelect,
+  onToggleCheckbox,
+  selectedCheckIds,
+}: CheckListFolderViewProps) {
+  const styles = useStyles2(getStyles);
+  const { folderGroups, rootChecks } = useChecksByFolder(checks);
+  
+  // Track which folders are expanded (default: all expanded)
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
+    () => new Set(folderGroups.map((g) => g.folderUid))
+  );
+
+  const toggleFolder = (folderUid: string) => {
+    setExpandedFolders((prev) => {
+      const next = new Set(prev);
+      if (next.has(folderUid)) {
+        next.delete(folderUid);
+      } else {
+        next.add(folderUid);
+      }
+      return next;
+    });
+  };
+
+  const expandAll = () => {
+    setExpandedFolders(new Set(folderGroups.map((g) => g.folderUid)));
+  };
+
+  const collapseAll = () => {
+    setExpandedFolders(new Set());
+  };
+
+  const allExpanded = expandedFolders.size === folderGroups.length;
+  const allCollapsed = expandedFolders.size === 0;
+
+  return (
+    <div className={styles.container}>
+      {/* Folders Section */}
+      {folderGroups.length > 0 && (
+        <div className={styles.foldersSection}>
+          <div className={styles.foldersSectionHeader}>
+            <h3 className={styles.sectionTitle}>Folders ({folderGroups.length})</h3>
+            <Stack gap={1}>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={expandAll}
+                disabled={allExpanded}
+                icon="angle-down"
+                tooltip="Expand all folders"
+              >
+                Expand all
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={collapseAll}
+                disabled={allCollapsed}
+                icon="angle-right"
+                tooltip="Collapse all folders"
+              >
+                Collapse all
+              </Button>
+            </Stack>
+          </div>
+          {folderGroups.map((group) => {
+            const isExpanded = expandedFolders.has(group.folderUid);
+            return (
+              <div key={group.folderUid} className={styles.folderGroup}>
+                <div className={styles.folderHeader} onClick={() => toggleFolder(group.folderUid)}>
+                  <Stack gap={1.5} alignItems="center">
+                    <Icon name={isExpanded ? 'angle-down' : 'angle-right'} size="lg" />
+                    <Icon name="folder" />
+                    <span className={styles.folderTitle}>
+                      {group.folder?.title || group.folderUid}
+                      {group.isOrphaned && <span className={styles.orphanedLabel}> (Folder deleted)</span>}
+                    </span>
+                    <span className={styles.checkCount}>
+                      {group.checks.length} {group.checks.length === 1 ? 'check' : 'checks'}
+                    </span>
+                  </Stack>
+                </div>
+                {isExpanded && (
+                  <div className={styles.folderContent}>
+                    {group.checks.map((check) => (
+                      <CheckListItem
+                        key={check.id}
+                        check={check}
+                        onLabelSelect={onLabelSelect}
+                        onStatusSelect={onStatusSelect}
+                        onTypeSelect={onTypeSelect}
+                        onToggleCheckbox={onToggleCheckbox}
+                        selected={selectedCheckIds.has(check.id!)}
+                        viewType={CheckListViewType.Card}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Root Checks Section */}
+      {rootChecks.length > 0 && (
+        <div className={styles.rootSection}>
+          <div className={styles.foldersSectionHeader}>
+            <h3 className={styles.sectionTitle}>Root Level ({rootChecks.length})</h3>
+          </div>
+          <div className={styles.rootChecks}>
+            {rootChecks.map((check) => (
+              <CheckListItem
+                key={check.id}
+                check={check}
+                onLabelSelect={onLabelSelect}
+                onStatusSelect={onStatusSelect}
+                onTypeSelect={onTypeSelect}
+                onToggleCheckbox={onToggleCheckbox}
+                selected={selectedCheckIds.has(check.id!)}
+                viewType={CheckListViewType.Card}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {folderGroups.length === 0 && rootChecks.length === 0 && (
+        <div className={styles.emptyState}>No checks to display</div>
+      )}
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(3),
+    width: '100%',
+  }),
+  foldersSection: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+  }),
+  foldersSectionHeader: css({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: theme.spacing(2),
+  }),
+  sectionTitle: css({
+    margin: 0,
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.h4.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+  }),
+  folderGroup: css({
+    marginBottom: theme.spacing(2),
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    overflow: 'hidden',
+    transition: 'box-shadow 0.2s',
+    '&:hover': {
+      boxShadow: theme.shadows.z2,
+    },
+  }),
+  folderHeader: css({
+    display: 'flex',
+    alignItems: 'center',
+    padding: theme.spacing(2),
+    backgroundColor: theme.colors.background.secondary,
+    cursor: 'pointer',
+    userSelect: 'none',
+    transition: 'background-color 0.2s',
+    '&:hover': {
+      backgroundColor: theme.colors.emphasize(theme.colors.background.secondary, 0.03),
+    },
+    '&:active': {
+      backgroundColor: theme.colors.emphasize(theme.colors.background.secondary, 0.05),
+    },
+  }),
+  folderTitle: css({
+    fontWeight: theme.typography.fontWeightMedium,
+    fontSize: theme.typography.h5.fontSize,
+    flex: 1,
+  }),
+  checkCount: css({
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+    padding: theme.spacing(0.5, 1),
+    backgroundColor: theme.colors.background.primary,
+    borderRadius: theme.shape.radius.default,
+  }),
+  orphanedLabel: css({
+    color: theme.colors.warning.text,
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontWeight: theme.typography.fontWeightRegular,
+  }),
+  folderContent: css({
+    padding: theme.spacing(2),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    backgroundColor: theme.colors.background.primary,
+  }),
+  rootSection: css({
+    marginTop: theme.spacing(3),
+    paddingTop: theme.spacing(2),
+  }),
+  rootChecks: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  }),
+  emptyState: css({
+    padding: theme.spacing(4),
+    textAlign: 'center',
+    color: theme.colors.text.secondary,
+  }),
+});
+

--- a/src/page/CheckList/components/CheckListItemCard.tsx
+++ b/src/page/CheckList/components/CheckListItemCard.tsx
@@ -9,6 +9,7 @@ import { useUsageCalc } from 'hooks/useUsageCalc';
 import { AlertStatus } from 'components/AlertStatus/AlertStatus';
 import { LatencyGauge, SuccessRateGaugeCheckReachability, SuccessRateGaugeCheckUptime } from 'components/Gauges';
 import { CheckCardLabel } from 'page/CheckList/components/CheckCardLabel';
+import { CheckFolderBadge } from 'page/CheckList/components/CheckFolderBadge';
 import { CheckItemActionButtons } from 'page/CheckList/components/CheckItemActionButtons';
 import { CheckListItemProps } from 'page/CheckList/components/CheckListItem';
 import { CheckListItemDetails } from 'page/CheckList/components/CheckListItemDetails';
@@ -76,6 +77,7 @@ export const CheckListItemCard = ({
           </div>
           <Stack wrap="wrap" justifyContent="flex-start">
             <div className={styles.labelsContainer}>
+              <CheckFolderBadge check={check} />
               {check.labels.map((label: Label, index) => (
                 <CheckCardLabel key={index} label={label} onLabelSelect={onLabelSelect} />
               ))}

--- a/src/page/CheckList/components/CheckListViewSwitcher.tsx
+++ b/src/page/CheckList/components/CheckListViewSwitcher.tsx
@@ -6,6 +6,7 @@ import { CheckListViewType } from 'page/CheckList/CheckList.types';
 const CHECK_LIST_VIEW_TYPE_OPTIONS = [
   { description: 'Card view', value: CheckListViewType.Card, icon: 'check-square' },
   { description: 'List view', value: CheckListViewType.List, icon: 'list-ul' },
+  { description: 'Folder view', value: CheckListViewType.Folder, icon: 'folder' },
 ];
 
 interface CheckListViewSwitcherProps {

--- a/src/page/EditCheck/EditCheckV2.tsx
+++ b/src/page/EditCheck/EditCheckV2.tsx
@@ -11,6 +11,7 @@ import { createNavModel } from 'utils';
 import { AppRoutes } from 'routing/types';
 import { generateRoutePath, getRoute } from 'routing/utils';
 import { useChecks } from 'data/useChecks';
+import { useCheckAccess } from 'hooks/useCheckAccess';
 import { useHandleSubmitCheckster } from 'hooks/useHandleSubmitCheckster';
 import { useNavigation } from 'hooks/useNavigation';
 import { useURLSearchParams } from 'hooks/useURLSearchParams';
@@ -26,6 +27,7 @@ export const EditCheckV2 = () => {
   const { data: checks, isLoading, error, refetch, isFetched } = useChecks();
   const check = checks?.find((c) => c.id === Number(id));
   const urlSearchParams = useURLSearchParams();
+  const hasAccess = useCheckAccess(check);
 
   const handleSubmit = useHandleSubmitCheckster(check);
 
@@ -49,6 +51,10 @@ export const EditCheckV2 = () => {
   // Only show spinner for the initial fetch.
   if (isLoading && !isFetched) {
     return <CenteredSpinner />;
+  }
+
+  if (hasAccess === false) {
+    return <AccessDeniedModal checkId={Number(id)} />;
   }
 
   const { canWriteChecks } = getUserPermissions();
@@ -95,6 +101,26 @@ const NotFoundModal = () => {
       <Alert title={``} severity="error">
         We were unable to find your check. It may have been deleted or you may not have access to it. If you think you
         are seeing this message in error, please contact your administrator.
+      </Alert>
+      <Modal.ButtonRow>
+        <LinkButton href={getRoute(AppRoutes.Checks)}>Go to check list</LinkButton>
+      </Modal.ButtonRow>
+    </Modal>
+  );
+};
+
+const AccessDeniedModal = ({ checkId }: { checkId: number }) => {
+  const navigate = useNavigation();
+
+  const handleOnDismiss = useCallback(() => {
+    navigate(AppRoutes.Checks);
+  }, [navigate]);
+
+  return (
+    <Modal title="Access Denied" isOpen onDismiss={handleOnDismiss} closeOnBackdropClick={false} closeOnEscape={false}>
+      <Alert title="" severity="error">
+        You do not have permission to access this check. It is in a folder you don&apos;t have access to. If you believe
+        this is an error, please contact your administrator.
       </Alert>
       <Modal.ButtonRow>
         <LinkButton href={getRoute(AppRoutes.Checks)}>Go to check list</LinkButton>

--- a/src/schemas/forms/BaseCheckSchema.ts
+++ b/src/schemas/forms/BaseCheckSchema.ts
@@ -21,6 +21,7 @@ export const baseCheckSchema = z.object({
   labels: labelsSchema,
   publishAdvancedMetrics: z.boolean(),
   alerts: checkAlertsSchema.optional(),
+  folderUid: z.string().optional(),
 });
 
 export function addRefinements<T extends CheckFormValuesBase>(schema: ZodType<T, any, any>) {

--- a/src/test/fixtures/checks.ts
+++ b/src/test/fixtures/checks.ts
@@ -73,7 +73,12 @@ const transformedValidCert = btoa(VALID_CERT);
 const transformedValidKey = btoa(VALID_KEY);
 
 export const BASIC_DNS_CHECK: DNSCheck = db.check.build(
-  { job: 'Job name for dns', target: 'dns.com', probes: [PRIVATE_PROBE.id, PUBLIC_PROBE.id] as number[] },
+  { 
+    job: 'Job name for dns', 
+    target: 'dns.com', 
+    probes: [PRIVATE_PROBE.id, PUBLIC_PROBE.id] as number[],
+    folderUid: 'platform-team',
+  },
   { transient: { type: CheckType.DNS } }
 ) as DNSCheck;
 
@@ -89,6 +94,7 @@ export const BASIC_HTTP_CHECK: HTTPCheck = db.check.build(
     ],
     alerts: [...BASIC_CHECK_ALERTS.alerts],
     probes: [PRIVATE_PROBE.id, PUBLIC_PROBE.id] as number[],
+    folderUid: 'frontend-team',
   },
   { transient: { type: CheckType.HTTP } }
 ) as HTTPCheck;
@@ -98,6 +104,7 @@ export const BASIC_SCRIPTED_CHECK: ScriptedCheck = db.check.build(
     job: 'Job name for k6',
     labels: [{ name: 'scriptedLabelName', value: 'scriptedLabelValue' }],
     probes: [PRIVATE_PROBE.id, PUBLIC_PROBE.id] as number[],
+    folderUid: 'sre-team',
     settings: {
       scripted: {
         script: btoa('console.log("hello world")'),
@@ -126,17 +133,18 @@ export const BASIC_MULTIHTTP_CHECK: MultiHTTPCheck = db.check.build(
     job: 'Job name for multihttp',
     labels: [{ name: 'labelName', value: 'labelValue' }],
     probes: [PRIVATE_PROBE.id, PUBLIC_PROBE.id] as number[],
+    folderUid: 'frontend-team',
     settings: {
-      multihttp: {
-        entries: [
-          {
-            request: {
-              url: 'https://www.multi1.com',
-              method: HttpMethod.GET,
-              headers: [
-                {
-                  name: 'aheader',
-                  value: 'yarp',
+        multihttp: {
+          entries: [
+            {
+              request: {
+                url: 'https://www.multi1.com',
+                method: HttpMethod.GET,
+                headers: [
+                  {
+                    name: 'aheader',
+                    value: 'yarp',
                 },
                 {
                   name: 'carne',
@@ -201,6 +209,7 @@ export const BASIC_PING_CHECK: PingCheck = db.check.build(
     target: 'grafana.com',
     labels: [{ name: 'labelName', value: 'labelValue' }],
     probes: [PRIVATE_PROBE.id, PUBLIC_PROBE.id] as number[],
+    folderUid: 'sre-team',
     settings: {
       ping: {
         ipVersion: IpVersion.V4,
@@ -219,6 +228,7 @@ export const BASIC_TCP_CHECK: TCPCheck = db.check.build(
     labels: [{ name: 'labelName', value: 'labelValue' }],
     probes: [PRIVATE_PROBE.id, PUBLIC_PROBE.id] as number[],
     target: 'grafana.com:43',
+    folderUid: 'platform-team',
   },
   { transient: { type: CheckType.TCP } }
 ) as TCPCheck;
@@ -241,6 +251,7 @@ export const FULL_HTTP_CHECK: HTTPCheck = db.check.build(
     labels: [{ name: 'agreatlabel', value: 'totally awesome label' }],
     probes: [PRIVATE_PROBE.id, PUBLIC_PROBE.id] as number[],
     basicMetricsOnly: true,
+    folderUid: 'platform-team',
     settings: {
       http: {
         method: HttpMethod.GET,

--- a/src/test/fixtures/folders.ts
+++ b/src/test/fixtures/folders.ts
@@ -1,0 +1,75 @@
+import { GrafanaFolder } from 'types';
+
+export const MOCK_FOLDERS: GrafanaFolder[] = [
+  {
+    id: 1,
+    uid: 'platform-team',
+    title: 'Platform Team',
+    url: '/dashboards/f/platform-team/platform-team',
+    hasAcl: true,
+    canSave: true,
+    canEdit: true,
+    canAdmin: true,
+    canDelete: true,
+    created: '2024-01-15T10:00:00Z',
+    updated: '2024-01-15T10:00:00Z',
+    createdBy: 'admin',
+    updatedBy: 'admin',
+    version: 1,
+  },
+  {
+    id: 2,
+    uid: 'frontend-team',
+    title: 'Frontend Team',
+    url: '/dashboards/f/frontend-team/frontend-team',
+    hasAcl: true,
+    canSave: true,
+    canEdit: true,
+    canAdmin: true,
+    canDelete: true,
+    created: '2024-01-15T10:05:00Z',
+    updated: '2024-01-15T10:05:00Z',
+    createdBy: 'admin',
+    updatedBy: 'admin',
+    version: 1,
+  },
+  {
+    id: 3,
+    uid: 'sre-team',
+    title: 'SRE Team',
+    url: '/dashboards/f/sre-team/sre-team',
+    hasAcl: true,
+    canSave: true,
+    canEdit: true,
+    canAdmin: true,
+    canDelete: true,
+    created: '2024-01-15T10:10:00Z',
+    updated: '2024-01-15T10:10:00Z',
+    createdBy: 'admin',
+    updatedBy: 'admin',
+    version: 1,
+  },
+  {
+    id: 4,
+    uid: 'readonly-team',
+    title: 'External Partners (Read-only)',
+    url: '/dashboards/f/readonly-team/external-partners-read-only',
+    hasAcl: true,
+    canSave: false,
+    canEdit: false,
+    canAdmin: false,
+    canDelete: false,
+    created: '2024-01-15T10:15:00Z',
+    updated: '2024-01-15T10:15:00Z',
+    createdBy: 'admin',
+    updatedBy: 'admin',
+    version: 1,
+  },
+];
+
+export const PLATFORM_TEAM_FOLDER = MOCK_FOLDERS[0];
+export const FRONTEND_TEAM_FOLDER = MOCK_FOLDERS[1];
+export const SRE_TEAM_FOLDER = MOCK_FOLDERS[2];
+export const READONLY_TEAM_FOLDER = MOCK_FOLDERS[3];
+
+

--- a/src/test/fixtures/folders.ts
+++ b/src/test/fixtures/folders.ts
@@ -65,11 +65,64 @@ export const MOCK_FOLDERS: GrafanaFolder[] = [
     updatedBy: 'admin',
     version: 1,
   },
+  {
+    id: 5,
+    uid: 'platform-staging',
+    title: 'Staging',
+    url: '/dashboards/f/platform-staging/staging',
+    parentUid: 'platform-team',
+    hasAcl: true,
+    canSave: true,
+    canEdit: true,
+    canAdmin: true,
+    canDelete: true,
+    created: '2024-01-15T11:00:00Z',
+    updated: '2024-01-15T11:00:00Z',
+    createdBy: 'admin',
+    updatedBy: 'admin',
+    version: 1,
+  },
+  {
+    id: 6,
+    uid: 'platform-production',
+    title: 'Production',
+    url: '/dashboards/f/platform-production/production',
+    parentUid: 'platform-team',
+    hasAcl: true,
+    canSave: true,
+    canEdit: true,
+    canAdmin: true,
+    canDelete: true,
+    created: '2024-01-15T11:05:00Z',
+    updated: '2024-01-15T11:05:00Z',
+    createdBy: 'admin',
+    updatedBy: 'admin',
+    version: 1,
+  },
+  {
+    id: 7,
+    uid: 'platform-staging-eu',
+    title: 'EU',
+    url: '/dashboards/f/platform-staging-eu/eu',
+    parentUid: 'platform-staging',
+    hasAcl: true,
+    canSave: true,
+    canEdit: true,
+    canAdmin: true,
+    canDelete: true,
+    created: '2024-01-15T12:00:00Z',
+    updated: '2024-01-15T12:00:00Z',
+    createdBy: 'admin',
+    updatedBy: 'admin',
+    version: 1,
+  },
 ];
 
 export const PLATFORM_TEAM_FOLDER = MOCK_FOLDERS[0];
 export const FRONTEND_TEAM_FOLDER = MOCK_FOLDERS[1];
 export const SRE_TEAM_FOLDER = MOCK_FOLDERS[2];
 export const READONLY_TEAM_FOLDER = MOCK_FOLDERS[3];
-
+export const PLATFORM_STAGING_FOLDER = MOCK_FOLDERS[4];
+export const PLATFORM_PRODUCTION_FOLDER = MOCK_FOLDERS[5];
+export const PLATFORM_STAGING_EU_FOLDER = MOCK_FOLDERS[6];
 

--- a/src/test/handlers/folders.ts
+++ b/src/test/handlers/folders.ts
@@ -1,0 +1,110 @@
+import { MOCK_FOLDERS } from 'test/fixtures/folders';
+
+import { ApiEntry } from 'test/handlers/types';
+import { GrafanaFolder } from 'types';
+
+export const listFolders: ApiEntry<GrafanaFolder[]> = {
+  route: `/api/folders`,
+  method: `get`,
+  result: () => {
+    return {
+      json: MOCK_FOLDERS,
+    };
+  },
+};
+
+export const getFolder: ApiEntry<GrafanaFolder> = {
+  route: `/api/folders/([^/]+)`,
+  method: `get`,
+  result: (req) => {
+    const uid = req.url.split('/').pop();
+    const folder = MOCK_FOLDERS.find((f) => f.uid === uid);
+
+    if (!folder) {
+      return {
+        status: 404,
+        json: { message: 'Folder not found' },
+      };
+    }
+
+    return {
+      json: folder,
+    };
+  },
+};
+
+export const createFolder: ApiEntry<GrafanaFolder> = {
+  route: `/api/folders`,
+  method: `post`,
+  result: async (req) => {
+    const body = await req.json();
+    
+    const newFolder: GrafanaFolder = {
+      id: Date.now(),
+      uid: `folder-${Date.now()}`,
+      title: body.title,
+      url: `/dashboards/f/folder-${Date.now()}/${body.title.toLowerCase()}`,
+      hasAcl: false,
+      canSave: true,
+      canEdit: true,
+      canAdmin: true,
+      canDelete: true,
+      created: new Date().toISOString(),
+      updated: new Date().toISOString(),
+      createdBy: 'admin',
+      updatedBy: 'admin',
+      version: 1,
+    };
+
+    return {
+      json: newFolder,
+    };
+  },
+};
+
+export const updateFolder: ApiEntry<GrafanaFolder> = {
+  route: `/api/folders/([^/]+)`,
+  method: `put`,
+  result: async (req) => {
+    const body = await req.json();
+    const uid = req.url.split('/').pop();
+    const folder = MOCK_FOLDERS.find((f) => f.uid === uid);
+
+    if (!folder) {
+      return {
+        status: 404,
+        json: { message: 'Folder not found' },
+      };
+    }
+
+    return {
+      json: {
+        ...folder,
+        title: body.title,
+        version: (folder.version || 0) + 1,
+        updated: new Date().toISOString(),
+      },
+    };
+  },
+};
+
+export const deleteFolder: ApiEntry<{ message: string; id: number }> = {
+  route: `/api/folders/([^/]+)`,
+  method: `delete`,
+  result: (req) => {
+    const uid = req.url.split('/').pop();
+    const folder = MOCK_FOLDERS.find((f) => f.uid === uid);
+
+    if (!folder) {
+      return {
+        status: 404,
+        json: { message: 'Folder not found' },
+      };
+    }
+
+    return {
+      json: { message: 'Folder deleted', id: folder.id },
+    };
+  },
+};
+

--- a/src/test/handlers/index.ts
+++ b/src/test/handlers/index.ts
@@ -20,6 +20,7 @@ import { createAccessToken } from 'test/handlers/tokens';
 import { ApiEntry } from 'test/handlers/types';
 
 import { listAlertsForCheck, updateAlertsForCheck } from './alerts';
+import { createFolder, deleteFolder, getFolder, listFolders, updateFolder } from './folders';
 import { listK6Channels } from './k6Channels';
 import { createSecret, deleteSecret, getSecret, listSecrets, updateSecret } from './secrets';
 
@@ -29,12 +30,15 @@ const apiRoutes = {
   bulkUpdateChecks,
   checkInfo,
   createAccessToken,
+  createFolder,
   createSecret,
   deleteCheck,
+  deleteFolder,
   deleteProbe,
   deleteSecret,
   getAlertRules,
   getDashboard,
+  getFolder,
   getGrafanaAlertRules,
   getHttpDashboard,
   getInstantMetrics,
@@ -49,11 +53,13 @@ const apiRoutes = {
   getTenantSettings,
   listAlertsForCheck,
   listChecks,
+  listFolders,
   listProbes,
   listSecrets,
   testCheck,
   updateAlertsForCheck,
   updateCheck,
+  updateFolder,
   updateProbe,
   updateSecret,
   updateTenantSettings,

--- a/src/types.ts
+++ b/src/types.ts
@@ -415,6 +415,7 @@ export interface CheckBase {
   probes: number[];
   alerts?: CheckAlertPublished[];
   disableReason?: string;
+  folderUid?: string; // Optional reference to Grafana folder
 }
 
 export type Check =
@@ -734,6 +735,7 @@ export enum FeatureName {
   TimepointExplorer = 'synthetic-monitoring-timepoint-explorer',
   CheckEditor = 'synthetic-monitoring-check-editor',
   VersionManagement = 'synthetic-monitoring-version-management',
+  Folders = 'synthetic-monitoring-folders',
   __TURNOFF = 'test-only-do-not-use',
 }
 
@@ -903,4 +905,30 @@ export interface K6Channel {
 
 export interface ListChannelsResponse {
   channels: K6Channel[];
+}
+
+/**
+ * Grafana Folder type from the Grafana Folders API
+ * https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/http-api/folder/
+ * 
+ * Note: Some fields may be missing depending on the API response.
+ * Basic list responses may only include id, uid, title.
+ */
+export interface GrafanaFolder {
+  id: number;
+  uid: string;
+  title: string;
+  url?: string;
+  hasAcl?: boolean;
+  canSave?: boolean;
+  canEdit?: boolean;
+  canAdmin?: boolean;
+  canDelete?: boolean;
+  created?: string;
+  updated?: string;
+  createdBy?: string;
+  updatedBy?: string;
+  version?: number;
+  parentUid?: string;
+  parents?: GrafanaFolder[];
 }


### PR DESCRIPTION
# Grafana Folders Integration for Synthetic Monitoring (POC)

This is an exploration on adding [Grafana Folders](https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/http-api/folder/#folder-api) to SM. 

Closes https://github.com/grafana/synthetic-monitoring/issues/270

## Problem

Grafana has a native folder system used across the platform for organizing dashboards, SLOs, and other resources. These folders support **folder-level permissions** (View/Edit/Admin), allowing granular access control. However, **Synthetic Monitoring checks are not integrated with this system**. They exist in a flat structure outside the Grafana data model.

Currently, SM uses an optional label system for organization, which provides minimal structure and no RBAC capabilities. As organizations scale their SM adoption (some managing 1,000+ checks across multiple teams), this lack of organization and access control becomes a significant pain point.

The [Grafana Folders API](https://grafana.com/docs/grafana-cloud/developer-resources/api-reference/http-api/folder/) provides:
- CRUD operations for folder management
- Built-in access control 
- Integration across grafana

## Solution

Integrate Synthetic Monitoring checks with Grafana's existing folder system by adding a `folderUid` reference field. This leverages Grafana's proven folder-based permissions (View/Edit/Admin levels) without requiring custom permission logic.

Similar integrations exist:
- **Grafana SLO**: [Implemented folders with RBAC in July 2024](https://grafana.com/whats-new/2024-07-26-grafana-slo-folder-rbac/)
- **Dashboards**: Native folder support
- **Alerts**: Organized by folders

### What This PR Includes

**See demo video:**
https://github.com/user-attachments/assets/4c327819-9329-45a5-8b2a-5ae3676c62b1

What this PR adds:
- `folderUid` field added to Check type and schema (**Note: this requires SM API support**)
- Folder selector in check forms
- Folder tag display in check list with navigation
- Folder filtering in check list
- Access control based on folder permissions
- Integration with Grafana Folders API (`/api/folders`)
- **Backward Compatible**: Checks without folders remain at root level

Screenshots:
<img width="2238" height="1229" alt="image" src="https://github.com/user-attachments/assets/8ccf2991-057d-431f-93e8-20b55afbe246" />

<img width="1570" height="670" alt="image" src="https://github.com/user-attachments/assets/614c16ef-d3ca-45c8-baac-f403978ef6a8" />

<img width="1565" height="827" alt="image" src="https://github.com/user-attachments/assets/56bf9848-ff84-4698-90f4-eeb9edc72bb5" />

<img width="1772" height="361" alt="image" src="https://github.com/user-attachments/assets/c6c6e9c6-da1d-47cc-baa8-42ee6fdb370a" />