### PR TITLE
chore: extract renovate-reviewer into its own top-level workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -145,13 +145,3 @@ jobs:
       statuses: write
     uses: ./.github/workflows/call_dangerJS.yml
 
-  # Renovate reviewer (only for renovate PRs)
-  renovate-reviewer:
-    name: Renovate Reviewer
-    if: github.event_name == 'pull_request' && github.actor == 'renovate-sh-app[bot]'
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
-    uses: ./.github/workflows/call_renovate_reviewer.yml
-

--- a/.github/workflows/renovate-reviewer.yml
+++ b/.github/workflows/renovate-reviewer.yml
@@ -2,18 +2,22 @@
 # slack context: https://raintank-corp.slack.com/archives/C07QXFPF1B2/p1761690200989699
 name: Renovate reviewer
 
-permissions:
-  pull-requests: write
-  contents: write
-  id-token: write
-
 on:
-  workflow_call:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+
+permissions: {}
 
 jobs:
   review-renovate-pr:
     runs-on: ubuntu-arm64-small
     if: ${{ github.event.pull_request.user.login == 'renovate-sh-app[bot]' }}
+    permissions:
+      id-token: write
     env:
       PR_URL: ${{github.event.pull_request.html_url}}
       COMMITS_URL: ${{ github.event.pull_request.commits_url }}


### PR DESCRIPTION
## Problem

Renovate-reviewer should run as its own top-level workflow. Today it lives inside `push.yml` as a reusable workflow (`call_renovate_reviewer.yml`) gated by an `if:` check, which means it shares an OIDC identity with everything else `push.yml` does — Vault's `workflow_ref` claim resolves to `push.yml`, not to the workflow that's actually minting the token. That couples renovate-reviewer's GATB scoping to whatever `push.yml` also needs and makes least-privilege scoping hard.

## Solution

Extract renovate-reviewer into its own top-level workflow following the pattern in [`grafana-adaptive-metrics-app`](https://github.com/grafana/grafana-adaptive-metrics-app/blob/main/.github/workflows/renovate-reviewer.yaml).

- New `.github/workflows/renovate-reviewer.yml`: triggered directly on `pull_request` events (`opened`, `reopened`, `synchronize`, `labeled`). Workflow-level `permissions: {}`, job-level `id-token: write` only. Same actor-gate (`if: github.event.pull_request.user.login == 'renovate-sh-app[bot]'`) and same four label-conditional approval steps as before.
- Delete `.github/workflows/call_renovate_reviewer.yml` — the reusable pattern bought nothing with only one caller.
- Remove the `renovate-reviewer:` job from `push.yml`.

Renovate auto-approval behaviour is unchanged. After this and the release-please migration land, `push.yml` no longer mints any tokens.

## Additional context

This PR is **coupled with a companion `deployment_tools` PR** that re-paths the `sm-release-app` GATB entry from `path: push.yml` to `path: renovate-reviewer.yml` (and also tightens its scope to `event_name: pull_request` + `pull_requests: write` only).

The two need to merge together or close back-to-back:

- If this PR lands first: OIDC sends `workflow_ref: renovate-reviewer.yml` but the GATB entry still expects `path: push.yml` — Vault auth fails until the deployment_tools PR lands.
- If the deployment_tools PR lands first: GATB expects `path: renovate-reviewer.yml` but the workflow on `main` still mints from `push.yml` — same failure mode.

This is the second half of the cleanup started in https://github.com/grafana/synthetic-monitoring-app/pull/1690

Related to https://github.com/grafana/synthetic-monitoring-app/pull/1689