### PR TITLE
chore: disable yarn lifecycle scripts for supply-chain security

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ After creating/changing provisioning files, restart Grafana (`yarn server` or `d
 
 ### Node.js version
 
-The project requires Node.js 24 (`.nvmrc`). Use `nvm use` or `nvm install 24`. Install dependencies with `yarn install --frozen-lockfile --ignore-engines` because `i18next-parser` does not yet declare Node 24 compatibility.
+The project requires Node.js 24 (`.nvmrc`). Use `nvm use` or `nvm install 24`. Install dependencies with `yarn install --frozen-lockfile --ignore-engines` because `i18next-parser` does not yet declare Node 24 compatibility. After installing, run `yarn prepare` once to set up git hooks (lifecycle scripts are disabled in `.yarnrc` for supply-chain security).
 
 ### Docker for Grafana
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,16 @@ There are two different "modes" for developing this plugin. You can either work 
 - Make sure you have Docker installed
 - Clone this repo to your local machine
 
+### Install
+
+After cloning and running `yarn install`, you need to manually set up git hooks:
+
+```bash
+yarn prepare
+```
+
+This is required because lifecycle scripts are disabled in `.yarnrc` for supply-chain security. The `prepare` script sets up [Husky](https://typicode.github.io/husky/) git hooks (commit message linting, pre-push checks). You only need to run this once per clone.
+
 ### Set up
 
 We need to configure our local Grafana using [provisioning](http://grafana.com/docs/grafana/latest/administration/provisioning/). Provisioning does three things for us:


### PR DESCRIPTION
## Problem

Dependency lifecycle scripts (postinstall, preinstall, etc.) run arbitrary code during `yarn install`. This is a known supply-chain attack vector where malicious packages can execute code on a developer's machine simply by being installed. This was flagged as a CyberGrot week action item for all repos.

## Solution

Adds a `.yarnrc` file with `ignore-scripts true` to disable all lifecycle scripts during `yarn install`. This prevents any dependency from executing code at install time.

The only project lifecycle script affected is `prepare` (which runs Husky to set up git hooks). Developers now need to run `yarn prepare` once after cloning. This is documented in both `CONTRIBUTING.md` and `AGENTS.md`.

Verified with a clean `rm -rf node_modules && yarn install` that all key commands still work:
- `yarn typecheck` -- passes
- `yarn lint` -- passes  
- `yarn build` -- succeeds
- `yarn test:ci` -- 192 suites, 1559 tests pass
- `esbuild` -- works (uses `optionalDependencies` for platform binaries)