### PR TITLE
chore: use grafana secrets api

### DIFF
--- a/src/data/clients/SecretsManagerClient/SecretsManagerClient.test.ts
+++ b/src/data/clients/SecretsManagerClient/SecretsManagerClient.test.ts
@@ -1,0 +1,155 @@
+import { apiRoute, getServerRequests } from 'test/handlers';
+import { server } from 'test/server';
+
+import { SECRETS_API_BASE, SM_SECRET_DECRYPTER } from './constants';
+import { SecretsManagerClient } from './SecretsManagerClient';
+
+const STACK_ID = 42;
+
+function setupClient() {
+  return new SecretsManagerClient(STACK_ID);
+}
+
+describe('SecretsManagerClient.fetchAll', () => {
+  it('requests the securevalues endpoint with a spec.decrypter fieldSelector', async () => {
+    const { record, read } = getServerRequests();
+    server.use(
+      apiRoute(
+        'listSecrets',
+        {
+          result: () => ({
+            status: 200,
+            json: {
+              apiVersion: 'secret.grafana.app/v1beta1',
+              kind: 'SecureValueList',
+              metadata: {},
+              items: [],
+            },
+          }),
+        },
+        record
+      )
+    );
+
+    await setupClient().fetchAll();
+
+    const { request } = await read(undefined, false);
+    const url = new URL(request.url);
+
+    expect(url.pathname).toBe(`${SECRETS_API_BASE}/namespaces/stacks-${STACK_ID}/securevalues`);
+    expect(url.searchParams.get('fieldSelector')).toBe(`spec.decrypter=${SM_SECRET_DECRYPTER}`);
+  });
+
+  it('normalizes every item the API returns (the server-side fieldSelector is trusted)', async () => {
+    server.use(
+      apiRoute('listSecrets', {
+        result: () => ({
+          status: 200,
+          json: {
+            apiVersion: 'secret.grafana.app/v1beta1',
+            kind: 'SecureValueList',
+            metadata: {},
+            items: [
+              {
+                metadata: {
+                  name: 'first',
+                  namespace: `stacks-${STACK_ID}`,
+                  uid: 'uid-1',
+                  resourceVersion: '1',
+                  creationTimestamp: '2024-01-01T00:00:00Z',
+                },
+                spec: { description: 'first', decrypters: [SM_SECRET_DECRYPTER] },
+              },
+              {
+                metadata: {
+                  name: 'second',
+                  namespace: `stacks-${STACK_ID}`,
+                  uid: 'uid-2',
+                  resourceVersion: '1',
+                  creationTimestamp: '2024-01-01T00:00:00Z',
+                },
+                spec: { description: 'second', decrypters: [SM_SECRET_DECRYPTER, 'other'] },
+              },
+            ],
+          },
+        }),
+      })
+    );
+
+    const result = await setupClient().fetchAll();
+
+    expect(result.map((s) => s.name)).toEqual(['first', 'second']);
+  });
+});
+
+describe('SecretsManagerClient.createSecret', () => {
+  it('POSTs a k8s-shaped create payload with synthetic-monitoring decrypter', async () => {
+    const { record, read } = getServerRequests();
+    server.use(apiRoute('createSecret', {}, record));
+
+    await setupClient().createSecret({
+      name: 'api-token',
+      description: 'An API token',
+      labels: [{ name: 'env', value: 'prod' }],
+      plaintext: 'p@ss',
+    });
+
+    const { request, body } = await read();
+    expect(request.method).toBe('POST');
+    expect(new URL(request.url).pathname).toBe(
+      `${SECRETS_API_BASE}/namespaces/stacks-${STACK_ID}/securevalues`
+    );
+    expect(body).toEqual({
+      metadata: { name: 'api-token', labels: { env: 'prod' } },
+      spec: {
+        description: 'An API token',
+        decrypters: [SM_SECRET_DECRYPTER],
+        value: 'p@ss',
+      },
+    });
+  });
+});
+
+describe('SecretsManagerClient.updateSecret', () => {
+  it('PUTs a k8s-shaped update payload that echoes back the existing decrypters', async () => {
+    const { record, read } = getServerRequests();
+    server.use(apiRoute('updateSecret', {}, record));
+
+    const existingDecrypters = [SM_SECRET_DECRYPTER, 'some-other-service'];
+    await setupClient().updateSecret(
+      {
+        uuid: 'uid-1',
+        name: 'api-token',
+        description: 'Rotated token',
+        labels: [{ name: 'env', value: 'prod' }],
+        plaintext: 'new-value',
+      },
+      existingDecrypters
+    );
+
+    const { request, body } = await read();
+    expect(request.method).toBe('PUT');
+    expect(new URL(request.url).pathname).toBe(
+      `${SECRETS_API_BASE}/namespaces/stacks-${STACK_ID}/securevalues/api-token`
+    );
+    expect(body).toEqual({
+      metadata: { name: 'api-token', labels: { env: 'prod' } },
+      spec: { description: 'Rotated token', decrypters: existingDecrypters, value: 'new-value' },
+    });
+  });
+});
+
+describe('SecretsManagerClient.deleteSecret', () => {
+  it('DELETEs the named resource', async () => {
+    const { record, read } = getServerRequests();
+    server.use(apiRoute('deleteSecret', {}, record));
+
+    await setupClient().deleteSecret('api-token');
+
+    const { request } = await read(undefined, false);
+    expect(request.method).toBe('DELETE');
+    expect(new URL(request.url).pathname).toBe(
+      `${SECRETS_API_BASE}/namespaces/stacks-${STACK_ID}/securevalues/api-token`
+    );
+  });
+});

--- a/src/data/clients/SecretsManagerClient/SecretsManagerClient.ts
+++ b/src/data/clients/SecretsManagerClient/SecretsManagerClient.ts
@@ -1,0 +1,91 @@
+import { BackendSrvRequest, getBackendSrv } from '@grafana/runtime';
+import { firstValueFrom } from 'rxjs';
+
+import { SecretResponseItem, SecretsListResponse } from './SecretsManagerClient.types';
+import { SecretWithMetadata } from 'page/ConfigPageLayout/tabs/SecretsManagementTab';
+import { SecretFormValues } from 'page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.utils';
+
+import { SECRETS_API_BASE, SM_SECRET_DECRYPTER } from './constants';
+import {
+  CreateSecretFormValues,
+  formValuesToCreatePayload,
+  formValuesToUpdatePayload,
+  normalizeSecret,
+} from './SecretsManagerClient.utils';
+
+/**
+ * Client for Grafana's secrets management API
+ * (`apis/secret.grafana.app/v1beta1/...`). Handles Kubernetes-style request
+ * and response shapes and normalizes results into `SecretWithMetadata` for
+ * consumers.
+ *
+ * The list call is scoped to secrets whose decrypters include
+ * `synthetic-monitoring` via a server-side `fieldSelector`. Individual reads
+ * (`fetchSecret`) do not apply that scope.
+ */
+export class SecretsManagerClient {
+  private readonly stackId: number;
+  private readonly basePath: string;
+
+  constructor(stackId: number) {
+    this.stackId = stackId;
+    this.basePath = `${SECRETS_API_BASE}/namespaces/stacks-${stackId}/securevalues`;
+  }
+
+  private async request<T>(options: Omit<BackendSrvRequest, 'url'> & { url: string }): Promise<T> {
+    const response = await firstValueFrom(
+      getBackendSrv().fetch<T>({
+        showErrorAlert: false,
+        showSuccessAlert: false,
+        ...options,
+      })
+    );
+    return response?.data as T;
+  }
+
+  async fetchAll(): Promise<SecretWithMetadata[]> {
+    const response = await this.request<SecretsListResponse>({
+      method: 'GET',
+      url: this.basePath,
+      params: { fieldSelector: `spec.decrypter=${SM_SECRET_DECRYPTER}` },
+    });
+
+    const items = response?.items ?? [];
+    return items.map((item) => normalizeSecret(item, this.stackId));
+  }
+
+  async fetchSecret(name: string): Promise<SecretWithMetadata> {
+    const response = await this.request<SecretResponseItem>({
+      method: 'GET',
+      url: `${this.basePath}/${name}`,
+    });
+    return normalizeSecret(response, this.stackId);
+  }
+
+  async createSecret(values: CreateSecretFormValues): Promise<SecretWithMetadata> {
+    const payload = formValuesToCreatePayload(values);
+    const response = await this.request<SecretResponseItem>({
+      method: 'POST',
+      url: this.basePath,
+      data: payload,
+    });
+    return normalizeSecret(response, this.stackId);
+  }
+
+  async updateSecret(values: SecretFormValues, currentDecrypters: string[]): Promise<SecretWithMetadata> {
+    const payload = formValuesToUpdatePayload(values, currentDecrypters);
+    const response = await this.request<SecretResponseItem>({
+      method: 'PUT',
+      url: `${this.basePath}/${values.name}`,
+      data: payload,
+    });
+    return normalizeSecret(response, this.stackId);
+  }
+
+  async deleteSecret(name: string): Promise<void> {
+    await this.request<unknown>({
+      method: 'DELETE',
+      url: `${this.basePath}/${name}`,
+    });
+  }
+}

--- a/src/data/clients/SecretsManagerClient/SecretsManagerClient.ts
+++ b/src/data/clients/SecretsManagerClient/SecretsManagerClient.ts
@@ -24,11 +24,9 @@ import {
  * (`fetchSecret`) do not apply that scope.
  */
 export class SecretsManagerClient {
-  private readonly stackId: number;
   private readonly basePath: string;
 
   constructor(stackId: number) {
-    this.stackId = stackId;
     this.basePath = `${SECRETS_API_BASE}/namespaces/stacks-${stackId}/securevalues`;
   }
 
@@ -51,7 +49,7 @@ export class SecretsManagerClient {
     });
 
     const items = response?.items ?? [];
-    return items.map((item) => normalizeSecret(item, this.stackId));
+    return items.map(normalizeSecret);
   }
 
   async fetchSecret(name: string): Promise<SecretWithMetadata> {
@@ -59,7 +57,7 @@ export class SecretsManagerClient {
       method: 'GET',
       url: `${this.basePath}/${name}`,
     });
-    return normalizeSecret(response, this.stackId);
+    return normalizeSecret(response);
   }
 
   async createSecret(values: CreateSecretFormValues): Promise<SecretWithMetadata> {
@@ -69,7 +67,7 @@ export class SecretsManagerClient {
       url: this.basePath,
       data: payload,
     });
-    return normalizeSecret(response, this.stackId);
+    return normalizeSecret(response);
   }
 
   async updateSecret(values: SecretFormValues, currentDecrypters: string[]): Promise<SecretWithMetadata> {
@@ -79,7 +77,7 @@ export class SecretsManagerClient {
       url: `${this.basePath}/${values.name}`,
       data: payload,
     });
-    return normalizeSecret(response, this.stackId);
+    return normalizeSecret(response);
   }
 
   async deleteSecret(name: string): Promise<void> {

--- a/src/data/clients/SecretsManagerClient/SecretsManagerClient.types.ts
+++ b/src/data/clients/SecretsManagerClient/SecretsManagerClient.types.ts
@@ -1,10 +1,12 @@
 /**
  * Annotation keys set by the secrets management API on resource metadata.
+ *
+ * Only annotations that SM surfaces to users are listed here; others
+ * (e.g. `grafana.app/updatedBy`, `grafana.app/updatedTimestamp`) exist on
+ * the API response but aren't consumed by SM today.
  */
 export const SECRET_ANNOTATIONS = {
   createdBy: 'grafana.app/createdBy',
-  updatedBy: 'grafana.app/updatedBy',
-  updatedTimestamp: 'grafana.app/updatedTimestamp',
 } as const;
 
 /**

--- a/src/data/clients/SecretsManagerClient/SecretsManagerClient.types.ts
+++ b/src/data/clients/SecretsManagerClient/SecretsManagerClient.types.ts
@@ -1,0 +1,80 @@
+/**
+ * Annotation keys set by the secrets management API on resource metadata.
+ */
+export const SECRET_ANNOTATIONS = {
+  createdBy: 'grafana.app/createdBy',
+  updatedBy: 'grafana.app/updatedBy',
+  updatedTimestamp: 'grafana.app/updatedTimestamp',
+} as const;
+
+/**
+ * Shape of a single secure value resource returned by the Grafana secrets API.
+ * The API follows Kubernetes resource conventions with `metadata`, `spec`, and
+ * `status` sections. The raw secret value is never returned on reads.
+ */
+export interface SecretResponseItem {
+  metadata: {
+    name: string;
+    namespace: string;
+    uid: string;
+    resourceVersion: string;
+    creationTimestamp: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: {
+    description: string;
+    decrypters?: string[];
+  };
+  status?: {
+    externalID?: string;
+    version?: number;
+  };
+}
+
+/**
+ * Shape of the list response from `GET .../securevalues`.
+ */
+export interface SecretsListResponse {
+  apiVersion: string;
+  kind: string;
+  metadata: Record<string, unknown>;
+  items: SecretResponseItem[];
+}
+
+/**
+ * Payload for `POST .../securevalues` (create).
+ *
+ * `spec.decrypters` must be set by SM to `[SM_SECRET_DECRYPTER]` so the
+ * new secret is visible and usable by Synthetic Monitoring.
+ */
+export interface CreateSecretParam {
+  metadata: {
+    name: string;
+    labels?: Record<string, string>;
+  };
+  spec: {
+    description: string;
+    decrypters: string[];
+    value: string;
+  };
+}
+
+/**
+ * Payload for `PUT .../securevalues/{name}` (update).
+ *
+ * `decrypters` is echoed back from the existing resource so SM preserves the
+ * user-managed decrypter list instead of clearing it. `value` is only sent
+ * when the user is resetting the secret.
+ */
+export interface UpdateSecretParam {
+  metadata: {
+    name: string;
+    labels?: Record<string, string>;
+  };
+  spec: {
+    description: string;
+    decrypters: string[];
+    value?: string;
+  };
+}

--- a/src/data/clients/SecretsManagerClient/SecretsManagerClient.utils.test.ts
+++ b/src/data/clients/SecretsManagerClient/SecretsManagerClient.utils.test.ts
@@ -20,8 +20,6 @@ function makeItem(overrides: Partial<SecretResponseItem['metadata']> = {}): Secr
       labels: { env: 'prod', type: 'api-key' },
       annotations: {
         [SECRET_ANNOTATIONS.createdBy]: 'user:1',
-        [SECRET_ANNOTATIONS.updatedBy]: 'user:2',
-        [SECRET_ANNOTATIONS.updatedTimestamp]: '2024-02-02T03:04:05Z',
       },
       ...overrides,
     },
@@ -34,7 +32,7 @@ function makeItem(overrides: Partial<SecretResponseItem['metadata']> = {}): Secr
 
 describe('normalizeSecret', () => {
   it('maps metadata, spec and annotations onto SecretWithMetadata', () => {
-    const result = normalizeSecret(makeItem(), 42);
+    const result = normalizeSecret(makeItem());
 
     expect(result).toEqual({
       uuid: 'uid-123',
@@ -46,28 +44,12 @@ describe('normalizeSecret', () => {
       ],
       decrypters: [SM_SECRET_DECRYPTER],
       created_at: Date.parse('2024-01-02T03:04:05Z'),
-      modified_at: Date.parse('2024-02-02T03:04:05Z'),
       created_by: 'user:1',
-      org_id: 0,
-      stack_id: 42,
     });
   });
 
-  it('falls back to creationTimestamp when updatedTimestamp annotation is missing', () => {
-    const result = normalizeSecret(
-      makeItem({
-        annotations: { [SECRET_ANNOTATIONS.createdBy]: 'user:1' },
-      }),
-      1
-    );
-    expect(result.modified_at).toBe(Date.parse('2024-01-02T03:04:05Z'));
-  });
-
   it('handles missing labels and annotations gracefully', () => {
-    const result = normalizeSecret(
-      makeItem({ labels: undefined, annotations: undefined }),
-      1
-    );
+    const result = normalizeSecret(makeItem({ labels: undefined, annotations: undefined }));
     expect(result.labels).toEqual([]);
     expect(result.created_by).toBe('');
   });
@@ -75,13 +57,13 @@ describe('normalizeSecret', () => {
   it('exposes the full decrypter list so it can be echoed back on update', () => {
     const item = makeItem();
     item.spec.decrypters = [SM_SECRET_DECRYPTER, 'some-other-service'];
-    expect(normalizeSecret(item, 1).decrypters).toEqual([SM_SECRET_DECRYPTER, 'some-other-service']);
+    expect(normalizeSecret(item).decrypters).toEqual([SM_SECRET_DECRYPTER, 'some-other-service']);
   });
 
   it('defaults decrypters to an empty array when the API omits them', () => {
     const item = makeItem();
     delete item.spec.decrypters;
-    expect(normalizeSecret(item, 1).decrypters).toEqual([]);
+    expect(normalizeSecret(item).decrypters).toEqual([]);
   });
 });
 

--- a/src/data/clients/SecretsManagerClient/SecretsManagerClient.utils.test.ts
+++ b/src/data/clients/SecretsManagerClient/SecretsManagerClient.utils.test.ts
@@ -1,0 +1,163 @@
+import { SECRET_ANNOTATIONS, SecretResponseItem } from './SecretsManagerClient.types';
+import { SecretFormValues } from 'page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.utils';
+
+import { SM_SECRET_DECRYPTER } from './constants';
+import {
+  CreateSecretFormValues,
+  formValuesToCreatePayload,
+  formValuesToUpdatePayload,
+  normalizeSecret,
+} from './SecretsManagerClient.utils';
+
+function makeItem(overrides: Partial<SecretResponseItem['metadata']> = {}): SecretResponseItem {
+  return {
+    metadata: {
+      name: 'my-secret',
+      namespace: 'stacks-1',
+      uid: 'uid-123',
+      resourceVersion: '1',
+      creationTimestamp: '2024-01-02T03:04:05Z',
+      labels: { env: 'prod', type: 'api-key' },
+      annotations: {
+        [SECRET_ANNOTATIONS.createdBy]: 'user:1',
+        [SECRET_ANNOTATIONS.updatedBy]: 'user:2',
+        [SECRET_ANNOTATIONS.updatedTimestamp]: '2024-02-02T03:04:05Z',
+      },
+      ...overrides,
+    },
+    spec: {
+      description: 'a secret',
+      decrypters: [SM_SECRET_DECRYPTER],
+    },
+  };
+}
+
+describe('normalizeSecret', () => {
+  it('maps metadata, spec and annotations onto SecretWithMetadata', () => {
+    const result = normalizeSecret(makeItem(), 42);
+
+    expect(result).toEqual({
+      uuid: 'uid-123',
+      name: 'my-secret',
+      description: 'a secret',
+      labels: [
+        { name: 'env', value: 'prod' },
+        { name: 'type', value: 'api-key' },
+      ],
+      decrypters: [SM_SECRET_DECRYPTER],
+      created_at: Date.parse('2024-01-02T03:04:05Z'),
+      modified_at: Date.parse('2024-02-02T03:04:05Z'),
+      created_by: 'user:1',
+      org_id: 0,
+      stack_id: 42,
+    });
+  });
+
+  it('falls back to creationTimestamp when updatedTimestamp annotation is missing', () => {
+    const result = normalizeSecret(
+      makeItem({
+        annotations: { [SECRET_ANNOTATIONS.createdBy]: 'user:1' },
+      }),
+      1
+    );
+    expect(result.modified_at).toBe(Date.parse('2024-01-02T03:04:05Z'));
+  });
+
+  it('handles missing labels and annotations gracefully', () => {
+    const result = normalizeSecret(
+      makeItem({ labels: undefined, annotations: undefined }),
+      1
+    );
+    expect(result.labels).toEqual([]);
+    expect(result.created_by).toBe('');
+  });
+
+  it('exposes the full decrypter list so it can be echoed back on update', () => {
+    const item = makeItem();
+    item.spec.decrypters = [SM_SECRET_DECRYPTER, 'some-other-service'];
+    expect(normalizeSecret(item, 1).decrypters).toEqual([SM_SECRET_DECRYPTER, 'some-other-service']);
+  });
+
+  it('defaults decrypters to an empty array when the API omits them', () => {
+    const item = makeItem();
+    delete item.spec.decrypters;
+    expect(normalizeSecret(item, 1).decrypters).toEqual([]);
+  });
+});
+
+describe('formValuesToCreatePayload', () => {
+  const baseValues: CreateSecretFormValues = {
+    name: 'new-secret',
+    description: 'description',
+    labels: [{ name: 'env', value: 'prod' }],
+    plaintext: 'p@ssw0rd',
+  };
+
+  it('builds a k8s-shaped create payload from form values', () => {
+    expect(formValuesToCreatePayload(baseValues)).toEqual({
+      metadata: {
+        name: 'new-secret',
+        labels: { env: 'prod' },
+      },
+      spec: {
+        description: 'description',
+        decrypters: [SM_SECRET_DECRYPTER],
+        value: 'p@ssw0rd',
+      },
+    });
+  });
+
+  it('always injects the synthetic-monitoring decrypter on create', () => {
+    const payload = formValuesToCreatePayload(baseValues);
+    expect(payload.spec.decrypters).toEqual([SM_SECRET_DECRYPTER]);
+  });
+
+  it('omits labels when none are provided', () => {
+    const payload = formValuesToCreatePayload({ ...baseValues, labels: [] });
+    expect(payload.metadata).not.toHaveProperty('labels');
+  });
+});
+
+describe('formValuesToUpdatePayload', () => {
+  const baseValues: SecretFormValues = {
+    uuid: 'uid-1',
+    name: 'existing-secret',
+    description: 'updated description',
+    labels: [{ name: 'env', value: 'prod' }],
+  };
+
+  it('builds a k8s-shaped update payload from form values', () => {
+    expect(formValuesToUpdatePayload(baseValues, [SM_SECRET_DECRYPTER])).toEqual({
+      metadata: {
+        name: 'existing-secret',
+        labels: { env: 'prod' },
+      },
+      spec: {
+        description: 'updated description',
+        decrypters: [SM_SECRET_DECRYPTER],
+      },
+    });
+  });
+
+  it('echoes back the existing decrypters verbatim to preserve user-managed decrypter lists', () => {
+    const decrypters = [SM_SECRET_DECRYPTER, 'some-other-service'];
+    const payload = formValuesToUpdatePayload(baseValues, decrypters);
+    expect(payload.spec.decrypters).toEqual(decrypters);
+  });
+
+  it('only includes spec.value when plaintext is provided', () => {
+    const withValue = formValuesToUpdatePayload(
+      { ...baseValues, plaintext: 'new-value' },
+      [SM_SECRET_DECRYPTER]
+    );
+    const withoutValue = formValuesToUpdatePayload(baseValues, [SM_SECRET_DECRYPTER]);
+
+    expect(withValue.spec.value).toBe('new-value');
+    expect(withoutValue.spec).not.toHaveProperty('value');
+  });
+
+  it('sends an empty label record when all labels are removed', () => {
+    const payload = formValuesToUpdatePayload({ ...baseValues, labels: [] }, [SM_SECRET_DECRYPTER]);
+    expect(payload.metadata.labels).toEqual({});
+  });
+});

--- a/src/data/clients/SecretsManagerClient/SecretsManagerClient.utils.ts
+++ b/src/data/clients/SecretsManagerClient/SecretsManagerClient.utils.ts
@@ -1,0 +1,112 @@
+import { CreateSecretParam, SECRET_ANNOTATIONS, SecretResponseItem, UpdateSecretParam } from './SecretsManagerClient.types';
+import { SecretWithMetadata } from 'page/ConfigPageLayout/tabs/SecretsManagementTab';
+import { SecretFormValues } from 'page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.utils';
+
+import { SM_SECRET_DECRYPTER } from './constants';
+
+function parseTimestamp(value?: string): number {
+  if (!value) {
+    return 0;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function labelsRecordToArray(labels?: Record<string, string>): Array<{ name: string; value: string }> {
+  return Object.entries(labels ?? {}).map(([name, value]) => ({ name, value }));
+}
+
+function labelsArrayToRecord(labels?: Array<{ name: string; value: string }>): Record<string, string> | undefined {
+  if (!labels || labels.length === 0) {
+    return undefined;
+  }
+  return labels.reduce<Record<string, string>>((acc, { name, value }) => {
+    if (name) {
+      acc[name] = value;
+    }
+    return acc;
+  }, {});
+}
+
+/**
+ * Normalizes a Kubernetes-style secret resource from the Grafana secrets API
+ * into the SecretWithMetadata shape the rest of the app expects.
+ *
+ * Fields the new API does not provide (org_id) are set to 0. `stack_id` is
+ * injected from the caller since it is not returned on the resource itself.
+ */
+export function normalizeSecret(item: SecretResponseItem, stackId: number): SecretWithMetadata {
+  const annotations = item.metadata.annotations ?? {};
+  const createdAt = parseTimestamp(item.metadata.creationTimestamp);
+  const modifiedAt = parseTimestamp(annotations[SECRET_ANNOTATIONS.updatedTimestamp]) || createdAt;
+
+  return {
+    uuid: item.metadata.uid,
+    name: item.metadata.name,
+    description: item.spec.description,
+    labels: labelsRecordToArray(item.metadata.labels),
+    decrypters: item.spec.decrypters ?? [],
+    created_at: createdAt,
+    modified_at: modifiedAt,
+    created_by: annotations[SECRET_ANNOTATIONS.createdBy] ?? '',
+    org_id: 0,
+    stack_id: stackId,
+  };
+}
+
+/**
+ * Form values for creating a new secret.
+ *
+ * Narrows {@link SecretFormValues} to guarantee a `plaintext` value at
+ * compile time, since the API requires it on create.
+ */
+export type CreateSecretFormValues = SecretFormValues & { plaintext: string };
+
+/**
+ * Builds the create payload for the Grafana secrets API from the form values
+ * used by SM's SecretEditModal.
+ *
+ * Always injects `synthetic-monitoring` as a decrypter so newly created
+ * secrets are usable by SM checks.
+ */
+export function formValuesToCreatePayload(values: CreateSecretFormValues): CreateSecretParam {
+  const labels = labelsArrayToRecord(values.labels);
+
+  return {
+    metadata: {
+      name: values.name,
+      ...(labels ? { labels } : {}),
+    },
+    spec: {
+      description: values.description,
+      decrypters: [SM_SECRET_DECRYPTER],
+      value: values.plaintext,
+    },
+  };
+}
+
+/**
+ * Builds the update payload for the Grafana secrets API from the form values
+ * used by SM's SecretEditModal.
+ *
+ * `decrypters` is echoed back from the existing resource so SM preserves the
+ * user-managed decrypter list (the API treats missing decrypters as a reset).
+ * `value` is only sent when the user reset the value. Labels are always sent
+ * (including as an empty record) so removing all labels takes effect.
+ */
+export function formValuesToUpdatePayload(
+  values: SecretFormValues,
+  currentDecrypters: string[]
+): UpdateSecretParam {
+  return {
+    metadata: {
+      name: values.name,
+      labels: labelsArrayToRecord(values.labels) ?? {},
+    },
+    spec: {
+      description: values.description,
+      decrypters: currentDecrypters,
+      ...(values.plaintext !== undefined ? { value: values.plaintext } : {}),
+    },
+  };
+}

--- a/src/data/clients/SecretsManagerClient/SecretsManagerClient.utils.ts
+++ b/src/data/clients/SecretsManagerClient/SecretsManagerClient.utils.ts
@@ -4,14 +4,6 @@ import { SecretFormValues } from 'page/ConfigPageLayout/tabs/SecretsManagementTa
 
 import { SM_SECRET_DECRYPTER } from './constants';
 
-function parseTimestamp(value?: string): number {
-  if (!value) {
-    return 0;
-  }
-  const parsed = Date.parse(value);
-  return Number.isNaN(parsed) ? 0 : parsed;
-}
-
 function labelsRecordToArray(labels?: Record<string, string>): Array<{ name: string; value: string }> {
   return Object.entries(labels ?? {}).map(([name, value]) => ({ name, value }));
 }
@@ -31,14 +23,10 @@ function labelsArrayToRecord(labels?: Array<{ name: string; value: string }>): R
 /**
  * Normalizes a Kubernetes-style secret resource from the Grafana secrets API
  * into the SecretWithMetadata shape the rest of the app expects.
- *
- * Fields the new API does not provide (org_id) are set to 0. `stack_id` is
- * injected from the caller since it is not returned on the resource itself.
  */
-export function normalizeSecret(item: SecretResponseItem, stackId: number): SecretWithMetadata {
+export function normalizeSecret(item: SecretResponseItem): SecretWithMetadata {
   const annotations = item.metadata.annotations ?? {};
-  const createdAt = parseTimestamp(item.metadata.creationTimestamp);
-  const modifiedAt = parseTimestamp(annotations[SECRET_ANNOTATIONS.updatedTimestamp]) || createdAt;
+  const createdAtRaw = Date.parse(item.metadata.creationTimestamp);
 
   return {
     uuid: item.metadata.uid,
@@ -46,11 +34,8 @@ export function normalizeSecret(item: SecretResponseItem, stackId: number): Secr
     description: item.spec.description,
     labels: labelsRecordToArray(item.metadata.labels),
     decrypters: item.spec.decrypters ?? [],
-    created_at: createdAt,
-    modified_at: modifiedAt,
+    created_at: Number.isNaN(createdAtRaw) ? 0 : createdAtRaw,
     created_by: annotations[SECRET_ANNOTATIONS.createdBy] ?? '',
-    org_id: 0,
-    stack_id: stackId,
   };
 }
 

--- a/src/data/clients/SecretsManagerClient/constants.ts
+++ b/src/data/clients/SecretsManagerClient/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Decrypter identifier used by Synthetic Monitoring in Grafana's secrets
+ * management API. Secrets that include this decrypter are visible to SM
+ * and can be referenced by SM checks.
+ */
+export const SM_SECRET_DECRYPTER = 'synthetic-monitoring';
+
+/**
+ * Base path for the Grafana secrets management API.
+ * Full list URL: `${SECRETS_API_BASE}/namespaces/stacks-{stackId}/securevalues`.
+ */
+export const SECRETS_API_BASE = '/apis/secret.grafana.app/v1beta1';

--- a/src/data/clients/SecretsManagerClient/index.ts
+++ b/src/data/clients/SecretsManagerClient/index.ts
@@ -1,0 +1,3 @@
+export { SM_SECRET_DECRYPTER } from './constants';
+export { SecretsManagerClient } from './SecretsManagerClient';
+export { useSecretsManagerClient } from './useSecretsManagerClient';

--- a/src/data/clients/SecretsManagerClient/useSecretsManagerClient.ts
+++ b/src/data/clients/SecretsManagerClient/useSecretsManagerClient.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+
+import { useMeta } from 'hooks/useMeta';
+
+import { SecretsManagerClient } from './SecretsManagerClient';
+
+export interface SecretsManagerClientContext {
+  client: SecretsManagerClient;
+  stackId: number;
+}
+
+/**
+ * Hook that provides a memoized `SecretsManagerClient` bound to the current
+ * stack. Returns `undefined` until the plugin meta has a stackId available.
+ *
+ * The `stackId` is returned alongside the client so consumers can build
+ * stack-scoped cache keys without needing to inspect the client instance.
+ */
+export function useSecretsManagerClient(): SecretsManagerClientContext | undefined {
+  const { jsonData } = useMeta();
+  const stackId = jsonData?.stackId;
+
+  return useMemo(() => {
+    if (typeof stackId !== 'number' || !Number.isFinite(stackId)) {
+      return undefined;
+    }
+    return { client: new SecretsManagerClient(stackId), stackId };
+  }, [stackId]);
+}

--- a/src/data/useSecrets.test.tsx
+++ b/src/data/useSecrets.test.tsx
@@ -1,0 +1,129 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { MOCKED_SECRETS, MOCKED_SECURE_VALUE_ITEMS } from 'test/fixtures/secrets';
+import { apiRoute, getServerRequests } from 'test/handlers';
+import { createWrapper } from 'test/render';
+import { server } from 'test/server';
+
+import { SM_SECRET_DECRYPTER } from 'data/clients/SecretsManagerClient';
+
+import { QUERY_KEYS, useSaveSecret, useSecret } from './useSecrets';
+
+const SECRET = MOCKED_SECRETS[0];
+const SECRET_ITEM = MOCKED_SECURE_VALUE_ITEMS[0];
+
+describe('useSaveSecret', () => {
+  it('echoes back the cached secret decrypters on update (preserves user-managed decrypter list)', async () => {
+    const existingDecrypters = [SM_SECRET_DECRYPTER, 'some-other-service'];
+    server.use(
+      apiRoute('getSecret', {
+        result: () => ({
+          status: 200,
+          json: {
+            ...SECRET_ITEM,
+            spec: { ...SECRET_ITEM.spec, decrypters: existingDecrypters },
+          },
+        }),
+      })
+    );
+    const { record, read } = getServerRequests();
+    server.use(apiRoute('updateSecret', {}, record));
+    const { Wrapper } = createWrapper();
+
+    // Prime the context query cache via useSecret, matching the flow the
+    // SecretEditModal uses when a user opens an existing secret.
+    const { result: secretResult } = renderHook(() => useSecret(SECRET.name), { wrapper: Wrapper });
+    await waitFor(() => expect(secretResult.current.isSuccess).toBe(true));
+
+    const { result } = renderHook(() => useSaveSecret(), { wrapper: Wrapper });
+    result.current.mutate({
+      uuid: SECRET.uuid,
+      name: SECRET.name,
+      description: 'new description',
+      labels: [],
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const { body } = await read();
+    expect(body.spec.decrypters).toEqual(existingDecrypters);
+  });
+
+  it('fetches the current decrypters synchronously on update when the cache is empty', async () => {
+    const existingDecrypters = [SM_SECRET_DECRYPTER, 'some-other-service'];
+    server.use(
+      apiRoute('getSecret', {
+        result: () => ({
+          status: 200,
+          json: {
+            ...SECRET_ITEM,
+            spec: { ...SECRET_ITEM.spec, decrypters: existingDecrypters },
+          },
+        }),
+      })
+    );
+    const { record, read } = getServerRequests();
+    server.use(apiRoute('updateSecret', {}, record));
+    const { Wrapper } = createWrapper();
+
+    // Note: no useSecret() call — the cache is empty; the mutation must fetch
+    // to discover the existing decrypters rather than guessing.
+    const { result } = renderHook(() => useSaveSecret(), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current).not.toBeNull());
+    result.current.mutate({
+      uuid: SECRET.uuid,
+      name: SECRET.name,
+      description: 'new description',
+      labels: [],
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const { body } = await read();
+    expect(body.spec.decrypters).toEqual(existingDecrypters);
+  });
+
+  it('fails the update when the current-decrypters fetch fails', async () => {
+    server.use(
+      apiRoute('getSecret', { result: () => ({ status: 500, json: { message: 'boom' } }) })
+    );
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSaveSecret(), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current).not.toBeNull());
+    result.current.mutate({
+      uuid: SECRET.uuid,
+      name: SECRET.name,
+      description: 'new description',
+      labels: [],
+    });
+
+    // Better to surface the error than silently save with an incorrect decrypter list.
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('always injects only synthetic-monitoring as the decrypter on create', async () => {
+    const { record, read } = getServerRequests();
+    server.use(apiRoute('createSecret', {}, record));
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSaveSecret(), { wrapper: Wrapper });
+    await waitFor(() => expect(result.current).not.toBeNull());
+    result.current.mutate({
+      name: 'new-secret',
+      description: 'description',
+      labels: [],
+      plaintext: 'value',
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const { body } = await read();
+    expect(body.spec.decrypters).toEqual([SM_SECRET_DECRYPTER]);
+  });
+
+});
+
+describe('QUERY_KEYS', () => {
+  it('scopes list and byName keys by stackId to prevent cross-stack cache bleed', () => {
+    expect(QUERY_KEYS.list(1)).toEqual(['secrets', 1]);
+    expect(QUERY_KEYS.list(2)).toEqual(['secrets', 2]);
+    expect(QUERY_KEYS.byName('foo', 1)).toEqual(['secrets', 1, 'foo']);
+  });
+});

--- a/src/data/useSecrets.ts
+++ b/src/data/useSecrets.ts
@@ -1,31 +1,28 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { type QueryKey, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { SMDataSource } from 'datasource/DataSource';
-import { useSMDS } from 'hooks/useSMDS';
+import { useSecretsManagerClient } from 'data/clients/SecretsManagerClient';
+import { CreateSecretFormValues } from 'data/clients/SecretsManagerClient/SecretsManagerClient.utils';
 import { SecretWithMetadata } from 'page/ConfigPageLayout/tabs/SecretsManagementTab';
 import { SECRETS_EDIT_MODE_ADD } from 'page/ConfigPageLayout/tabs/SecretsManagementTab/constants';
 import { SecretFormValues } from 'page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.utils';
 
-import { queryClient } from './queryClient';
-
-export interface SecretsResponse {
-  secrets: SecretWithMetadata[];
-}
-
+/**
+ * React-query keys for secrets. All keys are scoped by `stackId` so multiple
+ * stacks in the same session cannot share cache entries.
+ */
 export const QUERY_KEYS = {
-  list: ['secrets'],
-  byName: (name: string) => ['secrets', name],
+  list: (stackId: number): QueryKey => ['secrets', stackId],
+  byName: (name: string, stackId: number): QueryKey => ['secrets', stackId, name],
 };
 
-function secretsQuery(api: SMDataSource) {
-  return {
-    queryKey: QUERY_KEYS.list,
-    queryFn: () => api.getSecrets(),
-    throwOnError: true,
-    select: (data: SecretsResponse) => {
-      return (data?.secrets ?? []).map(secret => ({ ...secret, labels: secret.labels ?? [] }));
-    },
-  };
+/**
+ * Placeholder passed to `QUERY_KEYS` when the client is not yet available.
+ * No data is ever stored at this key because queries are gated via `enabled`.
+ */
+const INACTIVE_STACK_ID = -1;
+
+function isCreateSecretFormValues(values: SecretFormValues): values is CreateSecretFormValues {
+  return typeof values.plaintext === 'string';
 }
 
 /**
@@ -35,11 +32,16 @@ function secretsQuery(api: SMDataSource) {
  * @throws {Error} If the query fails - Use ErrorBoundary to catch errors
  */
 export function useSecrets(enabled: boolean) {
-  const smDS = useSMDS();
+  const ctx = useSecretsManagerClient();
+  const stackId = ctx?.stackId ?? INACTIVE_STACK_ID;
 
-  return useQuery<SecretsResponse, unknown, SecretWithMetadata[]>({
-    ...secretsQuery(smDS),
-    enabled,
+  return useQuery<SecretWithMetadata[], unknown, SecretWithMetadata[]>({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- `ctx` is derived from stackId, which IS in the key
+    queryKey: QUERY_KEYS.list(stackId),
+    queryFn: () => ctx!.client.fetchAll(),
+    throwOnError: true,
+    enabled: enabled && Boolean(ctx),
+    select: (secrets) => secrets.map((secret) => ({ ...secret, labels: secret.labels ?? [] })),
   });
 }
 
@@ -49,12 +51,14 @@ export function useSecrets(enabled: boolean) {
  * @throws {Error} If the query fails - Use ErrorBoundary to catch errors
  */
 export function useSecret(name?: string) {
-  const smDS = useSMDS();
+  const ctx = useSecretsManagerClient();
+  const stackId = ctx?.stackId ?? INACTIVE_STACK_ID;
 
   return useQuery<SecretWithMetadata, unknown, SecretWithMetadata>({
-    queryKey: QUERY_KEYS.byName(name!),
-    queryFn: () => smDS.getSecret(name!),
-    enabled: !!name && name !== SECRETS_EDIT_MODE_ADD,
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- `ctx` is derived from stackId, which IS in the key
+    queryKey: QUERY_KEYS.byName(name!, stackId),
+    queryFn: () => ctx!.client.fetchSecret(name!),
+    enabled: Boolean(ctx) && !!name && name !== SECRETS_EDIT_MODE_ADD,
     select: (secret) => ({ ...secret, labels: secret.labels ?? [] }),
   });
 }
@@ -64,16 +68,39 @@ export function useSecret(name?: string) {
  * @throws {Error} If the mutation fails - Use ErrorBoundary to catch errors
  */
 export function useSaveSecret() {
-  const smDS = useSMDS();
+  const ctx = useSecretsManagerClient();
+  const queryClient = useQueryClient();
 
   return useMutation<SecretWithMetadata, unknown, SecretFormValues & { uuid?: string }>({
-    mutationFn: (data) => {
-      return smDS.saveSecret(data);
+    mutationFn: async (data) => {
+      if (!ctx) {
+        throw new Error('Secrets API is not available: missing stackId');
+      }
+      const { client, stackId } = ctx;
+
+      if (!data.uuid) {
+        if (!isCreateSecretFormValues(data)) {
+          throw new Error('Cannot create a secret without a value');
+        }
+        return client.createSecret(data);
+      }
+
+      // When updating, we must echo back the secret's current decrypters so
+      // SM does not accidentally drop the user-managed decrypter list. Pull
+      // them from the react-query cache if present (populated by `useSecret`
+      // when the edit modal opened); otherwise fetch them synchronously so
+      // we never save with an incomplete decrypter set.
+      const current = await queryClient.fetchQuery<SecretWithMetadata>({
+        queryKey: QUERY_KEYS.byName(data.name, stackId),
+        queryFn: () => client.fetchSecret(data.name),
+      });
+      return client.updateSecret(data, current.decrypters);
     },
     onSuccess: async (_data, secret) => {
-      const { name, ...updatedData } = secret; // name cannot be changed
-      await queryClient.setQueryData(QUERY_KEYS.byName(secret.name!), updatedData);
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.list });
+      const stackId = ctx?.stackId ?? INACTIVE_STACK_ID;
+      const { name, ...updatedData } = secret;
+      await queryClient.setQueryData(QUERY_KEYS.byName(secret.name!, stackId), updatedData);
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.list(stackId) });
     },
   });
 }
@@ -83,12 +110,19 @@ export function useSaveSecret() {
  * @throws {Error} If the mutation fails - Use ErrorBoundary to catch errors
  */
 export function useDeleteSecret() {
-  const smDS = useSMDS();
+  const ctx = useSecretsManagerClient();
+  const queryClient = useQueryClient();
 
   return useMutation<unknown, unknown, string>({
-    mutationFn: (name) => smDS.deleteSecret(name),
-    onSuccess: async (_data) => {
-      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.list });
+    mutationFn: (name) => {
+      if (!ctx) {
+        throw new Error('Secrets API is not available: missing stackId');
+      }
+      return ctx.client.deleteSecret(name);
+    },
+    onSuccess: async () => {
+      const stackId = ctx?.stackId ?? INACTIVE_STACK_ID;
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.list(stackId) });
     },
     throwOnError: true,
   });

--- a/src/datasource/DataSource.test.ts
+++ b/src/datasource/DataSource.test.ts
@@ -106,31 +106,6 @@ const entries: Entry[] = [
     payload: undefined,
     handler: 'createAccessToken',
   },
-  {
-    method: 'getSecrets',
-    payload: undefined,
-    handler: 'listSecrets',
-  },
-  {
-    method: 'getSecret',
-    payload: 'new-secret',
-    handler: 'getSecret',
-  },
-  {
-    method: 'saveSecret',
-    payload: { name: `new-secret` },
-    handler: 'createSecret',
-  },
-  {
-    method: 'saveSecret',
-    payload: { uuid: 1, name: `update-secret` },
-    handler: 'updateSecret',
-  },
-  {
-    method: 'deleteSecret',
-    payload: `delete-secret`,
-    handler: 'deleteSecret',
-  },
 ];
 
 describe('SMDataSource', () => {

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -37,11 +37,8 @@ import {
 import { QueryType, SMOptions, SMQuery } from './types';
 import { findLinkedDatasource, getRandomProbes, queryLogs } from 'utils';
 import { ExtendedBulkUpdateCheckResult } from 'data/useChecks';
-import { SecretsResponse } from 'data/useSecrets';
-import { SecretFormValues } from 'page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.utils';
 
 import { LokiQueryResults } from '../components/Checkster/feature/adhoc-check/useAdHocLogs';
-import { SecretWithMetadata } from '../page/ConfigPageLayout/tabs/SecretsManagementTab';
 import { parseTracerouteLogs } from './traceroute-utils';
 
 export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
@@ -403,44 +400,6 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       method: 'POST',
       data: {},
     }).then((data) => data.token);
-  }
-
-  //--------------------------------------------------------------------------------
-  // SECRETS MANAGEMENT
-  //--------------------------------------------------------------------------------
-
-  async getSecrets(): Promise<SecretsResponse> {
-    return this.fetchAPI<SecretsResponse>(`${this.instanceSettings.url}/api/v1alpha1/secrets`, {
-      method: 'GET',
-    });
-  }
-
-  async getSecret(name: string): Promise<SecretWithMetadata> {
-    return this.fetchAPI<SecretWithMetadata>(`${this.instanceSettings.url}/api/v1alpha1/secrets/${name}`, {
-      method: 'GET',
-    });
-  }
-
-  async saveSecret(secret: SecretFormValues & { uuid?: string }): Promise<SecretWithMetadata> {
-    if (secret.uuid) {
-      // For updates: use name for URL but exclude it from payload
-      const { name, ...secretWithoutName } = secret;
-      return this.fetchAPI<SecretWithMetadata>(`${this.instanceSettings.url}/api/v1alpha1/secrets/${name}`, {
-        method: 'PUT',
-        data: secretWithoutName,
-      });
-    }
-    // For creates: include name in payload
-    return this.fetchAPI<SecretWithMetadata>(`${this.instanceSettings.url}/api/v1alpha1/secrets`, {
-      method: 'POST',
-      data: secret,
-    });
-  }
-
-  async deleteSecret(name: string): Promise<unknown> {
-    return this.fetchAPI<SecretWithMetadata>(`${this.instanceSettings.url}/api/v1alpha1/secrets/${name}`, {
-      method: 'DELETE',
-    });
   }
 
   //--------------------------------------------------------------------------------

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretCard.tsx
@@ -70,10 +70,6 @@ export function SecretCard({ secret, onEdit, onDelete }: SecretCardProps) {
       <div className={styles.keyValue}>
         <strong>Created:</strong> {formatDate(secret.created_at)} ({secret.created_by})
       </div>
-      {/* Currently there is no modified_at returned by the API(???) */}
-      {/*<div className={styles.keyValue}>*/}
-      {/*  <strong>Modified:</strong> {formatDate(secret.modified_at)}*/}
-      {/*</div>*/}
     </div>
   );
 }

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { DataTestIds } from 'test/dataTestIds';
-import { MOCKED_SECRETS_API_RESPONSE } from 'test/fixtures/secrets';
+import { MOCKED_SECRETS, MOCKED_SECURE_VALUE_ITEMS } from 'test/fixtures/secrets';
 import { apiRoute, getServerRequests } from 'test/handlers';
 import { render as testRender } from 'test/render';
 import { server } from 'test/server';
+
+import { SM_SECRET_DECRYPTER } from 'data/clients/SecretsManagerClient';
 
 import { SECRETS_EDIT_MODE_ADD } from './constants';
 import { SecretEditModal } from './SecretEditModal';
@@ -41,7 +43,7 @@ describe('SecretEditModal', () => {
   });
 
   it('should render edit secret form for existing secret', async () => {
-    const [secret1] = MOCKED_SECRETS_API_RESPONSE.secrets; // getSecret returns first secret, this must be the same as secret1
+    const [secret1] = MOCKED_SECRETS; // getSecret returns first secret, this must be the same as secret1
     await render(<SecretEditModal {...defaultProps} name={secret1.name} />);
 
     expect(screen.getByText('Edit secret')).toBeInTheDocument();
@@ -84,7 +86,7 @@ describe('SecretEditModal', () => {
       })
     );
 
-    const [secret1] = MOCKED_SECRETS_API_RESPONSE.secrets; // getSecret returns first secret, this must be the same as secret1
+    const [secret1] = MOCKED_SECRETS; // getSecret returns first secret, this must be the same as secret1
     await render(<SecretEditModal {...defaultProps} name={secret1.name} />);
 
     expect(await screen.findByText('Unable to fetch secret')).toBeInTheDocument();
@@ -113,9 +115,14 @@ describe('SecretEditModal', () => {
     const { body } = await read();
 
     expect(body).toStrictEqual({
-      ...inputValues,
-      name: 'new-secret', // transformed to lowercase and spaces replaced with dashes
-      labels: [],
+      metadata: {
+        name: 'new-secret', // transformed to lowercase and spaces replaced with dashes
+      },
+      spec: {
+        description: inputValues.description,
+        decrypters: [SM_SECRET_DECRYPTER],
+        value: inputValues.plaintext,
+      },
     });
   });
 
@@ -156,7 +163,7 @@ describe('SecretEditModal', () => {
   });
 
   it('should be possible to add labels to the secret', async () => {
-    const secretMock = MOCKED_SECRETS_API_RESPONSE.secrets[0];
+    const secretMock = MOCKED_SECRETS[0];
     const inputValues = {
       name: secretMock.name,
       description: secretMock.description,
@@ -183,16 +190,11 @@ describe('SecretEditModal', () => {
 
     const { body } = await read();
 
-    expect(body.labels).toStrictEqual([
-      {
-        name: labelName,
-        value: labelValue,
-      },
-    ]);
+    expect(body.metadata.labels).toStrictEqual({ [labelName]: labelValue });
   });
 
   it('should be possible to remove labels from the secret', async () => {
-    const secretMock = MOCKED_SECRETS_API_RESPONSE.secrets[0];
+    const secretMock = MOCKED_SECRETS[0];
 
     expect(secretMock.labels.length).toBeGreaterThan(0); // Ensure there are labels to remove
 
@@ -209,11 +211,11 @@ describe('SecretEditModal', () => {
 
     const { body } = await read();
 
-    expect(body.labels).toStrictEqual([]);
+    expect(body.metadata.labels).toStrictEqual({});
   });
 
   it('should not be possible to change name for existing secret', async () => {
-    const secretMock = MOCKED_SECRETS_API_RESPONSE.secrets[0];
+    const secretMock = MOCKED_SECRETS[0];
     const inputValues = {
       name: secretMock.name,
       description: secretMock.description,
@@ -230,13 +232,62 @@ describe('SecretEditModal', () => {
 
     const { body } = await read();
 
-    expect(body.name).toBeUndefined();
+    // The URL path encodes the name, but the payload name should always match
+    // the existing secret (the form blocks changes via readonly)
+    expect(body.metadata.name).toBe(secretMock.name);
+  });
+
+  it('should echo back the existing decrypters on update so they are not lost', async () => {
+    const secretMock = MOCKED_SECRETS[0];
+    const { record, read } = getServerRequests();
+    server.use(apiRoute('updateSecret', {}, record));
+    const { user } = await render(<SecretEditModal {...defaultProps} name={secretMock.name} />);
+
+    await user.click(screen.getByText('Save'));
+
+    const { body } = await read();
+
+    expect(body.spec.decrypters).toEqual(secretMock.decrypters);
+  });
+
+  it('should preserve extra non-SM decrypters on a secret when saving', async () => {
+    const extraDecrypters = [SM_SECRET_DECRYPTER, 'some-other-service', 'yet-another-service'];
+    const secretMock = MOCKED_SECURE_VALUE_ITEMS[0];
+
+    server.use(
+      apiRoute('getSecret', {
+        result: () => ({
+          status: 200,
+          json: {
+            ...secretMock,
+            spec: { ...secretMock.spec, decrypters: extraDecrypters },
+          },
+        }),
+      })
+    );
+
+    const { record, read } = getServerRequests();
+    server.use(apiRoute('updateSecret', {}, record));
+
+    const { user } = await render(<SecretEditModal {...defaultProps} name={secretMock.metadata.name} />);
+
+    // Wait for the modal to finish loading the existing secret so the
+    // assertion below reads the same decrypters that were served to the form.
+    await waitFor(() =>
+      expect(screen.getByDisplayValue(secretMock.spec.description)).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByText('Save'));
+
+    const { body } = await read();
+
+    expect(body.spec.decrypters).toEqual(extraDecrypters);
   });
 
   it('should show value textarea as disabled when configured', async () => {
     const { record, read } = getServerRequests();
     server.use(apiRoute('updateSecret', {}, record));
-    const secretMock = MOCKED_SECRETS_API_RESPONSE.secrets[0];
+    const secretMock = MOCKED_SECRETS[0];
     const { user } = await render(<SecretEditModal {...defaultProps} name={secretMock.name} />);
 
     const valueInput = screen.getByLabelText(/value/i);
@@ -247,14 +298,14 @@ describe('SecretEditModal', () => {
 
     const { body } = await read();
 
-    expect(body.plaintext).toBeUndefined();
+    expect(body.spec.value).toBeUndefined();
   });
 
   it('should be possible to reset the value', async () => {
     const newSecretValue = 'new secret value';
     const { record, read } = getServerRequests();
     server.use(apiRoute('updateSecret', {}, record));
-    const secretMock = MOCKED_SECRETS_API_RESPONSE.secrets[0];
+    const secretMock = MOCKED_SECRETS[0];
     const { user } = await render(<SecretEditModal {...defaultProps} name={secretMock.name} />);
 
     await user.click(screen.getByRole('button', { name: 'Reset' }));
@@ -264,11 +315,11 @@ describe('SecretEditModal', () => {
 
     const { body } = await read();
 
-    expect(body.plaintext).toBe(newSecretValue);
+    expect(body.spec.value).toBe(newSecretValue);
   });
 
   it('should show error message when secret name is already taken', async () => {
-    const secretMock = MOCKED_SECRETS_API_RESPONSE.secrets[0];
+    const secretMock = MOCKED_SECRETS[0];
     const inputValues = {
       name: secretMock.name,
       description: 'My short description',

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.test.tsx
@@ -51,7 +51,14 @@ describe('SecretsManagementTab', () => {
 
     it('shows secrets management UI for admin users', async () => {
       runTestAsSMAdmin();
-      server.use(apiRoute('listSecrets', { result: () => ({ status: 200, json: { secrets: [] } }) }));
+      server.use(
+        apiRoute('listSecrets', {
+          result: () => ({
+            status: 200,
+            json: { apiVersion: 'secret.grafana.app/v1beta1', kind: 'SecureValueList', metadata: {}, items: [] },
+          }),
+        })
+      );
 
       render(<SecretsManagementTab />);
 
@@ -67,7 +74,14 @@ describe('SecretsManagementTab', () => {
 
   describe('RBAC permissions', () => {
     beforeEach(() => {
-      server.use(apiRoute('listSecrets', { result: () => ({ status: 200, json: { secrets: [] } }) }));
+      server.use(
+        apiRoute('listSecrets', {
+          result: () => ({
+            status: 200,
+            json: { apiVersion: 'secret.grafana.app/v1beta1', kind: 'SecureValueList', metadata: {}, items: [] },
+          }),
+        })
+      );
     });
 
     it('allows full access for users with all secret permissions', async () => {

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/types.ts
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/types.ts
@@ -22,6 +22,7 @@ export interface SecretMetadata {
   org_id: number;
   stack_id: number;
   uuid: string;
+  decrypters: string[];
 }
 
 export interface SecretWithUuid extends Omit<Secret, 'uuid'> {

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/types.ts
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/types.ts
@@ -16,12 +16,14 @@ export interface SecretWithValue extends Omit<Secret, 'plaintext'> {
 }
 
 export interface SecretMetadata {
-  created_at: number;
-  modified_at: number;
-  created_by: string;
-  org_id: number;
-  stack_id: number;
   uuid: string;
+  created_at: number;
+  created_by: string;
+  /**
+   * List of services allowed to decrypt this secret. Only the capability
+   * list is ever returned by the API, never the raw value. SM only shows
+   * and operates on secrets whose decrypters include `synthetic-monitoring`.
+   */
   decrypters: string[];
 }
 

--- a/src/test/fixtures/secrets.ts
+++ b/src/test/fixtures/secrets.ts
@@ -1,6 +1,93 @@
-import { SecretsResponse } from '../../data/useSecrets';
-import { SecretWithMetadata } from '../../page/ConfigPageLayout/tabs/SecretsManagementTab';
+import {
+  SECRET_ANNOTATIONS,
+  SecretResponseItem,
+  SecretsListResponse,
+} from 'data/clients/SecretsManagerClient/SecretsManagerClient.types';
+import { SM_SECRET_DECRYPTER } from 'data/clients/SecretsManagerClient/constants';
 
+import { SecretWithMetadata } from '../../page/ConfigPageLayout/tabs/SecretsManagementTab';
+import { SM_META } from './meta';
+
+const STACK_ID = SM_META.jsonData.stackId;
+
+function makeAnnotations(createdBy: string, updatedBy: string, updatedTimestamp: string) {
+  return {
+    [SECRET_ANNOTATIONS.createdBy]: createdBy,
+    [SECRET_ANNOTATIONS.updatedBy]: updatedBy,
+    [SECRET_ANNOTATIONS.updatedTimestamp]: updatedTimestamp,
+  };
+}
+
+/**
+ * Raw k8s-shaped secure value resources as returned by the Grafana secrets API.
+ * Used by MSW handlers to simulate the backend.
+ *
+ * All three items are scoped to `synthetic-monitoring` — they represent what
+ * the server would return after applying the `spec.decrypter` fieldSelector.
+ */
+export const MOCKED_SECURE_VALUE_ITEMS: SecretResponseItem[] = [
+  {
+    metadata: {
+      name: 'test-secret-1',
+      namespace: `stacks-${STACK_ID}`,
+      uid: 'secret-1',
+      resourceVersion: '1',
+      creationTimestamp: '1970-01-01T00:00:00Z',
+      labels: { env: 'prod', type: 'test' },
+      annotations: makeAnnotations('user1', 'user1', '1970-01-01T00:00:00Z'),
+    },
+    spec: {
+      description: 'Test Description 1',
+      decrypters: [SM_SECRET_DECRYPTER],
+    },
+  },
+  {
+    metadata: {
+      name: 'test-secret-2',
+      namespace: `stacks-${STACK_ID}`,
+      uid: 'secret-2',
+      resourceVersion: '1',
+      creationTimestamp: '1970-01-01T00:00:00Z',
+      labels: { env: 'dev' },
+      annotations: makeAnnotations('user2', 'user2', '1970-01-01T00:00:00Z'),
+    },
+    spec: {
+      description: 'Test Description 2',
+      decrypters: [SM_SECRET_DECRYPTER],
+    },
+  },
+  {
+    metadata: {
+      name: 'test-secret-3',
+      namespace: `stacks-${STACK_ID}`,
+      uid: 'secret-3',
+      resourceVersion: '1',
+      creationTimestamp: '1970-01-01T00:00:00Z',
+      annotations: makeAnnotations('user3', 'user3', '1970-01-01T00:00:00Z'),
+    },
+    spec: {
+      description: 'Test Description 3 - No labels',
+      decrypters: [SM_SECRET_DECRYPTER],
+    },
+  },
+];
+
+/**
+ * Raw k8s list response returned by `GET .../securevalues`.
+ */
+export const MOCKED_SECURE_VALUES_API_RESPONSE: SecretsListResponse = {
+  apiVersion: 'secret.grafana.app/v1beta1',
+  kind: 'SecureValueList',
+  metadata: {},
+  items: MOCKED_SECURE_VALUE_ITEMS,
+};
+
+/**
+ * Normalized secrets used by UI-level tests to assert the shape consumers see.
+ *
+ * Kept in sync with {@link MOCKED_SECURE_VALUE_ITEMS} so that hitting the
+ * mocked API yields these values after normalization.
+ */
 export const MOCKED_SECRETS: SecretWithMetadata[] = [
   {
     uuid: 'secret-1',
@@ -11,10 +98,11 @@ export const MOCKED_SECRETS: SecretWithMetadata[] = [
     labels: [
       { name: 'env', value: 'prod' },
       { name: 'type', value: 'test' },
-    ], // Important: This mock must have AT LEAST one label to be used in the test
+    ],
+    decrypters: [SM_SECRET_DECRYPTER],
     modified_at: 0,
     org_id: 0,
-    stack_id: 0,
+    stack_id: STACK_ID,
   },
   {
     uuid: 'secret-2',
@@ -23,9 +111,10 @@ export const MOCKED_SECRETS: SecretWithMetadata[] = [
     created_at: 0,
     created_by: 'user2',
     labels: [{ name: 'env', value: 'dev' }],
+    decrypters: [SM_SECRET_DECRYPTER],
     modified_at: 0,
     org_id: 0,
-    stack_id: 0,
+    stack_id: STACK_ID,
   },
   {
     uuid: 'secret-3',
@@ -34,12 +123,9 @@ export const MOCKED_SECRETS: SecretWithMetadata[] = [
     created_at: 0,
     created_by: 'user3',
     labels: [],
+    decrypters: [SM_SECRET_DECRYPTER],
     modified_at: 0,
     org_id: 0,
-    stack_id: 0,
+    stack_id: STACK_ID,
   },
 ];
-
-export const MOCKED_SECRETS_API_RESPONSE: SecretsResponse = {
-  secrets: MOCKED_SECRETS,
-};

--- a/src/test/fixtures/secrets.ts
+++ b/src/test/fixtures/secrets.ts
@@ -10,11 +10,9 @@ import { SM_META } from './meta';
 
 const STACK_ID = SM_META.jsonData.stackId;
 
-function makeAnnotations(createdBy: string, updatedBy: string, updatedTimestamp: string) {
+function makeAnnotations(createdBy: string) {
   return {
     [SECRET_ANNOTATIONS.createdBy]: createdBy,
-    [SECRET_ANNOTATIONS.updatedBy]: updatedBy,
-    [SECRET_ANNOTATIONS.updatedTimestamp]: updatedTimestamp,
   };
 }
 
@@ -34,7 +32,7 @@ export const MOCKED_SECURE_VALUE_ITEMS: SecretResponseItem[] = [
       resourceVersion: '1',
       creationTimestamp: '1970-01-01T00:00:00Z',
       labels: { env: 'prod', type: 'test' },
-      annotations: makeAnnotations('user1', 'user1', '1970-01-01T00:00:00Z'),
+      annotations: makeAnnotations('user1'),
     },
     spec: {
       description: 'Test Description 1',
@@ -49,7 +47,7 @@ export const MOCKED_SECURE_VALUE_ITEMS: SecretResponseItem[] = [
       resourceVersion: '1',
       creationTimestamp: '1970-01-01T00:00:00Z',
       labels: { env: 'dev' },
-      annotations: makeAnnotations('user2', 'user2', '1970-01-01T00:00:00Z'),
+      annotations: makeAnnotations('user2'),
     },
     spec: {
       description: 'Test Description 2',
@@ -63,7 +61,7 @@ export const MOCKED_SECURE_VALUE_ITEMS: SecretResponseItem[] = [
       uid: 'secret-3',
       resourceVersion: '1',
       creationTimestamp: '1970-01-01T00:00:00Z',
-      annotations: makeAnnotations('user3', 'user3', '1970-01-01T00:00:00Z'),
+      annotations: makeAnnotations('user3'),
     },
     spec: {
       description: 'Test Description 3 - No labels',
@@ -100,9 +98,6 @@ export const MOCKED_SECRETS: SecretWithMetadata[] = [
       { name: 'type', value: 'test' },
     ],
     decrypters: [SM_SECRET_DECRYPTER],
-    modified_at: 0,
-    org_id: 0,
-    stack_id: STACK_ID,
   },
   {
     uuid: 'secret-2',
@@ -112,9 +107,6 @@ export const MOCKED_SECRETS: SecretWithMetadata[] = [
     created_by: 'user2',
     labels: [{ name: 'env', value: 'dev' }],
     decrypters: [SM_SECRET_DECRYPTER],
-    modified_at: 0,
-    org_id: 0,
-    stack_id: STACK_ID,
   },
   {
     uuid: 'secret-3',
@@ -124,8 +116,5 @@ export const MOCKED_SECRETS: SecretWithMetadata[] = [
     created_by: 'user3',
     labels: [],
     decrypters: [SM_SECRET_DECRYPTER],
-    modified_at: 0,
-    org_id: 0,
-    stack_id: STACK_ID,
   },
 ];

--- a/src/test/handlers/secrets.ts
+++ b/src/test/handlers/secrets.ts
@@ -1,100 +1,80 @@
 import { ApiEntry } from './types';
-import { SecretsResponse } from 'data/useSecrets';
-import { SecretWithMetadata } from 'page/ConfigPageLayout/tabs/SecretsManagementTab';
-import { SecretFormValues } from 'page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementTab.utils';
+import {
+  SecretResponseItem,
+  SecretsListResponse,
+} from 'data/clients/SecretsManagerClient/SecretsManagerClient.types';
 
-import { MOCKED_SECRETS_API_RESPONSE } from '../fixtures/secrets';
+import { MOCKED_SECURE_VALUE_ITEMS, MOCKED_SECURE_VALUES_API_RESPONSE } from '../fixtures/secrets';
+
+const LIST_ROUTE = `/apis/secret.grafana.app/v1beta1/namespaces/stacks-[^/]+/securevalues`;
+const ITEM_ROUTE = `/apis/secret.grafana.app/v1beta1/namespaces/stacks-[^/]+/securevalues/([^/]+)`;
 
 /**
- * Represents an API entry for retrieving a list of secrets.
+ * Handler for `GET .../securevalues`.
  *
- * The `listSecrets` variable is an instance of `ApiEntry` that defines the
- * necessary details for making a GET request to the `/api/v1alpha1/secrets`
- * endpoint. It retrieves secret data in the form of a `SecretsResponse`.
- *
- * Properties:
- * - `route`: Specifies the API's URL endpoint as a string (`/api/v1alpha1/secrets`).
- * - `method`: Defines the HTTP method (`get`) to be used for this API request.
- * - `result`: A function that simulates the server's response by returning
- *   mocked data (`MOCKED_SECRETS_API_RESPONSE`) as JSON.
- *
- * This API is generally used to query secrets information in a predefined format.
+ * Returns a Kubernetes-style `SecureValueList`. The real API filters the
+ * list by `fieldSelector=spec.decrypter=<name>`; this mock handler does not
+ * honor the fieldSelector, so tests should set up fixtures that already
+ * represent the filtered server-side result.
  */
-export const listSecrets: ApiEntry<SecretsResponse> = {
-  route: `/api/v1alpha1/secrets`,
+export const listSecrets: ApiEntry<SecretsListResponse> = {
+  route: LIST_ROUTE,
   method: `get`,
   result: () => {
     return {
-      json: MOCKED_SECRETS_API_RESPONSE,
+      json: MOCKED_SECURE_VALUES_API_RESPONSE,
     };
   },
 };
 
 /**
- * Represents an API entry for retrieving a secret along with its metadata.
- *
- * The `getSecret` object defines the route and method to retrieve a secret
- * and provides a mechanism for simulating a response with mock data.
- * It uses the `ApiEntry` type with the `SecretWithMetadata` structure to
- * ensure the returned data adheres to the expected format.
- *
- * Properties:
- * - `route`: Specifies the API endpoint for fetching the secret. Includes a dynamic UUID value based on mocked data.
- * - `method`: HTTP method used to interact with the API (in this case, `GET`).
- * - `result`: A function representing the response handler, returning a mock JSON payload containing the secret data.
+ * Handler for `GET .../securevalues/{name}`.
  */
-export const getSecret: ApiEntry<SecretWithMetadata> = {
-  route: `/api/v1alpha1/secrets/([^/]+)`,
+export const getSecret: ApiEntry<SecretResponseItem> = {
+  route: ITEM_ROUTE,
   method: `get`,
   result: () => {
     return {
-      json: MOCKED_SECRETS_API_RESPONSE.secrets[0],
+      json: MOCKED_SECURE_VALUE_ITEMS[0],
     };
   },
 };
 
 /**
- * An API entry configuration for creating a secret entity.
+ * Handler for `POST .../securevalues` (create).
  *
- * This configuration includes the API route, HTTP method, and the expected result.
- *
- * Properties:
- * - `route`: The API endpoint for creating a new secret.
- * - `method`: The HTTP method used for the request, which is "post" in this case.
- * - `result`: A function that returns the expected result of the API call, which is a JSON response with a value of `null`.
+ * Returns the first fixture item as a stand-in for the newly created resource.
  */
-export const createSecret: ApiEntry<SecretFormValues> = {
-  route: `/api/v1alpha1/secrets`,
+export const createSecret: ApiEntry<SecretResponseItem> = {
+  route: LIST_ROUTE,
   method: `post`,
   result: () => {
     return {
-      json: null,
+      json: MOCKED_SECURE_VALUE_ITEMS[0],
     };
   },
 };
 
 /**
- * Represents the API endpoint for updating a secret's details.
+ * Handler for `PUT .../securevalues/{name}` (update).
  *
- * This configuration includes the API route, HTTP method, and the expected result.
- *
- * Properties:
- * - `route`: The API endpoint for updating an existing secret.
- * - `method`: The HTTP method used for the request, which is "put" in this case.
- * - `result`: A function that returns the expected result of the API call, which is a JSON response with a value of `null`.
+ * Returns the first fixture item as a stand-in for the updated resource.
  */
-export const updateSecret: ApiEntry<SecretFormValues> = {
-  route: `/api/v1alpha1/secrets/([^/]+)`,
+export const updateSecret: ApiEntry<SecretResponseItem> = {
+  route: ITEM_ROUTE,
   method: `put`,
   result: () => {
     return {
-      json: null,
+      json: MOCKED_SECURE_VALUE_ITEMS[0],
     };
   },
 };
 
+/**
+ * Handler for `DELETE .../securevalues/{name}` (delete).
+ */
 export const deleteSecret: ApiEntry<unknown> = {
-  route: `/api/v1alpha1/secrets/([^/]+)`,
+  route: ITEM_ROUTE,
   method: `delete`,
   result: () => {
     return {


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces SM's own secrets passthrough (`/api/v1alpha1/secrets` on the SM backend) with direct calls to Grafana's secrets management API at `apis/secret.grafana.app/v1beta1/namespaces/stacks-{stackId}/securevalues`.

The SM passthrough was built before the shared Grafana secrets backend was available. Now that the backend (owned by `#grafana-operator-experience-squad`) is in place, SM should talk to it directly like `grafana-k6-app` already does. This also fixes a defect in the current implementation where secrets with decrypters other than `synthetic-monitoring` were visible to SM even though SM cannot actually use them.

**Changes**

- New client module `src/data/clients/SecretsManagerClient/` that mirrors the [k6-app pattern](https://github.com/grafana/grafana-k6-app/blob/b2f5675fe75414a1ab4375c39a8fe4ac7a5b3d16/src/data/clients/SecretsManagerClient/SecretsManagerClient.ts):
  - `SecretsManagerClient` class with `fetchAll / fetchSecret / createSecret / updateSecret / deleteSecret`
  - Scopes list calls server-side via `fieldSelector=spec.decrypter=synthetic-monitoring`
  - Normalizes Kubernetes-style responses into the existing `SecretWithMetadata` shape so UI consumers don't need to change
  - `useSecretsManagerClient()` hook bound to `useMeta().jsonData.stackId`, returning `{ client, stackId }`
- `src/data/useSecrets.ts` rewired to use the new client; hook signatures (`useSecrets`, `useSecret`, `useSaveSecret`, `useDeleteSecret`) unchanged. `QUERY_KEYS` are now stack-scoped.
- Removed `getSecrets/getSecret/saveSecret/deleteSecret` from `SMDataSource` along with their imports.
- MSW handlers and fixtures updated to the new routes and k8s response shape.


**Behavior diff worth highlighting**

- **Before**: editing a secret with extra decrypters silently dropped them on save (SM's passthrough only knew about its own field set).
- **After**: editing echoes back the full decrypter list; dropping decrypters requires going through Administration > Secrets Management explicitly.


https://github.com/user-attachments/assets/01d24d37-8932-4148-95d4-97b896a70a8b

