### PR TITLE
feat: add Grafana Assistant page context for Synthetic Monitoring

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -15,6 +15,7 @@ import { SMDatasourceProvider } from 'contexts/SMDatasourceContext';
 import { queryClient } from 'data/queryClient';
 import { QUERY_KEYS as alertingQueryKeys } from 'data/useAlerts';
 
+import { AssistantContext } from './AssistantContext';
 import { DevTools } from './DevTools';
 import { FeatureFlagProvider } from './FeatureFlagProvider';
 import { SMOpenFeatureProvider } from './SMOpenFeatureProvider';
@@ -61,6 +62,7 @@ const App = (props: AppRootProps<ProvisioningJsonData>) => {
             <GlobalStyles />
             <SMDatasourceProvider>
               <PermissionsContextProvider>
+                <AssistantContext />
                 <DevTools>
                   <InitialisedRouter />
                 </DevTools>

--- a/src/components/AssistantContext/AssistantContext.constants.ts
+++ b/src/components/AssistantContext/AssistantContext.constants.ts
@@ -1,0 +1,518 @@
+import { type ChatContextItem, createAssistantContextItem, type Question } from '@grafana/assistant';
+
+import { PLUGIN_URL_PATH } from 'routing/constants';
+import { AppRoutes } from 'routing/types';
+
+/**
+ * Routes that are intentionally not registered with the Grafana Assistant
+ * because they have no user-facing surface area (they immediately redirect
+ * elsewhere on mount; see SceneRedirecter).
+ */
+export const ASSISTANT_CONTEXT_EXCLUDED_ROUTES: ReadonlySet<AppRoutes> = new Set([
+  AppRoutes.Redirect,
+  AppRoutes.Scene,
+]);
+
+interface AssistantPageContextEntry {
+  /** Stable id used for diffing the registration list in tests. */
+  id: string;
+  /** The AppRoutes value this entry covers. Used by the coverage test. */
+  route: AppRoutes;
+  /**
+   * URL pattern matched against `window.location.pathname` by the Assistant SDK.
+   * Regex is used wherever a route has path params, so that, e.g.,
+   * `/checks/:id` does not accidentally also match `/checks/:id/edit`.
+   */
+  urlPattern: string | RegExp;
+  /**
+   * Factory that builds the context items for this page. A factory (rather
+   * than a static array) keeps the items lazily constructed so the Assistant
+   * SDK is only invoked when a consumer needs the value.
+   */
+  createContextItems: () => ChatContextItem[];
+  /**
+   * Optional factory that builds starter questions for this page. These
+   * surface as clickable prompts in the Assistant UI to help users discover
+   * what they can ask. Bracketed `[placeholders]` are intentional — Assistant
+   * pre-fills the chat input with the prompt so the user can edit before
+   * sending.
+   */
+  createQuestions?: () => Question[];
+}
+
+function structured(
+  title: string,
+  data: {
+    name: string;
+    pageType: string;
+    capabilities: string[];
+    help: string;
+  }
+): ChatContextItem {
+  return createAssistantContextItem('structured', {
+    title,
+    bypassLimits: true,
+    data,
+  });
+}
+
+/**
+ * Builds a `structured` context item that is sent to the LLM but does NOT
+ * appear as a visible chip in the Assistant UI. Useful for rules-of-the-road
+ * that should always influence the model's answer without cluttering the UI.
+ */
+function hiddenStructured(name: string, data: Record<string, unknown>): ChatContextItem {
+  return createAssistantContextItem('structured', {
+    title: name,
+    hidden: true,
+    bypassLimits: true,
+    data: { name, ...data },
+  });
+}
+
+function question(title: string, prompt: string): Question {
+  return { title, prompt };
+}
+
+/**
+ * Hidden context attached to any page where Assistant is likely to draft or
+ * edit a k6 script for Synthetic Monitoring. Tools like `k6-authoring` are
+ * perf-testing oriented and emit load-test-shaped scripts; this context tells
+ * the model loudly to transform tool output to the SM single-VU model before
+ * presenting it to the user.
+ */
+function smK6Conventions(): ChatContextItem {
+  return hiddenStructured('Synthetic Monitoring k6 conventions', {
+    pageType: 'sm-k6-conventions',
+    audience: 'k6-script-authoring',
+    summary:
+      'This script is for Grafana Synthetic Monitoring (single-VU probe check on a recurring schedule), NOT k6 load testing.',
+    rules: [
+      `DO use the k6-testing assertions library — \`import { expect } from 'https://jslib.k6.io/k6-testing/0.6.1/index.js';\` — for assertions. Reference: ${DOC_URLS.k6Assertions}. A failing expect() aborts the iteration, which directly maps to "SM check failed". This is the modern, recommended approach.`,
+      'For protocol-level checks (HTTP/DNS/TCP/gRPC scripted), use the non-retrying matchers: expect(res.status).toBe(200), expect(res.body).toContain("..."), expect(data.field).toBeDefined(), etc.',
+      'For browser checks, use the auto-retrying matchers on locators to handle async DOM: await expect(page.locator(...)).toBeVisible(), .toHaveText(...), .toHaveValue(...), etc. These wait for the condition rather than evaluating once.',
+      'AVOID the classic k6 `check()` function for SM. check() is designed for load tests — it records a metric and CONTINUES execution on failure, which does not cleanly map to "the SM check failed". Prefer expect() for fail-fast semantics.',
+      "DO NOT include options.stages, options.vus, options.thresholds, or other load-test ramping/SLO constructs — execution is single-VU at the check's configured frequency.",
+      'DO NOT call exec.test.abort() or other load-test lifecycle APIs that do not apply to SM.',
+      'DO reference credentials via the SM Secrets module (Config > Secrets tab in the Synthetic Monitoring app), NOT hardcoded strings or env vars.',
+      "DO keep total execution time within the check's configured timeout. Use sleep() sparingly.",
+      'DO emit custom Trend/Counter/Gauge metrics if useful for observability, but the primary pass/fail signal is the result of expect() assertions.',
+      'AVOID heavyweight third-party perf-testing helpers that do not fit a tight per-execution budget.',
+      'DO NOT suggest capturing screenshots (e.g. `page.screenshot()`) in browser checks. Screenshot capture is not currently functional for Synthetic Monitoring — the screenshots are produced by the script but cannot be viewed by the user in the SM UI. A fix is in progress; until it ships, do not direct users down this path. If a user explicitly asks about screenshots, acknowledge it is on the roadmap but not yet available rather than walking through page.screenshot() usage.',
+    ],
+    warning:
+      'Tools such as k6-authoring are oriented toward performance testing and tend to emit load-test-shaped scripts (stages, VUs, thresholds, env-var credentials, classic check() calls, page.screenshot() debug aids). When using their output for a Grafana Synthetic Monitoring check, TRANSFORM the script to follow the rules above before presenting it to the user — including swapping check() calls for expect() from the k6-testing library and stripping any screenshot calls.',
+  });
+}
+
+const DOC_URLS = {
+  privateProbes:
+    'https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/',
+  perCheckAlerts:
+    'https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/configure-per-check-alerts/',
+  k6Assertions: 'https://grafana.com/docs/k6/latest/using-k6/assertions/',
+};
+
+const root = PLUGIN_URL_PATH.replace(/\/$/, '');
+
+// Pre-built regex fragments so the route shape is obvious at the call site.
+const escapedRoot = root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const checkIdRegex = new RegExp(`^${escapedRoot}/checks/[^/]+$`);
+const editCheckRegex = new RegExp(`^${escapedRoot}/checks/[^/]+/edit$`);
+// /checks/choose-type and the bare /checks/new index render the same component.
+const chooseCheckGroupRegex = new RegExp(`^${escapedRoot}/checks/(choose-type|new)$`);
+const newCheckApiRegex = new RegExp(`^${escapedRoot}/checks/new/api-endpoint$`);
+const newCheckMultiStepRegex = new RegExp(`^${escapedRoot}/checks/new/multistep$`);
+const newCheckScriptedRegex = new RegExp(`^${escapedRoot}/checks/new/scripted$`);
+const newCheckBrowserRegex = new RegExp(`^${escapedRoot}/checks/new/browser$`);
+const probeIdRegex = new RegExp(`^${escapedRoot}/probes/[^/]+$`);
+const editProbeRegex = new RegExp(`^${escapedRoot}/probes/[^/]+/edit$`);
+
+export const ASSISTANT_PAGE_CONTEXTS: readonly AssistantPageContextEntry[] = [
+  {
+    id: 'sm-home',
+    route: AppRoutes.Home,
+    urlPattern: `${root}/home`,
+    createContextItems: () => [
+      structured('Synthetic Monitoring home', {
+        name: 'Synthetic Monitoring home',
+        pageType: 'sm-home',
+        capabilities: ['getting-started', 'navigation', 'overview'],
+        help: 'The Synthetic Monitoring home page summarises the user\'s checks, probe usage, and recent activity. Help with: getting started, understanding what Synthetic Monitoring is, navigating to checks/probes/alerts, and choosing which type of check to create first.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Get started with Synthetic Monitoring',
+        "I'm new to Synthetic Monitoring. Walk me through the key concepts (checks, probes, jobs) and help me decide what to create first."
+      ),
+      question(
+        'What check type should I use?',
+        'Help me choose between API endpoint checks, multi-step checks, k6 scripted checks, and k6 browser checks for a typical web application.'
+      ),
+      question(
+        'Show me example use cases',
+        'Give me 3-4 example monitoring use cases that Synthetic Monitoring is well-suited for, with the recommended check type for each.'
+      ),
+    ],
+  },
+  {
+    id: 'sm-check-list',
+    route: AppRoutes.Checks,
+    urlPattern: `${root}/checks`,
+    createContextItems: () => [
+      structured('Synthetic Monitoring checks list', {
+        name: 'Checks list',
+        pageType: 'sm-check-list',
+        capabilities: ['filter-checks', 'explain-statuses', 'explain-check-types'],
+        help: 'Lists all synthetic monitoring checks for the current tenant. Users can filter by check type, status, label, or search by job/instance. Help with: interpreting success/failure/disabled statuses, filtering and searching, bulk actions, and finding specific checks.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Explain the statuses',
+        'What do the success, failure, and disabled statuses on this list mean, and what causes each?'
+      ),
+      question('Filter and find a check', 'How do I filter this list to find a check by label, status, or check type?'),
+      question(
+        'Organize checks at scale',
+        'What are best practices for organising and labelling checks across teams and services?'
+      ),
+    ],
+  },
+  {
+    id: 'sm-choose-check-group',
+    route: AppRoutes.ChooseCheckGroup,
+    urlPattern: chooseCheckGroupRegex,
+    createContextItems: () => [
+      structured('Choose check type', {
+        name: 'Choose check type',
+        pageType: 'sm-choose-check-group',
+        capabilities: ['explain-check-types', 'recommend-check-type'],
+        help: 'User is picking which kind of synthetic check to create: API (HTTP, DNS, TCP, gRPC), Ping, Traceroute, k6 scripted, or k6 browser. Help with: which check type fits a given monitoring goal, the trade-offs between scripted and protocol-level checks, and when to choose browser checks.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Help me pick the right check type',
+        'Help me pick the right check type. Ask me a few questions about what I want to monitor, then recommend between API endpoint, multi-step, k6 scripted, and k6 browser.'
+      ),
+      question(
+        'HTTP check vs k6 script',
+        'What are the trade-offs between a protocol-level HTTP check and a k6 scripted check? When does scripting become necessary?'
+      ),
+      question(
+        'Browser vs scripted',
+        'Explain the difference between k6 scripted and k6 browser checks. When do I need a real browser?'
+      ),
+    ],
+  },
+  {
+    id: 'sm-new-check-api',
+    route: AppRoutes.NewCheck,
+    urlPattern: newCheckApiRegex,
+    createContextItems: () => [
+      structured('Create a new API endpoint check', {
+        name: 'New API endpoint check',
+        pageType: 'sm-new-check-api',
+        capabilities: ['http-check-configuration', 'dns-check', 'tcp-check', 'grpc-check', 'response-validation', 'probe-selection'],
+        help: 'User is creating a new API endpoint check (HTTP, DNS, TCP, or gRPC). Help with: configuring target URL/host, request method, headers and body for HTTP, response validation (status code, body content, regex, headers), SSL/TLS settings, timeout and frequency, and probe selection.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Configure my first HTTP check',
+        'Walk me through configuring an HTTP check end-to-end: target URL, method, response validation, timeout, and frequency.'
+      ),
+      question(
+        'Validate the response',
+        'How do I assert specific content, status codes, headers, or regex matches in an HTTP response?'
+      ),
+      question(
+        'DNS / TCP / gRPC checks',
+        'Explain how API endpoint checks support DNS, TCP, and gRPC, and what fields differ for each.'
+      ),
+    ],
+  },
+  {
+    id: 'sm-new-check-multistep',
+    route: AppRoutes.NewCheck,
+    urlPattern: newCheckMultiStepRegex,
+    createContextItems: () => [
+      structured('Create a new multi-step check', {
+        name: 'New multi-step check',
+        pageType: 'sm-new-check-multistep',
+        capabilities: ['multistep-flow', 'request-chaining', 'response-extraction', 'probe-selection'],
+        help: 'User is creating a multi-step HTTP check that runs multiple sequential requests with state passed between them. Help with: designing the request sequence, extracting values (tokens, ids) from one response and reusing them in subsequent requests, assertions per step, and choosing the right granularity for steps.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Build a multi-step flow',
+        'Help me design a multi-step HTTP check that simulates a login + fetch flow with state shared between requests.'
+      ),
+      question(
+        'Pass values between steps',
+        "How do I extract a value (e.g. an auth token) from one step's response and use it in the next?"
+      ),
+    ],
+  },
+  {
+    id: 'sm-new-check-scripted',
+    route: AppRoutes.NewCheck,
+    urlPattern: newCheckScriptedRegex,
+    createContextItems: () => [
+      structured('Create a new k6 scripted check', {
+        name: 'New k6 scripted check',
+        pageType: 'sm-new-check-scripted',
+        capabilities: ['k6-scripting', 'k6-checks', 'k6-metrics', 'secrets-reference', 'probe-selection'],
+        help: `User is creating a k6 scripted check (JavaScript) for synthetic monitoring. This is NOT a load test — the script runs as a single-VU probe check on a recurring schedule. Help with: writing the script (default export, http requests, sleep used sparingly), using the k6-testing assertions library (expect() from ${DOC_URLS.k6Assertions}) to fail-fast on assertion violations, referencing credentials via the SM Secrets module, and adapting existing perf-testing-shaped k6 scripts (stages/VUs/thresholds, classic check() calls) into the SM single-VU model. Prefer expect() over the classic check() function.`,
+      }),
+      smK6Conventions(),
+    ],
+    createQuestions: () => [
+      question(
+        'Help me write a k6 script',
+        `Help me write a Grafana Synthetic Monitoring k6 scripted check. Ask me about the target, expected response, and failure criteria, then draft the script using the k6-testing assertions library (expect() from ${DOC_URLS.k6Assertions}) so the iteration fails fast on assertion violations.`
+      ),
+      question(
+        'Common k6 patterns for SM',
+        `Show me common patterns for k6 scripted synthetic monitoring checks: expect() assertions from the k6-testing library (${DOC_URLS.k6Assertions}), custom Trend/Counter metrics for observability, error handling, and reading secrets via the SM Secrets module. Do not suggest load-test constructs or the classic check() function.`
+      ),
+      question(
+        'Adapt an existing k6 script',
+        "I have an existing k6 script — ask me to paste it, then walk me through transforming it into a Grafana Synthetic Monitoring scripted check (remove stages/VUs/thresholds, swap env-var credentials for SM Secrets, ensure execution fits the check timeout)."
+      ),
+      question(
+        'Reference a secret from my script',
+        'How do I securely reference a secret (API key, password) from within a k6 scripted check using the Synthetic Monitoring Secrets module?'
+      ),
+    ],
+  },
+  {
+    id: 'sm-new-check-browser',
+    route: AppRoutes.NewCheck,
+    urlPattern: newCheckBrowserRegex,
+    createContextItems: () => [
+      structured('Create a new k6 browser check', {
+        name: 'New k6 browser check',
+        pageType: 'sm-new-check-browser',
+        capabilities: ['k6-browser', 'browser-automation', 'page-assertions', 'multi-page-flows', 'probe-selection'],
+        help: `User is creating a k6 browser check (real headless browser) for synthetic monitoring. This is NOT a load test — the script runs as a single-VU probe check on a recurring schedule. Help with: writing browser scripts using the k6 browser API (page.goto, locator, waitForSelector), asserting on page content and DOM state with the k6-testing assertions library's auto-retrying matchers (await expect(page.locator(...)).toBeVisible(), .toHaveText(...), etc. — see ${DOC_URLS.k6Assertions}), navigating multi-page flows, referencing credentials via SM Secrets, and avoiding load-test constructs (no stages/VUs/thresholds). Prefer expect() over the classic check() function. Do NOT suggest page.screenshot() — screenshot capture is not currently functional in SM.`,
+      }),
+      smK6Conventions(),
+    ],
+    createQuestions: () => [
+      question(
+        'Help me write a browser script',
+        `Help me write a Grafana Synthetic Monitoring k6 browser script. Ask me which user flow I want to monitor (target URL, steps, what to assert on), then draft the script using the k6 browser API together with the k6-testing assertions library's auto-retrying matchers (await expect(locator).toBeVisible() etc. — ${DOC_URLS.k6Assertions}).`
+      ),
+      question(
+        'When do I need a browser check?',
+        'What monitoring goals require a k6 browser check rather than a scripted one, and what are the cost and performance trade-offs?'
+      ),
+      question(
+        'Common browser patterns for SM',
+        `Show me common patterns for k6 browser checks in synthetic monitoring: waiting for elements with the k6-testing library's auto-retrying matchers (await expect(locator).toBeVisible() etc. — ${DOC_URLS.k6Assertions}), navigating multi-page flows, and referencing secrets via the SM Secrets module. Do not suggest load-test constructs, the classic check() function, or page.screenshot() (screenshot capture is not currently functional in SM).`
+      ),
+    ],
+  },
+  {
+    id: 'sm-check-dashboard',
+    route: AppRoutes.CheckDashboard,
+    urlPattern: checkIdRegex,
+    createContextItems: () => [
+      structured('Check dashboard', {
+        name: 'Check dashboard',
+        pageType: 'sm-check-dashboard',
+        capabilities: ['explain-failures', 'explain-metrics', 'explain-logs', 'debug-check'],
+        help: 'Dashboard for a single synthetic monitoring check showing current status, recent results, latency, uptime, error breakdown by probe, and logs. Help with: diagnosing failures, interpreting latency and uptime metrics, identifying which probes are failing, and improving check reliability.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Diagnose a failing check',
+        'This check is showing failures — walk me through diagnosing it: probe-level breakdown, error logs, latency anomalies, and external causes.'
+      ),
+      question(
+        'Explain the metrics',
+        'What do the uptime, reachability, latency, and SSL expiry metrics on this dashboard mean and how are they calculated?'
+      ),
+    ],
+  },
+  {
+    id: 'sm-edit-check',
+    route: AppRoutes.EditCheck,
+    urlPattern: editCheckRegex,
+    createContextItems: () => [
+      structured('Edit a check', {
+        name: 'Edit check',
+        pageType: 'sm-edit-check',
+        capabilities: ['check-configuration', 'probe-selection', 'k6-scripting', 'alerting-setup'],
+        help: 'User is editing an existing synthetic monitoring check. Help with: adjusting target/URL, request method/headers/body, response validation, probe selection, frequency/timeout, k6 script edits for scripted/browser checks, and per-check alert configuration. If the check being edited is a k6 scripted or browser check, follow the SM k6 conventions in the hidden context — do not introduce load-test constructs.',
+      }),
+      smK6Conventions(),
+    ],
+    createQuestions: () => [
+      question(
+        'Tune frequency and timeout',
+        "What are the right frequency and timeout settings, and how do they interact with my plan's execution budget?"
+      ),
+      question('Pick probes', 'How do I decide which probes to run this check from? How many is too many?'),
+      question(
+        'Configure alerts during edit',
+        'How do I configure per-check alert sensitivity and thresholds while editing?'
+      ),
+    ],
+  },
+  {
+    id: 'sm-probes-list',
+    route: AppRoutes.Probes,
+    urlPattern: `${root}/probes`,
+    createContextItems: () => [
+      structured('Probes list', {
+        name: 'Probes list',
+        pageType: 'sm-probes-list',
+        capabilities: ['explain-probes', 'probe-regions', 'public-vs-private-probes'],
+        help: 'Lists all probes available to the user (both Grafana-hosted public probes and any private probes the user has added). Help with: probe regions, the difference between public and private probes, and which probes to pick for a check.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Set up a private probe',
+        `Walk me through setting up a Grafana Synthetic Monitoring private probe end-to-end, including auth, deployment, and verification. Reference ${DOC_URLS.privateProbes} for the full step-by-step guide.`
+      ),
+      question(
+        'Public vs private probes',
+        'When should I use Grafana-hosted public probes versus running my own private probes?'
+      ),
+      question(
+        'Pick probes for a check',
+        "What's the recommended probe selection strategy for a service used by global users vs a single region?"
+      ),
+    ],
+  },
+  {
+    id: 'sm-new-probe',
+    route: AppRoutes.NewProbe,
+    urlPattern: `${root}/probes/new`,
+    createContextItems: () => [
+      structured('Create a new probe', {
+        name: 'New probe',
+        pageType: 'sm-new-probe',
+        capabilities: ['probe-setup', 'private-probe-deployment'],
+        help: 'User is creating a new private probe. Help with: naming the probe, setting its region and coordinates, generating an authentication token, deploying the probe agent (container/binary), and verifying connectivity back to Grafana Cloud.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Deploy a private probe to Kubernetes',
+        `Help me deploy a private probe to a Kubernetes cluster using the Helm chart or manifest. The full setup guide is at ${DOC_URLS.privateProbes}.`
+      ),
+      question(
+        'Deploy a private probe via Docker',
+        `Show me how to run a private probe as a Docker container, with the right config and secret handling. Refer to ${DOC_URLS.privateProbes} for the full setup.`
+      ),
+      question(
+        'Probe deployment troubleshooting',
+        'What are the common reasons a newly deployed private probe fails to connect, and how do I troubleshoot each?'
+      ),
+    ],
+  },
+  {
+    id: 'sm-view-probe',
+    route: AppRoutes.ViewProbe,
+    urlPattern: probeIdRegex,
+    createContextItems: () => [
+      structured('View probe', {
+        name: 'View probe',
+        pageType: 'sm-view-probe',
+        capabilities: ['probe-status', 'probe-debug', 'probe-version'],
+        help: 'Viewing details of a single probe: region, version, connection status, and the checks assigned to it. Help with: probe health, version updates, and diagnosing why a probe might be disconnected.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Why is this probe disconnected?',
+        'Walk me through diagnosing why a private probe is disconnected: network, auth, version, resource limits.'
+      ),
+      question(
+        'Update probe version',
+        'How do I update this probe to the latest agent version safely without dropping checks?'
+      ),
+    ],
+  },
+  {
+    id: 'sm-edit-probe',
+    route: AppRoutes.EditProbe,
+    urlPattern: editProbeRegex,
+    createContextItems: () => [
+      structured('Edit probe', {
+        name: 'Edit probe',
+        pageType: 'sm-edit-probe',
+        capabilities: ['probe-setup', 'private-probe-config'],
+        help: 'User is editing a private probe. Help with: renaming, changing region/coordinates, rotating authentication tokens, and managing labels.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Rotate the auth token',
+        "Walk me through rotating this probe's authentication token without downtime."
+      ),
+      question(
+        'Probe labelling strategy',
+        "What's a good labelling strategy for private probes across multiple regions and teams?"
+      ),
+    ],
+  },
+  {
+    id: 'sm-alerts',
+    route: AppRoutes.Alerts,
+    urlPattern: `${root}/alerts`,
+    createContextItems: () => [
+      structured('Synthetic Monitoring alerts (legacy)', {
+        name: 'Alerts (legacy)',
+        pageType: 'sm-alerts',
+        capabilities: ['explain-alerts', 'alerting-migration', 'alerting-best-practices'],
+        help: 'The legacy alerts page for Synthetic Monitoring. Help with: understanding the legacy alerting model, migrating to per-check alerts, and writing alert rules for SM metrics.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Migrate to per-check alerts',
+        `Explain the newer per-check alerts model in Grafana Synthetic Monitoring and walk me through migrating from this legacy alerts page. Reference ${DOC_URLS.perCheckAlerts} for full details.`
+      ),
+      question(
+        'Best practices for SM alerts',
+        'What are best practices for alerting on synthetic monitoring metrics? Which metrics matter most?'
+      ),
+    ],
+  },
+  {
+    id: 'sm-config',
+    route: AppRoutes.Config,
+    urlPattern: new RegExp(`^${escapedRoot}/config(/.*)?$`),
+    createContextItems: () => [
+      structured('Synthetic Monitoring configuration', {
+        name: 'Configuration',
+        pageType: 'sm-config',
+        capabilities: ['app-setup', 'datasource-setup', 'access-tokens', 'terraform-export', 'secrets-management'],
+        help: 'Configuration area for the Synthetic Monitoring app, with tabs for General settings (datasources, API host), Access Tokens (for SM API and Terraform), Terraform export (download existing checks/probes as IaC), and Secrets management (referenced by scripted/browser checks at runtime). Help with: app provisioning, API token rotation, exporting checks to Terraform, and managing secrets safely.',
+      }),
+    ],
+    createQuestions: () => [
+      question(
+        'Export as Terraform',
+        'Walk me through exporting my existing checks and probes as Terraform configuration.'
+      ),
+      question(
+        'Manage API tokens',
+        "How do I create and rotate Synthetic Monitoring API tokens? What's each token type used for?"
+      ),
+      question(
+        'Use a secret in a scripted check',
+        'How do I create a secret here and reference it from a k6 scripted or browser check at runtime?'
+      ),
+    ],
+  },
+];

--- a/src/components/AssistantContext/AssistantContext.constants.ts
+++ b/src/components/AssistantContext/AssistantContext.constants.ts
@@ -80,6 +80,7 @@ const DOC_URLS = {
   perCheckAlerts:
     'https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/configure-per-check-alerts/',
   k6Assertions: 'https://grafana.com/docs/k6/latest/using-k6/assertions/',
+  k6BrowserPractices: 'https://grafana.com/docs/k6/latest/using-k6-browser/recommended-practices.md',
 };
 
 /**
@@ -298,7 +299,7 @@ export const ASSISTANT_PAGE_CONTEXTS: readonly AssistantPageContextEntry[] = [
         name: 'New k6 browser check',
         pageType: 'sm-new-check-browser',
         capabilities: ['k6-browser', 'browser-automation', 'page-assertions', 'multi-page-flows', 'probe-selection'],
-        help: `User is creating a k6 browser check (real headless browser) for synthetic monitoring. This is NOT a load test — the script runs as a single-VU probe check on a recurring schedule. Help with: writing browser scripts using the k6 browser API (page.goto, locator, waitForSelector), asserting on page content and DOM state with the k6-testing assertions library's auto-retrying matchers (await expect(page.locator(...)).toBeVisible(), .toHaveText(...), etc. — see ${DOC_URLS.k6Assertions}), navigating multi-page flows, referencing credentials via SM Secrets, and avoiding load-test constructs (no stages/VUs/thresholds). Prefer expect() over the classic check() function. Do NOT suggest page.screenshot() — screenshot capture is not currently functional in SM.`,
+        help: `User is creating a k6 browser check (real headless browser) for synthetic monitoring. This is NOT a load test — the script runs as a single-VU probe check on a recurring schedule. Help with: writing browser scripts using the k6 browser API (page.goto, locator, waitForSelector), asserting on page content and DOM state with the k6-testing assertions library's auto-retrying matchers (await expect(page.locator(...)).toBeVisible(), .toHaveText(...), etc. — see ${DOC_URLS.k6Assertions}), navigating multi-page flows, referencing credentials via SM Secrets, and avoiding load-test constructs (no stages/VUs/thresholds). Prefer expect() over the classic check() function. Do NOT suggest page.screenshot() — screenshot capture is not currently functional in SM. For recommended patterns on element selection, handling dynamic elements, simulating user input delay, and cleaning up resources, see ${DOC_URLS.k6BrowserPractices}.`,
       }),
       smK6Conventions(),
     ],

--- a/src/components/AssistantContext/AssistantContext.constants.ts
+++ b/src/components/AssistantContext/AssistantContext.constants.ts
@@ -74,6 +74,14 @@ function question(title: string, prompt: string): Question {
   return { title, prompt };
 }
 
+const DOC_URLS = {
+  privateProbes:
+    'https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/',
+  perCheckAlerts:
+    'https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/configure-per-check-alerts/',
+  k6Assertions: 'https://grafana.com/docs/k6/latest/using-k6/assertions/',
+};
+
 /**
  * Hidden context attached to any page where Assistant is likely to draft or
  * edit a k6 script for Synthetic Monitoring. Tools like `k6-authoring` are
@@ -104,14 +112,6 @@ function smK6Conventions(): ChatContextItem {
       'Tools such as k6-authoring are oriented toward performance testing and tend to emit load-test-shaped scripts (stages, VUs, thresholds, env-var credentials, classic check() calls, page.screenshot() debug aids). When using their output for a Grafana Synthetic Monitoring check, TRANSFORM the script to follow the rules above before presenting it to the user — including swapping check() calls for expect() from the k6-testing library and stripping any screenshot calls.',
   });
 }
-
-const DOC_URLS = {
-  privateProbes:
-    'https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/',
-  perCheckAlerts:
-    'https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/configure-per-check-alerts/',
-  k6Assertions: 'https://grafana.com/docs/k6/latest/using-k6/assertions/',
-};
 
 const root = PLUGIN_URL_PATH.replace(/\/$/, '');
 

--- a/src/components/AssistantContext/AssistantContext.test.tsx
+++ b/src/components/AssistantContext/AssistantContext.test.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { providePageContext, provideQuestions, useAssistant } from '@grafana/assistant';
+import { render } from '@testing-library/react';
+
+import { AppRoutes } from 'routing/types';
+
+import { AssistantContext } from './AssistantContext';
+import { ASSISTANT_CONTEXT_EXCLUDED_ROUTES, ASSISTANT_PAGE_CONTEXTS } from './AssistantContext.constants';
+
+const mockedProvidePageContext = jest.mocked(providePageContext);
+const mockedProvideQuestions = jest.mocked(provideQuestions);
+const mockedUseAssistant = jest.mocked(useAssistant);
+
+const ENTRIES_WITH_QUESTIONS = ASSISTANT_PAGE_CONTEXTS.filter((entry) => entry.createQuestions);
+
+function setAssistantState(overrides: Partial<ReturnType<typeof useAssistant>> = {}) {
+  mockedUseAssistant.mockReturnValue({
+    isAvailable: true,
+    isLoading: false,
+    openAssistant: jest.fn(),
+    closeAssistant: jest.fn(),
+    toggleAssistant: jest.fn(),
+    ...overrides,
+  });
+}
+
+describe('AssistantContext', () => {
+  beforeEach(() => {
+    setAssistantState();
+  });
+
+  describe('constants coverage', () => {
+    it('covers every AppRoutes value except the explicitly excluded ones', () => {
+      const coveredRoutes = new Set(ASSISTANT_PAGE_CONTEXTS.map((entry) => entry.route));
+      const allRoutes = Object.values(AppRoutes);
+
+      const missing = allRoutes.filter(
+        (route) => !coveredRoutes.has(route) && !ASSISTANT_CONTEXT_EXCLUDED_ROUTES.has(route)
+      );
+
+      expect(missing).toEqual([]);
+    });
+
+    it('does not have duplicate ids', () => {
+      const ids = ASSISTANT_PAGE_CONTEXTS.map((entry) => entry.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('produces at least one context item per entry', () => {
+      ASSISTANT_PAGE_CONTEXTS.forEach((entry) => {
+        expect(entry.createContextItems().length).toBeGreaterThan(0);
+      });
+    });
+
+    it('produces at least one starter question per entry that opts in', () => {
+      ENTRIES_WITH_QUESTIONS.forEach((entry) => {
+        const questions = entry.createQuestions!();
+        expect(questions.length).toBeGreaterThan(0);
+        questions.forEach((q) => {
+          expect(q.prompt.trim()).not.toBe('');
+        });
+      });
+    });
+
+    it('splits the new-check page into one entry per CheckTypeGroup', () => {
+      const newCheckEntries = ASSISTANT_PAGE_CONTEXTS.filter((entry) => entry.route === AppRoutes.NewCheck);
+      const ids = newCheckEntries.map((entry) => entry.id).sort();
+      expect(ids).toEqual([
+        'sm-new-check-api',
+        'sm-new-check-browser',
+        'sm-new-check-multistep',
+        'sm-new-check-scripted',
+      ]);
+    });
+
+    it('attaches the hidden SM k6 conventions context to all k6 authoring entries', () => {
+      const k6Authoring = new Set(['sm-new-check-scripted', 'sm-new-check-browser', 'sm-edit-check']);
+
+      ASSISTANT_PAGE_CONTEXTS.forEach((entry) => {
+        const items = entry.createContextItems();
+        const hasK6Conventions = items.some(
+          // The mock returns the params object verbatim, so `data.pageType` is reachable directly.
+          (item: unknown) => (item as { data?: { pageType?: string } }).data?.pageType === 'sm-k6-conventions'
+        );
+
+        if (k6Authoring.has(entry.id)) {
+          expect(hasK6Conventions).toBe(true);
+        } else {
+          expect(hasK6Conventions).toBe(false);
+        }
+      });
+    });
+
+    it('directs the k6 conventions toward the k6-testing assertions library (not classic check())', () => {
+      const items = ASSISTANT_PAGE_CONTEXTS.find((entry) => entry.id === 'sm-new-check-scripted')!.createContextItems();
+      const conventionsItem = items.find(
+        (item: unknown) => (item as { data?: { pageType?: string } }).data?.pageType === 'sm-k6-conventions'
+      ) as unknown as { data: { rules: string[]; warning: string } } | undefined;
+
+      expect(conventionsItem).toBeDefined();
+      const allText = [...conventionsItem!.data.rules, conventionsItem!.data.warning].join('\n');
+
+      // Recommends expect() from the k6-testing library and links the docs.
+      expect(allText).toMatch(/k6-testing/i);
+      expect(allText).toMatch(/expect\(\)/);
+      expect(allText).toMatch(/grafana\.com\/docs\/k6\/.+assertions/);
+
+      // Explicitly warns off classic check() for SM.
+      expect(allText.toLowerCase()).toContain('avoid the classic k6 `check()` function');
+
+      // Explicitly warns off screenshots — they are not currently functional in SM.
+      expect(allText.toLowerCase()).toContain('do not suggest capturing screenshots');
+    });
+
+    it('does not recommend screenshot capture anywhere in the visible context or prompts', () => {
+      // Surface any "screenshot" mentions and assert they are in DO-NOT framing.
+      // This guards against regressions where someone re-introduces "capturing screenshots on failure"
+      // before SM's screenshot feature ships.
+      const allVisibleStrings: string[] = [];
+
+      ASSISTANT_PAGE_CONTEXTS.forEach((entry) => {
+        entry.createContextItems().forEach((item) => {
+          const itemData = (item as unknown as { data?: Record<string, unknown>; hidden?: boolean }).data ?? {};
+          if (typeof itemData.help === 'string') {
+            allVisibleStrings.push(itemData.help);
+          }
+          if (Array.isArray(itemData.capabilities)) {
+            allVisibleStrings.push(...itemData.capabilities.filter((cap): cap is string => typeof cap === 'string'));
+          }
+        });
+
+        entry.createQuestions?.().forEach((q) => {
+          allVisibleStrings.push(q.prompt);
+          if (q.title) {
+            allVisibleStrings.push(q.title);
+          }
+        });
+      });
+
+      allVisibleStrings.forEach((text) => {
+        const lower = text.toLowerCase();
+        if (lower.includes('screenshot')) {
+          // Must appear in DO-NOT framing only.
+          expect(lower).toMatch(/do not|don't|not currently functional|not yet available/);
+        }
+      });
+    });
+
+    it('does not include unresolved placeholder tokens in starter prompts', () => {
+      ENTRIES_WITH_QUESTIONS.forEach((entry) => {
+        entry.createQuestions!().forEach((q) => {
+          expect(q.prompt).not.toMatch(/\[(describe|your|the)\b[^\]]*\]/i);
+        });
+      });
+    });
+  });
+
+  describe('when the Assistant is available', () => {
+    it('registers every entry as page context', () => {
+      render(<AssistantContext />);
+
+      expect(mockedProvidePageContext).toHaveBeenCalledTimes(ASSISTANT_PAGE_CONTEXTS.length);
+
+      ASSISTANT_PAGE_CONTEXTS.forEach((entry) => {
+        expect(mockedProvidePageContext).toHaveBeenCalledWith(entry.urlPattern, expect.any(Array));
+      });
+    });
+
+    it('registers starter questions for every entry that opts in', () => {
+      render(<AssistantContext />);
+
+      expect(mockedProvideQuestions).toHaveBeenCalledTimes(ENTRIES_WITH_QUESTIONS.length);
+
+      ENTRIES_WITH_QUESTIONS.forEach((entry) => {
+        expect(mockedProvideQuestions).toHaveBeenCalledWith(entry.urlPattern, expect.any(Array));
+      });
+    });
+
+    it('unregisters every context and question registration on unmount', () => {
+      const { unmount } = render(<AssistantContext />);
+      const contextUnregisters = mockedProvidePageContext.mock.results.map((result) => result.value.unregister);
+      const questionUnregisters = mockedProvideQuestions.mock.results.map((result) => result.value.unregister);
+
+      expect(contextUnregisters).toHaveLength(ASSISTANT_PAGE_CONTEXTS.length);
+      expect(questionUnregisters).toHaveLength(ENTRIES_WITH_QUESTIONS.length);
+
+      unmount();
+
+      contextUnregisters.forEach((unregister) => {
+        expect(unregister).toHaveBeenCalledTimes(1);
+      });
+      questionUnregisters.forEach((unregister) => {
+        expect(unregister).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('when the Assistant is unavailable', () => {
+    it('does not register anything', () => {
+      setAssistantState({
+        isAvailable: false,
+        openAssistant: undefined,
+        closeAssistant: undefined,
+        toggleAssistant: undefined,
+      });
+
+      render(<AssistantContext />);
+
+      expect(mockedProvidePageContext).not.toHaveBeenCalled();
+      expect(mockedProvideQuestions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('while the Assistant availability is loading', () => {
+    it('does not register anything until loading completes', () => {
+      setAssistantState({ isAvailable: false, isLoading: true });
+
+      render(<AssistantContext />);
+
+      expect(mockedProvidePageContext).not.toHaveBeenCalled();
+      expect(mockedProvideQuestions).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/AssistantContext/AssistantContext.tsx
+++ b/src/components/AssistantContext/AssistantContext.tsx
@@ -23,18 +23,24 @@ export function AssistantContext() {
       return;
     }
 
-    const contextRegistrations = ASSISTANT_PAGE_CONTEXTS.map((entry) =>
-      providePageContext(entry.urlPattern, entry.createContextItems())
-    );
+    try {
+      const contextRegistrations = ASSISTANT_PAGE_CONTEXTS.map((entry) =>
+        providePageContext(entry.urlPattern, entry.createContextItems())
+      );
 
-    const questionRegistrations = ASSISTANT_PAGE_CONTEXTS.filter((entry) => entry.createQuestions).map((entry) =>
-      provideQuestions(entry.urlPattern, entry.createQuestions!())
-    );
+      const questionRegistrations = ASSISTANT_PAGE_CONTEXTS.filter((entry) => entry.createQuestions).map((entry) =>
+        provideQuestions(entry.urlPattern, entry.createQuestions!())
+      );
 
-    return () => {
-      contextRegistrations.forEach((registration) => registration.unregister());
-      questionRegistrations.forEach((registration) => registration.unregister());
-    };
+      return () => {
+        contextRegistrations.forEach((registration) => registration.unregister());
+        questionRegistrations.forEach((registration) => registration.unregister());
+      };
+    } catch {
+      // Assistant SDK not fully available — registrations are best-effort.
+    }
+
+    return undefined;
   }, [isAvailable, isLoading]);
 
   return null;

--- a/src/components/AssistantContext/AssistantContext.tsx
+++ b/src/components/AssistantContext/AssistantContext.tsx
@@ -10,8 +10,7 @@ import { ASSISTANT_PAGE_CONTEXTS } from './AssistantContext.constants';
  *
  * This is Phase 1 of the Assistant integration: a fixed set of `structured`
  * context items and questions keyed by URL pattern. No dynamic state is
- * exposed yet (e.g. the current check id is not included). See
- * `.cursor/references/grafana-assistant-phase-2.md` for the follow-up plan.
+ * exposed yet (e.g. the current check id is not included).
  *
  * Renders nothing. Safe to mount once at the root of the application.
  */

--- a/src/components/AssistantContext/AssistantContext.tsx
+++ b/src/components/AssistantContext/AssistantContext.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { providePageContext, provideQuestions, useAssistant } from '@grafana/assistant';
+
+import { ASSISTANT_PAGE_CONTEXTS } from './AssistantContext.constants';
+
+/**
+ * Registers static page context and starter questions with the Grafana
+ * Assistant SDK so that the Assistant knows which Synthetic Monitoring
+ * page the user is currently on and can suggest relevant first prompts.
+ *
+ * This is Phase 1 of the Assistant integration: a fixed set of `structured`
+ * context items and questions keyed by URL pattern. No dynamic state is
+ * exposed yet (e.g. the current check id is not included). See
+ * `.cursor/references/grafana-assistant-phase-2.md` for the follow-up plan.
+ *
+ * Renders nothing. Safe to mount once at the root of the application.
+ */
+export function AssistantContext() {
+  const { isAvailable, isLoading } = useAssistant();
+
+  useEffect(() => {
+    if (isLoading || !isAvailable) {
+      return;
+    }
+
+    const contextRegistrations = ASSISTANT_PAGE_CONTEXTS.map((entry) =>
+      providePageContext(entry.urlPattern, entry.createContextItems())
+    );
+
+    const questionRegistrations = ASSISTANT_PAGE_CONTEXTS.filter((entry) => entry.createQuestions).map((entry) =>
+      provideQuestions(entry.urlPattern, entry.createQuestions!())
+    );
+
+    return () => {
+      contextRegistrations.forEach((registration) => registration.unregister());
+      questionRegistrations.forEach((registration) => registration.unregister());
+    };
+  }, [isAvailable, isLoading]);
+
+  return null;
+}

--- a/src/components/AssistantContext/index.ts
+++ b/src/components/AssistantContext/index.ts
@@ -1,0 +1,1 @@
+export { AssistantContext } from './AssistantContext';

--- a/src/test/mocks/@grafana/assistant.tsx
+++ b/src/test/mocks/@grafana/assistant.tsx
@@ -1,4 +1,47 @@
-jest.mock('@grafana/assistant', () => ({
-  useProvidePageContext: jest.fn(() => jest.fn()),
-  createAssistantContextItem: jest.fn((type, params) => ({ type, ...params })),
-}));
+/**
+ * Global mock for the @grafana/assistant SDK.
+ *
+ * The real SDK relies on global registries and event emitters that aren't
+ * exercised by our integration. Tests treat the SDK as a thin observable
+ * boundary: we assert that `providePageContext` is called with the right
+ * URL patterns when `useAssistant` reports the Assistant as available.
+ *
+ * Per-test overrides:
+ *   import { useAssistant, providePageContext } from '@grafana/assistant';
+ *   jest.mocked(useAssistant).mockReturnValueOnce({ isAvailable: false, ... });
+ */
+jest.mock('@grafana/assistant', () => {
+  const makeRegistration = () => {
+    const setter = jest.fn() as jest.Mock & { unregister: jest.Mock };
+    setter.unregister = jest.fn();
+    return setter;
+  };
+
+  const providePageContext = jest.fn(() => makeRegistration());
+  const provideQuestions = jest.fn(() => makeRegistration());
+  const useProvidePageContext = jest.fn(() => jest.fn());
+
+  const useAssistant = jest.fn(() => ({
+    isAvailable: true,
+    isLoading: false,
+    openAssistant: jest.fn(),
+    closeAssistant: jest.fn(),
+    toggleAssistant: jest.fn(),
+  }));
+
+  const isAssistantAvailable = jest.fn(() => ({
+    subscribe: jest.fn(),
+  }));
+
+  const createAssistantContextItem = jest.fn((type, params) => ({ type, ...params }));
+
+  return {
+    __esModule: true,
+    providePageContext,
+    provideQuestions,
+    useProvidePageContext,
+    useAssistant,
+    isAssistantAvailable,
+    createAssistantContextItem,
+  };
+});


### PR DESCRIPTION
## Problem

Users browsing the Synthetic Monitoring app and opening Grafana Assistant don't get help that's aware of which page they're on or what SM concepts are in scope. Assistant has to infer everything from the URL, which leads to generic answers that don't reference SM-specific concepts (checks, probes, k6 conventions, secrets, per-check alerts), and doesn't surface useful starter prompts at the right moments.

## Solution

This PR registers SM-specific page context with the `@grafana/assistant` SDK so Assistant knows where the user is in the SM app and can offer relevant first prompts.

Specifically:

- Static `structured` context per route (Home, Checks list, Choose check type, the four New Check sub-types by `CheckTypeGroup`, Check dashboard, Edit check, Probes list, View probe, Edit probe, New probe, Alerts, Config) with a short description of the page and what Assistant should help with.
- Starter questions per page that pre-fill the chat input with focused prompts and link canonical SM docs where relevant.
- Hidden "SM k6 conventions" context attached to the k6 scripted/browser/edit flows that tells Assistant to use `expect()` from the [k6-testing assertions library](https://grafana.com/docs/k6/latest/using-k6/assertions/) (rather than the classic `check()` API), avoid load-testing constructs, reference credentials via the SM Secrets module, and not suggest features that aren't currently functional (browser `page.screenshot()`).
- A small `<AssistantContext />` component mounted at the app root that registers all of the above when Assistant is available and unregisters on unmount.

The integration is a no-op when the `grafana-assistant-app` plugin isn't installed.

## How it works

- All registrations live in `src/components/AssistantContext/AssistantContext.constants.ts`, keyed off the existing `AppRoutes` enum and `PLUGIN_URL_PATH` constant so URLs don't drift.
- Routes with path parameters use regex patterns so e.g. `/checks/:id` does not also match `/checks/:id/edit`.
- The schema supports `createContextItems` and an optional `createQuestions` per entry, so adding new prompts or context for a page is a single-file edit.
- Tests assert that every `AppRoutes` value is covered (or in the explicit exclusion set for deep-link redirect routes), ids are unique, registration → unregistration lifecycle is correct, no starter prompt contains an unresolved bracket placeholder, hidden k6 conventions are attached to the right entries and recommend `expect()` over `check()`, and that "screenshot" only appears in DO-NOT framing.

## Verification

- Confirmed against a dev instance that the appropriate context chip appears in the Assistant sidebar on each SM route (and no chip appears on non-SM pages).
- Confirmed starter questions surface as clickable prompts on SM pages.
- Confirmed that scripts suggested by Assistant on the scripted / browser new-check pages use the k6-testing assertions library and SM Secrets module rather than perf-testing constructs.
- 14 new unit tests in `AssistantContext.test.tsx` covering constants coverage, registration lifecycle, k6-specific guardrails, and prompt hygiene. The full repo test suite still passes.

## Future work — input welcome from the frontend team

This PR is intentionally static — it gives Assistant the "where am I" awareness without flowing any live state through. The most impactful follow-ups, roughly ranked:

1. **Dynamic per-check context.** On the check dashboard and check edit pages, register a second context item alongside the static one containing `checkId`, `checkType`, `target`, `frequency`, `timeout`, probe count, and (for scripted/browser checks) the current script content. This unlocks "why is *this* check failing", "tune this timeout", and "help me fix this script" — questions the current static context cannot answer. Should use the SDK's `useProvidePageContext` hook wired into the existing react-query data hooks.
2. **`OpenAssistantButton` placements.** The SDK ships a self-hiding component that opens Assistant with a pre-filled prompt. Likely high-value placements: above the k6 script editor on the scripted/browser new and edit forms, on the check dashboard when the check is in a failing state, and near the per-check alert configuration. Each placement should use a distinct `origin` namespace (e.g. `grafana/sm/script-editor`) so entry points are distinguishable.
3. **Analytics on Assistant opens.** Wire `createSMEventFactory` Rudderstack events to fire when Assistant is opened from SM with `origin` as a property, so we can measure adoption and decide where to invest in deeper integration.
4. **Iterate on `help` and prompt copy.** The current copy was drafted without product input. A short pairing with an SM SE per area is likely the single biggest quality lever on answer relevance.

### Open questions worth raising with the Assistant team

Not blockers for this PR, but they'll shape the Phase 2 scope:

- **Write-back from Assistant into our editors.** The public SDK docs describe one-way page context → chat. The package's TypeScript definitions reference a `CALLBACK_EXTENSION_POINT` and a `tools` namespace that *appear* to enable functions Assistant could invoke (e.g. "insert this script into the editor"), but these aren't documented publicly. Worth confirming the supported pattern before scoping a script-insertion UX.
- **SM-specific k6 authoring.** Assistant currently uses a general k6 authoring tool oriented toward performance testing — different defaults, assertion patterns, and credential handling than synthetic monitoring needs. We've added hidden conventions to nudge the LLM toward transforming that tool's output for SM, but a dedicated SM-aware k6 authoring surface (registered by this plugin or owned elsewhere) would be a cleaner fix.
- **Browser screenshot support.** `page.screenshot()` is not currently functional in SM browser checks. The hidden conventions instruct Assistant not to suggest screenshots; when that feature ships, those rules should be relaxed.

Made with [Cursor](https://cursor.com)