### PR TITLE
fix: include k6/secrets types when version management is enabled

### DIFF
--- a/src/components/CodeEditor/CodeEditor.tsx
+++ b/src/components/CodeEditor/CodeEditor.tsx
@@ -7,6 +7,8 @@ import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
 import { CodeEditorProps, ConstrainedEditorProps } from './CodeEditor.types';
 // import { Overlay } from 'components/Overlay';
 import k6Types from './k6.types';
+import { FeatureName } from 'types';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 
 import { useK6TypesForChannel } from './k6TypesLoader/useK6TypesForChannel';
 import { initializeConstrainedInstance, updateConstrainedEditorRanges } from './CodeEditor.utils';
@@ -31,8 +33,14 @@ const addK6Types = (monaco: typeof monacoType, types: Record<string, string> = k
   // Clear existing k6 types first
   clearK6Types(monaco);
 
+  // Filter types based on feature flags
+  const filteredTypes = { ...types };
+  if (!isFeatureEnabled(FeatureName.SecretsManagement)) {
+    delete filteredTypes['k6/secrets'];
+  }
+
   // Add new k6 types
-  Object.entries(types).forEach(([name, type]) => {
+  Object.entries(filteredTypes).forEach(([name, type]) => {
     const uri = `file:///k6-types/${name.replace(/\//g, '-')}.d.ts`;
     monaco.languages.typescript.javascriptDefaults.addExtraLib(`declare module '${name}' { ${type} }`, uri);
     currentK6LibUris.push(uri);

--- a/src/components/CodeEditor/k6.types.ts
+++ b/src/components/CodeEditor/k6.types.ts
@@ -66,5 +66,5 @@ export default {
   'k6/experimental/redis': k6ExperimentalRedis,
   'k6/experimental/streams': k6ExperimentalStreams,
   'k6/experimental/websockets': k6ExperimentalWebsockets,
-  ...(secretsEnabled ? { 'k6/secrets': k6Secrets } : undefined),
+  ...(secretsEnabled ? { 'k6/secrets': k6Secrets } : {}),
 };

--- a/src/components/CodeEditor/k6TypesLoader/k6TypesCdnLoader.ts
+++ b/src/components/CodeEditor/k6TypesLoader/k6TypesCdnLoader.ts
@@ -21,6 +21,7 @@ const K6_MODULES: K6ModuleDefinition[] = [
   { name: 'k6/experimental/redis', path: 'experimental/redis/index.d.ts' },
   { name: 'k6/experimental/streams', path: 'experimental/streams/index.d.ts' },
   { name: 'k6/experimental/websockets', path: 'experimental/websockets/index.d.ts' },
+  { name: 'k6/secrets', path: 'secrets/index.d.ts' },
 ];
 
 const CDN_BASE_URL = 'https://unpkg.com/@types/k6';


### PR DESCRIPTION
## Problem

When version management is enabled, the script editor fetches `@types/k6` definitions from the Unpkg CDN and replaces the bundled `k6.types.ts` fallback. The CDN loader's module list was missing `k6/secrets`, so once dynamic types loaded, imports from `k6/secrets` in scripts would be reported as errors by Monaco even when the Secrets Management feature was enabled — losing autocomplete and type checking for that module.

## Solution

- Add `k6/secrets` to the CDN module list in `k6TypesCdnLoader` so it is fetched alongside the other `@types/k6` submodules.
- Filter `k6/secrets` out of the type registration step in `CodeEditor` when the `SecretsManagement` feature flag is disabled, so the types only surface in Monaco for tenants that can actually use them. This keeps the flag gate in one place regardless of whether types come from the CDN or the bundled fallback.


Made with [Cursor](https://cursor.com)