### PR TITLE
fix: improve version management terminology and add channel navigatio…

### DIFF
--- a/src/components/CheckEditor/CheckProbes/CheckProbes.tsx
+++ b/src/components/CheckEditor/CheckProbes/CheckProbes.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { ReactNode, useMemo, useState } from 'react';
 import { Field, Stack } from '@grafana/ui';
 
 import { ProbeWithMetadata } from 'types';
@@ -15,7 +15,7 @@ interface CheckProbesProps {
   onChange: (probes: number[]) => void;
   onBlur?: () => void;
   invalid?: boolean;
-  error?: string;
+  error?: ReactNode;
 }
 
 export const PROBES_FILTER_ID = 'check-probes-filter';

--- a/src/components/CheckEditor/FormComponents/ChannelDetails.test.tsx
+++ b/src/components/CheckEditor/FormComponents/ChannelDetails.test.tsx
@@ -82,7 +82,7 @@ describe('ChannelDetails', () => {
     render(<ChannelDetails channelId="deprecated" channels={mockChannels} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/deprecated channel/i)).toBeInTheDocument();
+      expect(screen.getByText(/deprecated k6 version channel/i)).toBeInTheDocument();
       expect(screen.getByText(/consider migrating to a newer channel/i)).toBeInTheDocument();
     });
   });

--- a/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
+++ b/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
@@ -40,9 +40,9 @@ export function ChannelDetails({ channelId, channels }: ChannelDetailsProps) {
       </Text>
 
       {isDeprecated && (
-        <Alert severity="warning" title="Deprecated Channel">
-          This channel is deprecated since {dateTimeFormat(new Date(channel.deprecatedAfter))}. Consider migrating to a
-          newer channel.
+        <Alert severity="warning" title="Deprecated k6 version channel">
+          This k6 version channel is deprecated since {dateTimeFormat(new Date(channel.deprecatedAfter))}. Consider
+          migrating to a newer channel.
         </Alert>
       )}
     </Stack>

--- a/src/components/CheckEditor/FormComponents/K6ChannelSelect.tsx
+++ b/src/components/CheckEditor/FormComponents/K6ChannelSelect.tsx
@@ -83,7 +83,7 @@ function K6ChannelSelectContent({ disabled }: K6ChannelSelectProps) {
   return (
     <div>
       <Field
-        label="k6 Version"
+        label="k6 version channel"
         description="Select the k6 version channel for this check"
         htmlFor={id}
         data-fs-element="k6 channel select"

--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { FieldErrors } from 'react-hook-form';
 
 import { CheckFormValues, CheckType, ProbeWithMetadata } from 'types';
@@ -10,6 +10,7 @@ import { CheckProbes } from './CheckProbes/CheckProbes';
 interface ProbeOptionsProps {
   checkType: CheckType;
   disabled?: boolean;
+  error?: ReactNode;
   errors?: FieldErrors<CheckFormValues>['probes'];
   onlyProbes?: boolean; // TODO: Remove when CheckEditor v1 is removed
   onChange: (probes: number[]) => void;
@@ -19,6 +20,7 @@ interface ProbeOptionsProps {
 export const ProbeOptions = ({
   checkType,
   disabled,
+  error,
   errors,
   onlyProbes,
   onChange,
@@ -33,7 +35,7 @@ export const ProbeOptions = ({
         availableProbes={getAvailableProbes(probes, checkType)}
         disabled={disabled}
         invalid={Boolean(errors)}
-        error={errors?.message}
+        error={error ?? errors?.message}
         onChange={onChange}
       />
       {!onlyProbes && <Frequency checkType={checkType} disabled={disabled} />}

--- a/src/schemas/forms/utils/probeCompatibilityRefinement.ts
+++ b/src/schemas/forms/utils/probeCompatibilityRefinement.ts
@@ -39,7 +39,7 @@ export function createProbeCompatibilityRefinement<T extends CheckFormValuesBase
       ctx.addIssue({
         code: 'custom',
         path: ['probes'],
-        message: `Some of the selected probes above (${probeList}) are not compatible with channel "${selectedChannel}". Please unselect them or choose a different channel.`,
+        message: `Some of the selected probes above (${probeList}) are not compatible with channel "${selectedChannel}".`,
       });
     }
   };


### PR DESCRIPTION
## Problem

The Version Management UI was using inconsistent terminology across the check form. The dropdown on step 1 was labelled "k6 Version", but the probe compatibility error on step 4 said "choose a different channel", and the deprecation alert said "Deprecated Channel".

Users are unlikely to connect these as referring to the same thing, especially those encountering the feature for the first time. Additionally, when users see a compatibility error on the Execution step, there is no quick way to navigate back to step 1 where the channel dropdown lives. See https://docs.google.com/document/d/1_byb4gYSA0KHgFSJNV7EzOVDZtnPxpyK2P5Jd2KezN4/edit?tab=t.0 for more context and direct feedback from Vesna.

## Solution

- **Channel dropdown label** updated from "k6 Version" to "k6 version channel" to match the terminology used elsewhere in the form
<img width="676" height="141" alt="image" src="https://github.com/user-attachments/assets/b43dc642-c702-4301-ab15-3641e8633c56" />

- **Deprecation alert title** updated from "Deprecated Channel" to "Deprecated k6 version channel" and body updated from "This channel is deprecated..." to "This k6 version channel is deprecated..." for clarity
<img width="1541" height="243" alt="image" src="https://github.com/user-attachments/assets/b2a2cd6f-695e-43eb-a0af-03f6b5fabfff" />


- **Probe compatibility error** now includes an inline navigation link ("choose a different channel") that takes users directly back to the Check step where the channel dropdown is
<img width="1039" height="284" alt="image" src="https://github.com/user-attachments/assets/2984e94b-1672-4d53-a190-22cd0615ab4d" />

https://github.com/user-attachments/assets/10565657-1b63-4596-9877-c2bfaba32ce1


