### PR TITLE
feat: LLM Evaluator check type — front-end

### DIFF
--- a/src/components/CheckEditor/FormComponents/Frequency.constants.ts
+++ b/src/components/CheckEditor/FormComponents/Frequency.constants.ts
@@ -1,4 +1,5 @@
 import { MIN_FREQUENCY_BROWSER } from 'schemas/forms/BrowserCheckSchema';
+import { MIN_FREQUENCY_LLM_EVALUATOR } from 'schemas/forms/LLMEvaluatorCheckSchema';
 import { MIN_FREQUENCY_MULTI_HTTP } from 'schemas/forms/MultiHttpCheckSchema';
 import { MIN_FREQUENCY_SCRIPTED } from 'schemas/forms/ScriptedCheckSchema';
 import { MIN_FREQUENCY_TRACEROUTE } from 'schemas/forms/TracerouteCheckSchema';
@@ -29,6 +30,7 @@ export const MIN_FREQUENCY_MAP = {
   [CheckType.Dns]: MIN_BASE_FREQUENCY,
   [CheckType.Grpc]: MIN_BASE_FREQUENCY,
   [CheckType.Http]: MIN_BASE_FREQUENCY,
+  [CheckType.LlmEvaluator]: MIN_FREQUENCY_LLM_EVALUATOR,
   [CheckType.MultiHttp]: MIN_FREQUENCY_MULTI_HTTP,
   [CheckType.Ping]: MIN_BASE_FREQUENCY,
   [CheckType.Scripted]: MIN_FREQUENCY_SCRIPTED,

--- a/src/components/CheckEditor/ProbeOptions.tsx
+++ b/src/components/CheckEditor/ProbeOptions.tsx
@@ -52,5 +52,11 @@ function getAvailableProbes(probes: ProbeWithMetadata[], checkType: CheckType) {
     return probes.filter((probe) => !probe.capabilities.disableBrowserChecks);
   }
 
+  if (checkType === CheckType.LlmEvaluator) {
+    return probes.filter(
+      (probe) => probe.capabilities.enableLLMEvaluatorChecks && probe.capabilities.enableProtocolSecrets
+    );
+  }
+
   return probes;
 }

--- a/src/components/Checkster/components/form/generic/GenericFrequencyField/Frequency.constants.ts
+++ b/src/components/Checkster/components/form/generic/GenericFrequencyField/Frequency.constants.ts
@@ -1,4 +1,5 @@
 import { MIN_FREQUENCY_BROWSER } from 'schemas/forms/BrowserCheckSchema';
+import { MIN_FREQUENCY_LLM_EVALUATOR } from 'schemas/forms/LLMEvaluatorCheckSchema';
 import { MIN_FREQUENCY_MULTI_HTTP } from 'schemas/forms/MultiHttpCheckSchema';
 import { MIN_FREQUENCY_SCRIPTED } from 'schemas/forms/ScriptedCheckSchema';
 import { MIN_FREQUENCY_TRACEROUTE } from 'schemas/forms/TracerouteCheckSchema';
@@ -29,6 +30,7 @@ export const MIN_FREQUENCY_MAP = {
   [CheckType.Dns]: MIN_BASE_FREQUENCY,
   [CheckType.Grpc]: MIN_BASE_FREQUENCY,
   [CheckType.Http]: MIN_BASE_FREQUENCY,
+  [CheckType.LlmEvaluator]: MIN_FREQUENCY_LLM_EVALUATOR,
   [CheckType.MultiHttp]: MIN_FREQUENCY_MULTI_HTTP,
   [CheckType.Ping]: MIN_BASE_FREQUENCY,
   [CheckType.Scripted]: MIN_FREQUENCY_SCRIPTED,

--- a/src/components/Checkster/components/form/layouts/LLMEvaluatorCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/LLMEvaluatorCheckContent.tsx
@@ -1,0 +1,194 @@
+import React, { Fragment, useMemo } from 'react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Button, Combobox, ComboboxOption, IconButton, Stack, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { CheckFormValues } from 'types';
+import { useSecrets } from 'data/useSecrets';
+
+import { MAX_CRITERIA_COUNT } from '../../../../../schemas/forms/LLMEvaluatorCheckSchema';
+import { FIELD_SPACING } from '../../../constants';
+import { createPath, getFieldErrorProps } from '../../../utils/form';
+import { Column } from '../../ui/Column';
+import { SectionContent } from '../../ui/SectionContent';
+import { StyledField } from '../../ui/StyledField';
+import { ChooseCheckType } from '../ChooseCheckType';
+import { FormJobField } from '../FormJobField';
+import { GenericInputField } from '../generic/GenericInputField';
+import { GenericTextareaField } from '../generic/GenericTextareaField';
+
+export const LLM_EVALUATOR_CHECK_FIELDS = [
+  'job',
+  'target',
+  'settings.llmEvaluator.endpoint',
+  'settings.llmEvaluator.model',
+  'settings.llmEvaluator.apiKeyRef',
+  'settings.llmEvaluator.systemPrompt',
+  'settings.llmEvaluator.prompt',
+  'settings.llmEvaluator.criteria',
+];
+
+const CRITERIA_FIELD_PATH = 'settings.llmEvaluator.criteria' as const;
+
+export function LLMEvaluatorCheckContent() {
+  return (
+    <SectionContent>
+      <Column gap={FIELD_SPACING}>
+        <FormJobField field="job" />
+        <ChooseCheckType />
+
+        <GenericInputField
+          field="target"
+          label="Instance"
+          description="A unique label for this check (used as the Prometheus instance label)."
+          placeholder="my-llm-check"
+          required
+        />
+
+        <GenericInputField
+          field="settings.llmEvaluator.endpoint"
+          label="Endpoint URL"
+          description="OpenAI-compatible base URL. The agent will POST to {endpoint}/v1/chat/completions."
+          placeholder="https://api.openai.com"
+          required
+        />
+
+        <GenericInputField
+          field="settings.llmEvaluator.model"
+          label="Model"
+          description="Model name passed in the chat completions request body."
+          placeholder="gpt-4o-mini"
+          required
+        />
+
+        <ApiKeyRefField />
+
+        <GenericTextareaField
+          field="settings.llmEvaluator.systemPrompt"
+          label="System prompt (optional)"
+          description="Optional system message prepended to each request. Max 500 characters."
+          rows={3}
+        />
+
+        <GenericTextareaField
+          field="settings.llmEvaluator.prompt"
+          label="Prompt"
+          description="User message sent to the LLM on each execution. Max 2,000 characters."
+          rows={5}
+          required
+        />
+
+        <CriteriaList />
+      </Column>
+    </SectionContent>
+  );
+}
+
+function ApiKeyRefField() {
+  const {
+    formState: { disabled, errors },
+    setValue,
+    watch,
+  } = useFormContext<CheckFormValues>();
+  const { data: secrets = [], isLoading } = useSecrets(true);
+  const value = watch('settings.llmEvaluator.apiKeyRef' as any);
+
+  const options: Array<ComboboxOption<string>> = useMemo(
+    () => secrets.map((s) => ({ label: s.name, value: s.name, description: s.description })),
+    [secrets]
+  );
+
+  return (
+    <StyledField
+      label="Target LLM API key"
+      description="Select an SM Secret holding the bearer token for the target LLM."
+      required
+      {...getFieldErrorProps(errors, 'settings.llmEvaluator.apiKeyRef' as any)}
+    >
+      <Combobox
+        value={value}
+        options={options}
+        loading={isLoading}
+        disabled={disabled}
+        placeholder={secrets.length === 0 ? 'No secrets configured — create one in Config → Secrets' : 'Select a secret'}
+        onChange={(opt) => setValue('settings.llmEvaluator.apiKeyRef' as any, opt.value, { shouldDirty: true, shouldValidate: true })}
+      />
+    </StyledField>
+  );
+}
+
+function CriteriaList() {
+  const styles = useStyles2(getStyles);
+  const {
+    control,
+    formState: { disabled, errors },
+  } = useFormContext<CheckFormValues>();
+  const { fields, append, remove } = useFieldArray({ control, name: CRITERIA_FIELD_PATH as any });
+
+  const arrayErrors = (errors as any)?.settings?.llmEvaluator?.criteria;
+  const rootError =
+    typeof arrayErrors?.message === 'string'
+      ? arrayErrors.message
+      : typeof arrayErrors?.root?.message === 'string'
+        ? arrayErrors.root.message
+        : undefined;
+
+  return (
+    <Stack direction="column" gap={1}>
+      <StyledField
+        label="Evaluation criteria"
+        description={`Up to ${MAX_CRITERIA_COUNT} natural-language assertions the judge LLM evaluates the response against. Each is a binary pass/fail.`}
+        required
+        invalid={Boolean(rootError)}
+        error={rootError}
+        emulate
+      >
+        <div />
+      </StyledField>
+
+      <div className={styles.list}>
+        {fields.map((row, index) => (
+          <Fragment key={row.id}>
+            <GenericInputField
+              field={createPath(CRITERIA_FIELD_PATH, index)}
+              aria-label={`Criterion ${index + 1}`}
+              placeholder={`Criterion ${index + 1} — e.g. "Response is under 100 words"`}
+            />
+            <IconButton
+              disabled={disabled || fields.length <= 1}
+              name="minus"
+              onClick={() => remove(index)}
+              tooltip="Remove criterion"
+            />
+          </Fragment>
+        ))}
+      </div>
+
+      <Button
+        className={css`
+          align-self: flex-start;
+        `}
+        icon="plus"
+        onClick={() => append('' as any)}
+        variant="secondary"
+        size="sm"
+        type="button"
+        disabled={disabled || fields.length >= MAX_CRITERIA_COUNT}
+      >
+        Add criterion
+      </Button>
+    </Stack>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    list: css`
+      display: grid;
+      grid-template-columns: 1fr min-content;
+      gap: ${theme.spacing(1)};
+      align-items: start;
+    `,
+  };
+}

--- a/src/components/Checkster/components/form/layouts/LLMEvaluatorUptimeContent.tsx
+++ b/src/components/Checkster/components/form/layouts/LLMEvaluatorUptimeContent.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { CheckType } from 'types';
+
+import { CHECK_TYPE_TIMEOUT_MAP } from '../../../constants';
+import { SectionContent } from '../../ui/SectionContent';
+import { FormTimeoutField } from '../FormTimeoutField';
+
+export function LLMEvaluatorUptimeContent() {
+  return (
+    <SectionContent>
+      <div>
+        Uptime is reported as <code>probe_success</code>: <code>1</code> when every criterion passes,{' '}
+        <code>0</code> otherwise. Per-criterion pass/fail is also exported as{' '}
+        <code>probe_llm_eval_criterion_passed</code>.
+      </div>
+      <FormTimeoutField field="timeout" {...CHECK_TYPE_TIMEOUT_MAP[CheckType.LlmEvaluator]} />
+    </SectionContent>
+  );
+}

--- a/src/components/Checkster/components/form/sections/CheckSection.tsx
+++ b/src/components/Checkster/components/form/sections/CheckSection.tsx
@@ -9,6 +9,7 @@ import { BROWSER_CHECK_FIELDS,BrowserCheckContent } from '../layouts/BrowserChec
 import { DNS_CHECK_FIELDS,DnsCheckContent } from '../layouts/DnsCheckContent';
 import { GRPC_CHECK_FIELDS,GrpcCheckContent } from '../layouts/GrpcCheckContent';
 import { HTTP_CHECK_FIELDS,HttpCheckContent } from '../layouts/HttpCheckContent';
+import { LLM_EVALUATOR_CHECK_FIELDS, LLMEvaluatorCheckContent } from '../layouts/LLMEvaluatorCheckContent';
 import { MULTI_HTTP_CHECK_REG_EXP_LIST,MultiHttpCheckContent } from '../layouts/MultiHttpCheckContent';
 import { PingCheckContent } from '../layouts/PingCheckContent';
 import { SCRIPTED_CHECK_FIELDS,ScriptedCheckContent } from '../layouts/ScriptedCheckContent';
@@ -35,6 +36,8 @@ function getCheckTypeFields(checkType: CheckType) {
       return SCRIPTED_CHECK_FIELDS;
     case CheckType.Browser:
       return BROWSER_CHECK_FIELDS;
+    case CheckType.LlmEvaluator:
+      return LLM_EVALUATOR_CHECK_FIELDS;
     default:
       return DEFAULT_CHECK_FIELDS;
   }
@@ -52,6 +55,8 @@ const CHECK_TYPE_LAYOUT_MAP: Record<CheckType, ComponentType> = {
   [CheckType.MultiHttp]: MultiHttpCheckContent,
   [CheckType.Scripted]: ScriptedCheckContent,
   [CheckType.Browser]: BrowserCheckContent,
+  /* LLM Evaluator */
+  [CheckType.LlmEvaluator]: LLMEvaluatorCheckContent,
 };
 
 function getNavLabel(checkType: CheckType) {
@@ -61,6 +66,8 @@ function getNavLabel(checkType: CheckType) {
       return 'Script';
     case CheckType.MultiHttp:
       return 'Requests';
+    case CheckType.LlmEvaluator:
+      return 'Evaluation';
     default:
       return 'Request';
   }

--- a/src/components/Checkster/components/form/sections/UptimeSection.tsx
+++ b/src/components/Checkster/components/form/sections/UptimeSection.tsx
@@ -10,6 +10,7 @@ import { BrowserUptimeContent } from '../layouts/BrowserUptimeContent';
 import { DnsUptimeContent } from '../layouts/DnsUptimeContent';
 import { GrpcUptimeContent } from '../layouts/GrpcUptimeContent';
 import { HTTP_UPTIME_FIELDS, HttpUptimeContent } from '../layouts/HttpUptimeContent';
+import { LLMEvaluatorUptimeContent } from '../layouts/LLMEvaluatorUptimeContent';
 import { MultiHttpUptimeContent } from '../layouts/MultiHttpUptimeContent';
 import { PingUptimeContent } from '../layouts/PingUptimeContent';
 import { ScriptedUptimeContent } from '../layouts/ScriptedUptimeContent';
@@ -28,6 +29,8 @@ const CHECK_TYPE_LAYOUT_MAP: Record<CheckType, ComponentType> = {
   [CheckType.MultiHttp]: MultiHttpUptimeContent,
   [CheckType.Scripted]: ScriptedUptimeContent,
   [CheckType.Browser]: BrowserUptimeContent,
+  /* LLM Evaluator */
+  [CheckType.LlmEvaluator]: LLMEvaluatorUptimeContent,
 };
 
 const DEFAULT_UPTIME_FIELDS = ['timeout'];

--- a/src/components/Checkster/constants.ts
+++ b/src/components/Checkster/constants.ts
@@ -3,6 +3,11 @@ import { dnsCheckSchema } from 'schemas/forms/DNSCheckSchema';
 import { grpcCheckSchema } from 'schemas/forms/GRPCCheckSchema';
 import { httpCheckSchema } from 'schemas/forms/HttpCheckSchema';
 import {
+  llmEvaluatorCheckSchema,
+  MAX_TIMEOUT_LLM_EVALUATOR,
+  MIN_TIMEOUT_LLM_EVALUATOR,
+} from 'schemas/forms/LLMEvaluatorCheckSchema';
+import {
   MAX_TIMEOUT_MULTI_HTTP,
   MIN_TIMEOUT_MULTI_HTTP,
   multiHttpCheckSchema,
@@ -36,6 +41,7 @@ import {
   HttpSslOption,
   HttpVersion,
   IpVersion,
+  LLMEvaluatorCheck,
   MultiHTTPCheck,
   PingCheck,
   ResponseMatchType,
@@ -74,6 +80,7 @@ export const CHECK_TYPE_GROUP_MAP: Record<CheckTypeGroup, CheckType[]> = {
   [CheckTypeGroup.MultiStep]: [CheckType.MultiHttp],
   [CheckTypeGroup.Scripted]: [CheckType.Scripted],
   [CheckTypeGroup.Browser]: [CheckType.Browser],
+  [CheckTypeGroup.LlmEvaluator]: [CheckType.LlmEvaluator],
 };
 
 export const CHECK_TYPE_GROUP_OPTIONS_MAP: Record<CheckTypeGroup, CheckTypeGroupOption> = {
@@ -104,6 +111,13 @@ export const CHECK_TYPE_GROUP_OPTIONS_MAP: Record<CheckTypeGroup, CheckTypeGroup
     value: CheckTypeGroup.Browser,
     icon: `globe`,
     protocols: CHECK_TYPE_GROUP_MAP[CheckTypeGroup.Browser],
+  },
+  [CheckTypeGroup.LlmEvaluator]: {
+    label: `LLM Evaluator`,
+    description: `Probe an LLM endpoint and evaluate its response against natural-language criteria.`,
+    value: CheckTypeGroup.LlmEvaluator,
+    icon: `ai-sparkle`,
+    protocols: CHECK_TYPE_GROUP_MAP[CheckTypeGroup.LlmEvaluator],
   },
 };
 
@@ -178,6 +192,17 @@ export const CHECK_TYPE_OPTION_MAP: Record<CheckType, CheckTypeOption> = {
     value: CheckType.Browser,
     description: 'Leverage k6 browser module to run checks in a browser.',
     group: getCheckTypeGroup(CheckType.Browser),
+  },
+  [CheckType.LlmEvaluator]: {
+    label: 'LLM Evaluator',
+    value: CheckType.LlmEvaluator,
+    description: 'Probe an LLM endpoint and evaluate its response against natural-language criteria.',
+    group: getCheckTypeGroup(CheckType.LlmEvaluator),
+    status: {
+      value: CheckStatus.Experimental,
+      description: `LLM Evaluator checks are experimental.`,
+    },
+    featureToggle: FeatureName.LLMEvaluatorChecks,
   },
 };
 
@@ -315,6 +340,21 @@ export const DEFAULT_CHECK_CONFIG_MAP: Record<CheckType, Check> = {
       timeout: 60 * 1000,
     }
   ),
+  [CheckType.LlmEvaluator]: mergeBaseConfig<LLMEvaluatorCheck>(
+    CheckType.LlmEvaluator,
+    {
+      endpoint: '',
+      model: '',
+      apiKeyRef: '',
+      systemPrompt: '',
+      prompt: '',
+      criteria: [''],
+    },
+    {
+      frequency: 5 * 60 * 1000,
+      timeout: 30 * 1000,
+    }
+  ),
 };
 
 // Always keep in sync with DEFAULT_CHECK_TYPE
@@ -325,6 +365,7 @@ export const FORM_CHECK_TYPE_SCHEMA_MAP = {
   [CheckType.Dns]: dnsCheckSchema,
   [CheckType.Grpc]: grpcCheckSchema,
   [CheckType.Http]: httpCheckSchema,
+  [CheckType.LlmEvaluator]: llmEvaluatorCheckSchema,
   [CheckType.MultiHttp]: multiHttpCheckSchema,
   [CheckType.Ping]: pingCheckSchema,
   [CheckType.Scripted]: scriptedCheckSchema,
@@ -495,6 +536,7 @@ export const CHECK_TYPE_TIMEOUT_MAP: Record<CheckType, { min: number; max: numbe
   [CheckType.Dns]: BASE_TIMEOUT_MAP,
   [CheckType.Grpc]: BASE_TIMEOUT_MAP,
   [CheckType.Http]: BASE_TIMEOUT_MAP,
+  [CheckType.LlmEvaluator]: { min: MIN_TIMEOUT_LLM_EVALUATOR, max: MAX_TIMEOUT_LLM_EVALUATOR },
   [CheckType.MultiHttp]: { min: MIN_TIMEOUT_MULTI_HTTP, max: MAX_TIMEOUT_MULTI_HTTP },
   [CheckType.Ping]: BASE_TIMEOUT_MAP,
   [CheckType.Scripted]: { min: MIN_TIMEOUT_SCRIPTED, max: MAX_TIMEOUT_SCRIPTED },
@@ -532,6 +574,7 @@ export const CHECK_TYPE_GROUP_DEFAULT_CHECK: Record<CheckTypeGroup, CheckType> =
   [CheckTypeGroup.MultiStep]: CheckType.MultiHttp,
   [CheckTypeGroup.Browser]: CheckType.Browser,
   [CheckTypeGroup.Scripted]: CheckType.Scripted,
+  [CheckTypeGroup.LlmEvaluator]: CheckType.LlmEvaluator,
 };
 
 export const ASSISTED_FORM_MERGE_FIELDS = ['job', 'target', 'probes', 'frequency', 'labels', 'timeout'] as const;

--- a/src/components/Checkster/transformations/toFormValues.llmevaluator.ts
+++ b/src/components/Checkster/transformations/toFormValues.llmevaluator.ts
@@ -1,0 +1,23 @@
+import { CheckFormValuesLLMEvaluator, CheckType, LLMEvaluatorCheck } from 'types';
+
+import { getBaseFormValuesFromCheck } from './toFormValues.utils';
+
+export function getLLMEvaluatorCheckFormValues(check: LLMEvaluatorCheck): CheckFormValuesLLMEvaluator {
+  const base = getBaseFormValuesFromCheck(check);
+  const settings = check.settings.llmEvaluator;
+
+  return {
+    ...base,
+    checkType: CheckType.LlmEvaluator,
+    settings: {
+      llmEvaluator: {
+        endpoint: settings.endpoint ?? '',
+        model: settings.model ?? '',
+        apiKeyRef: settings.apiKeyRef ?? '',
+        systemPrompt: settings.systemPrompt ?? '',
+        prompt: settings.prompt ?? '',
+        criteria: settings.criteria ?? [],
+      },
+    },
+  };
+}

--- a/src/components/Checkster/transformations/toPayload.llmevaluator.ts
+++ b/src/components/Checkster/transformations/toPayload.llmevaluator.ts
@@ -1,0 +1,18 @@
+import { CheckFormValuesLLMEvaluator, LLMEvaluatorCheck } from 'types';
+
+import { getBasePayloadValuesFromForm } from './toPayload.utils';
+
+export function getLLMEvaluatorPayload(formValues: CheckFormValuesLLMEvaluator): LLMEvaluatorCheck {
+  const base = getBasePayloadValuesFromForm(formValues);
+  const { systemPrompt, ...rest } = formValues.settings.llmEvaluator;
+
+  return {
+    ...base,
+    settings: {
+      llmEvaluator: {
+        ...rest,
+        ...(systemPrompt ? { systemPrompt } : {}),
+      },
+    },
+  };
+}

--- a/src/components/Checkster/utils/adaptors.ts
+++ b/src/components/Checkster/utils/adaptors.ts
@@ -6,6 +6,7 @@ import {
   DNSCheck,
   GRPCCheck,
   HTTPCheck,
+  LLMEvaluatorCheck,
   MultiHTTPCheck,
   PingCheck,
   ScriptedCheck,
@@ -19,6 +20,7 @@ import { getBrowserCheckFormValues } from '../transformations/toFormValues.brows
 import { getDNSCheckFormValues } from '../transformations/toFormValues.dns';
 import { getGRPCCheckFormValues } from '../transformations/toFormValues.grpc';
 import { getHTTPCheckFormValues } from '../transformations/toFormValues.http';
+import { getLLMEvaluatorCheckFormValues } from '../transformations/toFormValues.llmevaluator';
 import { getMultiHTTPCheckFormValues } from '../transformations/toFormValues.multihttp';
 import { getPingCheckFormValues } from '../transformations/toFormValues.ping';
 import { getScriptedCheckFormValues } from '../transformations/toFormValues.scripted';
@@ -28,6 +30,7 @@ import { getBrowserPayload } from '../transformations/toPayload.browser';
 import { getDNSPayload } from '../transformations/toPayload.dns';
 import { getGRPCPayload } from '../transformations/toPayload.grpc';
 import { getHTTPPayload } from '../transformations/toPayload.http';
+import { getLLMEvaluatorPayload } from '../transformations/toPayload.llmevaluator';
 import { getMultiHTTPPayload } from '../transformations/toPayload.multihttp';
 import { getPingPayload } from '../transformations/toPayload.ping';
 import { getScriptedPayload } from '../transformations/toPayload.scripted';
@@ -67,6 +70,8 @@ export function toFormValues(check: Check): CheckFormValues {
       return getTracerouteCheckFormValues(check as TracerouteCheck);
     case CheckType.Browser:
       return getBrowserCheckFormValues(check as BrowserCheck);
+    case CheckType.LlmEvaluator:
+      return getLLMEvaluatorCheckFormValues(check as LLMEvaluatorCheck);
     default:
       throw new Error(`Unable to convert check to form values. Unknown check type: '${checkType}'`);
   }
@@ -92,6 +97,8 @@ export function toPayload(formValues: CheckFormValues): Check {
       return getTraceroutePayload(formValues);
     case CheckType.Browser:
       return getBrowserPayload(formValues);
+    case CheckType.LlmEvaluator:
+      return getLLMEvaluatorPayload(formValues);
     default:
       throw new Error(`Unable to convert form values to check. Unknown check type: '${(formValues as any).checkType}'`);
   }

--- a/src/components/TerraformConfig/terraformConfigUtils.ts
+++ b/src/components/TerraformConfig/terraformConfigUtils.ts
@@ -188,9 +188,8 @@ const settingsToTF = (check: Check): TFCheckSettings => {
     };
   }
 
-  // @ts-expect-error - This should never happen
   const settingsKey = Object.keys(check.settings)[0];
-  throw new Error(`Unknown check type: ${settingsKey}`);
+  throw new Error(`Unsupported check type for Terraform export: ${settingsKey}`);
 };
 
 export const checkToTF = (check: Check): TFCheck => {

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -124,6 +124,8 @@ export enum AccountingClassNames {
   http_basic = 'http_basic',
   http_ssl = 'http_ssl',
   http_ssl_basic = 'http_ssl_basic',
+  llmEvaluator = 'llmevaluator',
+  llmEvaluator_basic = 'llmevaluator_basic',
   multihttp = 'multihttp',
   multihttp_basic = 'multihttp_basic',
   ping = 'ping',

--- a/src/hooks/useCheckTypeGroupOptions.tsx
+++ b/src/hooks/useCheckTypeGroupOptions.tsx
@@ -96,6 +96,21 @@ export const CHECK_TYPE_GROUP_OPTIONS: CheckTypeGroupOption[] = [
       },
     ],
   },
+  {
+    label: `LLM Evaluator`,
+    description: `Probe an LLM endpoint and evaluate its response against natural-language criteria.`,
+    value: CheckTypeGroup.LlmEvaluator,
+    icon: `ai-sparkle`,
+    protocols: [
+      {
+        label: `OpenAI-compatible`,
+        href: `${getRoute(AppRoutes.NewCheck)}/${CheckTypeGroup.LlmEvaluator}?checkType=${CheckType.LlmEvaluator}`,
+        featureToggle: FeatureName.LLMEvaluatorChecks,
+        onClick: () =>
+          trackAddCheckTypeButtonClicked({ checkTypeGroup: CheckTypeGroup.LlmEvaluator, protocol: CheckType.LlmEvaluator }),
+      },
+    ],
+  },
 ];
 
 export function useCheckTypeGroupOptions() {

--- a/src/hooks/useCheckTypeOptions.ts
+++ b/src/hooks/useCheckTypeOptions.ts
@@ -64,6 +64,17 @@ export const CHECK_TYPE_OPTIONS = [
     description: 'Leverage k6 browser module to run checks in a browser.',
     group: CheckTypeGroup.Browser,
   },
+  {
+    label: 'LLM Evaluator',
+    value: CheckType.LlmEvaluator,
+    description: 'Probe an LLM endpoint and evaluate its response against natural-language criteria.',
+    status: {
+      value: CheckStatus.Experimental,
+      description: `LLM Evaluator checks are experimental.`,
+    },
+    featureToggle: FeatureName.LLMEvaluatorChecks,
+    group: CheckTypeGroup.LlmEvaluator,
+  },
 ];
 
 /**

--- a/src/page/DashboardPage.tsx
+++ b/src/page/DashboardPage.tsx
@@ -10,6 +10,7 @@ import { BrowserDashboard } from 'scenes/BrowserDashboard/BrowserDashboard';
 import { DNSDashboard } from 'scenes/DNS/DnsDashboard';
 import { GrpcDashboard } from 'scenes/GRPC/GrpcDashboard';
 import { HttpDashboard } from 'scenes/HTTP/HttpDashboard';
+import { LLMEvaluatorDashboard } from 'scenes/LLMEvaluator/LLMEvaluatorDashboard';
 import { PingDashboard } from 'scenes/PING/PingDashboard';
 import { ScriptedDashboard } from 'scenes/Scripted/ScriptedDashboard';
 import { TcpDashboard } from 'scenes/TCP/TcpDashboard';
@@ -66,6 +67,10 @@ function DashboardPageContent() {
 
   if (check && getCheckType(check.settings) === CheckType.Browser) {
     return <BrowserDashboard check={check} />;
+  }
+
+  if (check && getCheckType(check.settings) === CheckType.LlmEvaluator) {
+    return <LLMEvaluatorDashboard check={check} />;
   }
 
   return <Spinner />;

--- a/src/page/__testHelpers__/checkForm.tsx
+++ b/src/page/__testHelpers__/checkForm.tsx
@@ -18,6 +18,7 @@ export const TARGET_MAP = {
   [CheckType.Dns]: 'grafana.com',
   [CheckType.Grpc]: 'grafana.com:50051',
   [CheckType.Http]: 'https://grafana.com/',
+  [CheckType.LlmEvaluator]: 'gpt-4o-mini',
   [CheckType.MultiHttp]: 'https://grafana.com/',
   [CheckType.Ping]: 'grafana.com',
   [CheckType.Scripted]: 'Whatever string we would like',

--- a/src/page/__testHelpers__/v2.utils.ts
+++ b/src/page/__testHelpers__/v2.utils.ts
@@ -10,6 +10,7 @@ const TARGET_MAP = {
   [CheckType.Dns]: 'grafana.com',
   [CheckType.Grpc]: 'grafana.com:50051',
   [CheckType.Http]: 'https://grafana.com/',
+  [CheckType.LlmEvaluator]: 'gpt-4o-mini',
   [CheckType.MultiHttp]: 'https://grafana.com/',
   [CheckType.Ping]: 'grafana.com',
   [CheckType.Scripted]: 'Whatever string we would like',

--- a/src/scenes/LLMEvaluator/LLMEvaluatorDashboard.tsx
+++ b/src/scenes/LLMEvaluator/LLMEvaluatorDashboard.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Stack, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { Check, CheckType } from 'types';
+import { DashboardContainer } from 'scenes/Common/DashboardContainer';
+import { ErrorLogs } from 'scenes/Common/ErrorLogsPanel';
+import { Frequency } from 'scenes/Common/FrequencyViz';
+import { UptimeStat } from 'scenes/Common/UptimeStatViz';
+import { TimepointExplorer } from 'scenes/components/TimepointExplorer/TimepointExplorer';
+
+import {
+  CriteriaPassRate,
+  CriterionPassFail,
+  EvalScore,
+  JudgeTokens,
+  TargetLatency,
+} from './panels';
+
+export const LLMEvaluatorDashboard = ({ check }: { check: Check }) => {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <DashboardContainer check={check} checkType={CheckType.LlmEvaluator}>
+      <Stack height="90px">
+        <UptimeStat check={check} />
+        <CriteriaPassRate />
+        <Frequency />
+      </Stack>
+
+      <div className={styles.fullWidth}>
+        <EvalScore />
+      </div>
+
+      <div className={styles.fullWidth}>
+        <CriterionPassFail />
+      </div>
+
+      <div className={styles.twoCol}>
+        <TargetLatency />
+        <JudgeTokens />
+      </div>
+
+      <TimepointExplorer check={check} />
+      <ErrorLogs startingUnsuccessfulOnly />
+    </DashboardContainer>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  fullWidth: css`
+    height: 250px;
+  `,
+  twoCol: css`
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: ${theme.spacing(1)};
+    height: 250px;
+  `,
+});

--- a/src/scenes/LLMEvaluator/panels.tsx
+++ b/src/scenes/LLMEvaluator/panels.tsx
@@ -1,0 +1,251 @@
+import React from 'react';
+import { VizConfigBuilders } from '@grafana/scenes';
+import { useQueryRunner, useTimeRange, VizPanel } from '@grafana/scenes-react';
+import { BigValueGraphMode, GraphDrawStyle, LegendDisplayMode, ThresholdsMode } from '@grafana/schema';
+
+import { useMetricsDS } from 'hooks/useMetricsDS';
+import { useVizPanelMenu } from 'scenes/Common/useVizPanelMenu';
+
+const TENANT_FILTER = `probe=~"$probe", instance="$instance", job="$job"`;
+
+function useLLMVizMenu(viz: ReturnType<typeof VizConfigBuilders.timeseries>['build'] extends () => infer T ? T : never, dataProvider: ReturnType<typeof useQueryRunner>) {
+  const data = dataProvider.useState();
+  const [currentTimeRange] = useTimeRange();
+  return useVizPanelMenu({ data, viz, currentTimeRange, variables: ['job', 'probe', 'instance'] });
+}
+
+export const EvalScore = () => {
+  const metricsDS = useMetricsDS();
+
+  const dataProvider = useQueryRunner({
+    maxDataPoints: 200,
+    queries: [
+      {
+        expr: `avg(probe_llm_eval_score{${TENANT_FILTER}})`,
+        instant: false,
+        legendFormat: 'eval score',
+        refId: 'A',
+      },
+    ],
+    datasource: metricsDS,
+  });
+
+  const viz = VizConfigBuilders.timeseries()
+    .setUnit('percentunit')
+    .setMin(0)
+    .setMax(1)
+    .setOption('legend', {
+      showLegend: true,
+      displayMode: LegendDisplayMode.List,
+      placement: 'bottom',
+    })
+    .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+    .setCustomFieldConfig('lineWidth', 2)
+    .setCustomFieldConfig('fillOpacity', 10)
+    .setColor({ mode: 'palette-classic' })
+    .setThresholds({
+      mode: ThresholdsMode.Absolute,
+      steps: [
+        { value: 0, color: 'red' },
+        { value: 0.5, color: 'yellow' },
+        { value: 0.9, color: 'green' },
+      ],
+    })
+    .build();
+
+  const menu = useLLMVizMenu(viz, dataProvider);
+
+  return (
+    <VizPanel
+      title="Evaluation score"
+      description="Fraction of criteria satisfied (0-1)."
+      viz={viz}
+      dataProvider={dataProvider}
+      menu={menu}
+    />
+  );
+};
+
+export const CriterionPassFail = () => {
+  const metricsDS = useMetricsDS();
+
+  const dataProvider = useQueryRunner({
+    maxDataPoints: 200,
+    queries: [
+      {
+        expr: `avg by (criterion_index) (probe_llm_eval_criterion_passed{${TENANT_FILTER}})`,
+        instant: false,
+        legendFormat: 'criterion {{criterion_index}}',
+        refId: 'A',
+      },
+    ],
+    datasource: metricsDS,
+  });
+
+  const viz = VizConfigBuilders.timeseries()
+    .setMin(0)
+    .setMax(1)
+    .setOption('legend', {
+      showLegend: true,
+      displayMode: LegendDisplayMode.Table,
+      placement: 'right',
+      calcs: ['mean', 'lastNotNull'],
+    })
+    .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+    .setCustomFieldConfig('lineWidth', 2)
+    .setColor({ mode: 'palette-classic' })
+    .build();
+
+  const menu = useLLMVizMenu(viz, dataProvider);
+
+  return (
+    <VizPanel
+      title="Pass/fail per criterion"
+      description="One series per criterion_index. 1 = passed, 0 = failed."
+      viz={viz}
+      dataProvider={dataProvider}
+      menu={menu}
+    />
+  );
+};
+
+export const CriteriaPassRate = () => {
+  const metricsDS = useMetricsDS();
+
+  const dataProvider = useQueryRunner({
+    maxDataPoints: 1,
+    queries: [
+      {
+        expr: `avg(probe_llm_eval_criteria_passed{${TENANT_FILTER}}) / avg(probe_llm_eval_criteria_total{${TENANT_FILTER}})`,
+        instant: false,
+        legendFormat: 'pass rate',
+        refId: 'A',
+      },
+    ],
+    datasource: metricsDS,
+  });
+
+  const viz = VizConfigBuilders.stat()
+    .setOption('graphMode', BigValueGraphMode.Area)
+    .setUnit('percentunit')
+    .setDecimals(0)
+    .setMin(0)
+    .setMax(1)
+    .setNoValue('No data')
+    .setThresholds({
+      mode: ThresholdsMode.Absolute,
+      steps: [
+        { value: 0, color: 'red' },
+        { value: 0.5, color: 'yellow' },
+        { value: 0.9, color: 'green' },
+      ],
+    })
+    .build();
+
+  const menu = useLLMVizMenu(viz, dataProvider);
+
+  return (
+    <VizPanel
+      title="Criteria pass rate"
+      description="Average passed / total across the time range."
+      viz={viz}
+      dataProvider={dataProvider}
+      menu={menu}
+    />
+  );
+};
+
+export const TargetLatency = () => {
+  const metricsDS = useMetricsDS();
+
+  const dataProvider = useQueryRunner({
+    maxDataPoints: 200,
+    queries: [
+      {
+        expr: `avg(probe_llm_target_response_seconds{${TENANT_FILTER}})`,
+        instant: false,
+        legendFormat: 'target LLM',
+        refId: 'A',
+      },
+      {
+        expr: `avg(probe_llm_judge_seconds{${TENANT_FILTER}})`,
+        instant: false,
+        legendFormat: 'judge LLM',
+        refId: 'B',
+      },
+    ],
+    datasource: metricsDS,
+  });
+
+  const viz = VizConfigBuilders.timeseries()
+    .setUnit('s')
+    .setOption('legend', {
+      showLegend: true,
+      displayMode: LegendDisplayMode.List,
+      placement: 'bottom',
+    })
+    .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+    .setCustomFieldConfig('lineWidth', 2)
+    .setColor({ mode: 'palette-classic' })
+    .build();
+
+  const menu = useLLMVizMenu(viz, dataProvider);
+
+  return (
+    <VizPanel
+      title="Target & judge latency"
+      description="Time spent calling the target LLM vs the judge proxy."
+      viz={viz}
+      dataProvider={dataProvider}
+      menu={menu}
+    />
+  );
+};
+
+export const JudgeTokens = () => {
+  const metricsDS = useMetricsDS();
+
+  const dataProvider = useQueryRunner({
+    maxDataPoints: 200,
+    queries: [
+      {
+        expr: `sum(rate(probe_llm_judge_input_tokens{${TENANT_FILTER}}[$__rate_interval]))`,
+        instant: false,
+        legendFormat: 'input tokens/s',
+        refId: 'A',
+      },
+      {
+        expr: `sum(rate(probe_llm_judge_output_tokens{${TENANT_FILTER}}[$__rate_interval]))`,
+        instant: false,
+        legendFormat: 'output tokens/s',
+        refId: 'B',
+      },
+    ],
+    datasource: metricsDS,
+  });
+
+  const viz = VizConfigBuilders.timeseries()
+    .setUnit('short')
+    .setOption('legend', {
+      showLegend: true,
+      displayMode: LegendDisplayMode.List,
+      placement: 'bottom',
+    })
+    .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
+    .setCustomFieldConfig('lineWidth', 2)
+    .setCustomFieldConfig('fillOpacity', 10)
+    .setColor({ mode: 'palette-classic' })
+    .build();
+
+  const menu = useLLMVizMenu(viz, dataProvider);
+
+  return (
+    <VizPanel
+      title="Judge token usage"
+      description="Per-second input/output tokens consumed by the judge LLM. Cost proxy."
+      viz={viz}
+      dataProvider={dataProvider}
+      menu={menu}
+    />
+  );
+};

--- a/src/schemas/forms/LLMEvaluatorCheckSchema.ts
+++ b/src/schemas/forms/LLMEvaluatorCheckSchema.ts
@@ -1,0 +1,62 @@
+import { createFrequencySchema } from 'schemas/general/Frequency';
+import { createTimeoutSchema } from 'schemas/general/Timeout';
+import { z, ZodType } from 'zod';
+
+import { CheckFormValuesLLMEvaluator, CheckType, LLMEvaluatorSettings } from 'types';
+import { ONE_MINUTE_IN_MS, ONE_SECOND_IN_MS } from 'utils.constants';
+
+import { baseCheckSchema } from './BaseCheckSchema';
+
+export const MIN_FREQUENCY_LLM_EVALUATOR = ONE_MINUTE_IN_MS * 5;
+export const MIN_TIMEOUT_LLM_EVALUATOR = ONE_SECOND_IN_MS * 5;
+export const MAX_TIMEOUT_LLM_EVALUATOR = ONE_MINUTE_IN_MS * 3;
+
+export const MAX_PROMPT_LENGTH = 2000;
+export const MAX_SYSTEM_PROMPT_LENGTH = 500;
+export const MAX_CRITERION_LENGTH = 200;
+export const MAX_CRITERIA_COUNT = 10;
+
+function createLLMEvaluatorSettingsSchema(): ZodType<LLMEvaluatorSettings> {
+  return z.object({
+    endpoint: z.url(`Endpoint must be a valid URL.`),
+    model: z.string().min(1, `Model is required.`),
+    apiKeyRef: z.string().min(1, `API key secret is required.`),
+    systemPrompt: z
+      .string()
+      .max(MAX_SYSTEM_PROMPT_LENGTH, `System prompt must be at most ${MAX_SYSTEM_PROMPT_LENGTH} characters.`)
+      .optional(),
+    prompt: z
+      .string()
+      .min(1, `Prompt is required.`)
+      .max(MAX_PROMPT_LENGTH, `Prompt must be at most ${MAX_PROMPT_LENGTH} characters.`),
+    criteria: z
+      .array(
+        z
+          .string()
+          .min(1, `Criterion cannot be empty.`)
+          .max(MAX_CRITERION_LENGTH, `Criterion must be at most ${MAX_CRITERION_LENGTH} characters.`)
+      )
+      .min(1, `At least one criterion is required.`)
+      .max(MAX_CRITERIA_COUNT, `At most ${MAX_CRITERIA_COUNT} criteria are allowed.`),
+  });
+}
+
+export function createLLMEvaluatorCheckSchema(): ZodType<CheckFormValuesLLMEvaluator> {
+  return baseCheckSchema
+    .omit({
+      frequency: true,
+      timeout: true,
+    })
+    .and(
+      z.object({
+        checkType: z.literal(CheckType.LlmEvaluator),
+        settings: z.object({
+          llmEvaluator: createLLMEvaluatorSettingsSchema(),
+        }),
+        frequency: createFrequencySchema(MIN_FREQUENCY_LLM_EVALUATOR),
+        timeout: createTimeoutSchema(MIN_TIMEOUT_LLM_EVALUATOR, MAX_TIMEOUT_LLM_EVALUATOR),
+      })
+    );
+}
+
+export const llmEvaluatorCheckSchema: ZodType<CheckFormValuesLLMEvaluator> = createLLMEvaluatorCheckSchema();

--- a/src/schemas/forms/utils/createCheckSchema.ts
+++ b/src/schemas/forms/utils/createCheckSchema.ts
@@ -6,6 +6,7 @@ import { createBrowserCheckSchema } from '../BrowserCheckSchema';
 import { dnsCheckSchema } from '../DNSCheckSchema';
 import { grpcCheckSchema } from '../GRPCCheckSchema';
 import { httpCheckSchema } from '../HttpCheckSchema';
+import { llmEvaluatorCheckSchema } from '../LLMEvaluatorCheckSchema';
 import { multiHttpCheckSchema } from '../MultiHttpCheckSchema';
 import { pingCheckSchema } from '../PingCheckSchema';
 import { createScriptedCheckSchema } from '../ScriptedCheckSchema';
@@ -16,6 +17,7 @@ const STATIC_SCHEMA_MAP = {
   [CheckType.Dns]: dnsCheckSchema,
   [CheckType.Grpc]: grpcCheckSchema,
   [CheckType.Http]: httpCheckSchema,
+  [CheckType.LlmEvaluator]: llmEvaluatorCheckSchema,
   [CheckType.MultiHttp]: multiHttpCheckSchema,
   [CheckType.Ping]: pingCheckSchema,
   [CheckType.Tcp]: tcpCheckSchema,

--- a/src/test/db/index.ts
+++ b/src/test/db/index.ts
@@ -255,6 +255,21 @@ export const DB = {
         };
       }
 
+      case CheckType.LlmEvaluator: {
+        return {
+          ...baseCheckModel({ sequence }),
+          settings: {
+            llmEvaluator: {
+              endpoint: 'https://api.openai.com',
+              model: 'gpt-4o-mini',
+              apiKeyRef: 'openai-api-key',
+              prompt: 'What is Grafana Synthetic Monitoring?',
+              criteria: ['Mentions monitoring or observability'],
+            },
+          },
+        };
+      }
+
       default: {
         throw new Error(`Unsupported check type: ${type}`);
       }

--- a/src/test/fixtures/checks.ts
+++ b/src/test/fixtures/checks.ts
@@ -10,6 +10,7 @@ import {
   HttpVersion,
   IpVersion,
   Label,
+  LLMEvaluatorCheck,
   MultiHTTPCheck,
   PingCheck,
   ScriptedCheck,
@@ -284,6 +285,29 @@ export const CUSTOM_ALERT_SENSITIVITY_CHECK: DNSCheck = DB.check.build(
   { transient: { type: CheckType.Dns } }
 ) as DNSCheck;
 
+export const BASIC_LLM_EVALUATOR_CHECK: LLMEvaluatorCheck = DB.check.build(
+  {
+    job: 'Job name for llm-evaluator',
+    target: 'gpt-4o-mini',
+    labels: [{ name: 'Team', value: 'ai' }],
+    probes: [PUBLIC_PROBE.id] as number[],
+    settings: {
+      llmEvaluator: {
+        endpoint: 'https://api.openai.com',
+        model: 'gpt-4o-mini',
+        apiKeyRef: 'openai-api-key',
+        systemPrompt: 'You are a helpful assistant.',
+        prompt: 'What is Grafana Synthetic Monitoring?',
+        criteria: [
+          'Mentions monitoring or observability',
+          'Does not mention competitor products',
+        ],
+      },
+    },
+  },
+  { transient: { type: CheckType.LlmEvaluator } }
+) as LLMEvaluatorCheck;
+
 export const BASIC_CHECK_LIST: Check[] = [
   BASIC_DNS_CHECK,
   BASIC_HTTP_CHECK,
@@ -293,6 +317,7 @@ export const BASIC_CHECK_LIST: Check[] = [
   BASIC_TCP_CHECK,
   BASIC_TRACEROUTE_CHECK,
   FULL_HTTP_CHECK,
+  BASIC_LLM_EVALUATOR_CHECK,
   CUSTOM_ALERT_SENSITIVITY_CHECK,
 ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,8 @@ export type ExtendedProbe = ProbeWithMetadata & { checks: number[] };
 interface ProbeCapabilities {
   disableScriptedChecks: boolean;
   disableBrowserChecks: boolean;
+  enableProtocolSecrets?: boolean;
+  enableLLMEvaluatorChecks?: boolean;
 }
 
 export enum ResponseMatchType {
@@ -186,6 +188,15 @@ export interface ScriptedSettings {
 
 export interface BrowserSettings {
   script: string;
+}
+
+export interface LLMEvaluatorSettings {
+  endpoint: string;
+  model: string;
+  apiKeyRef: string;
+  systemPrompt?: string;
+  prompt: string;
+  criteria: string[];
 }
 
 export interface TcpSettings {
@@ -405,6 +416,13 @@ export type CheckFormValuesBrowser = CheckFormValuesBase & {
   };
 };
 
+export type CheckFormValuesLLMEvaluator = CheckFormValuesBase & {
+  checkType: CheckType.LlmEvaluator;
+  settings: {
+    llmEvaluator: LLMEvaluatorSettings;
+  };
+};
+
 export interface CheckBase {
   job: string;
   target: string;
@@ -439,6 +457,7 @@ export type Check =
   | DNSCheck
   | GRPCCheck
   | HTTPCheck
+  | LLMEvaluatorCheck
   | MultiHTTPCheck
   | PingCheck
   | ScriptedCheck
@@ -449,6 +468,7 @@ export type CheckFormValues =
   | CheckFormValuesDns
   | CheckFormValuesGRPC
   | CheckFormValuesHttp
+  | CheckFormValuesLLMEvaluator
   | CheckFormValuesMultiHttp
   | CheckFormValuesPing
   | CheckFormValuesScripted
@@ -471,6 +491,7 @@ export type Settings =
   | DNSCheck['settings']
   | GRPCCheck['settings']
   | HTTPCheck['settings']
+  | LLMEvaluatorCheck['settings']
   | ScriptedCheck['settings']
   | MultiHTTPCheck['settings']
   | PingCheck['settings']
@@ -512,6 +533,13 @@ export type BrowserCheck = CheckBase &
     };
   };
 
+export type LLMEvaluatorCheck = CheckBase &
+  ExistingObject & {
+    settings: {
+      llmEvaluator: LLMEvaluatorSettings;
+    };
+  };
+
 export type MultiHTTPCheck = CheckBase &
   ExistingObject & {
     settings: {
@@ -545,6 +573,7 @@ export enum CheckType {
   Dns = 'dns',
   Grpc = 'grpc',
   Http = 'http',
+  LlmEvaluator = 'llmEvaluator',
   MultiHttp = 'multihttp',
   Ping = 'ping',
   Scripted = 'scripted',
@@ -557,6 +586,7 @@ export enum CheckTypeGroup {
   MultiStep = `multistep`,
   Scripted = `scripted`,
   Browser = `browser`,
+  LlmEvaluator = `llm-evaluator`,
 }
 
 export enum DnsResponseCodes {
@@ -749,6 +779,7 @@ export enum FeatureName {
   CALs = 'synthetic-monitoring-cals',
   Folders = 'synthetic-monitoring-folders',
   GRPCChecks = 'grpc-checks',
+  LLMEvaluatorChecks = 'synthetic-monitoring-llm-evaluator-checks',
   Screenshots = 'synthetic-monitoring-screenshots',
   SecretsManagement = 'synthetic-monitoring-secrets-management',
   TimepointExplorer = 'synthetic-monitoring-timepoint-explorer',

--- a/src/utils.types.ts
+++ b/src/utils.types.ts
@@ -10,6 +10,7 @@ import {
   DNSCheck,
   GRPCCheck,
   HTTPCheck,
+  LLMEvaluatorCheck,
   MultiHTTPCheck,
   PingCheck,
   ScriptedCheck,
@@ -75,6 +76,14 @@ export function isTracerouteCheck(check: Partial<Check>): check is TracerouteChe
 
 export function isBrowserCheck(check: Partial<Check>): check is BrowserCheck {
   return CheckType.Browser in (check.settings ?? {});
+}
+
+export function isLLMEvaluatorCheck(check: Partial<Check>): check is LLMEvaluatorCheck {
+  return CheckType.LlmEvaluator in (check.settings ?? {});
+}
+
+export function isLLMEvaluatorSettings(settings: Check['settings']): settings is LLMEvaluatorCheck['settings'] {
+  return Object.hasOwnProperty.call(settings, CheckType.LlmEvaluator);
 }
 
 export function isDNSSettings(settings: Check['settings']): settings is DNSCheck['settings'] {


### PR DESCRIPTION
## Summary

Front-end implementation for the new **LLM Evaluator** check type from the SM AI sprint. Mirrors the wire contract in [synthetic-monitoring-agent#1807](https://github.com/grafana/synthetic-monitoring-agent/pull/1807) (proto + agent scaffolding) and [synthetic-monitoring-api#2139](https://github.com/grafana/synthetic-monitoring-api/pull/2139) (persistence + probe gating).

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` clean
- [x] `yarn test` — 1565 passed, 0 failures
- [ ] Manually exercise the form in a local Grafana with the feature flag enabled (`?features=synthetic-monitoring-llm-evaluator-checks` or `[feature_toggles] enable = ...`):
  - [ ] Tile appears on Choose-check-type page
  - [ ] Form validates required fields, max lengths, criteria count
  - [ ] Save persists `settings.llmEvaluator` correctly (verified end-to-end against sm-dev: API stores, gRPC distributes, agent decodes, prober stub fires the expected M2-not-implemented error)
  - [ ] Probe selector hides ineligible probes