### PR TITLE
chore: auto approve ops and prod-canary argo workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
       # Argo CD inputs
       grafana-cloud-deployment-type: provisioned
       argo-workflow-slack-channel: "#sm-ops-deploys"
-      auto-merge-environments: dev, ops
+      auto-merge-environments: dev, ops, prod-canary
 
       # Other CI inputs
       node-version: 22


### PR DESCRIPTION
# Enable auto approval for ops and prod-canary argo workflows

## Overview

Enables automatic merging of deployment-tools PRs for `ops` and `prod-canary` environments after [successful verification](https://github.com/grafana/synthetic-monitoring-app/actions/runs/21182894201) of the manual deployment workflow.

Currently we're not using `prod-canary` so that's why I auto approve it in the argo release steps.

