### PR TITLE
fix: normalize empty alertSensitivity from API to none

### DIFF
--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -12,7 +12,7 @@ import { BackendSrvRequest, getBackendSrv, getTemplateSrv } from '@grafana/runti
 import { isArray } from 'lodash';
 import { firstValueFrom } from 'rxjs';
 
-import { Check, CheckAlertDraft, ListChannelsResponse, Probe, ThresholdSettings } from '../types';
+import { AlertSensitivity, Check, CheckAlertDraft, ListChannelsResponse, Probe, ThresholdSettings } from '../types';
 import {
   AccessTokenResponse,
   AddCheckResult,
@@ -311,7 +311,13 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
   }
 
   async listChecks(includeAlerts = false) {
-    return this.fetchAPI<ListCheckResult>(`${this.instanceSettings.url}/sm/check/list?includeAlerts=${includeAlerts}`);
+    return this.fetchAPI<ListCheckResult>(
+      `${this.instanceSettings.url}/sm/check/list?includeAlerts=${includeAlerts}`
+    ).then((checks) =>
+      checks.map((check) =>
+        check.alertSensitivity ? check : { ...check, alertSensitivity: AlertSensitivity.None }
+      )
+    );
   }
 
   async testCheck(check: Check) {


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-app/issues/1585

## Problem

Checks created directly via the API (e.g. through Terraform or custom integrations) may leave the `alertSensitivity` field as an empty string rather than explicitly setting it to `"none"`. The API accepts and handles this correctly, but the app does not.

When the app encounters a check with an empty `alertSensitivity`, it misinterprets it as a set value, causing two user-facing issues:

1. An incorrect "Alert configuration" warning is shown on the check, stating it has an alert sensitivity but no associated alerting rules could be found.
2. The alert sensitivity dropdown is disabled on the check edit form, preventing the user from changing the value or making any modifications to the check.

## Solution

Normalize empty `alertSensitivity` values to `"none"` at the data source layer when checks are fetched from the API. This is done in the `listChecks` method, which is the single entry point for all check data in the app. 