### PR TITLE
fix(ci): grant id-token: write to renovate-reviewer workflow

### DIFF
--- a/.github/workflows/call_renovate_reviewer.yml
+++ b/.github/workflows/call_renovate_reviewer.yml
@@ -5,6 +5,7 @@ name: Renovate reviewer
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
 
 on:
   workflow_call:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -152,5 +152,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     uses: ./.github/workflows/call_renovate_reviewer.yml
 


### PR DESCRIPTION
## Problem

The GATB migration in #1680 removed `id-token: write` from the renovate-reviewer workflow permissions. Subsequent fix PRs (#1683, #1685) restored this permission for the release-please workflow but missed the renovate-reviewer.

Without `id-token: write`, the `create-github-app-token` action cannot obtain an OIDC token to authenticate with Vault, causing Vault auth failures when the renovate-reviewer tries to get the `sm-release-app` token.

## Solution

Add `id-token: write` to:
- The `renovate-reviewer` caller job in `push.yml` (so the permission propagates to the called workflow)
- The top-level permissions in `call_renovate_reviewer.yml` (so the job can use the OIDC token)

This mirrors what was already done for the release-please workflow in #1685 and #1683.

## Additional context

A separate PR is needed in `deployment_tools` to update the Vault role config path from `.github/workflows/call_release-please.yml` to `.github/workflows/push.yml`. The current config uses the called workflow path, but `github.workflow_ref` resolves to the caller (`push.yml`). Until that change is merged, both release-please and renovate-reviewer will continue to fail Vault auth regardless of this permission fix.


Made with [Cursor](https://cursor.com)