### PR TITLE
fix(ci): grant id-token: write to release-please caller job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write # Needed for create-github-app-token in the called workflow
     uses: ./.github/workflows/call_release-please.yml
 
   # Publish TechDocs to Backstage


### PR DESCRIPTION
The reusable `call_release-please.yml` requests `id-token: write` (added in #1683), but the caller job's permissions are the ceiling — without granting it here too, the run fails at startup.

example failed run: https://github.com/grafana/synthetic-monitoring-app/actions/runs/26170898070/workflow#L17