### PR TITLE
fix: handle datasource Mismatch status and correct metrics UID fallback

### DIFF
--- a/src/components/AppInitializer.test.tsx
+++ b/src/components/AppInitializer.test.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
+import { screen, waitFor } from '@testing-library/react';
+import { APP_INITIALIZER_TEST_ID } from 'test/dataTestIds';
+import { LOGS_DATASOURCE, METRICS_DATASOURCE } from 'test/fixtures/datasources';
+import { render } from 'test/render';
+
+import { DEFAULT_LOGS_DS_UID, DEFAULT_METRICS_DS_UID } from 'datasource/constants';
+
+import { AppInitializer } from './AppInitializer';
+
+const METRICS_NAME = 'test-metrics';
+const LOGS_NAME = 'test-logs';
+
+function makeMetricsDs(
+  overrides: Partial<DataSourceInstanceSettings<DataSourceJsonData>> = {}
+): DataSourceInstanceSettings<DataSourceJsonData> {
+  return {
+    ...METRICS_DATASOURCE,
+    ...overrides,
+  };
+}
+
+function makeLogsDs(
+  overrides: Partial<DataSourceInstanceSettings<DataSourceJsonData>> = {}
+): DataSourceInstanceSettings<DataSourceJsonData> {
+  return {
+    ...LOGS_DATASOURCE,
+    ...overrides,
+  };
+}
+
+const metricsByName = makeMetricsDs({ name: METRICS_NAME, uid: 'metrics-uid' });
+const logsByName = makeLogsDs({ name: LOGS_NAME, uid: 'logs-uid' });
+
+function setConfigDatasources(datasources: Record<string, DataSourceInstanceSettings<DataSourceJsonData>>) {
+  const runtime = require('@grafana/runtime');
+  jest.replaceProperty(runtime, 'config', {
+    ...runtime.config,
+    datasources: {
+      ...datasources,
+    },
+  });
+}
+
+function renderAppInitializer(
+  datasources: Record<string, DataSourceInstanceSettings<DataSourceJsonData>>,
+  metaOverrides: Record<string, unknown> = {}
+) {
+  setConfigDatasources(datasources);
+
+  return render(<AppInitializer buttonText="Get started" />, {
+    meta: {
+      jsonData: {
+        metrics: {
+          grafanaName: METRICS_NAME,
+          hostedId: 100,
+        },
+        logs: {
+          grafanaName: LOGS_NAME,
+          hostedId: 200,
+        },
+        apiHost: 'https://synthetic-monitoring-api.grafana.net',
+        stackId: 1,
+      },
+      ...metaOverrides,
+    },
+  });
+}
+
+async function clickGetStarted(user: ReturnType<typeof render>['user']) {
+  const button = await screen.findByTestId(APP_INITIALIZER_TEST_ID.initButton);
+  await user.click(button);
+}
+
+describe('AppInitializer', () => {
+  describe('when both datasources are found by name (Match/NameOnly)', () => {
+    it('calls the install endpoint when the button is clicked', async () => {
+      const postMock = jest.fn().mockResolvedValue({ accessToken: 'test-token' });
+      jest.spyOn(require('@grafana/runtime'), 'getBackendSrv').mockReturnValue({
+        post: postMock,
+        fetch: jest.fn(),
+      });
+
+      const { user } = renderAppInitializer({
+        [METRICS_NAME]: metricsByName,
+        [LOGS_NAME]: logsByName,
+      });
+
+      await clickGetStarted(user);
+
+      await waitFor(() => {
+        expect(postMock).toHaveBeenCalledWith(
+          expect.stringContaining('/install'),
+          expect.objectContaining({
+            stackId: 1,
+            metricsInstanceId: 100,
+            logsInstanceId: 200,
+          })
+        );
+      });
+    });
+  });
+
+  describe('when metrics datasource is not found', () => {
+    it('shows an error message', async () => {
+      const { user } = renderAppInitializer({
+        [LOGS_NAME]: logsByName,
+      });
+
+      await clickGetStarted(user);
+
+      expect(await screen.findByText(/Could not find a metrics datasource/)).toBeInTheDocument();
+    });
+  });
+
+  describe('when logs datasource is not found', () => {
+    it('shows an error message', async () => {
+      const { user } = renderAppInitializer({
+        [METRICS_NAME]: metricsByName,
+      });
+
+      await clickGetStarted(user);
+
+      expect(await screen.findByText(/Could not find a logs datasource/)).toBeInTheDocument();
+    });
+  });
+
+  describe('when neither datasource is found', () => {
+    it('shows a metrics error message', async () => {
+      const { user } = renderAppInitializer({});
+
+      await clickGetStarted(user);
+
+      expect(await screen.findByText(/Could not find a metrics datasource/)).toBeInTheDocument();
+    });
+  });
+
+  describe('when datasources have a UID mismatch', () => {
+    it('opens the MismatchedDatasourceModal', async () => {
+      const mismatchedLogsByUid = makeLogsDs({ name: 'different-logs-name', uid: DEFAULT_LOGS_DS_UID });
+
+      const { user } = renderAppInitializer({
+        [LOGS_NAME]: logsByName,
+        [METRICS_NAME]: metricsByName,
+        'different-logs-name': mismatchedLogsByUid,
+      });
+
+      await clickGetStarted(user);
+
+      expect(await screen.findByText('Datasource selection')).toBeInTheDocument();
+    });
+  });
+
+  describe('when datasources are found by UID only', () => {
+    it('opens the MismatchedDatasourceModal', async () => {
+      const metricsByUidOnly = makeMetricsDs({
+        name: 'some-other-metrics',
+        uid: DEFAULT_METRICS_DS_UID,
+      });
+      const logsByUidOnly = makeLogsDs({ name: 'some-other-logs', uid: DEFAULT_LOGS_DS_UID });
+
+      const { user } = renderAppInitializer({
+        'some-other-metrics': metricsByUidOnly,
+        'some-other-logs': logsByUidOnly,
+      });
+
+      await clickGetStarted(user);
+
+      expect(await screen.findByText('Datasource selection')).toBeInTheDocument();
+    });
+  });
+
+  describe('when metricsHostedId is missing', () => {
+    it('shows an error about missing hostedId', async () => {
+      const { user } = renderAppInitializer(
+        {
+          [METRICS_NAME]: metricsByName,
+          [LOGS_NAME]: logsByName,
+        },
+        {
+          jsonData: {
+            metrics: {
+              grafanaName: METRICS_NAME,
+            },
+            logs: {
+              grafanaName: LOGS_NAME,
+              hostedId: 200,
+            },
+            apiHost: 'https://synthetic-monitoring-api.grafana.net',
+            stackId: 1,
+          },
+        }
+      );
+
+      await clickGetStarted(user);
+
+      expect(await screen.findByText(/Could not find metrics datasource hostedId/)).toBeInTheDocument();
+    });
+  });
+
+  describe('when logsHostedId is missing', () => {
+    it('shows an error about missing hostedId', async () => {
+      const { user } = renderAppInitializer(
+        {
+          [METRICS_NAME]: metricsByName,
+          [LOGS_NAME]: logsByName,
+        },
+        {
+          jsonData: {
+            metrics: {
+              grafanaName: METRICS_NAME,
+              hostedId: 100,
+            },
+            logs: {
+              grafanaName: LOGS_NAME,
+            },
+            apiHost: 'https://synthetic-monitoring-api.grafana.net',
+            stackId: 1,
+          },
+        }
+      );
+
+      await clickGetStarted(user);
+
+      expect(await screen.findByText(/Could not find logs datasource hostedId/)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/AppInitializer.test.tsx
+++ b/src/components/AppInitializer.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
 import { screen, waitFor } from '@testing-library/react';
+import { from } from 'rxjs';
 import { APP_INITIALIZER_TEST_ID } from 'test/dataTestIds';
-import { LOGS_DATASOURCE, METRICS_DATASOURCE } from 'test/fixtures/datasources';
+import { LOGS_DATASOURCE, METRICS_DATASOURCE, SM_DATASOURCE } from 'test/fixtures/datasources';
 import { render } from 'test/render';
 
 import { DEFAULT_LOGS_DS_UID, DEFAULT_METRICS_DS_UID } from 'datasource/constants';
@@ -149,6 +150,56 @@ describe('AppInitializer', () => {
       await clickGetStarted(user);
 
       expect(await screen.findByText('Datasource selection')).toBeInTheDocument();
+    });
+  });
+
+  describe('when one datasource is NameOnly and the other is Mismatch', () => {
+    it('proceeds using byName when byUid is missing for the NameOnly datasource', async () => {
+      const postMock = jest.fn().mockResolvedValue({ accessToken: 'test-token' });
+      const fetchMock = jest.fn().mockImplementation(() => from(Promise.resolve({ data: {} })));
+      jest.spyOn(require('@grafana/runtime'), 'getBackendSrv').mockReturnValue({
+        post: postMock,
+        fetch: fetchMock,
+      });
+
+      const mismatchedLogsByUid = makeLogsDs({ name: 'different-logs-name', uid: DEFAULT_LOGS_DS_UID });
+
+      const { user } = renderAppInitializer({
+        [SM_DATASOURCE.name]: SM_DATASOURCE,
+        [METRICS_NAME]: metricsByName,
+        [LOGS_NAME]: logsByName,
+        'different-logs-name': mismatchedLogsByUid,
+      });
+
+      await clickGetStarted(user);
+      expect(await screen.findByText('Datasource selection')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Proceed' }));
+
+      await waitFor(() => {
+        expect(postMock).toHaveBeenCalledWith(
+          expect.stringContaining('/install'),
+          expect.objectContaining({
+            stackId: 1,
+            metricsInstanceId: 100,
+            logsInstanceId: 200,
+          })
+        );
+      });
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: 'PUT',
+            data: expect.objectContaining({
+              jsonData: expect.objectContaining({
+                metrics: expect.objectContaining({ uid: metricsByName.uid }),
+                logs: expect.objectContaining({ uid: mismatchedLogsByUid.uid }),
+              }),
+            }),
+          })
+        );
+      });
     });
   });
 

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -1,9 +1,10 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, Spinner, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { APP_INITIALIZER_TEST_ID } from 'test/dataTestIds';
 
+import { FaroEvent, reportEvent } from 'faro';
 import { hasGlobalPermission } from 'utils';
 import { AppRoutes } from 'routing/types';
 import { getUserPermissions } from 'data/permissions';
@@ -15,10 +16,11 @@ import { ContactAdminAlert } from 'page/ContactAdminAlert';
 interface Props {
   redirectTo?: AppRoutes;
   buttonText: string;
+  autoInitialize?: boolean;
 }
 
 // TODO: Does this really belong under /page?
-export const AppInitializer = ({ redirectTo, buttonText }: PropsWithChildren<Props>) => {
+export const AppInitializer = ({ redirectTo, buttonText, autoInitialize = false }: PropsWithChildren<Props>) => {
   const { jsonData } = useMeta();
   const styles = useStyles2(getStyles);
   const { canWritePlugin } = getUserPermissions();
@@ -38,7 +40,17 @@ export const AppInitializer = ({ redirectTo, buttonText }: PropsWithChildren<Pro
     handleClick,
     datasourceModalOpen,
     setDataSouceModalOpen,
-  } = useAppInitializer(redirectTo);
+  } = useAppInitializer(redirectTo, autoInitialize);
+
+  const [autoInitializing, setAutoInitializing] = useState(autoInitialize);
+  const hasAutoInitialized = useRef(false);
+  useEffect(() => {
+    if (autoInitialize && !hasAutoInitialized.current && canReadDs && canInitialize) {
+      hasAutoInitialized.current = true;
+      reportEvent(FaroEvent.AutoInit);
+      handleClick();
+    }
+  }, [autoInitialize, canReadDs, canInitialize, handleClick]);
 
   if (!canReadDs) {
     return <ContactAdminAlert missingPermissions={['datasources:read']} />;
@@ -52,9 +64,15 @@ export const AppInitializer = ({ redirectTo, buttonText }: PropsWithChildren<Pro
 
   return (
     <div data-testid={APP_INITIALIZER_TEST_ID.root}>
-      <Button data-testid={APP_INITIALIZER_TEST_ID.initButton} onClick={handleClick} disabled={loading} size="lg">
-        {loading ? <Spinner /> : buttonText}
-      </Button>
+      {autoInitializing && !error && !datasourceModalOpen ? (
+        <div data-testid={APP_INITIALIZER_TEST_ID.autoInitSpinner}>
+          <Spinner size="xl" />
+        </div>
+      ) : (
+        <Button data-testid={APP_INITIALIZER_TEST_ID.initButton} onClick={handleClick} disabled={loading} size="lg">
+          {loading ? <Spinner /> : buttonText}
+        </Button>
+      )}
 
       {error && (
         <Alert title="Something went wrong:" className={styles.alert}>
@@ -68,14 +86,17 @@ export const AppInitializer = ({ redirectTo, buttonText }: PropsWithChildren<Pro
         metricsExpectedName={metricsByUid?.name ?? 'Not found'}
         logsFoundName={logsByName?.name ?? 'Not found'}
         logsExpectedName={logsByUid?.name ?? 'Not found'}
-        onDismiss={() => setDataSouceModalOpen(false)}
+        onDismiss={() => {
+          setDataSouceModalOpen(false);
+          setAutoInitializing(false);
+        }}
         isSubmitting={loading}
         onSubmit={() => {
           if (jsonData.metrics.hostedId && jsonData.logs.hostedId) {
             initialize({
-              metricsSettings: metricsByUid!, // we have already guaranteed that this exists above
+              metricsSettings: metricsByUid ?? metricsByName!,
               metricsHostedId: jsonData.metrics.hostedId,
-              logsSettings: logsByUid!, // we have already guaranteed that this exists above
+              logsSettings: logsByUid ?? logsByName!,
               logsHostedId: jsonData.logs.hostedId,
             });
           } else {

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -1,10 +1,9 @@
-import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import React, { PropsWithChildren } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, Spinner, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { APP_INITIALIZER_TEST_ID } from 'test/dataTestIds';
 
-import { FaroEvent, reportEvent } from 'faro';
 import { hasGlobalPermission } from 'utils';
 import { AppRoutes } from 'routing/types';
 import { getUserPermissions } from 'data/permissions';
@@ -16,11 +15,10 @@ import { ContactAdminAlert } from 'page/ContactAdminAlert';
 interface Props {
   redirectTo?: AppRoutes;
   buttonText: string;
-  autoInitialize?: boolean;
 }
 
 // TODO: Does this really belong under /page?
-export const AppInitializer = ({ redirectTo, buttonText, autoInitialize = false }: PropsWithChildren<Props>) => {
+export const AppInitializer = ({ redirectTo, buttonText }: PropsWithChildren<Props>) => {
   const { jsonData } = useMeta();
   const styles = useStyles2(getStyles);
   const { canWritePlugin } = getUserPermissions();
@@ -40,17 +38,7 @@ export const AppInitializer = ({ redirectTo, buttonText, autoInitialize = false 
     handleClick,
     datasourceModalOpen,
     setDataSouceModalOpen,
-  } = useAppInitializer(redirectTo, autoInitialize);
-
-  const [autoInitializing, setAutoInitializing] = useState(autoInitialize);
-  const hasAutoInitialized = useRef(false);
-  useEffect(() => {
-    if (autoInitialize && !hasAutoInitialized.current && canReadDs && canInitialize) {
-      hasAutoInitialized.current = true;
-      reportEvent(FaroEvent.AutoInit);
-      handleClick();
-    }
-  }, [autoInitialize, canReadDs, canInitialize, handleClick]);
+  } = useAppInitializer(redirectTo);
 
   if (!canReadDs) {
     return <ContactAdminAlert missingPermissions={['datasources:read']} />;
@@ -64,15 +52,9 @@ export const AppInitializer = ({ redirectTo, buttonText, autoInitialize = false 
 
   return (
     <div data-testid={APP_INITIALIZER_TEST_ID.root}>
-      {autoInitializing && !error && !datasourceModalOpen ? (
-        <div data-testid={APP_INITIALIZER_TEST_ID.autoInitSpinner}>
-          <Spinner size="xl" />
-        </div>
-      ) : (
-        <Button data-testid={APP_INITIALIZER_TEST_ID.initButton} onClick={handleClick} disabled={loading} size="lg">
-          {loading ? <Spinner /> : buttonText}
-        </Button>
-      )}
+      <Button data-testid={APP_INITIALIZER_TEST_ID.initButton} onClick={handleClick} disabled={loading} size="lg">
+        {loading ? <Spinner /> : buttonText}
+      </Button>
 
       {error && (
         <Alert title="Something went wrong:" className={styles.alert}>
@@ -86,10 +68,7 @@ export const AppInitializer = ({ redirectTo, buttonText, autoInitialize = false 
         metricsExpectedName={metricsByUid?.name ?? 'Not found'}
         logsFoundName={logsByName?.name ?? 'Not found'}
         logsExpectedName={logsByUid?.name ?? 'Not found'}
-        onDismiss={() => {
-          setDataSouceModalOpen(false);
-          setAutoInitializing(false);
-        }}
+        onDismiss={() => setDataSouceModalOpen(false)}
         isSubmitting={loading}
         onSubmit={() => {
           if (jsonData.metrics.hostedId && jsonData.logs.hostedId) {

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -410,8 +410,6 @@ export const COLORS = {
   grey: '#F7F8FA',
 };
 
-export const LEGACY_METRICS_DS_NAME = 'Synthetic Monitoring Metrics';
-export const LEGACY_LOGS_DS_NAME = 'Synthetic Monitoring Logs';
 export const SM_ALERTING_NAMESPACE = 'synthetic_monitoring';
 export const ALERTING_SEVERITY_OPTIONS: Array<ComboboxOption<AlertSeverity>> = [
   {

--- a/src/datasource/DataSource.test.ts
+++ b/src/datasource/DataSource.test.ts
@@ -7,6 +7,7 @@ import { apiRoute, ApiRoutes, getServerRequests } from 'test/handlers';
 import { server } from 'test/server';
 
 import { AlertSensitivity } from 'types';
+import { DEFAULT_LOGS_DS_UID, DEFAULT_METRICS_DS_UID } from 'datasource/constants';
 import { SMDataSource } from 'datasource/DataSource';
 
 type Entry = {
@@ -140,7 +141,7 @@ describe('SMDataSource', () => {
     });
 
     it('should fall back to default grafanacloud-logs UID when configured datasource does not exist', () => {
-      const defaultLogsDS = { ...LOGS_DATASOURCE, uid: 'grafanacloud-logs' };
+      const defaultLogsDS = { ...LOGS_DATASOURCE, uid: DEFAULT_LOGS_DS_UID };
       config.datasources = {
         [defaultLogsDS.name]: defaultLogsDS,
       };
@@ -159,7 +160,7 @@ describe('SMDataSource', () => {
       const result = smDataSourceWithMissingConfig.getLogsDS();
 
       expect(result).toEqual(defaultLogsDS);
-      expect(result?.uid).toEqual('grafanacloud-logs');
+      expect(result?.uid).toEqual(DEFAULT_LOGS_DS_UID);
     });
 
     it('should respect custom datasource configuration', () => {
@@ -209,8 +210,8 @@ describe('SMDataSource', () => {
       expect(result?.uid).toEqual('P4DCEA413A673ADCC');
     });
 
-    it('should fall back to default grafanacloud-metrics UID when configured datasource does not exist', () => {
-      const defaultMetricsDS = { ...METRICS_DATASOURCE, uid: 'grafanacloud-metrics' };
+    it('should fall back to default grafanacloud-prom UID when configured datasource does not exist', () => {
+      const defaultMetricsDS = { ...METRICS_DATASOURCE, name: 'renamed-metrics', uid: DEFAULT_METRICS_DS_UID };
       config.datasources = {
         [defaultMetricsDS.name]: defaultMetricsDS,
       };
@@ -222,6 +223,7 @@ describe('SMDataSource', () => {
           metrics: {
             ...SM_DATASOURCE.jsonData.metrics,
             uid: 'non-existent-uid',
+            grafanaName: 'non-existent-name',
           },
         },
       });
@@ -229,7 +231,7 @@ describe('SMDataSource', () => {
       const result = smDataSourceWithMissingConfig.getMetricsDS();
 
       expect(result).toEqual(defaultMetricsDS);
-      expect(result?.uid).toEqual('grafanacloud-metrics');
+      expect(result?.uid).toEqual(DEFAULT_METRICS_DS_UID);
     });
   });
 

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -36,6 +36,7 @@ import {
 } from './responses.types';
 import { QueryType, SMOptions, SMQuery } from './types';
 import { findLinkedDatasource, getRandomProbes, queryLogs } from 'utils';
+import { DEFAULT_LOGS_DS_UID, DEFAULT_METRICS_DS_UID } from 'datasource/constants';
 import { ExtendedBulkUpdateCheckResult } from 'data/useChecks';
 
 import { LokiQueryResults } from '../components/Checkster/feature/adhoc-check/useAdHocLogs';
@@ -105,7 +106,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       return configuredDs;
     }
     // Fall back to the default Grafana Cloud metrics datasource if configured one doesn't exist
-    return findLinkedDatasource({ ...info, uid: 'grafanacloud-metrics' });
+    return findLinkedDatasource({ ...info, uid: DEFAULT_METRICS_DS_UID });
   }
 
   getLogsDS() {
@@ -116,7 +117,7 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       return configuredDs;
     }
     // Fall back to the default Grafana Cloud logs datasource if configured one doesn't exist
-    return findLinkedDatasource({ ...info, uid: 'grafanacloud-logs' });
+    return findLinkedDatasource({ ...info, uid: DEFAULT_LOGS_DS_UID });
   }
 
   async query(options: DataQueryRequest<SMQuery>): Promise<DataQueryResponse> {

--- a/src/datasource/constants.ts
+++ b/src/datasource/constants.ts
@@ -1,0 +1,6 @@
+export const LEGACY_METRICS_DS_NAME = 'Synthetic Monitoring Metrics';
+export const LEGACY_LOGS_DS_NAME = 'Synthetic Monitoring Logs';
+
+/** Default Grafana Cloud datasource UIDs when resolving by UID without explicit provisioning. */
+export const DEFAULT_METRICS_DS_UID = 'grafanacloud-prom';
+export const DEFAULT_LOGS_DS_UID = 'grafanacloud-logs';

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -1,17 +1,14 @@
 import { useState } from 'react';
-import { useLocation } from 'react-router';
 import { DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
 import { config, getBackendSrv } from '@grafana/runtime';
-import { trackAutoInitialized, trackAutoInitializeFailed } from 'features/tracking/onboardingEvents';
 import { isNumber } from 'lodash';
 
 import { SubmissionErrorWrapper } from 'types';
 import { FaroEvent, reportError, reportEvent } from 'faro';
 import { initializeDatasource } from 'utils';
-import { PLUGIN_URL_PATH } from 'routing/constants';
 import { AppRoutes } from 'routing/types';
 import { getRoute } from 'routing/utils';
-import { LEGACY_LOGS_DS_NAME, LEGACY_METRICS_DS_NAME } from 'components/constants';
+import { DEFAULT_LOGS_DS_UID, DEFAULT_METRICS_DS_UID, LEGACY_LOGS_DS_NAME, LEGACY_METRICS_DS_NAME } from 'datasource/constants';
 
 import { useMeta } from './useMeta';
 
@@ -53,9 +50,9 @@ function findDatasourceByNameAndUid(
   if (!byUid) {
     byUid = Object.values(config.datasources).find((ds) => {
       if (type === 'loki') {
-        return ds.uid === 'grafanacloud-logs';
+        return ds.uid === DEFAULT_LOGS_DS_UID;
       } else {
-        return ds.uid === 'grafanacloud-metrics';
+        return ds.uid === DEFAULT_METRICS_DS_UID;
       }
     });
   }
@@ -97,14 +94,11 @@ function ensureNameAndUidMatch(
 }
 
 // TODO: Allow for the `redirectTo` to be a string (so that we can implement "return to" behaviour after initialization)
-export const useAppInitializer = (redirectTo?: AppRoutes, reloadCurrent = false) => {
+export const useAppInitializer = (redirectTo?: AppRoutes) => {
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
   const [datasourceModalOpen, setDataSouceModalOpen] = useState<boolean>(false);
   const { jsonData, id } = useMeta();
-  const { pathname } = useLocation();
-  // App-relative route for tracking, e.g. `checks/new/api-endpoint`.
-  const currentRoute = pathname.replace(PLUGIN_URL_PATH, '').replace(/^\//, '');
 
   const metricsName = getMetricsName(jsonData.metrics.grafanaName);
   const { byName: metricsByName, byUid: metricsByUid } = findDatasourceByNameAndUid(
@@ -127,13 +121,12 @@ export const useAppInitializer = (redirectTo?: AppRoutes, reloadCurrent = false)
       if (logsStatus === DatasourceStatus.NotFound) {
         throw new Error('Invalid plugin configuration. Could not find a logs datasource');
       }
-      // Either the plugin is running on prem and can find a datasource, or the provisioning matches with the default grafana cloud UIDs. Everything is good to go!
-      if (
-        (metricsStatus === DatasourceStatus.Match || metricsStatus === DatasourceStatus.NameOnly) &&
-        metricsByName &&
-        (logsStatus === DatasourceStatus.Match || logsStatus === DatasourceStatus.NameOnly) &&
-        logsByName
-      ) {
+
+      const metricsMatchOrNameOnly =
+        metricsStatus === DatasourceStatus.Match || metricsStatus === DatasourceStatus.NameOnly;
+      const logsMatchOrNameOnly = logsStatus === DatasourceStatus.Match || logsStatus === DatasourceStatus.NameOnly;
+
+      if (metricsMatchOrNameOnly && metricsByName && logsMatchOrNameOnly && logsByName) {
         const metricsHostedId = jsonData.metrics.hostedId;
         if (!metricsHostedId) {
           throw new Error('Invalid plugin configuration. Could not find metrics datasource hostedId');
@@ -154,7 +147,12 @@ export const useAppInitializer = (redirectTo?: AppRoutes, reloadCurrent = false)
         return;
       }
 
-      if (metricsStatus === DatasourceStatus.UidOnly || logsStatus === DatasourceStatus.UidOnly) {
+      if (
+        metricsStatus === DatasourceStatus.UidOnly ||
+        logsStatus === DatasourceStatus.UidOnly ||
+        metricsStatus === DatasourceStatus.Mismatch ||
+        logsStatus === DatasourceStatus.Mismatch
+      ) {
         setDataSouceModalOpen(true);
       }
     } catch (e: unknown) {
@@ -196,11 +194,7 @@ export const useAppInitializer = (redirectTo?: AppRoutes, reloadCurrent = false)
 
       await initializeDatasource(datasourcePayload);
 
-      if (reloadCurrent) {
-        trackAutoInitialized({ route: currentRoute });
-        // Reload the current deep-link so GrafanaBootConfig picks up the new datasource.
-        window.location.reload();
-      } else if (redirectTo) {
+      if (redirectTo) {
         window.location.href = `${window.location.origin}${getRoute(redirectTo)}`;
       } else {
         // force reload so that GrafanaBootConfig is updated.
@@ -209,9 +203,6 @@ export const useAppInitializer = (redirectTo?: AppRoutes, reloadCurrent = false)
     } catch (e) {
       const err = e as SubmissionErrorWrapper;
       const message = err.data?.msg ?? err.data?.err ?? 'Something went wrong';
-      if (reloadCurrent) {
-        trackAutoInitializeFailed({ route: currentRoute, reason: message });
-      }
       setError(message);
       setLoading(false);
       reportError(message, FaroEvent.Init);

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -1,11 +1,14 @@
 import { useState } from 'react';
+import { useLocation } from 'react-router';
 import { DataSourceInstanceSettings, DataSourceJsonData } from '@grafana/data';
 import { config, getBackendSrv } from '@grafana/runtime';
+import { trackAutoInitialized, trackAutoInitializeFailed } from 'features/tracking/onboardingEvents';
 import { isNumber } from 'lodash';
 
 import { SubmissionErrorWrapper } from 'types';
 import { FaroEvent, reportError, reportEvent } from 'faro';
 import { initializeDatasource } from 'utils';
+import { PLUGIN_URL_PATH } from 'routing/constants';
 import { AppRoutes } from 'routing/types';
 import { getRoute } from 'routing/utils';
 import { DEFAULT_LOGS_DS_UID, DEFAULT_METRICS_DS_UID, LEGACY_LOGS_DS_NAME, LEGACY_METRICS_DS_NAME } from 'datasource/constants';
@@ -94,11 +97,14 @@ function ensureNameAndUidMatch(
 }
 
 // TODO: Allow for the `redirectTo` to be a string (so that we can implement "return to" behaviour after initialization)
-export const useAppInitializer = (redirectTo?: AppRoutes) => {
+export const useAppInitializer = (redirectTo?: AppRoutes, reloadCurrent = false) => {
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
   const [datasourceModalOpen, setDataSouceModalOpen] = useState<boolean>(false);
   const { jsonData, id } = useMeta();
+  const { pathname } = useLocation();
+  // App-relative route for tracking, e.g. `checks/new/api-endpoint`.
+  const currentRoute = pathname.replace(PLUGIN_URL_PATH, '').replace(/^\//, '');
 
   const metricsName = getMetricsName(jsonData.metrics.grafanaName);
   const { byName: metricsByName, byUid: metricsByUid } = findDatasourceByNameAndUid(
@@ -194,7 +200,11 @@ export const useAppInitializer = (redirectTo?: AppRoutes) => {
 
       await initializeDatasource(datasourcePayload);
 
-      if (redirectTo) {
+      if (reloadCurrent) {
+        trackAutoInitialized({ route: currentRoute });
+        // Reload the current deep-link so GrafanaBootConfig picks up the new datasource.
+        window.location.reload();
+      } else if (redirectTo) {
         window.location.href = `${window.location.origin}${getRoute(redirectTo)}`;
       } else {
         // force reload so that GrafanaBootConfig is updated.
@@ -203,6 +213,9 @@ export const useAppInitializer = (redirectTo?: AppRoutes) => {
     } catch (e) {
       const err = e as SubmissionErrorWrapper;
       const message = err.data?.msg ?? err.data?.err ?? 'Something went wrong';
+      if (reloadCurrent) {
+        trackAutoInitializeFailed({ route: currentRoute, reason: message });
+      }
       setError(message);
       setLoading(false);
       reportError(message, FaroEvent.Init);


### PR DESCRIPTION
## Problem

When a user clicks "Get started" on the Welcome page to initialize Synthetic Monitoring, nothing happens if the provisioned datasource names and UID-resolved datasource names disagree (a `Mismatch` status). This is because `handleClick` only handled `NotFound`, `Match`, `NameOnly`, and `UidOnly` -- the `Mismatch` case silently fell through with no action taken.

Additionally, the metrics UID fallback used the non-existent UID `grafanacloud-metrics` instead of the correct Grafana Cloud convention `grafanacloud-prom`, meaning the fallback never matched any real datasource.

## Solution

The `Mismatch` status is now handled alongside `UidOnly`, opening the `MismatchedDatasourceModal` so the user can see the expected vs found datasources and choose to proceed.

The metrics UID fallback has been corrected from `grafanacloud-metrics` to `grafanacloud-prom` (via a new `DEFAULT_METRICS_DS_UID` constant), matching the standard Grafana Cloud UID convention. The logs UID (`grafanacloud-logs`) was already correct but has been extracted to a `DEFAULT_LOGS_DS_UID` constant for consistency. Both `useAppInitializer` and `DataSource.getMetricsDS`/`getLogsDS` now reference these shared constants.

Integration tests have been added for the `AppInitializer` component covering all `DatasourceStatus` branches, and the existing `DataSource.test.ts` fallback test has been updated to verify the corrected UID.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-run initialization and linked datasource resolution paths; wrong UID or status handling could block setup or pick the wrong datasources, though behavior is covered by new tests.
> 
> **Overview**
> Fixes **Welcome / Get started** doing nothing when provisioned metrics/logs names and UID lookups disagree by treating **`Mismatch`** like **`UidOnly`** and opening **`MismatchedDatasourceModal`**.
> 
> Centralizes Grafana Cloud default UIDs in **`datasource/constants`**: metrics fallback is **`grafanacloud-prom`** (replacing **`grafanacloud-metrics`**) and logs stays **`grafanacloud-logs`**. **`useAppInitializer`**, **`SMDataSource.getMetricsDS`/`getLogsDS`**, and legacy datasource name constants now use that module.
> 
> Adds **`AppInitializer`** integration tests for install success, missing datasources/hostedIds, mismatch, and UID-only cases; updates **`DataSource.test.ts`** for the new fallback UID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7359387aea8458efe3807a3567dbf9d4b2b51e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->