### PR TITLE
fix: prevent logs panel from auto scrolling to top

### DIFF
--- a/src/scenes/components/LogsRenderer/LogsRaw.tsx
+++ b/src/scenes/components/LogsRenderer/LogsRaw.tsx
@@ -27,7 +27,7 @@ const logPanelOptions = {
 
 const LOGS_HEIGHT = 400;
 
-export const LogsRaw = <T extends UnknownParsedLokiRecord>({ logs }: { logs: T[] }) => {
+const LogsRawComponent = <T extends UnknownParsedLokiRecord>({ logs }: { logs: T[] }) => {
   const [width, setWidth] = useState(0);
 
   return (
@@ -57,6 +57,8 @@ export const LogsRaw = <T extends UnknownParsedLokiRecord>({ logs }: { logs: T[]
     </div>
   );
 };
+
+export const LogsRaw = React.memo(LogsRawComponent) as typeof LogsRawComponent;
 
 const getPanelData = (logs: UnknownParsedLokiRecord[]): PanelData => {
   const firstLog = logs[0];

--- a/src/scenes/components/TimepointExplorer/TimepointViewer.hooks.ts
+++ b/src/scenes/components/TimepointExplorer/TimepointViewer.hooks.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { parseCheckLogs } from 'features/parseCheckLogs/parseCheckLogs';
 
 import { ExecutionLabelType, UnknownExecutionLog } from 'features/parseCheckLogs/checkLogs.types';
@@ -27,8 +28,11 @@ export function useTimepointLogs({ timepoint, job, instance, probe, staleTime }:
   });
 
   const { data } = props;
-  const parsedCheckLogs = data ? parseCheckLogs(data) : [];
-  const filteredCheckLogs = filterProbeExecutions(parsedCheckLogs, timepoint);
+
+  const filteredCheckLogs = useMemo(() => {
+    const parsedCheckLogs = data ? parseCheckLogs(data) : [];
+    return filterProbeExecutions(parsedCheckLogs, timepoint);
+  }, [data, timepoint]);
 
   return {
     ...props,


### PR DESCRIPTION
## Fix: Prevent scroll jumping in raw logs view

Closes https://github.com/grafana/synthetic-monitoring-app/issues/1516

### Problem
The raw logs view was jumping back to the top whenever the parent component re-rendered, even when the log data hadn't changed. This made it difficult to read logs as the scroll position was constantly reset.

### Root Cause
The parent component was creating new array references on every render, causing the `LogsRaw` component to re-render unnecessarily. Each re-render of the Grafana `PanelRenderer` reset its internal scroll state.

### Solution
1. **Stabilize data references**: Added `useMemo` in `useTimepointLogs` hook to return the same reference when data hasn't actually changed
2. **Prevent unnecessary re-renders**: Wrapped `LogsRaw` component with `React.memo` to skip re-renders when the `logs` prop reference is unchanged

https://github.com/user-attachments/assets/e16285d8-1aa9-4a99-9920-a5b81a5338d0

