### PR TITLE
chore: group @grafana/scenes packages in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,11 @@
   "internalChecksFilter": "strict", // https://docs.renovatebot.com/configuration-options/#await-x-time-duration-before-automerging
   "semanticCommitScope": null,
   "packageRules": [
+    // @grafana/scenes and @grafana/scenes-react must be updated together
+    {
+      "matchPackageNames": ["@grafana/scenes", "@grafana/scenes-react"],
+      "groupName": "grafana-scenes"
+    },
     // we can never update the React packages until grafana does
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Summary

- Configures Renovate to update `@grafana/scenes` and `@grafana/scenes-react` together in a single PR

## Problem

These two packages must stay in sync version-wise. When Renovate updates them separately (e.g. [#1403](https://github.com/grafana/synthetic-monitoring-app/pull/1403)), the version mismatch causes build/runtime failures.

## Solution

Added a `groupName` rule in `renovate.json5` that groups both packages together. Renovate will now create a single PR that updates both packages simultaneously.
