### PR TITLE
fix: add runbook url support to latency alerts

### DIFF
--- a/src/components/SceneRedirecter.test.tsx
+++ b/src/components/SceneRedirecter.test.tsx
@@ -94,6 +94,60 @@ describe('SceneRedirecter', () => {
       expect(mockDoRunbookRedirect).toHaveBeenCalledWith('https://example.com/runbooks/tls-certificate');
     });
 
+    test('redirects to runbook URL for HTTPRequestDurationTooHighAvg alert', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const searchParams = createMockSearchParams({
+        'var-job': BASIC_HTTP_CHECK.job,
+        'var-instance': BASIC_HTTP_CHECK.target,
+        'var-alert': 'HTTPRequestDurationTooHighAvg',
+        'var-runbook': 'true',
+      });
+      mockUseURLSearchParams.mockReturnValue(searchParams);
+
+      render(<SceneRedirecter />);
+
+      const takeNowButton = screen.getByText('Take me there now');
+      await user.click(takeNowButton);
+
+      expect(mockDoRunbookRedirect).toHaveBeenCalledWith('https://example.com/runbooks/http-latency');
+    });
+
+    test('redirects to runbook URL for PingRequestDurationTooHighAvg alert', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const searchParams = createMockSearchParams({
+        'var-job': BASIC_HTTP_CHECK.job,
+        'var-instance': BASIC_HTTP_CHECK.target,
+        'var-alert': 'PingRequestDurationTooHighAvg',
+        'var-runbook': 'true',
+      });
+      mockUseURLSearchParams.mockReturnValue(searchParams);
+
+      render(<SceneRedirecter />);
+
+      const takeNowButton = screen.getByText('Take me there now');
+      await user.click(takeNowButton);
+
+      expect(mockDoRunbookRedirect).toHaveBeenCalledWith('https://example.com/runbooks/ping-latency');
+    });
+
+    test('redirects to runbook URL for DNSRequestDurationTooHighAvg alert', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const searchParams = createMockSearchParams({
+        'var-job': BASIC_HTTP_CHECK.job,
+        'var-instance': BASIC_HTTP_CHECK.target,
+        'var-alert': 'DNSRequestDurationTooHighAvg',
+        'var-runbook': 'true',
+      });
+      mockUseURLSearchParams.mockReturnValue(searchParams);
+
+      render(<SceneRedirecter />);
+
+      const takeNowButton = screen.getByText('Take me there now');
+      await user.click(takeNowButton);
+
+      expect(mockDoRunbookRedirect).toHaveBeenCalledWith('https://example.com/runbooks/dns-latency');
+    });
+
     test('parses alert names with brackets correctly', async () => {
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       const searchParams = createMockSearchParams({
@@ -110,6 +164,24 @@ describe('SceneRedirecter', () => {
       await user.click(takeNowButton);
 
       expect(mockDoRunbookRedirect).toHaveBeenCalledWith('https://example.com/runbooks/probe-failures');
+    });
+
+    test('parses latency alert names with brackets correctly', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const searchParams = createMockSearchParams({
+        'var-job': BASIC_HTTP_CHECK.job,
+        'var-instance': BASIC_HTTP_CHECK.target,
+        'var-alert': 'HTTPRequestDurationTooHighAvg [5m]',
+        'var-runbook': 'true',
+      });
+      mockUseURLSearchParams.mockReturnValue(searchParams);
+
+      render(<SceneRedirecter />);
+
+      const takeNowButton = screen.getByText('Take me there now');
+      await user.click(takeNowButton);
+
+      expect(mockDoRunbookRedirect).toHaveBeenCalledWith('https://example.com/runbooks/http-latency');
     });
 
     test('navigates to fallback when runbook URL is not configured', () => {

--- a/src/components/SceneRedirecter.tsx
+++ b/src/components/SceneRedirecter.tsx
@@ -13,6 +13,9 @@ import { RunbookRedirectAlert } from 'components/RunbookRedirectAlert';
 const ALERT_NAME_TO_TYPE: Record<string, CheckAlertType> = {
   ProbeFailedExecutionsTooHigh: CheckAlertType.ProbeFailedExecutionsTooHigh,
   TLSTargetCertificateCloseToExpiring: CheckAlertType.TLSTargetCertificateCloseToExpiring,
+  HTTPRequestDurationTooHighAvg: CheckAlertType.HTTPRequestDurationTooHighAvg,
+  PingRequestDurationTooHighAvg: CheckAlertType.PingRequestDurationTooHighAvg,
+  DNSRequestDurationTooHighAvg: CheckAlertType.DNSRequestDurationTooHighAvg,
 };
 
 function parseAlertName(alertName: string): string {

--- a/src/test/fixtures/checkAlerts.ts
+++ b/src/test/fixtures/checkAlerts.ts
@@ -17,12 +17,15 @@ export const BASIC_CHECK_ALERTS: CheckAlertsResponse = {
     }),
     db.alert.build({
       name: CheckAlertType.HTTPRequestDurationTooHighAvg,
+      runbookUrl: 'https://example.com/runbooks/http-latency',
     }),
     db.alert.build({
       name: CheckAlertType.PingRequestDurationTooHighAvg,
+      runbookUrl: 'https://example.com/runbooks/ping-latency',
     }),
     db.alert.build({
       name: CheckAlertType.DNSRequestDurationTooHighAvg,
+      runbookUrl: 'https://example.com/runbooks/dns-latency',
     }),
   ],
 };


### PR DESCRIPTION
Addresses: grafana/support-escalations#20089

## Problem

When users configure custom runbook URLs for latency-based per-check alerts (HTTP Request Duration Too High Avg, Ping Request Duration Too High Avg, and DNS Request Duration Too High Avg), clicking on the runbook link from an alert does not redirect to the custom runbook URL. Instead, it incorrectly redirects users to the check dashboard.

This issue only affects the three latency alert types. The runbook redirect works correctly for the other two alert types (Probe Failed Executions Too High and TLS Target Certificate Close To Expiring).

## Solution

Fixed the incomplete `ALERT_NAME_TO_TYPE` mapping in `SceneRedirecter.tsx` by adding the three missing latency alert types:
- `HTTPRequestDurationTooHighAvg`
- `PingRequestDurationTooHighAvg`
- `DNSRequestDurationTooHighAvg`
