### PR TITLE
fix: wait for JS chunks on quickpizza login pages + use getByRole

### DIFF
--- a/src/components/BrowserExamplesMenu/snippets/fillform.js
+++ b/src/components/BrowserExamplesMenu/snippets/fillform.js
@@ -30,9 +30,12 @@ export default async function () {
 
     await page.getByRole('textbox', { name: 'Username' }).fill(username);
     await page.getByRole('textbox', { name: 'Password' }).fill(password);
-    await page.getByRole('button', { name: 'Sign in' }).click();
     
-    await expect(page.locator('//h2')).toContainText("Latest pizza recommendations");
+    const signIn = page.getByRole('button', { name: 'Sign in' });
+    await signIn.click();
+    await expect(signIn).toBeHidden();
+    
+    await expect(page.getByRole('heading')).toContainText("Latest pizza recommendations");
   
   } catch (e) {
     console.log('Error during execution:', e);

--- a/src/components/BrowserExamplesMenu/snippets/keyboard.js
+++ b/src/components/BrowserExamplesMenu/snippets/keyboard.js
@@ -31,9 +31,11 @@ export default async function () {
     await pwdInput.click();
     await page.keyboard.type('admin');
 
-    await page.getByRole('button', { name: 'Sign in' }).click();
+    const signIn = page.getByRole('button', { name: 'Sign in' });
+    await signIn.click();
+    await expect(signIn).toBeHidden();
 
-    await expect(page.locator('//h2')).toContainText('Latest pizza recommendations');
+    await expect(page.getByRole('heading')).toContainText('Latest pizza recommendations');
   } catch (e) {
     console.log('Error during execution:', e);
     throw e;

--- a/src/components/ScriptExamplesMenu/snippets/browser_fill_form.js
+++ b/src/components/ScriptExamplesMenu/snippets/browser_fill_form.js
@@ -35,7 +35,7 @@ export default async function () {
 
     await Promise.all([page.waitForNavigation(), submitButton.click()]);
 
-    await expect(page.locator('h2')).toContainText('Latest pizza recommendations');
+    await expect(page.getByRole('heading')).toContainText('Latest pizza recommendations');
   } catch (e) {
     console.log('Error during execution:', e);
     throw e;

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -213,11 +213,13 @@ export default async function () {
 
     await page.getByRole('textbox', { name: 'Username' }).fill(username);
     await page.getByRole('textbox', { name: 'Password' }).fill(password);
-    await page.getByRole('button', { name: 'Sign in' }).click();
 
-    const heading = page.locator('//h2');
-    await heading.waitFor({ state: "visible", timeout: 5000 });
+    const signIn = page.getByRole('button', { name: 'Sign in' });
+    await signIn.click();
+    await expect(signIn).toBeHidden();
 
+    const heading = page.getByRole('heading');
+    await expect(heading).toBeVisible();
     console.log('H2 header: ', await heading.textContent()); // will appear as logs in Loki
 
     // TIP: Use expect() to immediately abort execution and fail a test (impacts uptime/reachability)


### PR DESCRIPTION
**What this PR does / why we need it**:

The example scripts that interact with the quickpizza page currently do not work, as they do not wait for all the JS chunks to load. This failure could be seen in a regular browser by loading the page with the JS console open and immediately submitting the form, resulting in `Uncaught (in promise) TypeError: error loading dynamically imported module: https://quickpizza.grafana.com/_app/immutable/entry/app.Dx_ShQrU.js` being logged.

Also, opinion, but I think the examples should recommend using a11y-first locators such as `getByRole` with a role + label, rather than IDs from the DOM.

**Special notes for your reviewer**:

I'm slightly confused by why there are four near-identical versions of this snippet. I think the snippet in `constants.ts` could easily replace the `fillform.js` + `browser_fill_form.js` snippets (the latter of which seems not to be used anywhere), though I could understand wanting to keep `keyboard.js` around as an example of using `.type`.
