### PR TITLE
feat: promote folder view and add folder analytics

### DIFF
--- a/docs/analytics/analytics-events.md
+++ b/docs/analytics/analytics-events.md
@@ -180,6 +180,22 @@ Tracks when a feature feedback comment is submitted.
 | reaction | `"good" \| "bad"` | The reaction to the feature. |
 | comment  | `string`          | The comment text.            |
 
+### folders
+
+#### synthetic-monitoring_folders_folder_selected
+
+Tracks when a folder is selected in the folder selector.
+
+##### Properties
+
+| name      | type            | description                                           |
+| --------- | --------------- | ----------------------------------------------------- |
+| isDefault | `false \| true` | Whether the selected folder is the default SM folder. |
+
+#### synthetic-monitoring_folders_folder_created
+
+Tracks when a new folder is created via the folder selector.
+
 ### link
 
 #### synthetic-monitoring_link_clicked

--- a/src/components/FolderSelector/FolderSelector.tsx
+++ b/src/components/FolderSelector/FolderSelector.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Alert, Button, Combobox, ComboboxOption, Field, Input, LoadingPlaceholder, Modal, Stack } from '@grafana/ui';
+import { trackFolderCreated, trackFolderSelected } from 'features/tracking/folderEvents';
 
 import { GrafanaFolder } from 'types';
 import { DEFAULT_FOLDER_TITLE } from 'data/folders.constants';
@@ -54,10 +55,14 @@ export function FolderSelector({ value, onChange, disabled, 'aria-label': ariaLa
   }, [childFolders, defaultFolder, value]);
 
   const handleChange = (selected: ComboboxOption<string> | null) => {
+    if (selected?.value) {
+      trackFolderSelected({ isDefault: selected.value === defaultFolderUid });
+    }
     onChange(selected?.value ?? undefined);
   };
 
   const handleFolderCreated = (folder: GrafanaFolder) => {
+    trackFolderCreated();
     onChange(folder.uid);
     setShowCreateModal(false);
   };

--- a/src/features/tracking/folderEvents.ts
+++ b/src/features/tracking/folderEvents.ts
@@ -1,0 +1,14 @@
+import { createSMEventFactory, TrackingEventProps } from 'features/tracking/utils';
+
+const folderEvents = createSMEventFactory('folders');
+
+interface FolderSelectedEvent extends TrackingEventProps {
+  /** Whether the selected folder is the default SM folder. */
+  isDefault: boolean;
+}
+
+/** Tracks when a folder is selected in the folder selector. */
+export const trackFolderSelected = folderEvents<FolderSelectedEvent>('folder_selected');
+
+/** Tracks when a new folder is created via the folder selector. */
+export const trackFolderCreated = folderEvents('folder_created');

--- a/src/page/CheckList/CheckList.folderView.test.tsx
+++ b/src/page/CheckList/CheckList.folderView.test.tsx
@@ -162,13 +162,13 @@ describe('CheckList - Folder Badge', () => {
     beforeEach(() => mockFeatureToggles({ [FeatureName.Folders]: true }));
 
     test('displays folder path badge on check cards', async () => {
-      await renderCheckList([CHECK_IN_PRODUCTION]);
+      await renderCheckList([CHECK_IN_PRODUCTION], 'view=card');
 
       expect(await screen.findByText(FOLDER_PRODUCTION.title, {}, { timeout: 5000 })).toBeInTheDocument();
     });
 
     test('displays "Folder deleted" badge for orphaned folder', async () => {
-      await renderCheckList([CHECK_WITH_ORPHANED_FOLDER]);
+      await renderCheckList([CHECK_WITH_ORPHANED_FOLDER], 'view=card');
 
       await waitFor(
         () => expect(screen.getByText('Folder deleted')).toBeInTheDocument(),
@@ -177,7 +177,7 @@ describe('CheckList - Folder Badge', () => {
     });
 
     test('does not display folder badge for checks without a folder', async () => {
-      await renderCheckList([CHECK_WITHOUT_FOLDER]);
+      await renderCheckList([CHECK_WITHOUT_FOLDER], 'view=card');
 
       await screen.findByTestId(DataTestIds.CheckCard);
       expect(screen.queryByText('Folder deleted')).not.toBeInTheDocument();

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -38,9 +38,10 @@ import { CheckListHeader } from 'page/CheckList/components/CheckListHeader';
 import { CheckListItem } from 'page/CheckList/components/CheckListItem';
 
 export const CheckList = () => {
+  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
   const [viewType, setViewType] = useQueryParametersState<CheckListViewType>({
     key: 'view',
-    initialValue: CheckListViewType.Card,
+    initialValue: isFoldersEnabled ? CheckListViewType.Folder : CheckListViewType.Card,
     encode: (value) => value.toString(),
     decode: (value) => value as CheckListViewType,
   });

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -7,6 +7,7 @@ import { CheckListViewType } from 'page/CheckList/CheckList.types';
 import { Check, CheckType, GrafanaFolder, Label } from 'types';
 import { CheckRuntimeAlertStates, getCheckRuntimeAlertState } from 'data/useCheckAlertStates';
 import { buildChecksByFolder, collectAllFolderUids, FolderNode, getTotalCheckCount } from 'hooks/useChecksByFolder';
+import { Feedback } from 'components/Feedback';
 import { CHECKS_PER_PAGE_CARD } from 'page/CheckList/CheckList.constants';
 import { CheckListItem } from 'page/CheckList/components/CheckListItem';
 
@@ -84,7 +85,10 @@ export function CheckListFolderView({
       {folderTree.length > 0 && (
         <div className={styles.foldersSection}>
           <div className={styles.foldersSectionHeader}>
-            <h3 className={styles.sectionTitle}>Folders ({allUids.length})</h3>
+            <h3 className={styles.sectionTitle}>
+              Folders ({allUids.length})
+              <Feedback feature="folder-view" about={{ text: 'New feature!' }} />
+            </h3>
             <Stack gap={1}>
               <Button
                 variant="secondary"

--- a/src/page/CheckList/components/CheckListViewSwitcher.tsx
+++ b/src/page/CheckList/components/CheckListViewSwitcher.tsx
@@ -21,7 +21,7 @@ export function CheckListViewSwitcher({ viewType, onChange }: CheckListViewSwitc
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
   const options = useMemo(() => {
     if (isFoldersEnabled) {
-      return [...BASE_VIEW_TYPE_OPTIONS, FOLDER_VIEW_OPTION];
+      return [FOLDER_VIEW_OPTION, ...BASE_VIEW_TYPE_OPTIONS];
     }
     return BASE_VIEW_TYPE_OPTIONS;
   }, [isFoldersEnabled]);


### PR DESCRIPTION
Part of https://github.com/grafana/synthetic-monitoring/issues/519

## Problem

The folder view was added as the last option in the view switcher, making it easy to overlook. Users with the folders feature enabled had no indication that it was a new feature, and there was no analytics tracking on folder selection or creation to measure adoption.

## Solution

- Moves the folder view to the first position in the view switcher and makes it the default view when the folders feature is enabled.
- Adds a `Feedback` widget next to the "Folders" heading in the folder view so users can provide early reactions.
- Adds analytics tracking for folder selection and folder creation in the folder selector.

<img width="2221" height="1213" alt="image" src="https://github.com/user-attachments/assets/60df7a8d-15b8-42d2-82b5-b0f6e74a8b6a" />
