### PR TITLE
fix: update cal response to use names attribute

### DIFF
--- a/src/components/Checkster/components/form/layouts/GenericLabelContent.test.tsx
+++ b/src/components/Checkster/components/form/layouts/GenericLabelContent.test.tsx
@@ -16,7 +16,7 @@ jest.mock('../../../hooks/useRelevantErrors', () => ({
   useRelevantErrors: jest.fn(() => []),
 }));
 
-const calNames = TENANT_COST_ATTRIBUTION_LABELS.items;
+const calNames = TENANT_COST_ATTRIBUTION_LABELS.names;
 
 function renderGenericLabelContent(
   props: Partial<React.ComponentProps<typeof GenericLabelContent>> = {},

--- a/src/components/Checkster/components/form/sections/LabelSection.tsx
+++ b/src/components/Checkster/components/form/sections/LabelSection.tsx
@@ -32,7 +32,7 @@ export function LabelSection() {
       <GenericLabelContent
         description={description}
         isLoading={isInitialLoad}
-        calNames={calData?.items ?? []}
+        calNames={calData?.names ?? []}
         labelLimit={maxAllowedMetricLabels}
       />
     </FormSection>

--- a/src/datasource/responses.types.ts
+++ b/src/datasource/responses.types.ts
@@ -89,7 +89,7 @@ export type TenantResponse = {
 };
 
 export type ListTenantCostAttributionLabelsResponse = {
-  items: string[];
+  names: string[];
 };
 
 export type ListTenantLimitsResponse = {

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -75,7 +75,7 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
   const filters = useCheckFilters();
   const { isEnabled: isCALsEnabled } = useFeatureFlag(FeatureName.CALs);
   const { data: calData } = useTenantCostAttributionLabels();
-  const calNames = useMemo(() => (isCALsEnabled ? calData?.items ?? [] : []), [isCALsEnabled, calData?.items]);
+  const calNames = useMemo(() => (isCALsEnabled ? calData?.names ?? [] : []), [isCALsEnabled, calData?.names]);
 
   // Animate the initial alert-based reorder only once, when alert states first arrive.
   // Subsequent refetches re-sort silently to avoid distracting repeated animations.

--- a/src/page/NewCheck/__tests__/v2/apiEndpointChecks/CommonFields.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/apiEndpointChecks/CommonFields.payload.test.tsx
@@ -20,7 +20,7 @@ import { fillMandatoryFields } from '../../../../__testHelpers__/v2.utils';
 
 jest.mock('data/useTenantCostAttributionLabels', () => ({
   useTenantCostAttributionLabels: () => ({
-    data: { items: [] },
+    data: { names: [] },
     isLoading: false,
   }),
 }));

--- a/src/page/NewCheck/__tests__/v2/browserChecks/browser/3-labels.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/browserChecks/browser/3-labels.payload.test.tsx
@@ -8,7 +8,7 @@ import { fillMandatoryFields } from 'page/__testHelpers__/v2.utils';
 
 jest.mock('data/useTenantCostAttributionLabels', () => ({
   useTenantCostAttributionLabels: () => ({
-    data: { items: [] },
+    data: { names: [] },
     isLoading: false,
   }),
 }));

--- a/src/page/NewCheck/__tests__/v2/multiStepChecks/multiHttp/3-labels.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/multiStepChecks/multiHttp/3-labels.payload.test.tsx
@@ -8,7 +8,7 @@ import { fillMandatoryFields } from 'page/__testHelpers__/v2.utils';
 
 jest.mock('data/useTenantCostAttributionLabels', () => ({
   useTenantCostAttributionLabels: () => ({
-    data: { items: [] },
+    data: { names: [] },
     isLoading: false,
   }),
 }));

--- a/src/page/NewCheck/__tests__/v2/scriptedChecks/scripted/3-labels.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/scriptedChecks/scripted/3-labels.payload.test.tsx
@@ -8,7 +8,7 @@ import { fillMandatoryFields } from 'page/__testHelpers__/v2.utils';
 
 jest.mock('data/useTenantCostAttributionLabels', () => ({
   useTenantCostAttributionLabels: () => ({
-    data: { items: [] },
+    data: { names: [] },
     isLoading: false,
   }),
 }));

--- a/src/test/fixtures/tenants.ts
+++ b/src/test/fixtures/tenants.ts
@@ -50,7 +50,7 @@ export const TENANT_SETTINGS: ListTenantSettingsResult = {
 export const UPDATE_TENANT_SETTINGS: UpdateTenantSettingsResult = { msg: 'Settings updated' };
 
 export const TENANT_COST_ATTRIBUTION_LABELS: ListTenantCostAttributionLabelsResponse = {
-  items: ['Team', 'Service'],
+  names: ['Team', 'Service'],
 };
 
 export const TENANT_LIMITS: ListTenantLimitsResponse = {


### PR DESCRIPTION
There was a mismatch in the expected response from the app and what was defined in the openapi spec:
https://synthetic-monitoring-api-dev.grafana-dev.net/api/v1/swagger#/operations/GET_/api/v1/tenant/cals

The expected response has the following format:

```json
{
  "names": [
    "string"
  ]
}
```

This updates all the refernces to be names so that data flows through properly. I've tested this out against my personal stack using graft and validated against live data.

https://github.com/user-attachments/assets/f0c0afa0-1004-4339-acc0-f0232c65a514

