### PR TITLE
feat: update k6 channel deprecation UX for v2 launch

### DIFF
--- a/src/components/CheckEditor/FormComponents/ChannelDetails.test.tsx
+++ b/src/components/CheckEditor/FormComponents/ChannelDetails.test.tsx
@@ -13,14 +13,14 @@ describe('ChannelDetails', () => {
       id: 'v1',
       name: 'v1.x',
       default: false,
-      deprecatedAfter: '2125-12-31T00:00:00Z', // Far into the future, so it's not deprecated yet'
+      deprecatedAfter: '2126-07-01T00:00:00Z', // Not yet deprecated
       manifest: 'k6>=1',
     },
     {
       id: 'v2',
       name: 'v2.x',
       default: true,
-      deprecatedAfter: '2126-12-31T00:00:00Z', // Far into the future, so it's not deprecated yet'
+      deprecatedAfter: '2128-12-31T00:00:00Z',
       manifest: 'k6>=2',
     },
     {
@@ -33,8 +33,6 @@ describe('ChannelDetails', () => {
   ];
 
   it('should show probe default message when no channels are available', async () => {
-    // This occurs when no k6 channels are configured on the backend,
-    // so the API returns an empty array and no default channel can be determined
     render(<ChannelDetails channelId={null} channels={[]} />);
 
     await waitFor(() => {
@@ -42,40 +40,28 @@ describe('ChannelDetails', () => {
     });
   });
 
-  it('should show probe default message when all channels are deprecated', async () => {
-    // This occurs when the backend returns channels but they are all deprecated,
-    // so after filtering, no channels are available for new checks
-    const allDeprecatedChannels: K6Channel[] = [
-      {
-        id: 'old-v1',
-        name: 'old-v1.x',
-        default: true,
-        deprecatedAfter: '2020-01-01T00:00:00Z', // Already deprecated
-        manifest: 'k6>=1,k6<2',
-      },
-      {
-        id: 'old-v2',
-        name: 'old-v2.x',
-        default: false,
-        deprecatedAfter: '2021-01-01T00:00:00Z', // Already deprecated
-        manifest: 'k6>=2,k6<3',
-      },
-    ];
-
-    render(<ChannelDetails channelId={null} channels={allDeprecatedChannels} />);
+  it('should show channel details when the default channel is selected', async () => {
+    render(<ChannelDetails channelId="v2" channels={mockChannels} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/each probe will use its default k6 version/i)).toBeInTheDocument();
+      expect(screen.getByText(/k6 version constraint:/i)).toBeInTheDocument();
+      expect(screen.getByText(/k6>=2/)).toBeInTheDocument();
     });
+
+    expect(screen.queryByText(/newer version available/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/deprecated k6 version channel/i)).not.toBeInTheDocument();
   });
 
-  it('should show channel details when a channel is selected', async () => {
+  it('should show info message when a non-default, non-deprecated channel is selected', async () => {
     render(<ChannelDetails channelId="v1" channels={mockChannels} />);
 
     await waitFor(() => {
       expect(screen.getByText(/k6 version constraint:/i)).toBeInTheDocument();
       expect(screen.getByText(/k6>=1/)).toBeInTheDocument();
     });
+
+    expect(screen.getByText(/newer version available/i)).toBeInTheDocument();
+    expect(screen.getByText(/v2 is now the recommended default/i)).toBeInTheDocument();
   });
 
   it('should show deprecation warning for deprecated channels', async () => {
@@ -83,7 +69,7 @@ describe('ChannelDetails', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/deprecated k6 version channel/i)).toBeInTheDocument();
-      expect(screen.getByText(/consider migrating to a newer channel/i)).toBeInTheDocument();
+      expect(screen.getByText(/please migrate your checks to a newer channel/i)).toBeInTheDocument();
     });
   });
 

--- a/src/components/CheckEditor/FormComponents/ChannelDetails.test.tsx
+++ b/src/components/CheckEditor/FormComponents/ChannelDetails.test.tsx
@@ -69,7 +69,7 @@ describe('ChannelDetails', () => {
 
     await waitFor(() => {
     expect(screen.getByText(/deprecated k6 version channel/i)).toBeInTheDocument();
-    expect(screen.getByText(/expected to end with the release of k6 v3/i)).toBeInTheDocument();
+    expect(screen.getByText(/will end with the release of the next k6 major version/i)).toBeInTheDocument();
     });
   });
 

--- a/src/components/CheckEditor/FormComponents/ChannelDetails.test.tsx
+++ b/src/components/CheckEditor/FormComponents/ChannelDetails.test.tsx
@@ -68,8 +68,8 @@ describe('ChannelDetails', () => {
     render(<ChannelDetails channelId="deprecated" channels={mockChannels} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/deprecated k6 version channel/i)).toBeInTheDocument();
-      expect(screen.getByText(/please migrate your checks to a newer channel/i)).toBeInTheDocument();
+    expect(screen.getByText(/deprecated k6 version channel/i)).toBeInTheDocument();
+    expect(screen.getByText(/expected to end with the release of k6 v3/i)).toBeInTheDocument();
     });
   });
 

--- a/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
+++ b/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
@@ -39,9 +39,11 @@ export function ChannelDetails({ channelId, channels }: ChannelDetailsProps) {
 
       {isDeprecated && (
         <Alert severity="warning" title="Deprecated k6 version channel">
-          This k6 version channel was deprecated on {dateTimeFormat(new Date(channel.deprecatedAfter))}. Support for
-          this version is expected to end with the release of k6 v3 (~May 2027). Please migrate your checks to a newer
-          channel.
+          This k6 version channel was deprecated on {dateTimeFormat(new Date(channel.deprecatedAfter))}.{' '}
+          {channel.id === 'v1'
+            ? 'Support for this version is expected to end with the release of k6 v3 (~May 2027).'
+            : 'Support for this version will end with the release of the next k6 major version.'}{' '}
+          Please migrate your checks to a newer channel.
         </Alert>
       )}
 

--- a/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
+++ b/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
@@ -49,8 +49,8 @@ export function ChannelDetails({ channelId, channels }: ChannelDetailsProps) {
 
       {isV1PreDeprecation && (
         <Alert severity="info" title="Newer version available">
-          v2 is now the recommended default. v1 will be deprecated in the coming weeks and support is expected to end
-          with the release of k6 v3 (~May 2027).
+          v2 is now the recommended default. v1 will be deprecated in the coming weeks. Support for this version is
+          expected to end with the release of k6 v3 (~May 2027).
         </Alert>
       )}
     </Stack>

--- a/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
+++ b/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
@@ -40,7 +40,7 @@ export function ChannelDetails({ channelId, channels }: ChannelDetailsProps) {
       {isDeprecated && (
         <Alert severity="warning" title="Deprecated k6 version channel">
           This k6 version channel was deprecated on {dateTimeFormat(new Date(channel.deprecatedAfter))}. Support for
-          this version will end with the release of the next k6 major version. Please migrate your checks to a newer
+          this version is expected to end with the release of k6 v3 (~May 2027). Please migrate your checks to a newer
           channel.
         </Alert>
       )}

--- a/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
+++ b/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
@@ -15,9 +15,6 @@ export function ChannelDetails({ channelId, channels }: ChannelDetailsProps) {
 
   const validChannelId = channelId && typeof channelId === 'string' && channelId.trim() !== '' ? channelId : undefined;
 
-  // Show default message when no specific channel is selected
-  // This happens when no channels are available or when all channels are filtered out
-  // (e.g., all are deprecated for new checks)
   if (!validChannelId) {
     return (
       <Text variant="bodySmall" color="secondary">
@@ -32,6 +29,7 @@ export function ChannelDetails({ channelId, channels }: ChannelDetailsProps) {
   }
 
   const isDeprecated = new Date(channel.deprecatedAfter) < new Date();
+  const isV1PreDeprecation = channel.id === 'v1' && !isDeprecated;
 
   return (
     <Stack direction="column" gap={1}>
@@ -41,8 +39,16 @@ export function ChannelDetails({ channelId, channels }: ChannelDetailsProps) {
 
       {isDeprecated && (
         <Alert severity="warning" title="Deprecated k6 version channel">
-          This k6 version channel is deprecated since {dateTimeFormat(new Date(channel.deprecatedAfter))}. Consider
-          migrating to a newer channel.
+          This k6 version channel was deprecated on {dateTimeFormat(new Date(channel.deprecatedAfter))}. Support for
+          this version will end with the release of the next k6 major version. Please migrate your checks to a newer
+          channel.
+        </Alert>
+      )}
+
+      {isV1PreDeprecation && (
+        <Alert severity="info" title="Newer version available">
+          v2 is now the recommended default. v1 will be deprecated in the coming weeks and support is expected to end
+          with the release of k6 v3 (~May 2027).
         </Alert>
       )}
     </Stack>

--- a/src/components/CheckEditor/FormComponents/K6ChannelSelect.test.tsx
+++ b/src/components/CheckEditor/FormComponents/K6ChannelSelect.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { apiRoute } from 'test/handlers';
 import { render } from 'test/render';
 import { server } from 'test/server';
 import { mockFeatureToggles } from 'test/utils';
 
-import { CheckFormValuesBrowser, CheckType, FeatureName } from 'types';
+import { CheckType, FeatureName } from 'types';
+import { testUsesCombobox } from 'test/utils';
 import { ChecksterProvider } from 'components/Checkster/contexts/ChecksterContext';
 import { setupChannelTest } from 'page/__testHelpers__/channel';
 
@@ -13,17 +15,13 @@ import { K6ChannelSelect } from './K6ChannelSelect';
 
 const FormWrapper = ({ 
   children, 
-  defaultValues,
-  check,
   checkType = CheckType.Browser 
 }: { 
   children: React.ReactNode; 
-  defaultValues?: Partial<CheckFormValuesBrowser>;
-  check?: any;
   checkType?: CheckType;
   }) => {
     return (
-      <ChecksterProvider checkType={checkType} check={check}>
+      <ChecksterProvider checkType={checkType}>
         {children}
       </ChecksterProvider>
     );
@@ -63,7 +61,7 @@ describe('K6ChannelSelect', () => {
     expect(screen.getByText(/select the k6 version channel/i)).toBeInTheDocument();
   });
 
-  it('should show mock channel options', async () => {
+  it('should auto-select the default channel (v2)', async () => {
     setupChannelTest();
     
     render(
@@ -73,29 +71,31 @@ describe('K6ChannelSelect', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText(/k6 version/i)).toBeInTheDocument();
+      const combobox = screen.getByLabelText(/k6 version/i);
+      expect(combobox).toHaveValue('v2.x (default)');
     });
   });
 
-  it('should auto-select the first available channel when default is deprecated', async () => {
+  it('should allow selecting a deprecated channel', async () => {
+    testUsesCombobox();
     mockFeatureToggles({
       [FeatureName.VersionManagement]: true,
     });
     
-    const channelsWithDeprecatedDefault = {
+    const channelsWithDeprecated = {
       channels: [
         {
           id: 'v1',
           name: 'v1.x',
-          default: true,
+          default: false,
           deprecatedAfter: '2020-01-01T00:00:00Z', // Already deprecated
           manifest: 'k6>=1,k6<2',
         },
         {
           id: 'v2',
           name: 'v2.x',
-          default: false,
-          deprecatedAfter: '2028-12-31T00:00:00Z', // Not deprecated
+          default: true,
+          deprecatedAfter: '2128-12-31T00:00:00Z',
           manifest: 'k6>=2',
         },
       ],
@@ -103,10 +103,12 @@ describe('K6ChannelSelect', () => {
 
     server.use(
       apiRoute('listK6Channels', { 
-        result: () => ({ json: channelsWithDeprecatedDefault }) 
+        result: () => ({ json: channelsWithDeprecated }) 
       })
     );
     
+    const user = userEvent.setup();
+
     render(
       <FormWrapper>
         <K6ChannelSelect />
@@ -115,12 +117,16 @@ describe('K6ChannelSelect', () => {
 
     await waitFor(() => {
       const combobox = screen.getByLabelText(/k6 version/i);
-      // v1 is the default but deprecated, so v2 should be selected as the first available
-      expect(combobox).toHaveValue('v2.x');
+      expect(combobox).toHaveValue('v2.x (default)');
     });
-    
-    // v1 should not be visible since it's deprecated for new checks
-    expect(screen.queryByText(/v1\.x/i)).not.toBeInTheDocument();
+
+    const combobox = screen.getByLabelText(/k6 version/i);
+    await user.click(combobox);
+    await user.click(screen.getByRole('option', { name: /v1\.x/ }));
+
+    await waitFor(() => {
+      expect(combobox).toHaveValue('v1.x');
+    });
   });
 
   it('should display error message when channels fail to load', async () => {
@@ -146,86 +152,4 @@ describe('K6ChannelSelect', () => {
     expect(screen.getByText(/failed to load version channels/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /retry request/i })).toBeInTheDocument();
   });
-
-  it('should hide deprecated channels for new checks', async () => {
-    setupChannelTest(); // Uses mockChannelsResponse which has only non-deprecated channels for new checks
-    
-    render(
-      <FormWrapper>
-        <K6ChannelSelect />
-      </FormWrapper>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/k6 version/i)).toBeInTheDocument();
-    });
-    
-    // Should have v1 selected (the default)
-    const combobox = screen.getByLabelText(/k6 version/i);
-    await waitFor(() => {
-      expect(combobox).toHaveValue('v1.x (default)');
-    });
-  });
-
-  it('should show deprecated channel for existing checks if it was previously assigned', async () => {
-    mockFeatureToggles({
-      [FeatureName.VersionManagement]: true,
-    });
-    
-    const channelsWithDeprecated = {
-      channels: [
-        {
-          id: 'v1',
-          name: 'v1.x',
-          default: true,
-          deprecatedAfter: '2125-12-31T00:00:00Z', // Not deprecated
-          manifest: 'k6>=1,k6<2',
-        },
-        {
-          id: 'deprecated',
-          name: 'deprecated.x',
-          default: false,
-          deprecatedAfter: '2020-01-01T00:00:00Z', // Already deprecated
-          manifest: 'k6>=0.5,k6<1',
-        },
-      ],
-    };
-
-    const existingCheck = { 
-      id: 1,
-      settings: { 
-        browser: { 
-          script: 'test script',
-        } 
-      },
-      channels: {
-        k6: {
-          id: 'deprecated',
-          name: 'deprecated.x',
-          default: false,
-          deprecatedAfter: '2020-01-01T00:00:00Z',
-          manifest: 'k6>=0.5,k6<1',
-        }
-      }
-    };
-
-    server.use(
-      apiRoute('listK6Channels', { 
-        result: () => ({ json: channelsWithDeprecated }) 
-      })
-    );
-
-    render(
-      <FormWrapper check={existingCheck} checkType={CheckType.Browser}>
-        <K6ChannelSelect />
-      </FormWrapper>
-    );
-
-    await waitFor(() => {
-      const combobox = screen.getByLabelText(/k6 version/i);
-      // Should have the deprecated channel selected since it was previously assigned
-      expect(combobox).toHaveValue('deprecated');
-    });
-  });
-
 });

--- a/src/components/CheckEditor/FormComponents/K6ChannelSelect.test.tsx
+++ b/src/components/CheckEditor/FormComponents/K6ChannelSelect.test.tsx
@@ -4,28 +4,27 @@ import userEvent from '@testing-library/user-event';
 import { apiRoute } from 'test/handlers';
 import { render } from 'test/render';
 import { server } from 'test/server';
-import { mockFeatureToggles } from 'test/utils';
+import { mockFeatureToggles, testUsesCombobox } from 'test/utils';
 
 import { CheckType, FeatureName } from 'types';
-import { testUsesCombobox } from 'test/utils';
 import { ChecksterProvider } from 'components/Checkster/contexts/ChecksterContext';
 import { setupChannelTest } from 'page/__testHelpers__/channel';
 
 import { K6ChannelSelect } from './K6ChannelSelect';
 
-const FormWrapper = ({ 
-  children, 
-  checkType = CheckType.Browser 
-}: { 
-  children: React.ReactNode; 
+const FormWrapper = ({
+  children,
+  checkType = CheckType.Browser
+}: {
+  children: React.ReactNode;
   checkType?: CheckType;
-  }) => {
-    return (
-      <ChecksterProvider checkType={checkType}>
-        {children}
-      </ChecksterProvider>
-    );
-  };
+}) => {
+  return (
+    <ChecksterProvider checkType={checkType}>
+      {children}
+    </ChecksterProvider>
+  );
+};
 
 describe('K6ChannelSelect', () => {
   beforeEach(() => {
@@ -36,7 +35,7 @@ describe('K6ChannelSelect', () => {
     mockFeatureToggles({
       [FeatureName.VersionManagement]: false,
     });
-    
+
     render(
       <FormWrapper>
         <K6ChannelSelect />
@@ -48,13 +47,13 @@ describe('K6ChannelSelect', () => {
 
   it('should render when feature flag is enabled', async () => {
     setupChannelTest();
-    
+
     render(
       <FormWrapper>
         <K6ChannelSelect />
       </FormWrapper>
     );
-    
+
     await waitFor(() => {
       expect(screen.getByLabelText(/k6 version/i)).toBeInTheDocument();
     });
@@ -63,7 +62,7 @@ describe('K6ChannelSelect', () => {
 
   it('should auto-select the default channel (v2)', async () => {
     setupChannelTest();
-    
+
     render(
       <FormWrapper>
         <K6ChannelSelect />
@@ -81,7 +80,7 @@ describe('K6ChannelSelect', () => {
     mockFeatureToggles({
       [FeatureName.VersionManagement]: true,
     });
-    
+
     const channelsWithDeprecated = {
       channels: [
         {
@@ -102,11 +101,11 @@ describe('K6ChannelSelect', () => {
     };
 
     server.use(
-      apiRoute('listK6Channels', { 
-        result: () => ({ json: channelsWithDeprecated }) 
+      apiRoute('listK6Channels', {
+        result: () => ({ json: channelsWithDeprecated })
       })
     );
-    
+
     const user = userEvent.setup();
 
     render(
@@ -133,10 +132,10 @@ describe('K6ChannelSelect', () => {
     mockFeatureToggles({
       [FeatureName.VersionManagement]: true,
     });
-    
+
     server.use(
-      apiRoute('listK6Channels', { 
-        result: () => ({ status: 500, body: 'Failed to load K6 version channels. Please try again later.' }) 
+      apiRoute('listK6Channels', {
+        result: () => ({ status: 500, body: 'Failed to load K6 version channels. Please try again later.' })
       })
     );
 

--- a/src/components/CheckEditor/FormComponents/K6ChannelSelect.tsx
+++ b/src/components/CheckEditor/FormComponents/K6ChannelSelect.tsx
@@ -5,7 +5,6 @@ import { trackK6ChannelRetryClicked, trackK6ChannelSelected } from 'features/tra
 
 import { CheckFormValues, FeatureName } from 'types';
 import { useFilteredK6Channels } from 'data/useK6Channels';
-import { useChecksterContext } from 'components/Checkster/contexts/ChecksterContext';
 import { FeatureFlag } from 'components/FeatureFlag';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
 
@@ -35,7 +34,6 @@ export function K6ChannelSelect({ disabled }: K6ChannelSelectProps) {
 
 function K6ChannelSelectContent({ disabled }: K6ChannelSelectProps) {
   const { control, getValues } = useFormContext<CheckFormValues>();
-  const { check } = useChecksterContext();
   const id = 'k6-channel-select';
 
   const checkType = getValues('checkType');
@@ -51,7 +49,7 @@ function K6ChannelSelectContent({ disabled }: K6ChannelSelectProps) {
     isLoading: isLoadingChannels,
     isError: hasChannelError,
     error: channelError,
-  } = useFilteredK6Channels(true, check); // Always true since this component only renders for scripted/browser
+  } = useFilteredK6Channels(true);
 
   // Initialize with default channel when no channel is set (new checks or existing checks without channel)
   useEffect(() => {

--- a/src/data/useK6Channels.ts
+++ b/src/data/useK6Channels.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { type QueryKey, useQuery } from '@tanstack/react-query';
 
-import { Check, FeatureName, K6Channel } from 'types';
+import { FeatureName } from 'types';
 import { SMDataSource } from 'datasource/DataSource';
 import { useFeatureFlag } from 'hooks/useFeatureFlag';
 import { useSMDS } from 'hooks/useSMDS';
@@ -31,58 +31,20 @@ export function useK6Channels(isScriptedOrBrowser: boolean) {
   return useQuery(channelsQuery(smDS, enabled));
 }
 
-// Filter channels based on deprecation status
-export function getFilteredChannels(
-  channels: K6Channel[],
-  isExistingCheck: boolean,
-  previousChannelId?: string | null
-): K6Channel[] {
-  if (!channels.length) {
-    return [];
-  }
-
-  return channels.filter((channel) => {
-    const isDeprecated = new Date(channel.deprecatedAfter) < new Date();
-
-    // Skip deprecated channels for new checks
-    if (isDeprecated && !isExistingCheck) {
-      return false;
-    }
-
-    // Skip deprecated channels for existing checks unless it was previously assigned
-    if (isDeprecated && isExistingCheck && channel.id !== previousChannelId) {
-      return false;
-    }
-
-    return true;
-  });
-}
-
-
-export function useFilteredK6Channels(isScriptedOrBrowser: boolean, check?: Check) {
+export function useFilteredK6Channels(isScriptedOrBrowser: boolean) {
   const { data: channelsResponse, ...queryResult } = useK6Channels(isScriptedOrBrowser);
-  
-  const { filteredChannels, defaultChannelId } = useMemo(() => {
-    const originalChannels = channelsResponse?.channels || [];
-    const isExistingCheck = !!check;
-    
-    const previousChannelId = isExistingCheck && check?.channels?.k6?.id
-      ? check.channels.k6.id
-      : null;
-    
-    const filteredChannels = getFilteredChannels(originalChannels, isExistingCheck, previousChannelId);
-    
-    // Find the default channel from filtered channels
-    const defaultChannel = filteredChannels.find((channel) => channel.default) || filteredChannels[0];
-    const defaultChannelId = defaultChannel?.id || '';
-    
-    return { filteredChannels, defaultChannelId };
-  }, [channelsResponse?.channels, check]);
+
+  const { channels, defaultChannelId } = useMemo(() => {
+    const channels = channelsResponse?.channels || [];
+    const defaultChannel = channels.find((channel) => channel.default) || channels[0];
+
+    return { channels, defaultChannelId: defaultChannel?.id || '' };
+  }, [channelsResponse?.channels]);
 
   return {
     ...queryResult,
-    data: channelsResponse ? { ...channelsResponse, channels: filteredChannels } : undefined,
-    channels: filteredChannels,
+    data: channelsResponse,
+    channels,
     defaultChannelId,
   };
 }

--- a/src/page/NewCheck/__tests__/v2/browserChecks/browser/1-browser.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/browserChecks/browser/1-browser.payload.test.tsx
@@ -65,17 +65,17 @@ describe(`BrowserCheck - 1 (Script) payload`, () => {
     const { read, user } = await setupFormWithChannelSelector(checkType);
     await submitForm(user);
     const { body } = await read();
-    expect(body.channels?.k6?.id).toBe('v1');
+    expect(body.channels?.k6?.id).toBe('v2');
   });
 
   it(`can select and submit a non-default channel`, async () => {
     const { read, user, channelCombobox } = await setupFormWithChannelSelector(checkType);
 
-    await selectComboboxOption(user, channelCombobox, /v2\.x/i);
+    await selectComboboxOption(user, channelCombobox, /v1\.x/i);
 
     await submitForm(user);
     const { body } = await read();
-    expect(body.channels?.k6?.id).toBe('v2');
+    expect(body.channels?.k6?.id).toBe('v1');
   });
 
   it(`omits channel from payload when feature is disabled`, async () => {

--- a/src/page/NewCheck/__tests__/v2/scriptedChecks/scripted/1-script.payload.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/scriptedChecks/scripted/1-script.payload.test.tsx
@@ -64,17 +64,17 @@ describe(`ScriptedCheck - 1 (Script) payload`, () => {
     const { read, user } = await setupFormWithChannelSelector(checkType);
     await submitForm(user);
     const { body } = await read();
-    expect(body.channels?.k6?.id).toBe('v1');
+    expect(body.channels?.k6?.id).toBe('v2');
   });
 
   it(`can select and submit a non-default channel`, async () => {
     const { read, user, channelCombobox } = await setupFormWithChannelSelector(checkType);
 
-    await selectComboboxOption(user, channelCombobox, /v2\.x/i);
+    await selectComboboxOption(user, channelCombobox, /v1\.x/i);
 
     await submitForm(user);
     const { body } = await read();
-    expect(body.channels?.k6?.id).toBe('v2');
+    expect(body.channels?.k6?.id).toBe('v1');
   });
 
   it(`omits channel from payload when feature is disabled`, async () => {

--- a/src/page/__testHelpers__/channel.ts
+++ b/src/page/__testHelpers__/channel.ts
@@ -22,15 +22,15 @@ export const MOCK_CHANNELS_RESPONSE = {
     {
       id: 'v1',
       name: 'v1.x',
-      default: true,
-      deprecatedAfter: '2125-12-31T00:00:00Z', // Far into the future, so it's not deprecated yet'
+      default: false,
+      deprecatedAfter: '2126-07-01T00:00:00Z', // Not yet deprecated, but deprecation coming
       manifest: 'k6>=1,k6<2',
     },
     {
       id: 'v2',
       name: 'v2.x',
-      default: false,
-      deprecatedAfter: '2126-12-31T00:00:00Z', // Far into the future, so it's not deprecated yet'
+      default: true,
+      deprecatedAfter: '2128-12-31T00:00:00Z',
       manifest: 'k6>=2',
     },
   ],

--- a/src/test/fixtures/k6Channels.ts
+++ b/src/test/fixtures/k6Channels.ts
@@ -11,15 +11,15 @@ export const K6_CHANNELS: K6Channel[] = [
   {
     id: 'v1',
     name: 'v1.x',
-    default: true,
-    deprecatedAfter: '2126-01-01T00:00:00Z',
+    default: false,
+    deprecatedAfter: '2026-07-01T00:00:00Z', // Deprecation coming soon but not yet
     manifest: 'k6>=1,k6<2',
   },
   {
     id: 'v2',
     name: 'v2.x',
-    default: false,
-    deprecatedAfter: '2028-12-31T00:00:00Z',
+    default: true,
+    deprecatedAfter: '2128-12-31T00:00:00Z',
     manifest: 'k6>=2',
   },
 ];


### PR DESCRIPTION
## Problem

When a k6 version channel was deprecated, it was completely hidden from the channel dropdown for new checks. This meant users couldn't select it even if they had a valid reason to (e.g. compatibility testing, gradual migration). With v2 becoming the new default channel, we need a gentler deprecation experience that informs users rather than blocking them — especially since v1 isn't deprecated yet but will be soon.

## Solution

Deprecated channels are now always visible in the dropdown regardless of whether the check is new or existing. Instead of hiding them, we show contextual messaging:

- **When v1 is selected (before its deprecation date):** a blue info alert explains that v2 is the recommended default, v1 will be deprecated in the coming weeks, and support is expected to end with k6 v3 (~May 2027).

<img width="1531" height="231" alt="image" src="https://github.com/user-attachments/assets/15634db1-c352-4ac4-b1b6-f9dd6a3dfa9d" />

- **When a deprecated channel is selected:** a yellow warning alert with a copy asking users to migrate their checks.

<img width="1505" height="161" alt="image" src="https://github.com/user-attachments/assets/a628ef46-891a-451e-8b33-955035cc8486" />


Test fixtures and assertions are updated to reflect v2 as the new default channel, with v1's deprecation date set to July 1st 2026 (~4 weeks from release).

## Context

This aligns with the team decision to launch v2 as the default while keeping v1 available with progressive warnings rather than hard-blocking users. v1's deprecation date is set to July 1st 2026. The hard cutoff (disabling v1 execution) will be handled separately when v3 ships.
