### PR TITLE
fix(ci): drop leading dot from release-please manifest-file path

### DIFF
--- a/.github/workflows/call_release-please.yml
+++ b/.github/workflows/call_release-please.yml
@@ -31,4 +31,4 @@ jobs:
           token: ${{ steps.get-github-app-token.outputs.token }}
           target-branch: main
           config-file: .github/release-please/release-please-config.json
-          manifest-file: .github/release-please/.release-please-manifest.json
+          manifest-file: .github/release-please/release-please-manifest.json


### PR DESCRIPTION
#1681 renamed the manifest to `release-please-manifest.json` but the workflow still references the dot-prefixed path. Aligns with sm-agent.

failed run: https://github.com/grafana/synthetic-monitoring-app/actions/runs/26186968211/job/77144184231