### PR TITLE
chore: extend docker-compose from base and update default version

### DIFF
--- a/.config/docker-compose-base.yaml
+++ b/.config/docker-compose-base.yaml
@@ -7,7 +7,7 @@ services:
       context: .
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
-        grafana_version: ${GRAFANA_VERSION:-12.1.0}
+        grafana_version: ${GRAFANA_VERSION:-12.3.0}
         development: ${DEVELOPMENT:-false}
         anonymous_auth_enabled: ${ANONYMOUS_AUTH_ENABLED:-true}
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,16 +2,10 @@ version: '3.0'
 
 services:
   grafana:
-    container_name: 'grafana-synthetic-monitoring-app'
-    build:
-      context: ./.config
-      args:
-        grafana_version: ${GRAFANA_VERSION:-main}
-        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
-    ports:
-      - 3000:3000/tcp
+    extends:
+      file: .config/docker-compose-base.yaml
+      service: grafana
     volumes:
-      - ./dist:/var/lib/grafana/plugins/grafana-synthetic-monitoring-app
       - ./dev/provisioning:/etc/grafana/provisioning
       - ./dev/custom.ini:/etc/grafana/grafana.ini
       - ./dev/license.jwt:/var/lib/grafana/license.jwt


### PR DESCRIPTION
## Summary

- Simplifies `docker-compose.yaml` by using `extends` from `.config/docker-compose-base.yaml`
- Updates default `grafana_version` to `12.3.0` to align with the minimum version specified in `plugin.json`


## Verification 
- [x] Run `yarn server` and verify Grafana starts correctly
- [x] Verify plugin loads in browser