### PR TITLE
fix(ci): fix release-please permissions

### DIFF
--- a/.github/workflows/call_release-please.yml
+++ b/.github/workflows/call_release-please.yml
@@ -13,8 +13,9 @@ jobs:
     runs-on: ubuntu-arm64-small
 
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Needed for release-please action
+      pull-requests: write # Needed for release-please action
+      id-token: write      # Needed for create-github-app-token
 
     steps:
       - name: Get GitHub App token


### PR DESCRIPTION
Restore `id-token` permissions, required for create-github-app-token action.

Updates https://github.com/grafana/synthetic-monitoring/issues/587