### PR TITLE
Feat: integrate SM with Knowledge Graph

### DIFF
--- a/src/components/Checkster/components/form/sections/LabelSection.tsx
+++ b/src/components/Checkster/components/form/sections/LabelSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { KnowledgeGraphServiceLink } from 'features/knowledgeGraph/KnowledgeGraphServiceLink';
 
 import { FormSectionName } from '../../../types';
 import { useTenantCostAttributionLabels } from 'data/useTenantCostAttributionLabels';
@@ -35,6 +36,7 @@ export function LabelSection() {
         calNames={calData?.names ?? []}
         labelLimit={maxAllowedMetricLabels}
       />
+      <KnowledgeGraphServiceLink />
     </FormSection>
   );
 }

--- a/src/components/Checkster/components/form/sections/LabelSection.tsx
+++ b/src/components/Checkster/components/form/sections/LabelSection.tsx
@@ -30,13 +30,13 @@ export function LabelSection() {
           <LimitsFetchWarning refetch={refetch} isRefetching={isRefetching} error={error} />
         </div>
       )}
+      <KnowledgeGraphServiceLink />
       <GenericLabelContent
         description={description}
         isLoading={isInitialLoad}
         calNames={calData?.names ?? []}
         labelLimit={maxAllowedMetricLabels}
       />
-      <KnowledgeGraphServiceLink />
     </FormSection>
   );
 }

--- a/src/features/knowledgeGraph/KGEntityModal.tsx
+++ b/src/features/knowledgeGraph/KGEntityModal.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Badge, Modal, Spinner, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { Check, KGEntity } from 'types';
+
+import { buildKGEntityGraphUrl } from './knowledgeGraph';
+import { useKnowledgeGraphEntity } from './useKnowledgeGraphEntity';
+
+function severityBadgeColor(severity: string): 'red' | 'orange' | 'blue' | 'green' {
+  switch (severity.toLowerCase()) {
+    case 'critical':
+      return 'red';
+    case 'warning':
+      return 'orange';
+    case 'info':
+      return 'blue';
+    default:
+      return 'green';
+  }
+}
+
+function ServiceHealthSection({ entity, styles }: { entity: KGEntity; styles: ReturnType<typeof getStyles> }) {
+  const severity = entity.assertion?.severity;
+  const assertions = entity.assertion?.assertions ?? [];
+
+  return (
+    <div>
+      <Stack direction="row" gap={1} alignItems="center" justifyContent="space-between">
+        <Text variant="h5">{entity.name}</Text>
+        {severity ? (
+          <Badge text={severity} color={severityBadgeColor(severity)} />
+        ) : (
+          <Badge text="No active alerts" color="green" />
+        )}
+      </Stack>
+
+      {assertions.length > 0 && (
+        <div className={styles.section}>
+          <Text variant="bodySmall" weight="bold" color="secondary">Active alerts</Text>
+          <Stack direction="column" gap={0.5}>
+            {assertions.map((a) => (
+              <Stack key={a.assertionName} direction="row" gap={1} alignItems="center">
+                <Badge text={a.severity} color={severityBadgeColor(a.severity)} />
+                <Text variant="bodySmall">{a.assertionName}</Text>
+                <Text variant="bodySmall" color="secondary">({a.category})</Text>
+              </Stack>
+            ))}
+          </Stack>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConnectionsSection({ entity, styles }: { entity: KGEntity; styles: ReturnType<typeof getStyles> }) {
+  const connected = entity.connectedEntityTypes;
+  if (!connected || Object.keys(connected).length === 0) {
+    return null;
+  }
+
+  const entries = Object.entries(connected).filter(([, count]) => count > 0);
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.section}>
+      <Text variant="bodySmall" weight="bold" color="secondary">Connections</Text>
+      <table className={styles.table}>
+        <tbody>
+          {entries.map(([type, count]) => (
+            <tr key={type}>
+              <td className={styles.labelCell}>
+                <Text variant="bodySmall">{type}</Text>
+              </td>
+              <td className={styles.valueCell}>
+                <Text variant="bodySmall">{count} {type.toLowerCase()}{count !== 1 ? 's' : ''}</Text>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const SHOW_PROPERTIES = ['otel_service', 'service_version', 'telemetry_sdk_language', 'otel_namespace', 'job'];
+
+function ServiceDetailsSection({ entity, styles }: { entity: KGEntity; styles: ReturnType<typeof getStyles> }) {
+  const properties = SHOW_PROPERTIES
+    .filter((key) => entity.properties[key] != null)
+    .map((key) => [key, entity.properties[key]] as const);
+
+  if (properties.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.section}>
+      <Text variant="bodySmall" weight="bold" color="secondary">Service details</Text>
+      <table className={styles.table}>
+        <tbody>
+          {properties.map(([key, value]) => (
+            <tr key={key}>
+              <td className={styles.labelCell}>
+                <Text variant="bodySmall" color="secondary">{key}</Text>
+              </td>
+              <td className={styles.valueCell}>
+                <Text variant="bodySmall">{String(value)}</Text>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface KGEntityModalProps {
+  check: Check;
+  onDismiss: () => void;
+}
+
+export function KGEntityModal({ check, onDismiss }: KGEntityModalProps) {
+  const data = useKnowledgeGraphEntity(check);
+  const styles = useStyles2(getStyles);
+  const serviceEntity = data?.serviceEntity;
+
+  return (
+    <Modal title="Knowledge Graph Context" isOpen onDismiss={onDismiss}>
+      {data?.isLoading ? (
+        <Stack direction="row" gap={1} alignItems="center">
+          <Spinner size="sm" />
+          <Text color="secondary">Loading entity data...</Text>
+        </Stack>
+      ) : (
+        <Stack direction="column" gap={2}>
+          {serviceEntity ? (
+            <>
+              <Text color="secondary">
+                This check monitors the <strong>{serviceEntity.name}</strong> service
+              </Text>
+
+              <ServiceHealthSection entity={serviceEntity} styles={styles} />
+              <ConnectionsSection entity={serviceEntity} styles={styles} />
+              <ServiceDetailsSection entity={serviceEntity} styles={styles} />
+            </>
+          ) : data?.checkEntity ? (
+            <>
+              <Text color="secondary">
+                This check exists in the Knowledge Graph but is not linked to a service.
+                Add a <strong>service_name</strong> label to see service health and connections.
+              </Text>
+              <ConnectionsSection entity={data.checkEntity} styles={styles} />
+            </>
+          ) : (
+            <Text color="secondary">
+              Entity data not available. The check may not have been discovered by the Knowledge Graph yet.
+            </Text>
+          )}
+
+          <TextLink href={buildKGEntityGraphUrl(check)} external icon="external-link-alt">
+            View in Knowledge Graph
+          </TextLink>
+        </Stack>
+      )}
+    </Modal>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  section: css({
+    marginTop: theme.spacing(1),
+  }),
+  table: css({
+    width: '100%',
+    borderCollapse: 'collapse',
+    marginTop: theme.spacing(0.5),
+  }),
+  labelCell: css({
+    padding: theme.spacing(0.5, 1),
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
+    verticalAlign: 'top',
+    whiteSpace: 'nowrap',
+  }),
+  valueCell: css({
+    padding: theme.spacing(0.5, 1),
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
+    verticalAlign: 'top',
+    wordBreak: 'break-word',
+  }),
+});

--- a/src/features/knowledgeGraph/KnowledgeGraphServiceLink.tsx
+++ b/src/features/knowledgeGraph/KnowledgeGraphServiceLink.tsx
@@ -1,0 +1,114 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Combobox, Field, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { CheckFormValues, Label } from 'types';
+
+import {
+  fetchKGServiceNames,
+  fetchKGServiceNamespaces,
+  findLabelValue,
+  isKnowledgeGraphAvailable,
+  KG_NAMESPACE_LABEL,
+  KG_PLUGIN_ID,
+  KG_SERVICE_NAME_LABEL,
+} from './knowledgeGraph';
+
+function setLabelValue(labels: Label[], name: string, value: string): Label[] {
+  const filtered = labels.filter((l) => l.name !== name);
+  if (!value) {
+    return filtered;
+  }
+  return [...filtered, { name, value }];
+}
+
+export function KnowledgeGraphServiceLink() {
+  const styles = useStyles2(getStyles);
+  const { watch, setValue } = useFormContext<CheckFormValues>();
+  const labels = watch('labels');
+
+  const serviceName = findLabelValue(labels, KG_SERVICE_NAME_LABEL);
+  const namespace = findLabelValue(labels, KG_NAMESPACE_LABEL);
+
+  const [serviceOptions, setServiceOptions] = useState<Array<{ label: string; value: string }>>([]);
+  const [namespaceOptions, setNamespaceOptions] = useState<Array<{ label: string; value: string }>>([]);
+
+  useEffect(() => {
+    fetchKGServiceNames().then((names) => setServiceOptions(names.map((n) => ({ label: n, value: n }))));
+    fetchKGServiceNamespaces().then((ns) => setNamespaceOptions(ns.map((n) => ({ label: n, value: n }))));
+  }, []);
+
+  const handleServiceNameChange = useCallback(
+    (option: { value: string } | null) => {
+      const updated = setLabelValue(labels, KG_SERVICE_NAME_LABEL, option?.value ?? '');
+      setValue('labels', updated, { shouldDirty: true });
+    },
+    [labels, setValue]
+  );
+
+  const handleNamespaceChange = useCallback(
+    (option: { value: string } | null) => {
+      const updated = setLabelValue(labels, KG_NAMESPACE_LABEL, option?.value ?? '');
+      setValue('labels', updated, { shouldDirty: true });
+    },
+    [labels, setValue]
+  );
+
+  if (!isKnowledgeGraphAvailable()) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <Stack direction="column" gap={3}>
+        <Stack direction="column" gap={0.5}>
+          <Text variant="h6">Link to Knowledge Graph service</Text>
+          <Text variant="bodySmall" color="secondary">
+            Optionally link this check to a service discovered by the{' '}
+            <TextLink href={`/a/${KG_PLUGIN_ID}/`} external variant="bodySmall">
+              Knowledge Graph
+            </TextLink>
+            . This enables the MONITORS relationship in the entity graph.
+          </Text>
+        </Stack>
+        <Stack direction="row" gap={2}>
+          <Field label="Service name" className={styles.field}>
+            <Combobox
+              options={serviceOptions}
+              value={serviceName || null}
+              onChange={handleServiceNameChange}
+              placeholder="Select or type a service name"
+              createCustomValue
+              width={40}
+            />
+          </Field>
+          <Field label="Service namespace" className={styles.field}>
+            <Combobox
+              options={namespaceOptions}
+              value={namespace || null}
+              onChange={handleNamespaceChange}
+              placeholder="Select or type a namespace"
+              createCustomValue
+              width={40}
+            />
+          </Field>
+        </Stack>
+      </Stack>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    marginBottom: theme.spacing(2),
+    padding: theme.spacing(2),
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    background: theme.colors.background.secondary,
+  }),
+  field: css({
+    marginBottom: 0,
+  }),
+});

--- a/src/features/knowledgeGraph/ViewInKnowledgeGraph.tsx
+++ b/src/features/knowledgeGraph/ViewInKnowledgeGraph.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { IconButton, LinkButton, Stack } from '@grafana/ui';
+
+import { Check } from 'types';
+
+import { KGEntityModal } from './KGEntityModal';
+import { buildKGEntityGraphUrl, isKnowledgeGraphAvailable } from './knowledgeGraph';
+
+interface ViewInKnowledgeGraphProps {
+  check: Check;
+}
+
+export function ViewInKnowledgeGraph({ check }: ViewInKnowledgeGraphProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  if (!isKnowledgeGraphAvailable()) {
+    return null;
+  }
+
+  const url = buildKGEntityGraphUrl(check);
+
+  return (
+    <>
+      <Stack direction="row" gap={0.5} alignItems="center">
+        <LinkButton
+          variant="secondary"
+          href={url}
+          icon="external-link-alt"
+          fill="text"
+          target="_blank"
+          tooltip="View this check and its monitored service in the Knowledge Graph"
+        >
+          View in Knowledge Graph
+        </LinkButton>
+        <IconButton
+          name="sitemap"
+          size="md"
+          tooltip="View Knowledge Graph entity details"
+          onClick={() => setIsModalOpen(true)}
+        />
+      </Stack>
+      {isModalOpen && <KGEntityModal check={check} onDismiss={() => setIsModalOpen(false)} />}
+    </>
+  );
+}

--- a/src/features/knowledgeGraph/knowledgeGraph.ts
+++ b/src/features/knowledgeGraph/knowledgeGraph.ts
@@ -1,0 +1,132 @@
+import { isAppPluginInstalled } from '@grafana/runtime';
+
+import { Check, KGEntity, Label } from 'types';
+
+import {
+  createEntityRule,
+  createLogConfig,
+  entityRuleExists,
+  fetchEntity,
+  fetchServiceNames,
+  fetchServiceNamespaces,
+  logConfigExists,
+} from './knowledgeGraphApi';
+
+export const KG_PLUGIN_ID = 'grafana-asserts-app';
+export const KG_SERVICE_NAME_LABEL = 'service_name';
+export const KG_NAMESPACE_LABEL = 'namespace';
+
+let provisioningAttempted = false;
+let kgAvailable: boolean | undefined;
+
+export async function resolveKnowledgeGraphAvailability(): Promise<boolean> {
+  if (kgAvailable === undefined) {
+    kgAvailable = await isAppPluginInstalled(KG_PLUGIN_ID);
+  }
+  return kgAvailable;
+}
+
+export function isKnowledgeGraphAvailable(): boolean {
+  return kgAvailable ?? false;
+}
+
+export function getEntityName(target: string): string {
+  try {
+    return new URL(target).host;
+  } catch {
+    return target;
+  }
+}
+
+export function findLabelValue(labels: Label[], name: string): string | undefined {
+  return labels.find((l) => l.name === name)?.value || undefined;
+}
+
+export function buildKGEntityGraphUrl(check: Check): string {
+  const params = new URLSearchParams();
+  params.set('start', 'now-1h');
+  params.set('end', 'now');
+  params.set('view', 'graph');
+
+  params.set('filterCriteria[0][entityType]', 'SyntheticCheck');
+  params.set('filterCriteria[0][propertyMatchers][0][name]', 'name');
+  params.set('filterCriteria[0][propertyMatchers][0][type]', 'String');
+  params.set('filterCriteria[0][propertyMatchers][0][value]', getEntityName(check.target));
+  params.set('filterCriteria[0][propertyMatchers][0][id]', '1');
+  params.set('filterCriteria[0][propertyMatchers][0][op]', '=');
+  params.set('filterCriteria[0][propertyMatchers][1][name]', 'job');
+  params.set('filterCriteria[0][propertyMatchers][1][type]', 'String');
+  params.set('filterCriteria[0][propertyMatchers][1][value]', check.job);
+  params.set('filterCriteria[0][propertyMatchers][1][id]', '2');
+  params.set('filterCriteria[0][propertyMatchers][1][op]', '=');
+  params.set('filterCriteria[0][havingAssertion]', 'false');
+
+  const serviceName = check.labels.find((l) => l.name === KG_SERVICE_NAME_LABEL)?.value;
+  if (serviceName) {
+    params.set('filterCriteria[0][connectToEntityTypes][0]', 'Service');
+    let matcherId = 3;
+    params.set('filterCriteria[1][entityType]', 'Service');
+    params.set('filterCriteria[1][propertyMatchers][0][name]', 'name');
+    params.set('filterCriteria[1][propertyMatchers][0][type]', 'String');
+    params.set('filterCriteria[1][propertyMatchers][0][value]', serviceName);
+    params.set('filterCriteria[1][propertyMatchers][0][id]', String(matcherId++));
+    params.set('filterCriteria[1][propertyMatchers][0][op]', '=');
+
+    const namespace = check.labels.find((l) => l.name === KG_NAMESPACE_LABEL)?.value;
+    if (namespace) {
+      params.set('filterCriteria[1][propertyMatchers][1][name]', 'namespace');
+      params.set('filterCriteria[1][propertyMatchers][1][type]', 'String');
+      params.set('filterCriteria[1][propertyMatchers][1][value]', namespace);
+      params.set('filterCriteria[1][propertyMatchers][1][id]', String(matcherId));
+      params.set('filterCriteria[1][propertyMatchers][1][op]', '=');
+    }
+
+    const serviceConnectedTypes = ['Namespace', 'Pod', 'Service', 'ServiceInstance', 'SyntheticCheck'];
+    serviceConnectedTypes.forEach((type, i) => {
+      params.set(`filterCriteria[1][connectToEntityTypes][${i}]`, type);
+    });
+    params.set('filterCriteria[1][havingAssertion]', 'false');
+  }
+
+  const queryString = params.toString().replace(/%5B/g, '[').replace(/%5D/g, ']');
+  return `/a/${KG_PLUGIN_ID}/entities?${queryString}`;
+}
+
+export async function ensureKnowledgeGraphProvisioning(): Promise<void> {
+  await resolveKnowledgeGraphAvailability();
+
+  if (provisioningAttempted || !isKnowledgeGraphAvailable()) {
+    return;
+  }
+
+  provisioningAttempted = true;
+
+  const [entityExists, logExists] = await Promise.all([entityRuleExists(), logConfigExists()]);
+
+  await Promise.allSettled([!entityExists && createEntityRule(), !logExists && createLogConfig()]);
+}
+
+export async function fetchKGServiceNames(prefix?: string): Promise<string[]> {
+  if (!isKnowledgeGraphAvailable()) {
+    return [];
+  }
+  return fetchServiceNames(prefix);
+}
+
+export async function fetchKGServiceNamespaces(prefix?: string): Promise<string[]> {
+  if (!isKnowledgeGraphAvailable()) {
+    return [];
+  }
+  return fetchServiceNamespaces(prefix);
+}
+
+export async function fetchKGEntity(
+  entityType: string,
+  entityName: string,
+  knownScope?: Record<string, string>
+): Promise<KGEntity | null> {
+  if (!isKnowledgeGraphAvailable()) {
+    return null;
+  }
+  return fetchEntity(entityType, entityName, knownScope);
+}

--- a/src/features/knowledgeGraph/knowledgeGraphApi.ts
+++ b/src/features/knowledgeGraph/knowledgeGraphApi.ts
@@ -1,0 +1,275 @@
+import { config, getBackendSrv } from '@grafana/runtime';
+import { firstValueFrom } from 'rxjs';
+
+import { EntityPropertyValuesResponse, KGEntity } from 'types';
+
+const KG_PLUGIN_ID = 'grafana-asserts-app';
+const KG_API_BASE = `/api/plugins/${KG_PLUGIN_ID}/resources/asserts/api-server`;
+const ENTITY_RULE_NAME = 'synthetic-checks';
+const LOG_CONFIG_NAME = 'syntheticCheckLokiConfig';
+
+const KG_URLS = {
+  modelRules: `${KG_API_BASE}/v1/config/model-rules`,
+  modelRule: (name: string) => `${KG_API_BASE}/v1/config/model-rules/${name}`,
+  logConfig: `${KG_API_BASE}/v2/config/log`,
+  propertyValues: `${KG_API_BASE}/v1/entity_type/property_values`,
+  searchSample: `${KG_API_BASE}/v1/search/sample`,
+  assertionsGraph: `${KG_API_BASE}/v1/assertions/graph`,
+} as const;
+
+const SYNTHETIC_CHECK_ENTITY_RULE = {
+  name: ENTITY_RULE_NAME,
+  entities: [
+    {
+      type: 'SyntheticCheck',
+      name: 'instance',
+      scope: {
+        job: 'job',
+      },
+      definedBy: [
+        {
+          query: 'sm_check_info',
+          labelValues: {
+            check_type: 'check_name',
+            job_name: 'job',
+            target: 'instance',
+            probe_location: 'probe',
+            region: 'region',
+            frequency: 'frequency',
+            geohash: 'geohash',
+            service_name: 'label_service_name',
+            namespace: 'label_namespace',
+          },
+        },
+      ],
+    },
+  ],
+  relations: [
+    {
+      type: 'MONITORS',
+      startEntityType: 'SyntheticCheck',
+      endEntityType: 'Service',
+      definedBy: {
+        source: 'PROPERTY_MATCH',
+        startEntityProperties: ['service_name', 'namespace'],
+        endEntityProperties: ['name', 'namespace'],
+      },
+    },
+  ],
+};
+
+interface SearchSampleResponse {
+  entities: KGEntity[];
+}
+
+interface AssertionsGraphResponse {
+  type: string;
+  data: {
+    entities: KGEntity[];
+    edges: unknown[];
+  };
+}
+
+export async function entityRuleExists(): Promise<boolean> {
+  try {
+    await firstValueFrom(
+      getBackendSrv().fetch({
+        url: KG_URLS.modelRule(ENTITY_RULE_NAME),
+        method: 'GET',
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      })
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function createEntityRule(): Promise<void> {
+  await firstValueFrom(
+    getBackendSrv().fetch({
+      url: KG_URLS.modelRules,
+      method: 'PUT',
+      data: SYNTHETIC_CHECK_ENTITY_RULE,
+      showErrorAlert: false,
+      showSuccessAlert: false,
+    })
+  );
+}
+
+function getSmLogsDataSourceUid(): string | undefined {
+  const smPlugin = Object.values(config.datasources ?? {}).find((ds) => ds.type === 'synthetic-monitoring-datasource');
+  const configuredUid = (smPlugin?.jsonData as { logs?: { uid?: string } })?.logs?.uid;
+
+  if (configuredUid && config.datasources[configuredUid]) {
+    return configuredUid;
+  }
+
+  const fallback = Object.values(config.datasources ?? {}).find(
+    (ds) => ds.type === 'loki' && ds.uid === 'grafanacloud-logs'
+  );
+  return fallback?.uid;
+}
+
+export async function logConfigExists(): Promise<boolean> {
+  try {
+    const response = await firstValueFrom(
+      getBackendSrv().fetch<{ logDrilldownConfigs: Array<{ name: string }> }>({
+        url: KG_URLS.logConfig,
+        method: 'GET',
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      })
+    );
+    return response.data?.logDrilldownConfigs?.some((c) => c.name === LOG_CONFIG_NAME) ?? false;
+  } catch {
+    return false;
+  }
+}
+
+export async function createLogConfig(): Promise<void> {
+  const lokiUid = getSmLogsDataSourceUid();
+  if (!lokiUid) {
+    return;
+  }
+
+  await firstValueFrom(
+    getBackendSrv().fetch({
+      url: KG_URLS.logConfig,
+      method: 'POST',
+      data: {
+        name: LOG_CONFIG_NAME,
+        priority: 100,
+        defaultConfig: false,
+        dataSourceUid: lokiUid,
+        errorLabel: 'error',
+        match: [{ property: 'asserts_entity_type', op: '=', values: ['SyntheticCheck'] }],
+        entityPropertyToLogLabelMapping: {
+          job_name: 'job',
+          target: 'instance',
+        },
+        filterBySpanId: false,
+        filterByTraceId: false,
+      },
+      showErrorAlert: false,
+      showSuccessAlert: false,
+    })
+  );
+}
+
+export async function fetchServiceNames(prefix?: string): Promise<string[]> {
+  try {
+    const now = Date.now();
+    const oneHourAgo = now - 60 * 60 * 1000;
+
+    const response = await firstValueFrom(
+      getBackendSrv().fetch<EntityPropertyValuesResponse>({
+        url: KG_URLS.propertyValues,
+        method: 'POST',
+        data: {
+          entityType: 'Service',
+          propertyName: 'name',
+          prefix: prefix || '',
+          start: oneHourAgo,
+          end: now,
+          limit: 50,
+        },
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      })
+    );
+
+    return response.data.values ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export async function fetchServiceNamespaces(prefix?: string): Promise<string[]> {
+  try {
+    const now = Date.now();
+    const oneHourAgo = now - 60 * 60 * 1000;
+
+    const response = await firstValueFrom(
+      getBackendSrv().fetch<EntityPropertyValuesResponse>({
+        url: KG_URLS.propertyValues,
+        method: 'POST',
+        data: {
+          entityType: 'Service',
+          propertyName: 'namespace',
+          prefix: prefix || '',
+          start: oneHourAgo,
+          end: now,
+          limit: 50,
+        },
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      })
+    );
+
+    return response.data.values ?? [];
+  } catch {
+    return [];
+  }
+}
+
+async function findEntityScope(entityType: string, entityName: string): Promise<Record<string, string> | null> {
+  try {
+    const now = Date.now();
+    const response = await firstValueFrom(
+      getBackendSrv().fetch<SearchSampleResponse>({
+        url: KG_URLS.searchSample,
+        method: 'POST',
+        data: {
+          timeCriteria: { start: now - 60 * 60 * 1000, end: now },
+          filterCriteria: [
+            {
+              entityType,
+              propertyMatchers: [{ name: 'name', value: entityName, op: '=' }],
+            },
+          ],
+          sampleSize: 1,
+        },
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      })
+    );
+    return response.data?.entities?.[0]?.scope ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchEntity(
+  entityType: string,
+  entityName: string,
+  knownScope?: Record<string, string>
+): Promise<KGEntity | null> {
+  try {
+    const scope = knownScope ?? (await findEntityScope(entityType, entityName));
+    if (!scope) {
+      return null;
+    }
+
+    const now = Date.now();
+    const response = await firstValueFrom(
+      getBackendSrv().fetch<AssertionsGraphResponse>({
+        url: KG_URLS.assertionsGraph,
+        method: 'POST',
+        data: {
+          startTime: now - 60 * 60 * 1000,
+          endTime: now,
+          entityKeys: [{ type: entityType, name: entityName, scope }],
+          includeConnectedAssertions: true,
+        },
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      })
+    );
+
+    return response.data?.data?.entities?.[0] ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/features/knowledgeGraph/useKnowledgeGraphEntity.ts
+++ b/src/features/knowledgeGraph/useKnowledgeGraphEntity.ts
@@ -1,0 +1,89 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { Check, KGEntity, KGEntityData, KGEntityRelationship } from 'types';
+
+import {
+  fetchKGEntity,
+  findLabelValue,
+  getEntityName,
+  isKnowledgeGraphAvailable,
+  KG_SERVICE_NAME_LABEL,
+} from './knowledgeGraph';
+
+export function useKnowledgeGraphEntity(check: Check): KGEntityData | null {
+  const serviceName = useMemo(() => findLabelValue(check.labels, KG_SERVICE_NAME_LABEL), [check.labels]);
+
+  const [checkEntity, setCheckEntity] = useState<KGEntity | null>(null);
+  const [serviceEntity, setServiceEntity] = useState<KGEntity | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const target = check.target;
+  const job = check.job;
+
+  useEffect(() => {
+    if (!isKnowledgeGraphAvailable()) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+
+    const entityName = getEntityName(target);
+
+    async function load() {
+      const [checkResult, serviceResult] = await Promise.all([
+        fetchKGEntity('SyntheticCheck', entityName),
+        serviceName ? fetchKGEntity('Service', serviceName) : Promise.resolve(null),
+      ]);
+
+      if (cancelled) {
+        return;
+      }
+
+      setCheckEntity(checkResult);
+      setServiceEntity(serviceResult);
+      setIsLoading(false);
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [target, job, serviceName]);
+
+  if (!isKnowledgeGraphAvailable()) {
+    return null;
+  }
+
+  const relationships: KGEntityRelationship[] = [];
+
+  if (serviceName) {
+    relationships.push({
+      relationshipType: 'MONITORS',
+      entityType: 'Service',
+      entityName: serviceName,
+    });
+  }
+
+  if (checkEntity?.connectedEntityTypes) {
+    for (const [entityType, count] of Object.entries(checkEntity.connectedEntityTypes)) {
+      if (count === 0 || (entityType === 'Service' && serviceName)) {
+        continue;
+      }
+      relationships.push({
+        relationshipType: 'CONNECTED_TO',
+        entityType,
+        entityName: `${count} ${entityType}${count !== 1 ? 's' : ''}`,
+      });
+    }
+  }
+
+  return {
+    serviceName,
+    relationships,
+    checkEntity,
+    serviceEntity,
+    isLoading,
+  };
+}

--- a/src/features/knowledgeGraph/useKnowledgeGraphProvisioning.ts
+++ b/src/features/knowledgeGraph/useKnowledgeGraphProvisioning.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+
+import { ensureKnowledgeGraphProvisioning } from './knowledgeGraph';
+
+export function useKnowledgeGraphProvisioning() {
+  useEffect(() => {
+    ensureKnowledgeGraphProvisioning().catch(() => {});
+  }, []);
+}

--- a/src/routing/InitialisedRouter.tsx
+++ b/src/routing/InitialisedRouter.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Navigate, Route, Routes } from 'react-router';
 import { TextLink } from '@grafana/ui';
+import { useKnowledgeGraphProvisioning } from 'features/knowledgeGraph/useKnowledgeGraphProvisioning';
 
 import { FeatureName } from 'types';
 import { LegacyEditRedirect } from 'routing/LegacyEditRedirect';
@@ -34,6 +35,7 @@ import { EditCheckV2 } from '../page/EditCheck/EditCheckV2';
 import { NewCheckV2 } from '../page/NewCheck/NewCheckV2';
 
 export const InitialisedRouter = () => {
+  useKnowledgeGraphProvisioning();
   const urlSearchParams = useURLSearchParams();
   const navigate = useNavigation();
   const { isFeatureEnabled } = useFeatureFlagContext();

--- a/src/scenes/Common/DashboardHeader.tsx
+++ b/src/scenes/Common/DashboardHeader.tsx
@@ -3,6 +3,7 @@ import { AnnotationQuery, GrafanaTheme2 } from '@grafana/data';
 import { RefreshPicker, TimeRangePicker, VariableControl } from '@grafana/scenes-react';
 import { useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { ViewInKnowledgeGraph } from 'features/knowledgeGraph/ViewInKnowledgeGraph';
 
 import { Check } from 'types';
 import { DashboardAnnotationControls } from 'scenes/Common/DashboardAnnotationControls';
@@ -24,6 +25,7 @@ export const DashboardHeader = ({ annotations, check }: DashboardHeaderProps) =>
           <DashboardAnnotationControls annotations={annotations} />
         </div>
         <div className={styles.actions}>
+          <ViewInKnowledgeGraph check={check} />
           <EditCheckButton id={check.id} />
           <div className={styles.dashboardControls}>
             <TimeRangePicker />

--- a/src/types.ts
+++ b/src/types.ts
@@ -927,3 +927,47 @@ export type K6ChannelRef = Pick<K6Channel, 'id'>;
 export interface ListChannelsResponse {
   channels: K6Channel[];
 }
+
+export interface EntityPropertyValuesResponse {
+  entityType: string;
+  propertyName: string;
+  values: string[];
+}
+
+export interface GraphAssertionSummary {
+  severity?: string;
+  amend?: boolean;
+  assertions?: Array<{
+    assertionName: string;
+    severity: string;
+    category: string;
+    entityType: string;
+  }>;
+}
+
+export interface KGEntity {
+  id?: number;
+  type: string;
+  name: string;
+  active?: boolean;
+  scope: Record<string, string>;
+  properties: Record<string, unknown>;
+  connectedEntityTypes?: Record<string, number>;
+  assertion?: GraphAssertionSummary;
+  connectedAssertion?: GraphAssertionSummary;
+  assertionCount?: number;
+}
+
+export interface KGEntityRelationship {
+  relationshipType: string;
+  entityType: string;
+  entityName: string;
+}
+
+export interface KGEntityData {
+  serviceName: string | undefined;
+  relationships: KGEntityRelationship[];
+  checkEntity: KGEntity | null;
+  serviceEntity: KGEntity | null;
+  isLoading: boolean;
+}


### PR DESCRIPTION
## Problem

Synthetic Monitoring checks operate in isolation from the rest of a user's observability stack. When a check detects that an endpoint is down or latency is high, there is no built-in connection to the underlying service, its dependencies, or its current health in the broader environment. Users must manually switch between SM and other tools to understand *why* a problem is happening.

For users who have the Knowledge Graph (grafana-asserts-app) enabled, this is a missed opportunity as the KG already maps services, pods, and infrastructure with automatic insight detection, but SM checks are invisible to it.

## Solution

This PR is a **proof of concept** for connecting Synthetic Monitoring to the Knowledge Graph. It introduces four capabilities:

1. **Checks - Service integration:**  Introduces the integration between SM and the KG by modelling checks as `SyntheticCheck` entities that can be linked to KG Service entities via a `MONITORS` relationship.
<img width="1820" height="1037" alt="image" src="https://github.com/user-attachments/assets/d347ce00-b8d7-43c3-944e-e3e58599da4a" />

2. **Auto-provisioning:** On plugin initialisation, SM automatically creates the `SyntheticCheck` entity rule and log config in the KG via the Asserts API if they don't already exist. This ensures SM checks are discoverable as KG entities. Full integration (the `MONITORS` relationship) requires users to set a `service_name` label on their checks.
<img width="1773" height="865" alt="image" src="https://github.com/user-attachments/assets/fa697c29-1e47-423b-9514-a8238597b661" />
<img width="1289" height="900" alt="image" src="https://github.com/user-attachments/assets/9b38e78d-9304-48a4-989e-555a8eab1748" />

3. **Service linking in the check editor:** Two combobox fields (`service_name`, `namespace`) in the labels section of the check form, with autocomplete from known KG services. Setting these creates a `MONITORS` relationship between the check and the service in the entity graph.
<img width="1435" height="251" alt="image" src="https://github.com/user-attachments/assets/cfc5fbfd-facb-4005-bfc9-78e76a285b1a" />

5. **"View in Knowledge Graph" on the check dashboard:** A deep-link button and an entity detail modal in the dashboard header. The modal fetches live entity data and displays service health, active alerts, connections, and service properties.
<img width="320" height="94" alt="image" src="https://github.com/user-attachments/assets/72baf84a-5c92-4134-986f-4738a3a5adbb" />
<img width="1824" height="848" alt="image" src="https://github.com/user-attachments/assets/cc6f256a-3b7d-4fd5-b562-89f51e50ae8e" />

## Future improvements

There are a few things we'd want to explore with the Asserts team to take this further:

- **Built-in provisioning**: Right now we're creating the entity rule, log config, and potentially metrics config via the Asserts API on every plugin load. Ideally SM would be a built-in KG dataset so this configuration is provided out of the box.
- **Automatic service discovery via traces**: Currently users have to manually set the `service_name` label on a check to create the `MONITORS` relationship. If we could leverage trace IDs from check executions, the KG could discover which service a check targets and create that connection automatically.

## Notes

Video demo in this thread: 

https://raintank-corp.slack.com/archives/C0175SS6SA3/p1773109804407679?thread_ts=1770394450.006799&cid=C0175SS6SA3
