### PR TITLE
Fix routing preview visualization

### DIFF
--- a/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useMatchInstancesToRouteTrees } from '@grafana/alerting';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Icon, LoadingPlaceholder, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -15,6 +14,7 @@ import {
   generateAlertLabels,
 } from './alertRoutingUtils';
 import { RouteTreeDisplay } from './RouteTreeDisplay';
+import { useMatchInstancesToRouteTrees } from './useMatchInstancesToRouteTrees';
 
 interface AlertRoutingPreviewProps {
   alertType: CheckAlertType;

--- a/src/components/CheckForm/AlertsPerCheck/useMatchInstancesToRouteTrees.ts
+++ b/src/components/CheckForm/AlertsPerCheck/useMatchInstancesToRouteTrees.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { matchInstancesToRouteTrees } from '@grafana/alerting';
+import type { RoutingTreeList } from '@grafana/alerting/dist/types/grafana/api/notifications/v0alpha1/notifications.api.gen';
+import type { Label } from '@grafana/alerting/dist/types/grafana/matchers/types';
+import type { InstanceMatchResult } from '@grafana/alerting/dist/types/grafana/notificationPolicies/hooks/useMatchPolicies';
+import { config, getBackendSrv } from '@grafana/runtime';
+import { firstValueFrom } from 'rxjs';
+
+interface UseMatchInstancesToRouteTreesResult {
+  matchInstancesToRouteTrees: ((instances: Label[][]) => InstanceMatchResult[]) | null;
+  isLoading: boolean;
+  isError: boolean;
+  currentData?: RoutingTreeList;
+}
+
+/**
+ * Hook for useMatchInstancesToRouteTrees that doesn't rely on RTK-Query middleware which breaks if not registered
+ * (https://github.com/grafana/grafana/blob/main/packages/grafana-alerting/src/grafana/notificationPolicies/hooks/useMatchPolicies.ts#L47)
+ * Uses React Query for caching and getBackendSrv to fetch routing tree data, then uses the standalone matchInstancesToRouteTrees function.
+ */
+export function useMatchInstancesToRouteTrees(): UseMatchInstancesToRouteTreesResult {
+  const namespace = config.namespace;
+  const subPath = config.appSubUrl || '';
+
+  const {
+    data: routingTreeData,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['routingTrees', namespace, subPath],
+    queryFn: () => {
+      const url = `${subPath}/apis/notifications.alerting.grafana.app/v0alpha1/namespaces/${namespace}/routingtrees`;
+      return firstValueFrom(
+        getBackendSrv().fetch<RoutingTreeList>({
+          method: 'GET',
+          url,
+        })
+      ).then((res) => res.data);
+    },
+    enabled: Boolean(namespace),
+  });
+
+  const matchFunction = useMemo(
+    () =>
+      routingTreeData?.items
+        ? (instances: Label[][]) => matchInstancesToRouteTrees(routingTreeData.items, instances)
+        : null,
+    [routingTreeData?.items]
+  );
+
+  return {
+    matchInstancesToRouteTrees: matchFunction,
+    isLoading,
+    isError,
+    currentData: routingTreeData,
+  };
+}


### PR DESCRIPTION
## Problem

The alert routing preview feature was failing with the following error:

```
Plugin failed to load
Error: Warning: Middleware for RTK-Query API at reducerPath "notifications.alerting.grafana.app/v0alpha1" has not been added to the store.
You must add the middleware for RTK-Query to function correctly!
```

or

```
Plugin failed to load
Details
TypeError: g.current.isRequestSubscribed is not a function

    at ZE (https://plugins-cdn.grafana.net/grafana-synthetic-monitoring-app/1.43.0/public/plugins/grafana-synthetic-monitoring-app/962.93e179f421b17fdeb963.js:1044:17700)
    at div
    at div
    at Cw (https://plugins-cdn.grafana.net/grafana-synthetic-monitoring-app/1.43.0/public/plugins/grafana-synthetic-monitoring-app/962.93e179f421b17fdeb963.js:1044:37516)
```

depending whether it's run with Graft or without it.

This error started appearing after the `12.3.0` Grafana release. The root cause is that the `useMatchInstancesToRouteTrees` hook from `@grafana/alerting` uses RTK-Query internally, which requires middleware to be registered in the Redux store. Plugins don't have access to configure Grafana's main Redux store, and it breaks when trying to run it.

## Solution

Created a custom implementation of `useMatchInstancesToRouteTrees` that bypasses the RTK-Query middleware requirement while maintaining full compatibility with the original hook.

The implementation:
- Manually fetches routing tree data using `getBackendSrv()`
- Uses the standalone `matchInstancesToRouteTrees` function from `@grafana/alerting` to process the data
- Returns the same interface as the original hook, making it a drop-in replacement

**Note:** This should be a temporary solution as the `grafana/alerting` hook should not break because of this. The alerting team has been notified of the problem.

Before:
<img width="2227" height="1257" alt="image" src="https://github.com/user-attachments/assets/477e13bc-ccc4-45dd-8ac5-f02b1af3a896" />

After: 

<img width="2022" height="1138" alt="image" src="https://github.com/user-attachments/assets/1fc7e652-2bde-40f6-be4e-f5819ae64cd1" />
