### PR TITLE
fix: add link to docs for v1 migration

### DIFF
--- a/src/components/CheckEditor/FormComponents/ChannelDetails.test.tsx
+++ b/src/components/CheckEditor/FormComponents/ChannelDetails.test.tsx
@@ -68,8 +68,31 @@ describe('ChannelDetails', () => {
     render(<ChannelDetails channelId="deprecated" channels={mockChannels} />);
 
     await waitFor(() => {
-    expect(screen.getByText(/deprecated k6 version channel/i)).toBeInTheDocument();
-    expect(screen.getByText(/will end with the release of the next k6 major version/i)).toBeInTheDocument();
+      expect(screen.getByText(/deprecated k6 version channel/i)).toBeInTheDocument();
+      expect(screen.getByText(/your checks continue to run/i)).toBeInTheDocument();
+      expect(screen.getByText(/we recommend switching to a supported channel \(v2\)/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should show v1-specific deprecation warning when v1 is deprecated', async () => {
+    const channels: K6Channel[] = [
+      ...mockChannels.filter((ch) => ch.id !== 'v1'),
+      {
+        id: 'v1',
+        name: 'v1.x',
+        default: false,
+        deprecatedAfter: '2020-01-01T00:00:00Z',
+        manifest: 'k6>=1,k6<2',
+      },
+    ];
+
+    render(<ChannelDetails channelId="v1" channels={channels} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/we recommend switching this check to the v2 k6 version channel/i)).toBeInTheDocument();
+      expect(screen.getByText(/most scripted and browser checks do not need script changes/i)).toBeInTheDocument();
+      const migrationGuide = screen.getByRole('link', { name: /k6 v2 migration guide/i });
+      expect(migrationGuide).toHaveAttribute('href', 'https://grafana.com/docs/k6/latest/get-started/migrating-to-v2/');
     });
   });
 

--- a/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
+++ b/src/components/CheckEditor/FormComponents/ChannelDetails.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { dateTimeFormat, GrafanaTheme2 } from '@grafana/data';
-import { Alert, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Alert, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { K6Channel } from 'types';
+
+const K6_V2_MIGRATION_DOC_URL = 'https://grafana.com/docs/k6/latest/get-started/migrating-to-v2/';
 
 interface ChannelDetailsProps {
   channelId: string | null;
@@ -39,11 +41,22 @@ export function ChannelDetails({ channelId, channels }: ChannelDetailsProps) {
 
       {isDeprecated && (
         <Alert severity="warning" title="Deprecated k6 version channel">
-          This k6 version channel was deprecated on {dateTimeFormat(new Date(channel.deprecatedAfter))}.{' '}
-          {channel.id === 'v1'
-            ? 'Support for this version is expected to end with the release of k6 v3 (~May 2027).'
-            : 'Support for this version will end with the release of the next k6 major version.'}{' '}
-          Please migrate your checks to a newer channel.
+          {channel.id === 'v1' ? (
+            <>
+              This channel was deprecated on {dateTimeFormat(new Date(channel.deprecatedAfter))}. Your checks continue
+              to run. We recommend switching this check to the v2 k6 version channel. Most scripted and browser checks
+              do not need script changes. If a check fails after switching, see the{' '}
+              <TextLink href={K6_V2_MIGRATION_DOC_URL} external>
+                k6 v2 migration guide
+              </TextLink>
+              .
+            </>
+          ) : (
+            <>
+              This channel was deprecated on {dateTimeFormat(new Date(channel.deprecatedAfter))}. Your checks continue
+              to run. We recommend switching to a supported channel (v2).
+            </>
+          )}
         </Alert>
       )}
 


### PR DESCRIPTION
## Problem

The k6 v1 deprecation warning message was vague and gave no instructions on what to do to fix it.

## Solution

Update deprecation copy in the check editor (`ChannelDetails`) to match the version management rollout plan:

- State that **checks continue to run** after deprecation.
- **Recommend switching to the v2 k6 version channel** (v1-specific message).
- Reassure users that **most scripted and browser checks do not need script changes**.
- Link to the [k6 v2 migration guide](https://grafana.com/docs/k6/latest/get-started/migrating-to-v2/) only as troubleshooting if a check fails after switching—not as the primary migration path.

<img width="1514" height="121" alt="image" src="https://github.com/user-attachments/assets/4a4dfebe-8ea6-4cdd-9ffe-68a1befc7476" />