### PR TITLE
Chore: Use routes with UID, not internal ID

### DIFF
--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -452,7 +452,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       jsonData: options,
       access: 'proxy',
     };
-    await getBackendSrv().put(`api/datasources/${this.instanceSettings.id}`, data);
+    await getBackendSrv().put(`api/datasources/uid/${this.instanceSettings.uid}`, data);
   };
 
   async registerSave(apiToken: string, options: SMOptions, accessToken: string): Promise<any> {
@@ -464,7 +464,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       },
       access: 'proxy',
     };
-    await getBackendSrv().put(`api/datasources/${this.instanceSettings.id}`, data);
+    await getBackendSrv().put(`api/datasources/uid/${this.instanceSettings.uid}`, data);
 
     // Note the accessToken above must be saved first!
     return await getBackendSrv().fetch({
@@ -492,7 +492,6 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       showErrorAlert: false,
     });
   }
-
 
   //--------------------------------------------------------------------------------
   // TEST

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,7 +86,7 @@ export function initializeDatasource(datasourcePayload: DatasourcePayload) {
     return firstValueFrom(
       getBackendSrv().fetch<SMOptions>({
         method: 'PUT',
-        url: `api/datasources/${existingDatasource.id}`,
+        url: `api/datasources/uid/${existingDatasource.uid}`,
         data: {
           ...existingDatasource,
           access: 'proxy',


### PR DESCRIPTION
Datasources routes with internal ID have been deprecated for 3+ years -- with multi-tenancy, this will either be removed or have pretty expensive shims to keep them working. Ideally we can avoid the deprecated APIs.

This PR updates the frontend so it makes requests using UID rather than ID.

NOTE: I only updated the code, i have not tested it beyond the build!