### PR TITLE
fix: preserve adhoc test panel state during probe refreshes

### DIFF
--- a/src/components/Checkster/feature/adhoc-check/AdhocCheckPanel.test.tsx
+++ b/src/components/Checkster/feature/adhoc-check/AdhocCheckPanel.test.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { act, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { CHECKSTER_TEST_ID, DataTestIds } from 'test/dataTestIds';
+import { PRIVATE_PROBE } from 'test/fixtures/probes';
+import { apiRoute, getServerRequests } from 'test/handlers';
+import { render } from 'test/render';
+import { server } from 'test/server';
+
+import { CheckType } from 'types';
+import { getCheckTypeGroup } from 'utils';
+import { AppRoutes } from 'routing/types';
+import { generateRoutePath, getRoute } from 'routing/utils';
+import { gotoSection } from 'components/Checkster/__testHelpers__/formHelpers';
+import { doAdhocCheck } from 'components/Checkster/feature/adhoc-check/__testHelpers__/adhocCheck';
+import { FormSectionName } from 'components/Checkster/types';
+import { NewCheckV2 } from 'page/NewCheck/NewCheckV2';
+
+let probeRequests: Request[] = [];
+
+function buildLokiLogsResponse() {
+  return {
+    results: {
+      A: {
+        status: 200,
+        frames: [
+          {
+            schema: {
+              fields: [
+                { name: 'timestamp', type: 'time' },
+                { name: 'body', type: 'string' },
+              ],
+            },
+            data: {
+              values: [
+                [1704067202000],
+                [
+                  JSON.stringify({
+                    id: 'adhoc-1',
+                    level: 'info',
+                    target: 'https://grafana.com/',
+                    probe: PRIVATE_PROBE.name,
+                    check_name: 'JOB FIELD',
+                    message: 'done',
+                    logs: [
+                      {
+                        level: 'info',
+                        msg: 'second log',
+                        time: '2024-01-01T00:00:02Z',
+                        status_code: '202',
+                      },
+                    ],
+                    timeseries: [
+                      { name: 'probe_success', help: 'success', type: 1, metric: [{ gauge: { value: 1 } }] },
+                    ],
+                  }),
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe('adhoc-check', () => {
+  beforeEach(() => {
+    const { record, requests } = getServerRequests();
+    probeRequests = requests;
+
+    server.use(
+      apiRoute(
+        'listProbes',
+        {
+          result: () => ({
+            json: [PRIVATE_PROBE],
+          }),
+        },
+        record
+      )
+    );
+
+    server.use(
+      apiRoute('testCheck', {
+        result: () => ({
+          json: {
+            id: 'adhoc-1',
+            probes: [PRIVATE_PROBE.id!],
+            timeout: 1000,
+          },
+        }),
+      })
+    );
+
+    server.use(
+      http.post(new RegExp('^http://localhost.*/api/ds/query(?:\\?.*)?$'), async () => {
+        return HttpResponse.json(buildLokiLogsResponse());
+      })
+    );
+  });
+
+  async function renderHttpNewCheckForm() {
+    const checkType = CheckType.Http;
+    const checkTypeGroup = getCheckTypeGroup(checkType);
+    const result = render(<NewCheckV2 />, {
+      path: `${generateRoutePath(AppRoutes.NewCheck)}/${checkTypeGroup}?checkType=${checkType}`,
+      route: `${getRoute(AppRoutes.NewCheck)}/:checkTypeGroup`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId(DataTestIds.PageReady)).toBeInTheDocument();
+    });
+
+    return result;
+  }
+
+  it('does not reset open test logs when probes refresh for the same adhoc request', async () => {
+    const { user, queryClient } = await renderHttpNewCheckForm();
+
+    const jobField = screen.getByLabelText(/Job name/);
+    await user.click(jobField);
+    await user.paste('JOB FIELD');
+
+    const targetField = screen.getByLabelText(/Request target/);
+    await user.click(targetField);
+    await user.paste('https://grafana.com/');
+
+    await gotoSection(user, FormSectionName.Execution);
+    const probeCheckbox = await screen.findByRole('checkbox', { name: new RegExp(PRIVATE_PROBE.name) });
+    await user.click(probeCheckbox);
+
+    await doAdhocCheck(user);
+
+    await waitFor(() => {
+      expect(screen.getByText('Logs: 1, Metrics: 1')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByText(PRIVATE_PROBE.name).at(-1)!);
+    await user.click(screen.getByText('second log'));
+
+    expect(screen.getByTestId('preformatted')).toHaveTextContent('status_code: 202');
+
+    const initialProbeRequestCount = probeRequests.length;
+
+    await act(async () => {
+      await queryClient.refetchQueries({ queryKey: ['probes'] });
+    });
+
+    await waitFor(() => {
+      expect(probeRequests.length).toBeGreaterThan(initialProbeRequestCount);
+    });
+
+    expect(screen.getByTestId(CHECKSTER_TEST_ID.feature.adhocCheck.TestButton.root)).toBeInTheDocument();
+    expect(screen.getByText('Logs: 1, Metrics: 1')).toBeInTheDocument();
+    expect(screen.getByTestId('preformatted')).toHaveTextContent('status_code: 202');
+  });
+});

--- a/src/components/Checkster/feature/adhoc-check/AdhocCheckPanel.tsx
+++ b/src/components/Checkster/feature/adhoc-check/AdhocCheckPanel.tsx
@@ -117,6 +117,10 @@ export function AdhocCheckPanel() {
       checkTimeoutInSeconds: newHocCheckRequest.timeout / 1000,
     };
     setLogState((prevState) => {
+      if (checkState.id in prevState) {
+        return prevState;
+      }
+
       return {
         ...prevState,
         [checkState.id]: checkState,

--- a/src/components/Checkster/feature/adhoc-check/LogsPanel.test.tsx
+++ b/src/components/Checkster/feature/adhoc-check/LogsPanel.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ProbeStateStatus } from './types.adhoc-check';
+
+import { LogsPanel } from './LogsPanel';
+
+function buildLog({ msg, time, statusCode }: { msg: string; time: string; statusCode: string }) {
+  return {
+    level: 'info',
+    msg,
+    time,
+    status_code: statusCode,
+  };
+}
+
+describe('adhoc-check', () => {
+  describe('LogsPanel', () => {
+    it('keeps an expanded log open when polling adds a new entry', async () => {
+      const user = userEvent.setup();
+      const initialLogs = [
+        buildLog({ msg: 'first log', time: '2024-01-01T00:00:01Z', statusCode: '101' }),
+        buildLog({ msg: 'second log', time: '2024-01-01T00:00:02Z', statusCode: '202' }),
+      ];
+
+      const { rerender } = render(
+        <LogsPanel logs={initialLogs} probe="test probe" state={ProbeStateStatus.Success} timeseries={[]} />
+      );
+
+      await user.click(screen.getByText('test probe'));
+      await user.click(screen.getByText('second log'));
+
+      expect(screen.getByTestId('preformatted')).toHaveTextContent('status_code: 202');
+
+      rerender(
+        <LogsPanel
+          logs={[buildLog({ msg: 'new log', time: '2024-01-01T00:00:00Z', statusCode: '000' }), ...initialLogs]}
+          probe="test probe"
+          state={ProbeStateStatus.Success}
+          timeseries={[]}
+        />
+      );
+
+      expect(screen.getByTestId('preformatted')).toHaveTextContent('status_code: 202');
+    });
+  });
+});

--- a/src/components/Checkster/feature/adhoc-check/LogsPanel.tsx
+++ b/src/components/Checkster/feature/adhoc-check/LogsPanel.tsx
@@ -14,6 +14,11 @@ interface LogsPanelProps {
   state: ProbeStateStatus;
   timeseries?: AdHocResult['line']['timeseries'];
 }
+
+function getLogItemKey(log: NonNullable<LogsPanelProps['logs']>[number]) {
+  return JSON.stringify(log);
+}
+
 export function LogsPanel({ logs, state, probe, timeseries }: LogsPanelProps) {
   const styles = useStyles2(getStyles);
   const [isOpen, setIsOpen] = useState(false);
@@ -49,8 +54,8 @@ export function LogsPanel({ logs, state, probe, timeseries }: LogsPanelProps) {
               Timed out while waiting for logs.
             </Text>
           )}
-          {logs?.map((log, index) => (
-            <LogItem key={`${log.time}-${index}`} log={log} />
+          {logs?.map((log) => (
+            <LogItem key={getLogItemKey(log)} log={log} />
           ))}
           {!logs?.length && state === ProbeStateStatus.Success && (
             <Text variant="bodySmall" element="span" color="secondary">

--- a/src/test/render.tsx
+++ b/src/test/render.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, type ReactElement, type ReactNode } from 'react';
 import { Route, Router, Routes } from 'react-router';
-import { QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AppPluginMeta } from '@grafana/data';
 import { locationService, LocationServiceProvider } from '@grafana/runtime';
 import { render, type RenderOptions } from '@testing-library/react';
@@ -19,12 +19,14 @@ import { FeatureFlagProvider } from 'components/FeatureFlagProvider';
 export type ComponentWrapperProps = {
   children: ReactNode;
   initialEntries?: string[];
+  queryClient: QueryClient;
   route?: string;
   meta?: Partial<AppPluginMeta<ProvisioningJsonData>>;
 };
 
 type CreateWrapperProps = {
   path?: string;
+  queryClient?: QueryClient;
   route?: string;
   meta?: Partial<AppPluginMeta<ProvisioningJsonData>>;
   wrapper?: (props: ComponentWrapperProps) => ReactElement;
@@ -42,7 +44,7 @@ function getRelativeRoute(route?: string) {
   return route;
 }
 
-const DefaultWrapper = ({ children, route: _route, initialEntries, meta }: ComponentWrapperProps) => {
+const DefaultWrapper = ({ children, route: _route, initialEntries, meta, queryClient }: ComponentWrapperProps) => {
   const relativeRoute = getRelativeRoute(_route);
   const initialPath = initialEntries?.[0] || APP_ROOT;
   const { history, location } = useLocationServiceHistory(initialPath);
@@ -51,7 +53,7 @@ const DefaultWrapper = ({ children, route: _route, initialEntries, meta }: Compo
   return (
     <LocationServiceProvider service={locationService}>
       <Router navigator={history} location={location}>
-        <QueryClientProvider client={getQueryClient()}>
+        <QueryClientProvider client={queryClient}>
           <MetaContextProvider meta={{ ...SM_META, ...meta }}>
             <FeatureFlagProvider>
               <SMDatasourceProvider>
@@ -71,7 +73,8 @@ const DefaultWrapper = ({ children, route: _route, initialEntries, meta }: Compo
   );
 };
 
-export const createWrapper = ({ route = '*', meta, path: _path, wrapper }: CreateWrapperProps = {}) => {
+export const createWrapper = ({ route = '*', meta, path: _path, queryClient, wrapper }: CreateWrapperProps) => {
+  const activeQueryClient = queryClient ?? getQueryClient();
   const path = _path
     ? _path.startsWith(`${APP_ROOT}/`)
       ? _path
@@ -81,7 +84,7 @@ export const createWrapper = ({ route = '*', meta, path: _path, wrapper }: Creat
   const initialEntries = [path];
 
   const Wrapper = ({ children }: PropsWithChildren) => (
-    <Component route={route} meta={meta} initialEntries={initialEntries}>
+    <Component route={route} meta={meta} initialEntries={initialEntries} queryClient={activeQueryClient}>
       {children}
     </Component>
   );
@@ -93,9 +96,11 @@ export type CustomRenderOptions = Omit<RenderOptions, 'wrapper'> & CreateWrapper
 
 const customRender = (ui: ReactElement, options: CustomRenderOptions = {}) => {
   const { path, route, meta, wrapper, ...rest } = options;
+  const queryClient = getQueryClient();
   const user = userEventLib.setup();
   const { Wrapper, initialEntries } = createWrapper({
     path,
+    queryClient,
     route,
     meta,
     wrapper,
@@ -103,6 +108,7 @@ const customRender = (ui: ReactElement, options: CustomRenderOptions = {}) => {
 
   return {
     user,
+    queryClient,
     initialEntries,
     ...render(ui, {
       wrapper: Wrapper,

--- a/src/test/render.tsx
+++ b/src/test/render.tsx
@@ -73,7 +73,7 @@ const DefaultWrapper = ({ children, route: _route, initialEntries, meta, queryCl
   );
 };
 
-export const createWrapper = ({ route = '*', meta, path: _path, queryClient, wrapper }: CreateWrapperProps) => {
+export const createWrapper = ({ route = '*', meta, path: _path, queryClient, wrapper }: CreateWrapperProps = {}) => {
   const activeQueryClient = queryClient ?? getQueryClient();
   const path = _path
     ? _path.startsWith(`${APP_ROOT}/`)


### PR DESCRIPTION
## Problem

The checks editor's Test panel could collapse open log details while a test was still visible. This happened when probe refreshes or new log entries caused the panel state to be rebuilt, which interrupted the debugging flow and made it harder to inspect test output.

## Solution

This change preserves adhoc test panel state across refreshes by avoiding duplicate state initialization for the same adhoc request and by using stable keys for rendered log entries.

It also updates the shared test render helper to return the mounted React Query client so tests can trigger refetches against the same client instance the UI is using. The adhoc panel regression coverage now uses the codebase's normal MSW-backed request flow instead of hook-level mocks.

Made with [Cursor](https://cursor.com)