### PR TITLE
chore: add .yarnrc.yml to disable scripts for Yarn Berry

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableScripts: false


### PR DESCRIPTION
## Problem

The existing `.yarnrc` only disables lifecycle scripts for Yarn Classic (v1). If a developer has Yarn Berry (v2+) installed globally and doesn't use Corepack, the `.yarnrc` is silently ignored and dependency lifecycle scripts run unprotected during install.

## Solution

Adds a `.yarnrc.yml` with `enableScripts: false` — the Yarn Berry equivalent. This ensures lifecycle scripts are disabled regardless of which yarn version a developer has installed globally, closing the gap left by the Yarn Classic-only config.