### PR TITLE
Feat: add folders bulk assignment

### DIFF
--- a/src/components/FolderSelector/FolderSelector.tsx
+++ b/src/components/FolderSelector/FolderSelector.tsx
@@ -16,8 +16,8 @@ interface FolderSelectorProps {
 }
 
 export function FolderSelector({ value, onChange, disabled, autoSelectDefault = true, 'aria-label': ariaLabel }: FolderSelectorProps) {
-  const { defaultFolder, defaultFolderUid, isLoading: isDefaultLoading, isError: isDefaultError } = useDefaultFolder();
-  const { data: childFolders = [], isLoading: isChildrenLoading, isError: isChildrenError } = useFolderChildren(defaultFolderUid);
+  const { defaultFolder, defaultFolderUid, isLoading: isDefaultLoading, isError: isDefaultError, refetch: refetchDefault } = useDefaultFolder();
+  const { data: childFolders = [], isLoading: isChildrenLoading, isError: isChildrenError, refetch: refetchChildren } = useFolderChildren(defaultFolderUid);
   const [showCreateModal, setShowCreateModal] = useState(false);
 
   const allFolders = useMemo(() => (defaultFolder ? [defaultFolder, ...childFolders] : []), [defaultFolder, childFolders]);

--- a/src/components/FolderSelector/FolderSelector.tsx
+++ b/src/components/FolderSelector/FolderSelector.tsx
@@ -1,27 +1,27 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Alert, Button, Combobox, ComboboxOption, Field, Input, LoadingPlaceholder, Modal, Stack } from '@grafana/ui';
 import { trackFolderCreated, trackFolderSelected } from 'features/tracking/folderEvents';
 
 import { GrafanaFolder } from 'types';
 import { useDefaultFolder } from 'data/useDefaultFolder';
+import { useFolderPermissions } from 'data/useFolderPermissions';
 import { getFolderPathParts, useCreateFolder, useFolderChildren } from 'data/useFolders';
 
 interface FolderSelectorProps {
   value?: string;
   onChange: (folderUid: string | undefined) => void;
   disabled?: boolean;
+  autoSelectDefault?: boolean;
   'aria-label'?: string;
 }
 
-export function FolderSelector({ value, onChange, disabled, 'aria-label': ariaLabel }: FolderSelectorProps) {
-  const { defaultFolder, defaultFolderUid, isLoading: isDefaultLoading, isError: isDefaultError, refetch: refetchDefault } = useDefaultFolder();
-  const {
-    data: childFolders = [],
-    isLoading: isChildrenLoading,
-    isError: isChildrenError,
-    refetch: refetchChildren,
-  } = useFolderChildren(defaultFolderUid);
+export function FolderSelector({ value, onChange, disabled, autoSelectDefault = true, 'aria-label': ariaLabel }: FolderSelectorProps) {
+  const { defaultFolder, defaultFolderUid, isLoading: isDefaultLoading, isError: isDefaultError } = useDefaultFolder();
+  const { data: childFolders = [], isLoading: isChildrenLoading, isError: isChildrenError } = useFolderChildren(defaultFolderUid);
   const [showCreateModal, setShowCreateModal] = useState(false);
+
+  const allFolders = useMemo(() => (defaultFolder ? [defaultFolder, ...childFolders] : []), [defaultFolder, childFolders]);
+  const { folderDetailsByUid } = useFolderPermissions(allFolders.map((f) => f.uid));
 
   const isLoading = isDefaultLoading || isChildrenLoading;
   const isError = isDefaultError || isChildrenError;
@@ -31,28 +31,45 @@ export function FolderSelector({ value, onChange, disabled, 'aria-label': ariaLa
       return [];
     }
 
-    const allFolders = [defaultFolder, ...childFolders];
     const foldersMap = new Map(allFolders.map((f) => [f.uid, f]));
 
-    const children: Array<ComboboxOption<string>> = childFolders.map((folder) => {
+    const editableFolders = allFolders.filter((folder) => {
+      const state = folderDetailsByUid.get(folder.uid);
+      return state?.type === 'accessible' && state.permissions.canEdit;
+    });
+
+    const result: Array<ComboboxOption<string>> = editableFolders.map((folder) => {
+      if (folder.uid === defaultFolder.uid) {
+        return { label: `${folder.title} (Default)`, value: folder.uid };
+      }
+
       const parts = getFolderPathParts(folder, foldersMap);
       const withoutRoot = parts.length > 1 ? parts.slice(1) : parts;
       return { label: withoutRoot.join(' > '), value: folder.uid };
     });
 
-    children.sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''));
-
-    const result: Array<ComboboxOption<string>> = [
-      { label: `${defaultFolder.title} (Default)`, value: defaultFolder.uid },
-      ...children,
-    ];
+    result.sort((a, b) => {
+      if (a.value === defaultFolder.uid) {
+        return -1;
+      }
+      if (b.value === defaultFolder.uid) {
+        return 1;
+      }
+      return (a.label ?? '').localeCompare(b.label ?? '');
+    });
 
     if (value && !result.some((opt) => opt.value === value)) {
       result.push({ label: `${value} (folder not found)`, value });
     }
 
     return result;
-  }, [childFolders, defaultFolder, value]);
+  }, [allFolders, defaultFolder, value, folderDetailsByUid]);
+
+  useEffect(() => {
+    if (autoSelectDefault && value === undefined && defaultFolderUid) {
+      onChange(defaultFolderUid);
+    }
+  }, [autoSelectDefault, value, defaultFolderUid, onChange]);
 
   const handleChange = (selected: ComboboxOption<string> | null) => {
     if (selected?.value) {
@@ -67,7 +84,7 @@ export function FolderSelector({ value, onChange, disabled, 'aria-label': ariaLa
     setShowCreateModal(false);
   };
 
-  const selectedValue = value ?? defaultFolderUid ?? null;
+  const selectedValue = value ?? (autoSelectDefault ? defaultFolderUid : null) ?? null;
 
   if (isLoading) {
     return <LoadingPlaceholder text="Loading folders..." />;

--- a/src/components/FolderSelector/FolderSelector.tsx
+++ b/src/components/FolderSelector/FolderSelector.tsx
@@ -21,7 +21,8 @@ export function FolderSelector({ value, onChange, disabled, autoSelectDefault = 
   const [showCreateModal, setShowCreateModal] = useState(false);
 
   const allFolders = useMemo(() => (defaultFolder ? [defaultFolder, ...childFolders] : []), [defaultFolder, childFolders]);
-  const { folderDetailsByUid } = useFolderPermissions(allFolders.map((f) => f.uid));
+  const allFolderUids = useMemo(() => allFolders.map((f) => f.uid), [allFolders]);
+  const { folderDetailsByUid } = useFolderPermissions(allFolderUids);
 
   const isLoading = isDefaultLoading || isChildrenLoading;
   const isError = isDefaultError || isChildrenError;

--- a/src/hooks/useChecksByFolder.ts
+++ b/src/hooks/useChecksByFolder.ts
@@ -37,6 +37,22 @@ export function getTotalCheckCount(node: FolderNode): number {
   return count;
 }
 
+export function collectAllCheckIds(node: FolderNode): number[] {
+  const ids = node.checks.map((c) => c.id!);
+  node.children.forEach((child) => {
+    ids.push(...collectAllCheckIds(child));
+  });
+  return ids;
+}
+
+export function collectAllChecks(node: FolderNode): Check[] {
+  const checks = [...node.checks];
+  node.children.forEach((child) => {
+    checks.push(...collectAllChecks(child));
+  });
+  return checks;
+}
+
 /**
  * Build a folder tree from checks and a pre-fetched list of folders.
  *

--- a/src/page/CheckList/CheckList.bulkMoveToFolder.test.tsx
+++ b/src/page/CheckList/CheckList.bulkMoveToFolder.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { screen, within } from '@testing-library/react';
+import { DataTestIds } from 'test/dataTestIds';
+import { CHECK_IN_PRODUCTION, CHECK_IN_READONLY_FOLDER, CHECK_IN_STAGING } from 'test/fixtures/folderChecks';
+import { FOLDER_STAGING } from 'test/fixtures/folders';
+import { PRIVATE_PROBE, PUBLIC_PROBE } from 'test/fixtures/probes';
+import { apiRoute, getServerRequests } from 'test/handlers';
+import { render } from 'test/render';
+import { server } from 'test/server';
+import { mockFeatureToggles } from 'test/utils';
+
+import { Check, FeatureName } from 'types';
+import { AppRoutes } from 'routing/types';
+import { generateRoutePath } from 'routing/utils';
+
+import { BulkMoveToFolderModal } from './components/BulkMoveToFolderModal';
+import { CheckList } from './CheckList';
+
+const renderCheckList = async (checks: Check[]) => {
+  server.use(
+    apiRoute(`listChecks`, {
+      result: () => ({ json: checks }),
+    }),
+    apiRoute(`listProbes`, {
+      result: () => ({ json: [PRIVATE_PROBE, PUBLIC_PROBE] }),
+    })
+  );
+
+  const path = generateRoutePath(AppRoutes.Checks);
+
+  const res = render(<CheckList />, {
+    route: AppRoutes.Checks,
+    path,
+  });
+
+  expect(await screen.findByText('Create new check')).toBeInTheDocument();
+  return res;
+};
+
+describe('CheckList - Bulk Move to Folder', () => {
+  describe('with folders feature enabled', () => {
+    beforeEach(() => mockFeatureToggles({ [FeatureName.Folders]: true }));
+
+    it('shows the "Move to folder" button when checks are selected', async () => {
+      const { user } = await renderCheckList([CHECK_IN_PRODUCTION, CHECK_IN_STAGING]);
+      const selectAll = await screen.findByTestId(DataTestIds.SelectAllChecks);
+      await user.click(selectAll);
+
+      expect(await screen.findByRole('button', { name: /Move to folder/i })).toBeInTheDocument();
+    });
+
+    it('opens a modal with a folder selector when "Move to folder" is clicked', async () => {
+      const { user } = await renderCheckList([CHECK_IN_PRODUCTION, CHECK_IN_STAGING]);
+      const selectAll = await screen.findByTestId(DataTestIds.SelectAllChecks);
+      await user.click(selectAll);
+
+      const moveButton = await screen.findByRole('button', { name: /Move to folder/i });
+      await user.click(moveButton);
+
+      const modal = await screen.findByRole('dialog');
+      expect(within(modal).getByText('Move 2 checks to folder')).toBeInTheDocument();
+      expect(within(modal).getByText('Target folder')).toBeInTheDocument();
+      expect(within(modal).getByText('All selected checks will be moved to this folder.')).toBeInTheDocument();
+      expect(within(modal).getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+      expect(within(modal).getByRole('button', { name: 'Move' })).toBeDisabled();
+    });
+
+    it('disables "Move to folder" when selected checks include one in a read-only folder', async () => {
+      const { user } = await renderCheckList([CHECK_IN_PRODUCTION, CHECK_IN_READONLY_FOLDER]);
+      const selectAll = await screen.findByTestId(DataTestIds.SelectAllChecks);
+      await user.click(selectAll);
+
+      const moveButton = await screen.findByRole('button', { name: /Move to folder/i });
+      expect(moveButton).toBeDisabled();
+    });
+
+    it('closes the modal when cancel is clicked', async () => {
+      const { user } = await renderCheckList([CHECK_IN_PRODUCTION, CHECK_IN_STAGING]);
+      const selectAll = await screen.findByTestId(DataTestIds.SelectAllChecks);
+      await user.click(selectAll);
+
+      const moveButton = await screen.findByRole('button', { name: /Move to folder/i });
+      await user.click(moveButton);
+
+      const modal = await screen.findByRole('dialog');
+      const cancelButton = within(modal).getByRole('button', { name: 'Cancel' });
+      await user.click(cancelButton);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with folders feature disabled', () => {
+    it('does not show the "Move to folder" button', async () => {
+      const { user } = await renderCheckList([CHECK_IN_PRODUCTION, CHECK_IN_STAGING]);
+      const selectAll = await screen.findByTestId(DataTestIds.SelectAllChecks);
+      await user.click(selectAll);
+
+      await screen.findByText('2 checks are selected.');
+      expect(screen.queryByRole('button', { name: /Move to folder/i })).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('BulkMoveToFolderModal', () => {
+  it('sends bulk update with selected folder when confirmed', async () => {
+    const { read, record } = getServerRequests();
+    server.use(apiRoute(`bulkUpdateChecks`, {}, record));
+
+    const onDismiss = jest.fn();
+    const checks = [CHECK_IN_PRODUCTION, CHECK_IN_STAGING];
+
+    const { user } = render(
+      <BulkMoveToFolderModal checks={checks} isOpen onDismiss={onDismiss} />
+    );
+
+    const combobox = await screen.findByPlaceholderText(/Select a folder/);
+
+    await user.click(combobox);
+    await user.clear(combobox);
+    await user.type(combobox, 'Staging{enter}');
+
+    const submitButton = await screen.findByRole('button', { name: 'Move' });
+    expect(submitButton).not.toBeDisabled();
+    await user.click(submitButton);
+
+    const { body } = await read();
+
+    expect(body).toEqual(
+      checks.map((check) => ({
+        ...check,
+        folderUid: FOLDER_STAGING.uid,
+      }))
+    );
+  });
+
+  it('does not offer read-only folders as options', async () => {
+    const { user } = render(
+      <BulkMoveToFolderModal checks={[CHECK_IN_PRODUCTION]} isOpen onDismiss={jest.fn()} />
+    );
+
+    const combobox = await screen.findByPlaceholderText(/Select a folder/);
+    await user.click(combobox);
+    await user.clear(combobox);
+    await user.type(combobox, 'Read Only{enter}');
+
+    expect(screen.getByRole('button', { name: 'Move' })).toBeDisabled();
+  });
+
+  it('disables the Move button when no folder is selected', async () => {
+    render(
+      <BulkMoveToFolderModal checks={[CHECK_IN_PRODUCTION]} isOpen onDismiss={jest.fn()} />
+    );
+
+    await screen.findByPlaceholderText(/Select a folder/);
+    expect(screen.getByRole('button', { name: 'Move' })).toBeDisabled();
+  });
+
+  it('shows singular title for a single check', async () => {
+    render(
+      <BulkMoveToFolderModal checks={[CHECK_IN_PRODUCTION]} isOpen onDismiss={jest.fn()} />
+    );
+
+    expect(await screen.findByText('Move 1 check to folder')).toBeInTheDocument();
+  });
+});

--- a/src/page/CheckList/CheckList.bulkMoveToFolder.test.tsx
+++ b/src/page/CheckList/CheckList.bulkMoveToFolder.test.tsx
@@ -111,7 +111,7 @@ describe('BulkMoveToFolderModal', () => {
     const checks = [CHECK_IN_PRODUCTION, CHECK_IN_STAGING];
 
     const { user } = render(
-      <BulkMoveToFolderModal checks={checks} isOpen onDismiss={onDismiss} />
+      <BulkMoveToFolderModal checks={checks} isOpen onDismiss={jest.fn()} onMoved={onDismiss} />
     );
 
     const combobox = await screen.findByPlaceholderText(/Select a folder/);
@@ -136,7 +136,7 @@ describe('BulkMoveToFolderModal', () => {
 
   it('does not offer read-only folders as options', async () => {
     const { user } = render(
-      <BulkMoveToFolderModal checks={[CHECK_IN_PRODUCTION]} isOpen onDismiss={jest.fn()} />
+      <BulkMoveToFolderModal checks={[CHECK_IN_PRODUCTION]} isOpen onDismiss={jest.fn()} onMoved={jest.fn()} />
     );
 
     const combobox = await screen.findByPlaceholderText(/Select a folder/);
@@ -149,7 +149,7 @@ describe('BulkMoveToFolderModal', () => {
 
   it('disables the Move button when no folder is selected', async () => {
     render(
-      <BulkMoveToFolderModal checks={[CHECK_IN_PRODUCTION]} isOpen onDismiss={jest.fn()} />
+      <BulkMoveToFolderModal checks={[CHECK_IN_PRODUCTION]} isOpen onDismiss={jest.fn()} onMoved={jest.fn()} />
     );
 
     await screen.findByPlaceholderText(/Select a folder/);
@@ -158,7 +158,7 @@ describe('BulkMoveToFolderModal', () => {
 
   it('shows singular title for a single check', async () => {
     render(
-      <BulkMoveToFolderModal checks={[CHECK_IN_PRODUCTION]} isOpen onDismiss={jest.fn()} />
+      <BulkMoveToFolderModal checks={[CHECK_IN_PRODUCTION]} isOpen onDismiss={jest.fn()} onMoved={jest.fn()} />
     );
 
     expect(await screen.findByText('Move 1 check to folder')).toBeInTheDocument();

--- a/src/page/CheckList/CheckList.bulkMoveToFolder.test.tsx
+++ b/src/page/CheckList/CheckList.bulkMoveToFolder.test.tsx
@@ -46,7 +46,8 @@ describe('CheckList - Bulk Move to Folder', () => {
       const selectAll = await screen.findByTestId(DataTestIds.SelectAllChecks);
       await user.click(selectAll);
 
-      expect(await screen.findByRole('button', { name: /Move to folder/i })).toBeInTheDocument();
+      const moveButtons = await screen.findAllByRole('button', { name: /Move to folder/i });
+      expect(moveButtons.length).toBeGreaterThan(0);
     });
 
     it('opens a modal with a folder selector when "Move to folder" is clicked', async () => {
@@ -54,8 +55,8 @@ describe('CheckList - Bulk Move to Folder', () => {
       const selectAll = await screen.findByTestId(DataTestIds.SelectAllChecks);
       await user.click(selectAll);
 
-      const moveButton = await screen.findByRole('button', { name: /Move to folder/i });
-      await user.click(moveButton);
+      const moveButtons = await screen.findAllByRole('button', { name: /Move to folder/i });
+      await user.click(moveButtons[0]);
 
       const modal = await screen.findByRole('dialog');
       expect(within(modal).getByText('Move 2 checks to folder')).toBeInTheDocument();
@@ -70,8 +71,9 @@ describe('CheckList - Bulk Move to Folder', () => {
       const selectAll = await screen.findByTestId(DataTestIds.SelectAllChecks);
       await user.click(selectAll);
 
-      const moveButton = await screen.findByRole('button', { name: /Move to folder/i });
-      expect(moveButton).toBeDisabled();
+      const moveButtons = await screen.findAllByRole('button', { name: /Move to folder/i });
+      const globalMoveButton = moveButtons[0];
+      expect(globalMoveButton).toBeDisabled();
     });
 
     it('closes the modal when cancel is clicked', async () => {
@@ -79,8 +81,8 @@ describe('CheckList - Bulk Move to Folder', () => {
       const selectAll = await screen.findByTestId(DataTestIds.SelectAllChecks);
       await user.click(selectAll);
 
-      const moveButton = await screen.findByRole('button', { name: /Move to folder/i });
-      await user.click(moveButton);
+      const moveButtons = await screen.findAllByRole('button', { name: /Move to folder/i });
+      await user.click(moveButtons[0]);
 
       const modal = await screen.findByRole('dialog');
       const cancelButton = within(modal).getByRole('button', { name: 'Cancel' });

--- a/src/page/CheckList/CheckList.folderBulkActions.test.tsx
+++ b/src/page/CheckList/CheckList.folderBulkActions.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { screen, waitFor, within } from '@testing-library/react';
+import { CHECK_IN_PRODUCTION, CHECK_IN_STAGING } from 'test/fixtures/folderChecks';
+import { PRIVATE_PROBE, PUBLIC_PROBE } from 'test/fixtures/probes';
+import { apiRoute } from 'test/handlers';
+import { render } from 'test/render';
+import { server } from 'test/server';
+import { mockFeatureToggles } from 'test/utils';
+
+import { Check, FeatureName } from 'types';
+import { AppRoutes } from 'routing/types';
+import { generateRoutePath } from 'routing/utils';
+
+import { CheckList } from './CheckList';
+
+const renderCheckList = async (checks: Check[]) => {
+  server.use(
+    apiRoute(`listChecks`, {
+      result: () => ({ json: checks }),
+    }),
+    apiRoute(`listProbes`, {
+      result: () => ({ json: [PRIVATE_PROBE, PUBLIC_PROBE] }),
+    })
+  );
+
+  const res = render(<CheckList />, {
+    route: AppRoutes.Checks,
+    path: generateRoutePath(AppRoutes.Checks),
+  });
+
+  expect(await screen.findByText('Create new check')).toBeInTheDocument();
+  return res;
+};
+
+describe('CheckList - Per-folder Bulk Actions', () => {
+  beforeEach(() => mockFeatureToggles({ [FeatureName.Folders]: true }));
+
+  it('shows a select-all checkbox in each folder header', async () => {
+    await renderCheckList([CHECK_IN_PRODUCTION, CHECK_IN_STAGING]);
+
+    expect(await screen.findByLabelText('Select all checks in Production')).toBeInTheDocument();
+    expect(screen.getByLabelText('Select all checks in Staging')).toBeInTheDocument();
+  });
+
+  it('shows selected count and inline bulk actions when folder checkbox is clicked', async () => {
+    const { user } = await renderCheckList([CHECK_IN_PRODUCTION]);
+
+    const folderCheckbox = await screen.findByLabelText('Select all checks in Production');
+    await user.click(folderCheckbox);
+
+    const selectedLabel = await screen.findByText('1 selected');
+    const folderActions = selectedLabel.closest('div')!;
+
+    expect(within(folderActions).getByRole('button', { name: 'Move to folder' })).toBeInTheDocument();
+    expect(within(folderActions).getByRole('button', { name: 'Enable' })).toBeInTheDocument();
+    expect(within(folderActions).getByRole('button', { name: 'Disable' })).toBeInTheDocument();
+    expect(within(folderActions).getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('deselects all checks when the folder checkbox is clicked again', async () => {
+    const { user } = await renderCheckList([CHECK_IN_PRODUCTION]);
+
+    const folderCheckbox = await screen.findByLabelText('Select all checks in Production');
+    await user.click(folderCheckbox);
+    expect(await screen.findByText('1 selected')).toBeInTheDocument();
+
+    await user.click(folderCheckbox);
+    await waitFor(() => {
+      expect(screen.queryByText('1 selected')).not.toBeInTheDocument();
+    });
+  });
+
+  it('selects individual check checkboxes when folder select-all is clicked', async () => {
+    const { user } = await renderCheckList([CHECK_IN_PRODUCTION]);
+
+    const folderCheckbox = await screen.findByLabelText('Select all checks in Production');
+    await user.click(folderCheckbox);
+
+    await waitFor(() => {
+      const checkCheckboxes = screen.getAllByLabelText('Select check');
+      checkCheckboxes.forEach((cb) => expect(cb).toBeChecked());
+    });
+  });
+
+  it('does not show bulk actions when no checks are selected in folder', async () => {
+    await renderCheckList([CHECK_IN_PRODUCTION]);
+
+    await screen.findByLabelText('Select all checks in Production');
+    expect(screen.queryByText(/selected/)).not.toBeInTheDocument();
+  });
+
+  it('shows per-folder actions for multiple folders independently', async () => {
+    const { user } = await renderCheckList([CHECK_IN_PRODUCTION, CHECK_IN_STAGING]);
+
+    const productionCheckbox = await screen.findByLabelText('Select all checks in Production');
+    await user.click(productionCheckbox);
+
+    expect(await screen.findByText('1 selected')).toBeInTheDocument();
+
+    const stagingCheckbox = screen.getByLabelText('Select all checks in Staging');
+    expect(stagingCheckbox).not.toBeChecked();
+  });
+});

--- a/src/page/CheckList/CheckList.folderFilter.test.tsx
+++ b/src/page/CheckList/CheckList.folderFilter.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { screen, within } from '@testing-library/react';
-import { BASIC_DNS_CHECK, BASIC_HTTP_CHECK, BASIC_PING_CHECK } from 'test/fixtures/checks';
+import { CHECK_IN_PRODUCTION, CHECK_IN_STAGING, CHECK_WITHOUT_FOLDER } from 'test/fixtures/folderChecks';
 import { FOLDER_PRODUCTION, FOLDER_STAGING } from 'test/fixtures/folders';
 import { PRIVATE_PROBE, PUBLIC_PROBE } from 'test/fixtures/probes';
 import { apiRoute } from 'test/handlers';
@@ -11,30 +11,9 @@ import { mockFeatureToggles } from 'test/utils';
 import { Check, FeatureName } from 'types';
 import { AppRoutes } from 'routing/types';
 import { generateRoutePath } from 'routing/utils';
-import { defaultFilters,matchesAllFilters } from 'page/CheckList/CheckList.utils';
+import { defaultFilters, matchesAllFilters } from 'page/CheckList/CheckList.utils';
 
 import { CheckList } from './CheckList';
-
-const CHECK_IN_PRODUCTION: Check = {
-  ...BASIC_HTTP_CHECK,
-  id: 100,
-  job: 'Production HTTP check',
-  folderUid: FOLDER_PRODUCTION.uid,
-};
-
-const CHECK_IN_STAGING: Check = {
-  ...BASIC_DNS_CHECK,
-  id: 101,
-  job: 'Staging DNS check',
-  folderUid: FOLDER_STAGING.uid,
-};
-
-const CHECK_WITHOUT_FOLDER: Check = {
-  ...BASIC_PING_CHECK,
-  id: 102,
-  job: 'Root level ping check',
-  folderUid: undefined,
-};
 
 const FOLDER_CHECKS = [CHECK_IN_PRODUCTION, CHECK_IN_STAGING, CHECK_WITHOUT_FOLDER];
 

--- a/src/page/CheckList/CheckList.folderPermissions.test.tsx
+++ b/src/page/CheckList/CheckList.folderPermissions.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
-import { BASIC_DNS_CHECK, BASIC_HTTP_CHECK, BASIC_PING_CHECK } from 'test/fixtures/checks';
+import { BASIC_PING_CHECK } from 'test/fixtures/checks';
 import {
-  FOLDER_FORBIDDEN_UID,
-  FOLDER_PRODUCTION,
-  FOLDER_READONLY,
-  FOLDER_STAGING,
-} from 'test/fixtures/folders';
+  CHECK_IN_FORBIDDEN_FOLDER,
+  CHECK_IN_PRODUCTION,
+  CHECK_IN_READONLY_FOLDER,
+  CHECK_IN_STAGING,
+  CHECK_WITH_ORPHANED_FOLDER,
+  CHECK_WITHOUT_FOLDER,
+} from 'test/fixtures/folderChecks';
 import { PRIVATE_PROBE, PUBLIC_PROBE } from 'test/fixtures/probes';
 import { apiRoute } from 'test/handlers';
 import { render } from 'test/render';
@@ -19,55 +21,12 @@ import { generateRoutePath } from 'routing/utils';
 
 import { CheckList } from './CheckList';
 
-const CHECK_IN_PRODUCTION: Check = {
-  ...BASIC_HTTP_CHECK,
-  id: 200,
-  job: 'Production API check',
-  folderUid: FOLDER_PRODUCTION.uid,
-};
-
-const CHECK_IN_STAGING: Check = {
-  ...BASIC_DNS_CHECK,
-  id: 201,
-  job: 'Staging DNS check',
-  folderUid: FOLDER_STAGING.uid,
-};
-
-const CHECK_IN_READONLY_FOLDER: Check = {
-  ...BASIC_PING_CHECK,
-  id: 202,
-  job: 'Read-only folder check',
-  folderUid: FOLDER_READONLY.uid,
-};
-
-const CHECK_IN_FORBIDDEN_FOLDER: Check = {
-  ...BASIC_HTTP_CHECK,
-  id: 203,
-  job: 'Forbidden folder check',
-  folderUid: FOLDER_FORBIDDEN_UID,
-};
-
-const CHECK_WITHOUT_FOLDER: Check = {
-  ...BASIC_PING_CHECK,
-  id: 204,
-  job: 'Unassigned check',
-  folderUid: undefined,
-};
-
 const CHECK_WITH_EMPTY_FOLDER_UID: Check = {
   ...BASIC_PING_CHECK,
   id: 206,
   job: 'Empty folderUid check',
   folderUid: '',
 };
-
-const CHECK_WITH_ORPHANED_FOLDER: Check = {
-  ...BASIC_DNS_CHECK,
-  id: 205,
-  job: 'Orphaned folder check',
-  folderUid: 'deleted-folder-uid',
-};
-
 const ALL_CHECKS = [
   CHECK_IN_PRODUCTION,
   CHECK_IN_STAGING,
@@ -122,7 +81,7 @@ describe('CheckList - Folder Permissions', () => {
     describe('visibility', () => {
       it('shows checks in accessible folders', async () => {
         await renderCheckList();
-        expect(await screen.findByText('Production API check')).toBeInTheDocument();
+        expect(await screen.findByText('Production HTTP check')).toBeInTheDocument();
         expect(screen.getByText('Staging DNS check')).toBeInTheDocument();
       });
 
@@ -138,13 +97,13 @@ describe('CheckList - Folder Permissions', () => {
 
       it('hides checks in forbidden folders', async () => {
         await renderCheckList();
-        await screen.findByText('Production API check');
+        await screen.findByText('Production HTTP check');
         expect(screen.queryByText('Forbidden folder check')).not.toBeInTheDocument();
       });
 
       it('shows checks with orphaned folders after resolving 404', async () => {
         await renderCheckList();
-        await screen.findByText('Production API check');
+        await screen.findByText('Production HTTP check');
         expect(await screen.findByText('Orphaned folder check')).toBeInTheDocument();
       });
     });
@@ -197,7 +156,7 @@ describe('CheckList - Folder Permissions', () => {
   describe('with folders feature disabled', () => {
     it('shows all checks regardless of folderUid', async () => {
       await renderCheckList();
-      expect(await screen.findByText('Production API check')).toBeInTheDocument();
+      expect(await screen.findByText('Production HTTP check')).toBeInTheDocument();
       expect(screen.getByText('Forbidden folder check')).toBeInTheDocument();
       expect(screen.getByText('Unassigned check')).toBeInTheDocument();
     });

--- a/src/page/CheckList/CheckList.folderView.test.tsx
+++ b/src/page/CheckList/CheckList.folderView.test.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { DataTestIds } from 'test/dataTestIds';
-import { BASIC_DNS_CHECK, BASIC_HTTP_CHECK, BASIC_PING_CHECK } from 'test/fixtures/checks';
+import { BASIC_HTTP_CHECK } from 'test/fixtures/checks';
+import {
+  CHECK_IN_PRODUCTION,
+  CHECK_IN_STAGING,
+  CHECK_WITH_ORPHANED_FOLDER,
+  CHECK_WITHOUT_FOLDER,
+} from 'test/fixtures/folderChecks';
 import { DEFAULT_FOLDER, FOLDER_PRODUCTION, FOLDER_STAGING, MOCK_FOLDERS } from 'test/fixtures/folders';
 import { PRIVATE_PROBE, PUBLIC_PROBE } from 'test/fixtures/probes';
 import { apiRoute } from 'test/handlers';
@@ -15,34 +21,6 @@ import { generateRoutePath } from 'routing/utils';
 import { buildChecksByFolder, collectAllFolderUids } from 'hooks/useChecksByFolder';
 
 import { CheckList } from './CheckList';
-
-const CHECK_IN_PRODUCTION: Check = {
-  ...BASIC_HTTP_CHECK,
-  id: 100,
-  job: 'Production HTTP check',
-  folderUid: FOLDER_PRODUCTION.uid,
-};
-
-const CHECK_IN_STAGING: Check = {
-  ...BASIC_DNS_CHECK,
-  id: 101,
-  job: 'Staging DNS check',
-  folderUid: FOLDER_STAGING.uid,
-};
-
-const CHECK_WITHOUT_FOLDER: Check = {
-  ...BASIC_PING_CHECK,
-  id: 102,
-  job: 'Root level ping check',
-  folderUid: undefined,
-};
-
-const CHECK_WITH_ORPHANED_FOLDER: Check = {
-  ...BASIC_DNS_CHECK,
-  id: 103,
-  job: 'Orphaned folder check',
-  folderUid: 'deleted-folder-uid',
-};
 
 const FOLDER_CHECKS = [CHECK_IN_PRODUCTION, CHECK_IN_STAGING, CHECK_WITHOUT_FOLDER];
 

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -238,6 +238,22 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
     setSelectedChecksIds(new Set());
   };
 
+  const handleSelectChecks = (checkIds: number[]) => {
+    setSelectedChecksIds((prev) => {
+      const next = new Set(prev);
+      checkIds.forEach((id) => next.add(id));
+      return next;
+    });
+  };
+
+  const handleDeselectChecks = (checkIds: number[]) => {
+    setSelectedChecksIds((prev) => {
+      const next = new Set(prev);
+      checkIds.forEach((id) => next.delete(id));
+      return next;
+    });
+  };
+
   if (checks.length === 0) {
     return <ChecksEmptyState />;
   }
@@ -279,6 +295,8 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
           onStatusSelect={handleStatusSelect}
           onTypeSelect={handleTypeSelect}
           onToggleCheckbox={handleCheckSelect}
+          onSelectChecks={handleSelectChecks}
+          onDeselectChecks={handleDeselectChecks}
           selectedCheckIds={selectedCheckIds}
         />
       ) : (

--- a/src/page/CheckList/components/BulkActions.hooks.ts
+++ b/src/page/CheckList/components/BulkActions.hooks.ts
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+
+import { Check, FeatureName } from 'types';
+import { useBulkCheckPermissions } from 'contexts/CheckFolderAccessContext';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
+import { useBulkDeleteChecks, useBulkUpdateChecks } from 'data/useChecks';
+
+interface UseBulkActionsOptions {
+  checks: Check[];
+  onResolved: () => void;
+}
+
+export function useBulkActions({ checks, onResolved }: UseBulkActionsOptions) {
+  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
+  const { canWriteAll, canDeleteAll } = useBulkCheckPermissions(checks);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showMoveToFolderModal, setShowMoveToFolderModal] = useState(false);
+  const { mutate: bulkUpdateChecks } = useBulkUpdateChecks({ onSuccess: onResolved });
+
+  const handleDeleteResolved = () => {
+    setShowDeleteModal(false);
+    onResolved();
+  };
+
+  const handleMoveResolved = () => {
+    setShowMoveToFolderModal(false);
+    onResolved();
+  };
+
+  const { mutate: bulkDeleteChecks } = useBulkDeleteChecks({ onSuccess: handleDeleteResolved });
+
+  const enableChecks = () => {
+    bulkUpdateChecks(checks.filter((check) => !check.enabled).map((check) => ({ ...check, enabled: true })));
+  };
+
+  const disableChecks = () => {
+    bulkUpdateChecks(checks.filter((check) => check.enabled).map((check) => ({ ...check, enabled: false })));
+  };
+
+  const deleteChecks = () => {
+    bulkDeleteChecks(checks.map((check) => check.id!));
+  };
+
+  const deleteModalProps = {
+    title: `Delete ${checks.length} check${checks.length !== 1 ? 's' : ''}`,
+    body: 'Are you sure you want to delete these checks?',
+    confirmText: 'Delete checks',
+  };
+
+  return {
+    isFoldersEnabled,
+    canWriteAll,
+    canDeleteAll,
+    showDeleteModal,
+    setShowDeleteModal,
+    showMoveToFolderModal,
+    setShowMoveToFolderModal,
+    handleMoveResolved,
+    enableChecks,
+    disableChecks,
+    deleteChecks,
+    deleteModalProps,
+  };
+}

--- a/src/page/CheckList/components/BulkActions.hooks.ts
+++ b/src/page/CheckList/components/BulkActions.hooks.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { Check, FeatureName } from 'types';
 import { useBulkCheckPermissions } from 'contexts/CheckFolderAccessContext';
@@ -17,29 +17,29 @@ export function useBulkActions({ checks, onResolved }: UseBulkActionsOptions) {
   const [showMoveToFolderModal, setShowMoveToFolderModal] = useState(false);
   const { mutate: bulkUpdateChecks } = useBulkUpdateChecks({ onSuccess: onResolved });
 
-  const handleDeleteResolved = () => {
+  const handleDeleteResolved = useCallback(() => {
     setShowDeleteModal(false);
     onResolved();
-  };
+  }, [onResolved]);
 
-  const handleMoveResolved = () => {
+  const handleMoveResolved = useCallback(() => {
     setShowMoveToFolderModal(false);
     onResolved();
-  };
+  }, [onResolved]);
 
   const { mutate: bulkDeleteChecks } = useBulkDeleteChecks({ onSuccess: handleDeleteResolved });
 
-  const enableChecks = () => {
+  const enableChecks = useCallback(() => {
     bulkUpdateChecks(checks.filter((check) => !check.enabled).map((check) => ({ ...check, enabled: true })));
-  };
+  }, [bulkUpdateChecks, checks]);
 
-  const disableChecks = () => {
+  const disableChecks = useCallback(() => {
     bulkUpdateChecks(checks.filter((check) => check.enabled).map((check) => ({ ...check, enabled: false })));
-  };
+  }, [bulkUpdateChecks, checks]);
 
-  const deleteChecks = () => {
+  const deleteChecks = useCallback(() => {
     bulkDeleteChecks(checks.map((check) => check.id!));
-  };
+  }, [bulkDeleteChecks, checks]);
 
   const deleteModalProps = {
     title: `Delete ${checks.length} check${checks.length !== 1 ? 's' : ''}`,

--- a/src/page/CheckList/components/BulkActions.tsx
+++ b/src/page/CheckList/components/BulkActions.tsx
@@ -139,13 +139,12 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
           onDismiss={() => setShowDeleteModal(false)}
         />
       )}
-      {showMoveToFolderModal && (
-        <BulkMoveToFolderModal
-          checks={checks}
-          isOpen={showMoveToFolderModal}
-          onDismiss={handleMoveResolved}
-        />
-      )}
+      <BulkMoveToFolderModal
+        checks={checks}
+        isOpen={showMoveToFolderModal}
+        onDismiss={() => setShowMoveToFolderModal(false)}
+        onMoved={handleMoveResolved}
+      />
     </>
   );
 };

--- a/src/page/CheckList/components/BulkActions.tsx
+++ b/src/page/CheckList/components/BulkActions.tsx
@@ -3,12 +3,11 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Button, ButtonCascader, ConfirmModal, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
-import { Check, FeatureName } from 'types';
-import { useBulkCheckPermissions } from 'contexts/CheckFolderAccessContext';
-import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
-import { useBulkDeleteChecks, useBulkUpdateChecks } from 'data/useChecks';
+import { Check } from 'types';
 import { BulkActionsModal } from 'page/CheckList/components/BulkActionsModal';
 import { BulkMoveToFolderModal } from 'page/CheckList/components/BulkMoveToFolderModal';
+
+import { useBulkActions } from './BulkActions.hooks';
 
 interface BulkActionsProps {
   checks: Check[];
@@ -21,37 +20,22 @@ enum BulkAction {
 }
 
 export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
-  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
-  const { canWriteAll, canDeleteAll } = useBulkCheckPermissions(checks);
   const styles = useStyles2(getStyles);
   const [bulkEditAction, setBulkEditAction] = useState<BulkAction | null>(null);
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [showMoveToFolderModal, setShowMoveToFolderModal] = useState(false);
-  const { mutate: bulkUpdateChecks } = useBulkUpdateChecks({ onSuccess: onResolved });
-
-  const handleDeleteResolved = () => {
-    setShowDeleteModal(false);
-    onResolved();
-  };
-
-  const handleMoveResolved = () => {
-    setShowMoveToFolderModal(false);
-    onResolved();
-  };
-
-  const { mutate: bulkDeleteChecks } = useBulkDeleteChecks({ onSuccess: handleDeleteResolved });
-
-  const handleDisableSelectedChecks = () => {
-    bulkUpdateChecks(checks.filter((check) => check.enabled).map((check) => ({ ...check, enabled: false })));
-  };
-
-  const handleEnableSelectedChecks = () => {
-    bulkUpdateChecks(checks.filter((check) => !check.enabled).map((check) => ({ ...check, enabled: true })));
-  };
-
-  const handleDeleteSelectedChecks = () => {
-    bulkDeleteChecks(checks.map((check) => check.id!));
-  };
+  const {
+    isFoldersEnabled,
+    canWriteAll,
+    canDeleteAll,
+    showDeleteModal,
+    setShowDeleteModal,
+    showMoveToFolderModal,
+    setShowMoveToFolderModal,
+    handleMoveResolved,
+    enableChecks,
+    disableChecks,
+    deleteChecks,
+    deleteModalProps,
+  } = useBulkActions({ checks, onResolved });
 
   return (
     <>
@@ -96,7 +80,7 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
           type="button"
           variant="primary"
           fill="text"
-          onClick={handleEnableSelectedChecks}
+          onClick={enableChecks}
           disabled={!canWriteAll}
         >
           Enable
@@ -105,7 +89,7 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
           type="button"
           variant="secondary"
           fill="text"
-          onClick={handleDisableSelectedChecks}
+          onClick={disableChecks}
           disabled={!canWriteAll}
         >
           Disable
@@ -132,10 +116,8 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
       {showDeleteModal && (
         <ConfirmModal
           isOpen={showDeleteModal}
-          title={`Delete ${checks.length} checks`}
-          body="Are you sure you want to delete these checks?"
-          confirmText="Delete checks"
-          onConfirm={handleDeleteSelectedChecks}
+          {...deleteModalProps}
+          onConfirm={deleteChecks}
           onDismiss={() => setShowDeleteModal(false)}
         />
       )}

--- a/src/page/CheckList/components/BulkActions.tsx
+++ b/src/page/CheckList/components/BulkActions.tsx
@@ -3,10 +3,12 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Button, ButtonCascader, ConfirmModal, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
-import { Check } from 'types';
+import { Check, FeatureName } from 'types';
 import { useBulkCheckPermissions } from 'contexts/CheckFolderAccessContext';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 import { useBulkDeleteChecks, useBulkUpdateChecks } from 'data/useChecks';
 import { BulkActionsModal } from 'page/CheckList/components/BulkActionsModal';
+import { BulkMoveToFolderModal } from 'page/CheckList/components/BulkMoveToFolderModal';
 
 interface BulkActionsProps {
   checks: Check[];
@@ -19,14 +21,21 @@ enum BulkAction {
 }
 
 export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
+  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
   const { canWriteAll, canDeleteAll } = useBulkCheckPermissions(checks);
   const styles = useStyles2(getStyles);
   const [bulkEditAction, setBulkEditAction] = useState<BulkAction | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showMoveToFolderModal, setShowMoveToFolderModal] = useState(false);
   const { mutate: bulkUpdateChecks } = useBulkUpdateChecks({ onSuccess: onResolved });
 
   const handleDeleteResolved = () => {
     setShowDeleteModal(false);
+    onResolved();
+  };
+
+  const handleMoveResolved = () => {
+    setShowMoveToFolderModal(false);
     onResolved();
   };
 
@@ -70,6 +79,18 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
           >
             Bulk Edit Probes
           </ButtonCascader>
+        )}
+        {isFoldersEnabled && (
+          <Button
+            type="button"
+            variant="secondary"
+            fill="text"
+            icon="folder"
+            onClick={() => setShowMoveToFolderModal(true)}
+            disabled={!canWriteAll}
+          >
+            Move to folder
+          </Button>
         )}
         <Button
           type="button"
@@ -116,6 +137,13 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
           confirmText="Delete checks"
           onConfirm={handleDeleteSelectedChecks}
           onDismiss={() => setShowDeleteModal(false)}
+        />
+      )}
+      {showMoveToFolderModal && (
+        <BulkMoveToFolderModal
+          checks={checks}
+          isOpen={showMoveToFolderModal}
+          onDismiss={handleMoveResolved}
         />
       )}
     </>

--- a/src/page/CheckList/components/BulkMoveToFolderModal.tsx
+++ b/src/page/CheckList/components/BulkMoveToFolderModal.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Alert, Button, Field, Modal } from '@grafana/ui';
+
+import { Check } from 'types';
+import { useBulkUpdateChecks } from 'data/useChecks';
+import { FolderSelector } from 'components/FolderSelector/FolderSelector';
+import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
+
+interface BulkMoveToFolderModalProps {
+  checks: Check[];
+  isOpen: boolean;
+  onDismiss: () => void;
+}
+
+export function BulkMoveToFolderModal(props: BulkMoveToFolderModalProps) {
+  return (
+    <QueryErrorBoundary>
+      <BulkMoveToFolderModalContent {...props} />
+    </QueryErrorBoundary>
+  );
+}
+
+function BulkMoveToFolderModalContent({ checks, isOpen, onDismiss }: BulkMoveToFolderModalProps) {
+  const [targetFolderUid, setTargetFolderUid] = useState<string | undefined>();
+  const { mutate: bulkUpdateChecks, isPending, isError } = useBulkUpdateChecks({ onSuccess: onDismiss });
+
+  const handleSubmit = () => {
+    if (!targetFolderUid) {
+      return;
+    }
+
+    const updatedChecks = checks.map((check) => ({ ...check, folderUid: targetFolderUid }));
+    bulkUpdateChecks(updatedChecks);
+  };
+
+  return (
+    <Modal
+      title={`Move ${checks.length} check${checks.length !== 1 ? 's' : ''} to folder`}
+      isOpen={isOpen}
+      onDismiss={onDismiss}
+    >
+      {isError && (
+        <Alert title="Bulk move failed" severity="error">
+          The move operation failed. Try selecting fewer checks and retrying.
+        </Alert>
+      )}
+      <Field label="Target folder" description="All selected checks will be moved to this folder.">
+        <FolderSelector
+          value={targetFolderUid}
+          onChange={setTargetFolderUid}
+          autoSelectDefault={false}
+          aria-label="Select target folder"
+        />
+      </Field>
+      <Modal.ButtonRow>
+        <Button variant="secondary" onClick={onDismiss} type="button">
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          disabled={!targetFolderUid || isPending}
+          icon={isPending ? 'fa fa-spinner' : undefined}
+        >
+          {isPending ? 'Moving...' : 'Move'}
+        </Button>
+      </Modal.ButtonRow>
+    </Modal>
+  );
+}

--- a/src/page/CheckList/components/BulkMoveToFolderModal.tsx
+++ b/src/page/CheckList/components/BulkMoveToFolderModal.tsx
@@ -10,6 +10,7 @@ interface BulkMoveToFolderModalProps {
   checks: Check[];
   isOpen: boolean;
   onDismiss: () => void;
+  onMoved: () => void;
 }
 
 export function BulkMoveToFolderModal(props: BulkMoveToFolderModalProps) {
@@ -20,9 +21,9 @@ export function BulkMoveToFolderModal(props: BulkMoveToFolderModalProps) {
   );
 }
 
-function BulkMoveToFolderModalContent({ checks, isOpen, onDismiss }: BulkMoveToFolderModalProps) {
+function BulkMoveToFolderModalContent({ checks, isOpen, onDismiss, onMoved }: BulkMoveToFolderModalProps) {
   const [targetFolderUid, setTargetFolderUid] = useState<string | undefined>();
-  const { mutate: bulkUpdateChecks, isPending, isError } = useBulkUpdateChecks({ onSuccess: onDismiss });
+  const { mutate: bulkUpdateChecks, isPending, isError } = useBulkUpdateChecks({ onSuccess: onMoved });
 
   const handleSubmit = () => {
     if (!targetFolderUid) {

--- a/src/page/CheckList/components/BulkMoveToFolderModal.tsx
+++ b/src/page/CheckList/components/BulkMoveToFolderModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Alert, Button, Field, Modal } from '@grafana/ui';
 
 import { Check } from 'types';
@@ -24,6 +24,12 @@ export function BulkMoveToFolderModal(props: BulkMoveToFolderModalProps) {
 function BulkMoveToFolderModalContent({ checks, isOpen, onDismiss, onMoved }: BulkMoveToFolderModalProps) {
   const [targetFolderUid, setTargetFolderUid] = useState<string | undefined>();
   const { mutate: bulkUpdateChecks, isPending, isError } = useBulkUpdateChecks({ onSuccess: onMoved });
+
+  useEffect(() => {
+    if (isOpen) {
+      setTargetFolderUid(undefined);
+    }
+  }, [isOpen]);
 
   const handleSubmit = () => {
     if (!targetFolderUid) {

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -241,6 +241,14 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
   return (
     <div className={isRoot ? styles.folderGroup : styles.nestedFolder}>
       <div className={isRoot ? styles.folderHeaderRoot : styles.folderHeaderNested}>
+        {totalChecks > 0 && (
+          <Checkbox
+            aria-label={`Select all checks in ${node.folder?.title ?? 'folder'}`}
+            checked={isAllInFolderSelected}
+            indeterminate={isSomeInFolderSelected}
+            onChange={handleFolderSelectAll}
+          />
+        )}
         <button
           className={styles.folderToggle}
           onClick={() => toggleFolder(node.folderUid)}
@@ -284,20 +292,10 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
             </span>
           </Stack>
         </button>
-        {totalChecks > 0 && (
+        {selectedCount > 0 && (
           <div className={styles.folderActions}>
-            {selectedCount > 0 && (
-              <>
-                <FolderBulkActions checks={selectedChecksInFolder} onResolved={handleFolderBulkResolved} />
-                <span className={styles.selectedCount}>{selectedCount} selected</span>
-              </>
-            )}
-            <Checkbox
-              aria-label={`Select all checks in ${node.folder?.title ?? 'folder'}`}
-              checked={isAllInFolderSelected}
-              indeterminate={isSomeInFolderSelected}
-              onChange={handleFolderSelectAll}
-            />
+            <FolderBulkActions checks={selectedChecksInFolder} onResolved={handleFolderBulkResolved} />
+            <span className={styles.selectedCount}>{selectedCount} selected</span>
           </div>
         )}
       </div>

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -1,15 +1,16 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Icon, Pagination, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import { Button, Checkbox, Icon, Pagination, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { CheckListViewType } from 'page/CheckList/CheckList.types';
 import { Check, CheckType, GrafanaFolder, Label } from 'types';
 import { CheckRuntimeAlertStates, getCheckRuntimeAlertState } from 'data/useCheckAlertStates';
-import { buildChecksByFolder, collectAllFolderUids, FolderNode, getTotalCheckCount } from 'hooks/useChecksByFolder';
+import { buildChecksByFolder, collectAllCheckIds, collectAllChecks, collectAllFolderUids, FolderNode, getTotalCheckCount } from 'hooks/useChecksByFolder';
 import { Feedback } from 'components/Feedback';
 import { CHECKS_PER_PAGE_CARD } from 'page/CheckList/CheckList.constants';
 import { CheckListItem } from 'page/CheckList/components/CheckListItem';
+import { FolderBulkActions } from 'page/CheckList/components/FolderBulkActions';
 
 interface CheckListFolderViewProps {
   checks: Check[];
@@ -25,6 +26,8 @@ interface CheckListFolderViewProps {
   onStatusSelect: (enabled: boolean) => void;
   onTypeSelect: (checkType: CheckType) => void;
   onToggleCheckbox: (checkId: number) => void;
+  onSelectChecks: (checkIds: number[]) => void;
+  onDeselectChecks: (checkIds: number[]) => void;
   selectedCheckIds: Set<number>;
 }
 
@@ -42,6 +45,8 @@ export function CheckListFolderView({
   onStatusSelect,
   onTypeSelect,
   onToggleCheckbox,
+  onSelectChecks,
+  onDeselectChecks,
   selectedCheckIds,
 }: CheckListFolderViewProps) {
   const styles = useStyles2(getStyles);
@@ -107,6 +112,8 @@ export function CheckListFolderView({
     onStatusSelect,
     onTypeSelect,
     onToggleCheckbox,
+    onSelectChecks,
+    onDeselectChecks,
     selectedCheckIds,
   };
 
@@ -187,6 +194,8 @@ interface CheckItemCallbacks {
   onStatusSelect: (enabled: boolean) => void;
   onTypeSelect: (checkType: CheckType) => void;
   onToggleCheckbox: (checkId: number) => void;
+  onSelectChecks: (checkIds: number[]) => void;
+  onDeselectChecks: (checkIds: number[]) => void;
   selectedCheckIds: Set<number>;
 }
 
@@ -207,51 +216,91 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
 
   const isRoot = depth === 0;
 
+  const allFolderCheckIds = useMemo(() => collectAllCheckIds(node), [node]);
+  const allChecksInFolder = useMemo(() => collectAllChecks(node), [node]);
+  const selectedChecksInFolder = useMemo(
+    () => allChecksInFolder.filter((c) => checkItemProps.selectedCheckIds.has(c.id!)),
+    [allChecksInFolder, checkItemProps.selectedCheckIds]
+  );
+  const selectedCount = selectedChecksInFolder.length;
+  const isAllInFolderSelected = totalChecks > 0 && selectedCount === totalChecks;
+  const isSomeInFolderSelected = selectedCount > 0 && !isAllInFolderSelected;
+
+  const handleFolderSelectAll = () => {
+    if (isAllInFolderSelected) {
+      checkItemProps.onDeselectChecks(allFolderCheckIds);
+    } else {
+      checkItemProps.onSelectChecks(allFolderCheckIds);
+    }
+  };
+
+  const handleFolderBulkResolved = () => {
+    checkItemProps.onDeselectChecks(allFolderCheckIds);
+  };
+
   return (
     <div className={isRoot ? styles.folderGroup : styles.nestedFolder}>
-      <button
-        className={isRoot ? styles.folderHeaderRoot : styles.folderHeaderNested}
-        onClick={() => toggleFolder(node.folderUid)}
-        aria-expanded={isExpanded}
-        aria-label={`${isExpanded ? 'Collapse' : 'Expand'} folder ${node.folder?.title ?? node.folderUid}`}
-        type="button"
-      >
-        <Stack gap={1.5} alignItems="center" wrap="wrap">
-          <Icon name={isExpanded ? 'angle-down' : 'angle-right'} size="lg" />
-          {node.isOrphaned && !checkItemProps.foldersLoading ? (
-            <Tooltip content={`Folder UID: ${node.folderUid}`}>
-              <Icon name="exclamation-triangle" />
-            </Tooltip>
-          ) : (
-            <Icon name={isExpanded ? 'folder-open' : 'folder'} />
-          )}
-          <span className={isRoot ? styles.folderTitleRoot : styles.folderTitleNested}>
-            {node.isOrphaned && checkItemProps.foldersLoading ? (
-              <Spinner size="sm" />
-            ) : node.isOrphaned && checkItemProps.foldersError ? (
-              'Failed to load folder info'
-            ) : node.isOrphaned ? (
-              <span className={styles.orphanedLabel}>Folder not found</span>
+      <div className={isRoot ? styles.folderHeaderRoot : styles.folderHeaderNested}>
+        <button
+          className={styles.folderToggle}
+          onClick={() => toggleFolder(node.folderUid)}
+          aria-expanded={isExpanded}
+          aria-label={`${isExpanded ? 'Collapse' : 'Expand'} folder ${node.folder?.title ?? node.folderUid}`}
+          type="button"
+        >
+          <Stack gap={1.5} alignItems="center" wrap="wrap">
+            <Icon name={isExpanded ? 'angle-down' : 'angle-right'} size="lg" />
+            {node.isOrphaned && !checkItemProps.foldersLoading ? (
+              <Tooltip content={`Folder UID: ${node.folderUid}`}>
+                <Icon name="exclamation-triangle" />
+              </Tooltip>
             ) : (
-              node.folder?.title ?? node.folderUid
+              <Icon name={isExpanded ? 'folder-open' : 'folder'} />
             )}
-          </span>
-          {node.isOrphaned && !checkItemProps.foldersLoading && checkItemProps.foldersError && onRetryFolders && (
-            <Button
-              variant="secondary"
-              size="sm"
-              icon="sync"
-              onClick={(e) => { e.stopPropagation(); onRetryFolders(); }}
-              tooltip="Retry loading folders"
-            >
-              Retry
-            </Button>
-          )}
-          <span className={styles.checkCount}>
-            {totalChecks} {totalChecks === 1 ? 'check' : 'checks'}
-          </span>
-        </Stack>
-      </button>
+            <span className={isRoot ? styles.folderTitleRoot : styles.folderTitleNested}>
+              {node.isOrphaned && checkItemProps.foldersLoading ? (
+                <Spinner size="sm" />
+              ) : node.isOrphaned && checkItemProps.foldersError ? (
+                'Failed to load folder info'
+              ) : node.isOrphaned ? (
+                <span className={styles.orphanedLabel}>Folder not found</span>
+              ) : (
+                node.folder?.title ?? node.folderUid
+              )}
+            </span>
+            {node.isOrphaned && !checkItemProps.foldersLoading && checkItemProps.foldersError && onRetryFolders && (
+              <Button
+                variant="secondary"
+                size="sm"
+                icon="sync"
+                onClick={(e) => { e.stopPropagation(); onRetryFolders(); }}
+                tooltip="Retry loading folders"
+              >
+                Retry
+              </Button>
+            )}
+            <span className={styles.checkCount}>
+              {totalChecks} {totalChecks === 1 ? 'check' : 'checks'}
+            </span>
+          </Stack>
+        </button>
+        {totalChecks > 0 && (
+          <div className={styles.folderActions}>
+            {selectedCount > 0 && (
+              <>
+                <FolderBulkActions checks={selectedChecksInFolder} onResolved={handleFolderBulkResolved} />
+                <span className={styles.selectedCount}>{selectedCount} selected</span>
+              </>
+            )}
+            <Checkbox
+              aria-label={`Select all checks in ${node.folder?.title ?? 'folder'}`}
+              checked={isAllInFolderSelected}
+              indeterminate={isSomeInFolderSelected}
+              onChange={handleFolderSelectAll}
+            />
+          </div>
+        )}
+      </div>
 
       {isExpanded && hasContent && (
         <div className={isRoot ? styles.folderContentRoot : styles.folderContentNested}>
@@ -360,47 +409,51 @@ const getStyles = (theme: GrafanaTheme2) => ({
     borderTop: `1px solid ${theme.colors.border.weak}`,
   }),
   folderHeaderRoot: css({
-    appearance: 'none',
-    border: 'none',
-    background: 'none',
-    width: '100%',
-    textAlign: 'left',
-    font: 'inherit',
-    color: 'inherit',
     display: 'flex',
     alignItems: 'center',
+    justifyContent: 'space-between',
     padding: theme.spacing(1.5, 2),
     backgroundColor: theme.colors.background.secondary,
-    cursor: 'pointer',
-    userSelect: 'none',
-    '&:hover': {
-      backgroundColor: theme.colors.action.hover,
-    },
-    '&:focus-visible': {
-      outline: `2px solid ${theme.colors.primary.border}`,
-      outlineOffset: -2,
-    },
+    gap: theme.spacing(2),
   }),
   folderHeaderNested: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: theme.spacing(1, 2),
+    gap: theme.spacing(2),
+  }),
+  folderToggle: css({
     appearance: 'none',
     border: 'none',
     background: 'none',
-    width: '100%',
+    padding: 0,
     textAlign: 'left',
     font: 'inherit',
     color: 'inherit',
-    display: 'flex',
-    alignItems: 'center',
-    padding: theme.spacing(1, 2),
     cursor: 'pointer',
     userSelect: 'none',
+    flex: '1 1 auto',
+    minWidth: 0,
     '&:hover': {
-      backgroundColor: theme.colors.action.hover,
+      color: theme.colors.text.maxContrast,
     },
     '&:focus-visible': {
       outline: `2px solid ${theme.colors.primary.border}`,
-      outlineOffset: -2,
+      outlineOffset: 2,
+      borderRadius: theme.shape.radius.default,
     },
+  }),
+  folderActions: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    flexShrink: 0,
+  }),
+  selectedCount: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    whiteSpace: 'nowrap',
   }),
   folderTitleRoot: css({
     fontWeight: theme.typography.fontWeightMedium,

--- a/src/page/CheckList/components/FolderBulkActions.tsx
+++ b/src/page/CheckList/components/FolderBulkActions.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { ConfirmModal, IconButton, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { Check } from 'types';
+import { BulkMoveToFolderModal } from 'page/CheckList/components/BulkMoveToFolderModal';
+
+import { useBulkActions } from './BulkActions.hooks';
+
+interface FolderBulkActionsProps {
+  checks: Check[];
+  onResolved: () => void;
+}
+
+export function FolderBulkActions({ checks, onResolved }: FolderBulkActionsProps) {
+  const styles = useStyles2(getStyles);
+  const {
+    isFoldersEnabled,
+    canWriteAll,
+    canDeleteAll,
+    showDeleteModal,
+    setShowDeleteModal,
+    showMoveToFolderModal,
+    setShowMoveToFolderModal,
+    handleMoveResolved,
+    enableChecks,
+    disableChecks,
+    deleteChecks,
+    deleteModalProps,
+  } = useBulkActions({ checks, onResolved });
+
+  return (
+    <div className={styles.container}>
+      {isFoldersEnabled && (
+        <IconButton
+          name="folder"
+          aria-label="Move to folder"
+          tooltip="Move to folder"
+          size="sm"
+          onClick={(e) => { e.stopPropagation(); setShowMoveToFolderModal(true); }}
+          disabled={!canWriteAll}
+        />
+      )}
+      <IconButton
+        name="check-circle"
+        aria-label="Enable"
+        tooltip="Enable"
+        size="sm"
+        onClick={(e) => { e.stopPropagation(); enableChecks(); }}
+        disabled={!canWriteAll}
+      />
+      <IconButton
+        name="pause-circle"
+        aria-label="Disable"
+        tooltip="Disable"
+        size="sm"
+        onClick={(e) => { e.stopPropagation(); disableChecks(); }}
+        disabled={!canWriteAll}
+      />
+      <IconButton
+        name="trash-alt"
+        aria-label="Delete"
+        tooltip="Delete"
+        size="sm"
+        variant="destructive"
+        onClick={(e) => { e.stopPropagation(); setShowDeleteModal(true); }}
+        disabled={!canDeleteAll}
+      />
+      {showDeleteModal && (
+        <ConfirmModal
+          isOpen={showDeleteModal}
+          {...deleteModalProps}
+          onConfirm={deleteChecks}
+          onDismiss={() => setShowDeleteModal(false)}
+        />
+      )}
+      <BulkMoveToFolderModal
+        checks={checks}
+        isOpen={showMoveToFolderModal}
+        onDismiss={() => setShowMoveToFolderModal(false)}
+        onMoved={handleMoveResolved}
+      />
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+  }),
+});

--- a/src/test/fixtures/folderChecks.ts
+++ b/src/test/fixtures/folderChecks.ts
@@ -1,0 +1,46 @@
+import { Check } from 'types';
+
+import { BASIC_DNS_CHECK, BASIC_HTTP_CHECK, BASIC_PING_CHECK } from './checks';
+import { FOLDER_FORBIDDEN_UID, FOLDER_PRODUCTION, FOLDER_READONLY, FOLDER_STAGING } from './folders';
+
+export const CHECK_IN_PRODUCTION: Check = {
+  ...BASIC_HTTP_CHECK,
+  id: 200,
+  job: 'Production HTTP check',
+  folderUid: FOLDER_PRODUCTION.uid,
+};
+
+export const CHECK_IN_STAGING: Check = {
+  ...BASIC_DNS_CHECK,
+  id: 201,
+  job: 'Staging DNS check',
+  folderUid: FOLDER_STAGING.uid,
+};
+
+export const CHECK_IN_READONLY_FOLDER: Check = {
+  ...BASIC_PING_CHECK,
+  id: 202,
+  job: 'Read-only folder check',
+  folderUid: FOLDER_READONLY.uid,
+};
+
+export const CHECK_IN_FORBIDDEN_FOLDER: Check = {
+  ...BASIC_HTTP_CHECK,
+  id: 203,
+  job: 'Forbidden folder check',
+  folderUid: FOLDER_FORBIDDEN_UID,
+};
+
+export const CHECK_WITHOUT_FOLDER: Check = {
+  ...BASIC_PING_CHECK,
+  id: 204,
+  job: 'Unassigned check',
+  folderUid: undefined,
+};
+
+export const CHECK_WITH_ORPHANED_FOLDER: Check = {
+  ...BASIC_DNS_CHECK,
+  id: 205,
+  job: 'Orphaned folder check',
+  folderUid: 'deleted-folder-uid',
+};


### PR DESCRIPTION
## Feat: add folders bulk assignment

Addresses: https://github.com/grafana/synthetic-monitoring/issues/525

## Problem

When users have many checks across different folders, there is no way to reassign multiple checks to a different folder at once. Users must edit each check individually to change its folder, which is tedious at scale. Additionally, the folder selector in both the check form and the bulk move modal shows all visible folders regardless of the user's permission level, allowing users to select folders they only have View access on, where saving or moving would be invalid.

## Solution

Adds a "Move to folder" action to the existing bulk actions bar. When checks are selected, users can pick a target folder from a combobox and move them all at once via the existing bulk update API (`POST /sm/check/update/bulk`). The action is gated behind `FeatureName.Folders` and respects the M3 permission model. The button is disabled when the user lacks write permission on any of the selected checks (determined by the combined SM RBAC + folder permission model).

The folder selector now filters out folders where the user does not have Edit permission. This applies to all consumers of `FolderSelector`: both the bulk move modal and the check edit form benefit from the same protection.


https://github.com/user-attachments/assets/08b12063-c960-4221-b267-b8c871d5705b


https://github.com/user-attachments/assets/1f937d1c-d5e1-4cfa-83af-d95cdd447f1d

