### PR TITLE
Sm app issue

### DIFF
--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -7,6 +7,8 @@ import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
 import { CodeEditorProps, ConstrainedEditorProps } from './CodeEditor.types';
 // import { Overlay } from 'components/Overlay';
 import k6Types from './k6.types';
+import { FeatureName } from 'types';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 
 import { useK6TypesForChannel } from './k6TypesLoader/useK6TypesForChannel';
 import { initializeConstrainedInstance, updateConstrainedEditorRanges } from './CodeEditor.utils';
@@ -31,8 +33,14 @@ const addK6Types = (monaco: typeof monacoType, types: Record<string, string> = k
   // Clear existing k6 types first
   clearK6Types(monaco);
 
+  // Filter types based on feature flags
+  const filteredTypes = { ...types };
+  if (!isFeatureEnabled(FeatureName.SecretsManagement)) {
+    delete filteredTypes['k6/secrets'];
+  }
+
   // Add new k6 types
-  Object.entries(types).forEach(([name, type]) => {
+  Object.entries(filteredTypes).forEach(([name, type]) => {
     const uri = `file:///k6-types/${name.replace(/\//g, '-')}.d.ts`;
     monaco.languages.typescript.javascriptDefaults.addExtraLib(`declare module '${name}' { ${type} }`, uri);
     currentK6LibUris.push(uri);

--- a/src/components/CodeEditor/k6.types.ts
+++ b/src/components/CodeEditor/k6.types.ts
@@ -41,10 +41,6 @@ import k6ExperimentalStreams from '!raw-loader!@types/k6/experimental/streams';
 import k6ExperimentalWebsockets from '!raw-loader!@types/k6/experimental/websockets';
 // @ts-expect-error
 import k6Secrets from '!raw-loader!./k6Secrets.d.ts';
-import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
-import { FeatureName } from 'types';
-
-const secretsEnabled = isFeatureEnabled(FeatureName.SecretsManagement);
 
 // eslint-disable-next-line no-restricted-syntax
 export default {
@@ -66,5 +62,5 @@ export default {
   'k6/experimental/redis': k6ExperimentalRedis,
   'k6/experimental/streams': k6ExperimentalStreams,
   'k6/experimental/websockets': k6ExperimentalWebsockets,
-  ...(secretsEnabled ? { 'k6/secrets': k6Secrets } : undefined),
+  'k6/secrets': k6Secrets,
 };

--- a/src/components/CodeEditor/k6TypesLoader/k6TypesCdnLoader.ts
+++ b/src/components/CodeEditor/k6TypesLoader/k6TypesCdnLoader.ts
@@ -21,6 +21,7 @@ const K6_MODULES: K6ModuleDefinition[] = [
   { name: 'k6/experimental/redis', path: 'experimental/redis/index.d.ts' },
   { name: 'k6/experimental/streams', path: 'experimental/streams/index.d.ts' },
   { name: 'k6/experimental/websockets', path: 'experimental/websockets/index.d.ts' },
+  { name: 'k6/secrets', path: 'secrets/index.d.ts' },
 ];
 
 const CDN_BASE_URL = 'https://unpkg.com/@types/k6';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix `k6/secrets` module resolution in the k6 script editor.

TypeScript was not recognizing the `k6/secrets` module because it was conditionally included based on a feature flag in the static types and was missing from the dynamic CDN type loader.

[Slack Thread](https://raintank-corp.slack.com/archives/D0ABFH9NM5W/p1769189527810049?thread_ts=1769189527.810049&cid=D0ABFH9NM5W)

<div><a href="https://cursor.com/agents/bc-6d80bd57-c160-57ba-9bde-f20efb0ace92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d80bd57-c160-57ba-9bde-f20efb0ace92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->