### PR TITLE
feat: track alerts per-check routing preview and external link clicks

### DIFF
--- a/docs/analytics/analytics-events.md
+++ b/docs/analytics/analytics-events.md
@@ -240,6 +240,17 @@ Tracks when the threshold of an alert is changed
 | name      | `"ProbeFailedExecutionsTooHigh" \| "TLSTargetCertificateCloseToExpiring" \| "HTTPRequestDurationTooHighAvg" \| "PingRequestDurationTooHighAvg" \| "DNSRequestDurationTooHighAvg"` | The name of the alert      |
 | threshold | `string`                                                                                                                                                                          | The threshold of the alert |
 
+#### synthetic-monitoring_per_check_alerts_routing_preview_toggled
+
+Tracks when the routing preview is toggled for an alert
+
+##### Properties
+
+| name   | type                                                                                                                                                                              | description                                          |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| name   | `"ProbeFailedExecutionsTooHigh" \| "TLSTargetCertificateCloseToExpiring" \| "HTTPRequestDurationTooHighAvg" \| "PingRequestDurationTooHighAvg" \| "DNSRequestDurationTooHighAvg"` | The name of the alert                                |
+| action | `"show" \| "hide"`                                                                                                                                                                | Whether the routing preview is being shown or hidden |
+
 #### synthetic-monitoring_per_check_alerts_creation_success
 
 Tracks when an alert is created successfully

--- a/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
@@ -3,6 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import { GrafanaTheme2, urlUtil } from '@grafana/data';
 import { Button, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { trackRoutingPreviewToggled } from 'features/tracking/perCheckAlertsEvents';
 
 import { CheckAlertType, CheckFormValuesWithAlert } from 'types';
 import { useMetricsDS } from 'hooks/useMetricsDS';
@@ -106,7 +107,14 @@ export const AlertItem = ({
             size="sm"
             fill="text"
             icon={showRouting ? 'angle-up' : 'angle-down'}
-            onClick={() => setShowRouting(!showRouting)}
+            onClick={() => {
+              const newShowRouting = !showRouting;
+              setShowRouting(newShowRouting);
+              trackRoutingPreviewToggled({
+                name: alert.type,
+                action: newShowRouting ? 'show' : 'hide',
+              });
+            }}
             className={styles.routingToggle}
           >
             {showRouting ? 'Hide' : 'Show'} routing

--- a/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
@@ -3,6 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Icon, LoadingPlaceholder, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { trackLinkClick } from 'features/tracking/linkEvents';
 
 import { CheckAlertType, CheckFormValues } from 'types';
 
@@ -125,7 +126,21 @@ export const AlertRoutingPreview: React.FC<AlertRoutingPreviewProps> = ({ alertT
             <Text variant="body" color="secondary">
               Notification policies determine which contact point receives this alert based on the labels shown above.
               To change where alerts are sent,{' '}
-              <TextLink href="/alerting/routes" external={true} variant="body">
+              <TextLink
+                href="/alerting/routes"
+                external={true}
+                variant="body"
+                onClick={() => {
+                  const url = new URL('/alerting/routes', window.location.origin);
+                  trackLinkClick({
+                    href: url.href,
+                    hostname: url.hostname,
+                    path: url.pathname,
+                    search: url.search,
+                    source: 'alert-routing-preview-info-section',
+                  });
+                }}
+              >
                 configure notification policies
               </TextLink>{' '}
               in the Alerting section.
@@ -157,13 +172,40 @@ export const AlertRoutingPreview: React.FC<AlertRoutingPreviewProps> = ({ alertT
                         external={true}
                         variant="bodySmall"
                         className={styles.contactPointLink}
+                        onClick={() => {
+                          const path = `/alerting/notifications/receivers/${encodeReceiverForUrl(
+                            defaultPolicyInfo.receiverName
+                          )}/edit`;
+                          const url = new URL(path, window.location.origin);
+                          trackLinkClick({
+                            href: url.href,
+                            hostname: url.hostname,
+                            path: url.pathname,
+                            search: url.search,
+                            source: 'alert-routing-preview-receiver',
+                          });
+                        }}
                       >
                         {defaultPolicyInfo.receiverName}
                       </TextLink>
                     </div>
                   )}
                   <div className={styles.configureLink}>
-                    <TextLink href="/alerting/routes" external={true} variant="body">
+                    <TextLink
+                      href="/alerting/routes"
+                      external={true}
+                      variant="body"
+                      onClick={() => {
+                        const url = new URL('/alerting/routes', window.location.origin);
+                        trackLinkClick({
+                          href: url.href,
+                          hostname: url.hostname,
+                          path: url.pathname,
+                          search: url.search,
+                          source: 'alert-routing-preview-default-policy-configure',
+                        });
+                      }}
+                    >
                       Configure notification policies to route to a different contact point
                     </TextLink>
                   </div>

--- a/src/components/CheckForm/AlertsPerCheck/AlertsPerCheck.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertsPerCheck.tsx
@@ -3,6 +3,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Field, Stack, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { trackLinkClick } from 'features/tracking/linkEvents';
 
 import { CheckAlertType, CheckFormValues } from 'types';
 import { useRevalidateForm } from 'hooks/useRevalidateForm';
@@ -60,11 +61,37 @@ export const AlertsPerCheck = () => {
         <div>
           <p>
             Enable and configure thresholds for common alerting scenarios. Use Grafana Alerting to{' '}
-            <TextLink href="alerting/new/alerting" external={true}>
+            <TextLink
+              href="alerting/new/alerting"
+              external={true}
+              onClick={() => {
+                const url = new URL('/alerting/new/alerting', window.location.origin);
+                trackLinkClick({
+                  href: url.href,
+                  hostname: url.hostname,
+                  path: url.pathname,
+                  search: url.search,
+                  source: 'alerts-per-check-info-create-rule',
+                });
+              }}
+            >
               create a custom alert rule
             </TextLink>{' '}
             and configure{' '}
-            <TextLink href="alerting/routes" external={true}>
+            <TextLink
+              href="alerting/routes"
+              external={true}
+              onClick={() => {
+                const url = new URL('/alerting/routes', window.location.origin);
+                trackLinkClick({
+                  href: url.href,
+                  hostname: url.hostname,
+                  path: url.pathname,
+                  search: url.search,
+                  source: 'alerts-per-check-info-notification-policies',
+                });
+              }}
+            >
               notification policies
             </TextLink>{' '}
             to define where your alerts will be routed.

--- a/src/components/CheckForm/AlertsPerCheck/RouteTreeDisplay.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/RouteTreeDisplay.tsx
@@ -3,6 +3,7 @@ import { type InstanceMatchResult, type Route } from '@grafana/alerting';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, Text, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
+import { trackLinkClick } from 'features/tracking/linkEvents';
 
 import { encodeReceiverForUrl, getPolicyIdentifier } from './alertRoutingUtils';
 
@@ -87,10 +88,12 @@ const RouteNode: React.FC<{
     <div className={styles.routeNode} style={{ marginLeft: level * 16 }}>
       <div className={styles.routeHeader}>
         <div className={styles.routeInfo}>
-          <div className={cx(styles.badge, {
-            [styles.matchers]: policyInfo.type === 'matchers',
-            [styles.matchesAll]: policyInfo.type === 'matchesAll',
-          })}>
+          <div
+            className={cx(styles.badge, {
+              [styles.matchers]: policyInfo.type === 'matchers',
+              [styles.matchesAll]: policyInfo.type === 'matchesAll',
+            })}
+          >
             <Text variant="bodySmall">
               <strong>{policyInfo.text}</strong>
             </Text>
@@ -117,6 +120,17 @@ const RouteNode: React.FC<{
                 external={true}
                 variant="bodySmall"
                 className={styles.contactPointLink}
+                onClick={() => {
+                  const path = `/alerting/notifications/receivers/${encodeReceiverForUrl(route.receiver!)}/edit`;
+                  const url = new URL(path, window.location.origin);
+                  trackLinkClick({
+                    href: url.href,
+                    hostname: url.hostname,
+                    path: url.pathname,
+                    search: url.search,
+                    source: 'alert-routing-preview-route-receiver',
+                  });
+                }}
               >
                 {route.receiver}
               </TextLink>

--- a/src/features/tracking/perCheckAlertsEvents.ts
+++ b/src/features/tracking/perCheckAlertsEvents.ts
@@ -22,6 +22,14 @@ interface PerCheckAlertChangeThreshold extends TrackingEventProps {
   /** The threshold of the alert */
   threshold: string;
 }
+
+interface PerCheckAlertRoutingPreviewToggled extends TrackingEventProps {
+  /** The name of the alert */
+  name: CheckAlertType;
+  /** Whether the routing preview is being shown or hidden */
+  action: 'show' | 'hide';
+}
+
 /** Tracks when an alert is selected from the per-check alerts list */
 export const trackSelectAlert = perCheckAlertEvents<PerCheckAlertEvent>('select_alert');
 
@@ -33,6 +41,9 @@ export const trackChangePeriod = perCheckAlertEvents<PerCheckAlertChangePeriod>(
 
 /** Tracks when the threshold of an alert is changed */
 export const trackChangeThreshold = perCheckAlertEvents<PerCheckAlertChangeThreshold>('change_threshold');
+
+/** Tracks when the routing preview is toggled for an alert */
+export const trackRoutingPreviewToggled = perCheckAlertEvents<PerCheckAlertRoutingPreviewToggled>('routing_preview_toggled');
 
 /** Tracks when an alert is created successfully */
 export const trackAlertCreationSuccess = perCheckAlertEvents<PerCheckAlertEvent>('creation_success');


### PR DESCRIPTION
## Add analytics tracking for alert routing preview interactions

### What
Adds analytics tracking to measure user engagement with the alert routing preview feature in the per-check alerts section.

### Changes

#### New Tracking Events

**1. Routing Preview Toggle** (`synthetic-monitoring_per_check_alerts_routing_preview_toggled`)
- Tracks when users click "Show routing" / "Hide routing" button
- Properties:
  - `name`: Alert type (e.g., `ProbeFailedExecutionsTooHigh`)
  - `action`: `show` or `hide`

**2. Link Click Tracking** (using existing `synthetic-monitoring_link_clicked` event)

Tracks clicks on all notification policy-related links with unique source identifiers:

**In AlertRoutingPreview:**
- `alert-routing-preview-info-section` - "configure notification policies" link in info section
- `alert-routing-preview-receiver` - Receiver name link in default policy
- `alert-routing-preview-default-policy-configure` - "Configure notification policies" CTA in default policy alert

**In RouteTreeDisplay:**
- `alert-routing-preview-route-receiver` - Receiver name links in matched route tree

**In AlertsPerCheck:**
- `alerts-per-check-info-create-rule` - "create a custom alert rule" link
- `alerts-per-check-info-notification-policies` - "notification policies" link
