### PR TITLE
feat: replace inline screenshot boilerplate with sm-screenshots jslib

### DIFF
--- a/src/components/BrowserExamplesMenu/snippets/screenshotsGCS.js
+++ b/src/components/BrowserExamplesMenu/snippets/screenshotsGCS.js
@@ -1,117 +1,30 @@
 // Screenshots (External storage — GCS)
 //
-// Captures a screenshot, uploads the image to a Google Cloud Storage bucket
-// using S3-compatible HMAC authentication, and logs a URL reference to Loki.
-// The image bytes never pass through Loki — only a small reference log line
-// is stored. Best for large-scale checks where Loki ingestion volume is a concern.
-//
-// IMPORTANT: The bucket must allow public read access for the stored objects.
-// The screenshots are rendered via <img> tags in the browser, which cannot attach
-// storage credentials. The object URLs contain UUIDs and are not guessable.
+// Captures a screenshot, uploads to a GCS bucket, and logs a URL reference to Loki.
+// Best for production/scale — avoids Loki ingestion volume from large images.
 //
 // Required secrets (Synthetic Monitoring > Config > Secrets):
 //   - sm-screenshot-loki-host: your Loki base URL (e.g. https://logs-dev-005.grafana-dev.net)
 //   - sm-screenshot-loki-auth: base64-encoded user:token string
-//   - sm-screenshot-gcs-access-key: GCS HMAC access key 
+//   - sm-screenshot-gcs-access-key: GCS HMAC access key
 //   - sm-screenshot-gcs-secret-key: GCS HMAC secret key
-//   - sm-screenshot-gcs-bucket: your GCS bucket name (e.g. my-screenshots-bucket)
+//   - sm-screenshot-gcs-bucket: GCS bucket name
 //
-// The frontend detects screenshots via two required log lines:
-//   1. console.log(`screenshot:${uuid}`) — written to execution logs for discovery
-//   2. A JSON log line with source="synthetic-monitoring-agent-screenshot" — the payload
-// Both are required for the screenshot to appear in the UI.
+// IMPORTANT: The bucket must allow public read access for stored objects.
+// Screenshots are rendered via <img> tags that cannot attach auth headers.
+// Object URLs contain UUIDs and are not guessable.
 
-import http from 'k6/http';
-import secrets from 'k6/secrets';
 import { browser } from 'k6/browser';
-import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
-import { AWSConfig, S3Client } from 'https://jslib.k6.io/aws/0.14.0/s3.js';
+import { captureScreenshot, gcs } from 'https://jslib.k6.io/sm-screenshots/0.1.0/index.js';
 
 export const options = {
   scenarios: {
     ui: {
       executor: 'shared-iterations',
-      options: {
-        browser: {
-          type: 'chromium',
-        },
-      },
+      options: { browser: { type: 'chromium' } },
     },
   },
 };
-
-function nowNano() {
-  return String(Date.now() * 1_000_000);
-}
-
-async function captureAndUploadScreenshot(page, caption) {
-  const screenshotBuffer = await page.screenshot();
-  const uuid = uuidv4();
-  const filename = `${uuid}.png`;
-
-  const gcsAccessKey = await secrets.get('sm-screenshot-gcs-access-key');
-  const gcsSecretKey = await secrets.get('sm-screenshot-gcs-secret-key');
-  const gcsBucket = await secrets.get('sm-screenshot-gcs-bucket');
-
-  // GCS offers an S3-compatible API (https://cloud.google.com/storage/docs/interoperability)
-  // so we reuse k6's S3Client with the same signing protocol, just a different endpoint.
-  const s3 = new S3Client(new AWSConfig({
-    region: 'auto',
-    accessKeyId: gcsAccessKey,
-    secretAccessKey: gcsSecretKey,
-    endpoint: 'storage.googleapis.com',
-  }));
-
-  try {
-    await s3.putObject(gcsBucket, filename, screenshotBuffer, {
-      contentType: 'image/png',
-    });
-  } catch (err) {
-    console.error(`GCS upload failed: ${err}`);
-    return;
-  }
-
-  // Public download URL
-  const screenshotUrl = `https://storage.googleapis.com/${gcsBucket}/${filename}`;
-
-  // Push a small reference log line to Loki (no image data, just the URL)
-  const lokiHost = await secrets.get('sm-screenshot-loki-host');
-  const lokiAuth = await secrets.get('sm-screenshot-loki-auth');
-
-  const host = lokiHost.startsWith('http') ? lokiHost : `https://${lokiHost}`;
-
-  const payload = JSON.stringify({
-    streams: [
-      {
-        stream: { source: 'synthetic-monitoring-agent-screenshot', level: 'info' },
-        values: [
-          [
-            nowNano(),
-            JSON.stringify({
-              id: uuid,
-              screenshot_url: screenshotUrl,
-              caption,
-            }),
-          ],
-        ],
-      },
-    ],
-  });
-
-  const lokiRes = http.post(`${host}/loki/api/v1/push`, payload, {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Basic ${lokiAuth}`,
-    },
-  });
-
-  if (lokiRes.status !== 204) {
-    console.error(`Loki push failed [${lokiRes.status}]: ${lokiRes.body}`);
-  } else {
-    // This log line is required — the frontend uses it to discover screenshots
-    console.log(`screenshot:${uuid}`);
-  }
-}
 
 export default async function () {
   const context = await browser.newContext();
@@ -119,7 +32,7 @@ export default async function () {
 
   try {
     await page.goto('https://quickpizza.grafana.com', { waitUntil: 'networkidle' });
-    await captureAndUploadScreenshot(page, `Snapshot of ${page.url()}`);
+    await captureScreenshot(page, { caption: `Snapshot of ${page.url()}`, store: gcs() });
   } finally {
     await page.close();
   }

--- a/src/components/BrowserExamplesMenu/snippets/screenshotsLoki.js
+++ b/src/components/BrowserExamplesMenu/snippets/screenshotsLoki.js
@@ -5,98 +5,19 @@
 //
 // Required secrets (Synthetic Monitoring > Config > Secrets):
 //   - sm-screenshot-loki-host: your Loki base URL (e.g. https://logs-dev-005.grafana-dev.net)
-//   - sm-screenshot-loki-auth: base64-encoded user:token string (used directly to avoid credential leaking via httpDebug)
-//
-// The frontend detects screenshots via two required log lines:
-//   1. console.log(`screenshot:${uuid}`) — written to execution logs for discovery
-//   2. A JSON log line with source="synthetic-monitoring-agent-screenshot" — the payload
-// Both are required for the screenshot to appear in the UI.
+//   - sm-screenshot-loki-auth: base64-encoded user:token string
 
-import http from 'k6/http';
-import encoding from 'k6/encoding';
-import secrets from 'k6/secrets';
 import { browser } from 'k6/browser';
-import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+import { captureScreenshot, loki } from 'https://jslib.k6.io/sm-screenshots/0.1.0/index.js';
 
 export const options = {
   scenarios: {
     ui: {
       executor: 'shared-iterations',
-      options: {
-        browser: {
-          type: 'chromium',
-        },
-      },
+      options: { browser: { type: 'chromium' } },
     },
   },
 };
-
-function nowNano() {
-  return String(Date.now() * 1_000_000);
-}
-
-function buildLogLine(level, message, extra) {
-  return JSON.stringify({
-    level,
-    message,
-    timestamp: new Date().toISOString(),
-    ...extra,
-  });
-}
-
-async function pushScreenshotToLoki(screenshotBuffer, caption) {
-  const screenshotBase64 = encoding.b64encode(screenshotBuffer);
-  const screenshotSize = `${Math.ceil(screenshotBase64.length * 0.75)} bytes`;
-  const uuid = uuidv4();
-  const CHUNK_SIZE = 200 * 1024;
-  const chunkTotal = Math.ceil(screenshotBase64.length / CHUNK_SIZE);
-
-  for (let i = 0; i < chunkTotal; i++) {
-    const chunk = screenshotBase64.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE);
-    await pushToLoki(
-      [
-        {
-          stream: { source: 'synthetic-monitoring-agent-screenshot', level: 'info' },
-          values: [
-            [
-              nowNano(),
-              buildLogLine('info', 'page screenshot', {
-                id: uuid,
-                screenshot_base64: chunk,
-                caption,
-                screenshot_size_bytes: screenshotSize,
-                chunk_index: i,
-                chunk_total: chunkTotal,
-              }),
-            ],
-          ],
-        },
-      ],
-      i === 0 ? uuid : null
-    );
-  }
-}
-
-async function pushToLoki(streams, uuid) {
-  const lokiHost = await secrets.get('sm-screenshot-loki-host');
-  const lokiAuth = await secrets.get('sm-screenshot-loki-auth');
-
-  const host = lokiHost.startsWith('http') ? lokiHost : `https://${lokiHost}`;
-
-  const res = http.post(`${host}/loki/api/v1/push`, JSON.stringify({ streams }), {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Basic ${lokiAuth}`,
-    },
-  });
-
-  if (res.status !== 204) {
-    console.error(`Loki push failed [${res.status}]: ${res.body}`);
-  } else if (uuid) {
-    // This log line is required — the frontend uses it to discover screenshots
-    console.log(`screenshot:${uuid}`);
-  }
-}
 
 export default async function () {
   const context = await browser.newContext();
@@ -104,7 +25,7 @@ export default async function () {
 
   try {
     await page.goto('https://quickpizza.grafana.com', { waitUntil: 'networkidle' });
-    await pushScreenshotToLoki(await page.screenshot(), `Snapshot of ${page.url()}`);
+    await captureScreenshot(page, { caption: `Snapshot of ${page.url()}`, store: loki() });
   } finally {
     await page.close();
   }


### PR DESCRIPTION
## Problem

The browser screenshot example snippets (`screenshotsLoki.js` and `screenshotsGCS.js`) contain ~200 lines of inline boilerplate — base64 encoding, chunking, Loki push logic, GCS upload via S3-compatible HMAC auth, and discovery log lines. This makes the examples hard for users to understand and copy into their own checks, and creates a maintenance burden if the log format ever changes.

## Solution

Replace both snippets with imports from the new [`sm-screenshots` jslib](https://github.com/grafana/k6-jslib-sm-screenshots), published at `https://jslib.k6.io/sm-screenshots/0.1.0/index.js`. The jslib produces the exact same log format as the previous inline code, so no frontend parsing changes are needed and secret names are unchanged.

The result is two clean ~35-line example scripts that clearly show users what they need to do: import the helpers, call `captureScreenshot`, and choose a storage backend (`loki()` or `gcs()`).

## Additional context

- Both snippets have been tested end-to-end against real SM infrastructure — screenshots appear correctly with thumbnails in execution logs.
- The required secrets are documented in script comments at the top of each snippet, which users see when the example is inserted into the editor.
- Relates to #1610 which originally added these snippets.
- PRs that adds the lib to the repo: https://github.com/grafana/k6-jslib-sm-screenshots/pull/2 and https://github.com/grafana/jslib.k6.io/pull/229

<img width="2087" height="1169" alt="image" src="https://github.com/user-attachments/assets/d4bfc311-d634-4ebf-a585-d6c38b00b95b" />
<img width="1558" height="900" alt="image" src="https://github.com/user-attachments/assets/85350ff4-f2f4-4834-9111-69ca06ed5ab9" />
<img width="1482" height="1075" alt="image" src="https://github.com/user-attachments/assets/2098cff8-4289-42b2-9594-dfbcccab4d36" />
