### PR TITLE
chore(ci): Migrate workflows to use GATB

### DIFF
--- a/.github/workflows/call_release-please.yml
+++ b/.github/workflows/call_release-please.yml
@@ -10,43 +10,24 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-small
 
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
 
     steps:
-      - name: Retrieve release app credentials
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:
-          repo_secrets: |
-            GITHUB_APP_ID=github-app:app-id
-            GITHUB_APP_INSTALLATION_ID=github-app:app-installation-id
-            GITHUB_APP_PRIVATE_KEY=github-app:private-key
-
-      - name: Get repository name
-        env:
-          REPOSITORY: ${{ github.repository }}
-        id: info
-        run: echo "repository_name=${REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
-
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ steps.info.outputs.repository_name }}
+          github_app: sm-release-app
 
       - name: Release
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.get-github-app-token.outputs.token }}
           target-branch: main
           config-file: .github/release-please/release-please-config.json
           manifest-file: .github/release-please/.release-please-manifest.json

--- a/.github/workflows/call_renovate_reviewer.yml
+++ b/.github/workflows/call_renovate_reviewer.yml
@@ -5,57 +5,44 @@ name: Renovate reviewer
 permissions:
   pull-requests: write
   contents: write
-  id-token: write
 
 on:
   workflow_call:
 
 jobs:
   review-renovate-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-small
     if: ${{ github.event.pull_request.user.login == 'renovate-sh-app[bot]' }}
     env:
       PR_URL: ${{github.event.pull_request.html_url}}
       COMMITS_URL: ${{ github.event.pull_request.commits_url }}
     steps:
-      - name: Get secrets
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@bae259f9ed5b6fcb050e3b58adf7aee776d4edb5
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:
-          common_secrets: |
-            GRAFANA_ACCESS_POLICY_TOKEN=plugins/sign-plugin-access-policy-token:token
-          repo_secrets: |
-            GITHUB_APP_ID=github-app:app-id
-            GITHUB_APP_PRIVATE_KEY=github-app:private-key
-
-      - name: Create GitHub app token
-        id: app-token
-        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          github_app: sm-release-app
 
       - name: Approve security updates
         if: contains(github.event.pull_request.labels.*.name, 'automerge-security-update')
         env:
-          GH_TOKEN: "${{ steps.app-token.outputs.token }}"
+          GH_TOKEN: "${{ steps.get-github-app-token.outputs.token }}"
         run: gh pr review "$PR_URL" --approve -b "**Approving** SECURITY update 🎉. Will now merge..."
 
       - name: Approve patch updates
         if: (contains(github.event.pull_request.labels.*.name, 'automerge-patch'))
         env:
-          GH_TOKEN: "${{ steps.app-token.outputs.token }}"
+          GH_TOKEN: "${{ steps.get-github-app-token.outputs.token }}"
         run: gh pr review "$PR_URL" --approve -b "**Approving** PATCH update 🎉. Will now merge..."
 
       - name: Approve minor updates
         if: (contains(github.event.pull_request.labels.*.name, 'automerge-minor'))
         env:
-          GH_TOKEN: "${{ steps.app-token.outputs.token }}"
+          GH_TOKEN: "${{ steps.get-github-app-token.outputs.token }}"
         run: gh pr review "$PR_URL" --approve -b "**Approving** MINOR update 🎉. Will now merge..."
 
       - name: Approve digest updates
         if: (contains(github.event.pull_request.labels.*.name, 'automerge-digest'))
         env:
-          GH_TOKEN: "${{ steps.app-token.outputs.token }}"
+          GH_TOKEN: "${{ steps.get-github-app-token.outputs.token }}"
         run: gh pr review "$PR_URL" --approve -b "**Approving** DIGEST update 🎉. Will now merge..."

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     uses: ./.github/workflows/call_release-please.yml
 
   # Publish TechDocs to Backstage

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -151,6 +151,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     uses: ./.github/workflows/call_renovate_reviewer.yml
 


### PR DESCRIPTION
Migrates the workflows:
- release-please
- renovate-reviewer

In order to adopt Github App Token Broker.