### PR TITLE
fix: add keywords array to plugin.json

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -23,11 +23,7 @@
     ],
     "version": "%VERSION%",
     "updated": "%TODAY%",
-    "keywords": [
-      "synthetic-monitoring",
-      "Synthetic Monitoring",
-      "Synthetics"
-    ]
+    "keywords": ["synthetic-monitoring", "Synthetic Monitoring", "Synthetics"]
   },
   "routes": [
     {
@@ -92,383 +88,198 @@
         "name": "Checks reader",
         "description": "Read checks in the Synthetic Monitoring app",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.checks:read"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+
+          { "action": "grafana-synthetic-monitoring-app.checks:read" }
         ]
       },
-      "grants": [
-        "Viewer"
-      ]
+      "grants": ["Viewer"]
     },
     {
       "role": {
         "name": "Checks writer",
         "description": "Create, edit and delete checks in the Synthetic Monitoring app",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.checks:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.checks:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.checks:delete"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+          { "action": "grafana-synthetic-monitoring-app:write" },
+
+          { "action": "grafana-synthetic-monitoring-app.checks:write" },
+          { "action": "grafana-synthetic-monitoring-app.checks:read" },
+          { "action": "grafana-synthetic-monitoring-app.checks:delete" }
         ]
       },
-      "grants": [
-        "Admin",
-        "Editor"
-      ]
+      "grants": ["Admin", "Editor"]
     },
     {
       "role": {
         "name": "Probes reader",
         "description": "Read probes in the Synthetic Monitoring app",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.probes:read"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+
+          { "action": "grafana-synthetic-monitoring-app.probes:read" }
         ]
       },
-      "grants": [
-        "Viewer"
-      ]
+      "grants": ["Viewer"]
     },
     {
       "role": {
         "name": "Probes writer",
         "description": "Create, edit and delete probes in the Synthetic Monitoring app",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.probes:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.probes:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.probes:delete"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+          { "action": "grafana-synthetic-monitoring-app:write" },
+
+          { "action": "grafana-synthetic-monitoring-app.probes:write" },
+          { "action": "grafana-synthetic-monitoring-app.probes:read" },
+          { "action": "grafana-synthetic-monitoring-app.probes:delete" }
         ]
       },
-      "grants": [
-        "Admin",
-        "Editor"
-      ]
+      "grants": ["Admin", "Editor"]
     },
     {
       "role": {
         "name": "Alerts reader",
         "description": "Read alerts in the Synthetic Monitoring app",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.alerts:read"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+
+          { "action": "grafana-synthetic-monitoring-app.alerts:read" }
         ]
       },
-      "grants": [
-        "Viewer"
-      ]
+      "grants": ["Viewer"]
     },
     {
       "role": {
         "name": "Alerts writer",
         "description": "Create, edit and delete alerts in the Synthetic Monitoring app",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.alerts:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.alerts:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.alerts:delete"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+          { "action": "grafana-synthetic-monitoring-app:write" },
+
+          { "action": "grafana-synthetic-monitoring-app.alerts:write" },
+          { "action": "grafana-synthetic-monitoring-app.alerts:read" },
+          { "action": "grafana-synthetic-monitoring-app.alerts:delete" }
         ]
       },
-      "grants": [
-        "Admin",
-        "Editor"
-      ]
+      "grants": ["Admin", "Editor"]
     },
     {
       "role": {
         "name": "Thresholds reader",
         "description": "Read thresholds in the Synthetic Monitoring app",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.thresholds:read"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+
+          { "action": "grafana-synthetic-monitoring-app.thresholds:read" }
         ]
       },
-      "grants": [
-        "Viewer"
-      ]
+      "grants": ["Viewer"]
     },
     {
       "role": {
         "name": "Thresholds writer",
         "description": "Read and edit thresholds in the Synthetic Monitoring app",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.thresholds:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.thresholds:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.thresholds:delete"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+          { "action": "grafana-synthetic-monitoring-app:write" },
+
+          { "action": "grafana-synthetic-monitoring-app.thresholds:write" },
+          { "action": "grafana-synthetic-monitoring-app.thresholds:read" },
+          { "action": "grafana-synthetic-monitoring-app.thresholds:delete" }
         ]
       },
-      "grants": [
-        "Admin",
-        "Editor"
-      ]
+      "grants": ["Admin", "Editor"]
     },
     {
       "role": {
         "name": "Access tokens writer",
         "description": "Create and delete access tokens in the Synthetic Monitoring app",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.access-tokens:write"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+          { "action": "grafana-synthetic-monitoring-app:write" },
+
+          { "action": "grafana-synthetic-monitoring-app.access-tokens:write" }
         ]
       },
-      "grants": [
-        "Admin"
-      ]
+      "grants": ["Admin"]
     },
     {
       "role": {
         "name": "Admin",
         "description": "Full access to write and manage checks, probes, alerts, thresholds, and access tokens as well as enabling/disabling the Synthetic Monitoring plugin",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.plugin:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.checks:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.probes:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.alerts:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.thresholds:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.access-tokens:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.checks:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.probes:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.alerts:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.thresholds:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.checks:delete"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.probes:delete"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.alerts:delete"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.thresholds:delete"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+          { "action": "grafana-synthetic-monitoring-app:write" },
+
+          { "action": "grafana-synthetic-monitoring-app.plugin:write" },
+          { "action": "grafana-synthetic-monitoring-app.checks:write" },
+          { "action": "grafana-synthetic-monitoring-app.probes:write" },
+          { "action": "grafana-synthetic-monitoring-app.alerts:write" },
+          { "action": "grafana-synthetic-monitoring-app.thresholds:write" },
+          { "action": "grafana-synthetic-monitoring-app.access-tokens:write" },
+          { "action": "grafana-synthetic-monitoring-app.checks:read" },
+          { "action": "grafana-synthetic-monitoring-app.probes:read" },
+          { "action": "grafana-synthetic-monitoring-app.alerts:read" },
+          { "action": "grafana-synthetic-monitoring-app.thresholds:read" },
+          { "action": "grafana-synthetic-monitoring-app.checks:delete" },
+          { "action": "grafana-synthetic-monitoring-app.probes:delete" },
+          { "action": "grafana-synthetic-monitoring-app.alerts:delete" },
+          { "action": "grafana-synthetic-monitoring-app.thresholds:delete" }
         ]
       },
-      "grants": [
-        "Admin"
-      ]
+      "grants": ["Admin"]
     },
     {
       "role": {
         "name": "Editor",
         "description": "Add, update and delete checks, probes, alerts, and thresholds in the Synthetic Monitoring app",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.checks:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.probes:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.alerts:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.thresholds:write"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.checks:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.probes:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.alerts:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.thresholds:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.checks:delete"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.probes:delete"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.alerts:delete"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.thresholds:delete"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+          { "action": "grafana-synthetic-monitoring-app:write" },
+
+          { "action": "grafana-synthetic-monitoring-app.checks:write" },
+          { "action": "grafana-synthetic-monitoring-app.probes:write" },
+          { "action": "grafana-synthetic-monitoring-app.alerts:write" },
+          { "action": "grafana-synthetic-monitoring-app.thresholds:write" },
+          { "action": "grafana-synthetic-monitoring-app.checks:read" },
+          { "action": "grafana-synthetic-monitoring-app.probes:read" },
+          { "action": "grafana-synthetic-monitoring-app.alerts:read" },
+          { "action": "grafana-synthetic-monitoring-app.thresholds:read" },
+          { "action": "grafana-synthetic-monitoring-app.checks:delete" },
+          { "action": "grafana-synthetic-monitoring-app.probes:delete" },
+          { "action": "grafana-synthetic-monitoring-app.alerts:delete" },
+          { "action": "grafana-synthetic-monitoring-app.thresholds:delete" }
         ]
       },
-      "grants": [
-        "Admin",
-        "Editor"
-      ]
+      "grants": ["Admin", "Editor"]
     },
     {
       "role": {
         "name": "Reader",
         "description": "Read checks, probes, alerts, thresholds, and access tokens in the Synthetic Monitoring app",
         "permissions": [
-          {
-            "action": "plugins.app:access",
-            "scope": "plugins:id:grafana-synthetic-monitoring-app"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.checks:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.probes:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.alerts:read"
-          },
-          {
-            "action": "grafana-synthetic-monitoring-app.thresholds:read"
-          }
+          { "action": "plugins.app:access", "scope": "plugins:id:grafana-synthetic-monitoring-app" },
+          { "action": "grafana-synthetic-monitoring-app:read" },
+
+          { "action": "grafana-synthetic-monitoring-app.checks:read" },
+          { "action": "grafana-synthetic-monitoring-app.probes:read" },
+          { "action": "grafana-synthetic-monitoring-app.alerts:read" },
+          { "action": "grafana-synthetic-monitoring-app.thresholds:read" }
         ]
       },
-      "grants": [
-        "Viewer"
-      ]
+      "grants": ["Viewer"]
     }
   ],
   "dependencies": {


### PR DESCRIPTION
Added keywords array to `plugin.json` and the $schema so we can be made aware of any invalidations moving forwards.

This is needed as the CI/CD check in the release process failed: https://github.com/grafana/synthetic-monitoring-app/actions/runs/22096907179/job/63891288305

_(like our ID doesn't match the regex pattern...)_