### PR TITLE
fix: prevent text overlap in check list view on narrow screens

### DIFF
--- a/src/page/CheckList/components/CheckListItemDetails.tsx
+++ b/src/page/CheckList/components/CheckListItemDetails.tsx
@@ -116,6 +116,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   detailItem: css({
     minWidth: 0,
     fontVariantNumeric: 'tabular-nums',
+    whiteSpace: 'nowrap',
   }),
   wrapDetailItem: css({
     backgroundColor: theme.colors.background.primary,

--- a/src/page/CheckList/components/CheckListItemRow.tsx
+++ b/src/page/CheckList/components/CheckListItemRow.tsx
@@ -88,7 +88,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   listCardWrapper: css({
     display: 'grid',
-    gridTemplateColumns: 'auto minmax(220px, 1.25fr) minmax(1px, 1fr) auto auto auto',
+    gridTemplateColumns: 'auto minmax(150px, 1.25fr) minmax(100px, 1fr) auto auto auto',
     alignItems: 'center',
     gridColumnGap: theme.spacing(2),
     padding: theme.spacing(1.5, 2),
@@ -96,6 +96,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   checkTarget: css({
     display: `flex`,
     fontSize: theme.typography.bodySmall.fontSize,
+    minWidth: 0,
+    overflow: 'hidden',
   }),
   checkJobListViewContainer: css({
     display: 'flex',


### PR DESCRIPTION
## Summary

Fixes #1638 — Column text overlaps with adjacent columns in check list view when screen width is below ~1550px.

## Changes

**`CheckListItemRow.tsx`**:
- Adjusted grid column min widths: job name column from `220px` to `150px`, target column from `1px` to `100px`. This gives columns better space distribution on narrow viewports
- Added `overflow: hidden` and `minWidth: 0` to the target column container to enable proper text truncation within CSS Grid

**`CheckListItemDetails.tsx`**:
- Added `whiteSpace: nowrap` to detail items to prevent awkward line breaks in frequency/series/location text

## How it works

The root cause was that `minmax(1px, 1fr)` allowed the target column to shrink to almost nothing, while `auto` columns for details could grow unconstrained. The fix gives more balanced minimum widths and ensures text truncation via `overflow: hidden` + `minWidth: 0` (required for CSS Grid children to respect truncation).