### PR TITLE
chore(parseLokiLogs): replace raw data frame in error log with safe metadata

### DIFF
--- a/src/features/parseLokiLogs/parseLokiLogs.test.ts
+++ b/src/features/parseLokiLogs/parseLokiLogs.test.ts
@@ -154,9 +154,17 @@ describe(`parseLokiLogs`, () => {
 });
 
 describe(`parseLokiLogs error path`, () => {
-  it(`returns [] and logs only safe schema metadata when required fields are missing`, () => {
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  let consoleErrorSpy: jest.SpyInstance;
 
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it(`returns [] and logs only safe schema metadata when required fields are missing`, () => {
     // New-schema frame missing labelTypes and id, so normalizeLokiDataFrame
     // returns it as-is and isLokiFields rejects it.
     const malformedFrame = {
@@ -170,13 +178,14 @@ describe(`parseLokiLogs error path`, () => {
     } as unknown as LokiDataFrame<Record<string, string>, Record<string, string>>;
 
     expect(parseLokiLogs(malformedFrame)).toEqual([]);
+    // toHaveBeenCalledWith uses strict deep-equal; any extra key (e.g. row data
+    // smuggled into the metadata object) would fail this assertion, which is
+    // the no-PII-in-logs guarantee we care about.
     expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to normalize LokiDataFrame fields', {
       fieldNames: [LokiFieldNames.Labels, LokiFieldNames.TimeStamp, LokiFieldNames.Body],
       length: 0,
       refId: 'A',
     });
-
-    consoleErrorSpy.mockRestore();
   });
 });
 

--- a/src/features/parseLokiLogs/parseLokiLogs.test.ts
+++ b/src/features/parseLokiLogs/parseLokiLogs.test.ts
@@ -153,6 +153,73 @@ describe(`parseLokiLogs`, () => {
   });
 });
 
+describe(`parseLokiLogs error path`, () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it(`returns an empty array and logs only safe schema metadata when required fields are missing`, () => {
+    // Sentinel values that would be PII / customer payload in real usage.
+    // We assert they never appear in the console.error call.
+    const SENSITIVE_LABEL_VALUE = 'user-secret-label-value';
+    const SENSITIVE_LOG_LINE = 'secret-payload-DO-NOT-LEAK';
+
+    // New-schema frame intentionally missing labelTypes and id. normalizeLokiDataFrame
+    // returns it unchanged (no Time/Line triggers the no-op branch), so isLokiFields
+    // rejects it and parseLokiLogs hits the error path we care about.
+    const malformedFrame = {
+      length: 1,
+      refId: 'A',
+      fields: [
+        {
+          name: LokiFieldNames.Labels,
+          type: FieldType.other,
+          values: [{ secretKey: SENSITIVE_LABEL_VALUE }],
+          config: {},
+          typeInfo: { frame: 'json.RawMessage' },
+        },
+        {
+          name: LokiFieldNames.TimeStamp,
+          type: FieldType.time,
+          values: [1000],
+          nanos: [0],
+          config: {},
+          typeInfo: { frame: 'time.Time' },
+        },
+        {
+          name: LokiFieldNames.Body,
+          type: FieldType.string,
+          values: [SENSITIVE_LOG_LINE],
+          config: {},
+          typeInfo: { frame: 'string' },
+        },
+      ],
+    } as unknown as LokiDataFrame<Record<string, string>, Record<string, string>>;
+
+    const result = parseLokiLogs(malformedFrame);
+
+    expect(result).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to normalize LokiDataFrame fields', {
+      fieldNames: [LokiFieldNames.Labels, LokiFieldNames.TimeStamp, LokiFieldNames.Body],
+      length: 1,
+      refId: 'A',
+    });
+
+    // Defense-in-depth: serialize the full call payload and assert no row values
+    // leaked through, in case the metadata shape gains a new key in the future.
+    const serialized = JSON.stringify(consoleErrorSpy.mock.calls);
+    expect(serialized).not.toContain(SENSITIVE_LABEL_VALUE);
+    expect(serialized).not.toContain(SENSITIVE_LOG_LINE);
+  });
+});
+
 describe(`normalizeLokiDataFrame`, () => {
   it(`should leave new schema fields unchanged (timestamp, body)`, () => {
     const newSchemaFrame: LokiDataFrame<Record<string, string>, Record<string, string>> = {

--- a/src/features/parseLokiLogs/parseLokiLogs.test.ts
+++ b/src/features/parseLokiLogs/parseLokiLogs.test.ts
@@ -165,8 +165,7 @@ describe(`parseLokiLogs error path`, () => {
   });
 
   it(`returns [] and logs only safe schema metadata when required fields are missing`, () => {
-    // New-schema frame missing labelTypes and id, so normalizeLokiDataFrame
-    // returns it as-is and isLokiFields rejects it.
+    // Missing labelTypes and id: normalize passes through, isLokiFields rejects.
     const malformedFrame = {
       length: 0,
       refId: 'A',
@@ -178,9 +177,6 @@ describe(`parseLokiLogs error path`, () => {
     } as unknown as LokiDataFrame<Record<string, string>, Record<string, string>>;
 
     expect(parseLokiLogs(malformedFrame)).toEqual([]);
-    // toHaveBeenCalledWith uses strict deep-equal; any extra key (e.g. row data
-    // smuggled into the metadata object) would fail this assertion, which is
-    // the no-PII-in-logs guarantee we care about.
     expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to normalize LokiDataFrame fields', {
       fieldNames: [LokiFieldNames.Labels, LokiFieldNames.TimeStamp, LokiFieldNames.Body],
       length: 0,
@@ -189,10 +185,6 @@ describe(`parseLokiLogs error path`, () => {
   });
 
   it(`does not leak row values when fields contain data`, () => {
-    // Same malformed shape as above (missing labelTypes and id) but with
-    // sentinel values populated in the rows that would represent real user
-    // log content. Demonstrates the no-leak property the way a reader
-    // naturally looks for it: rows in, rows definitely not out.
     const SENSITIVE_LABEL_VALUE = 'should-not-leak';
     const SENSITIVE_LOG_LINE = 'sensitive log line content';
 

--- a/src/features/parseLokiLogs/parseLokiLogs.test.ts
+++ b/src/features/parseLokiLogs/parseLokiLogs.test.ts
@@ -154,69 +154,29 @@ describe(`parseLokiLogs`, () => {
 });
 
 describe(`parseLokiLogs error path`, () => {
-  let consoleErrorSpy: jest.SpyInstance;
+  it(`returns [] and logs only safe schema metadata when required fields are missing`, () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-  beforeEach(() => {
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
-  });
-
-  it(`returns an empty array and logs only safe schema metadata when required fields are missing`, () => {
-    // Sentinel values that would be PII / customer payload in real usage.
-    // We assert they never appear in the console.error call.
-    const SENSITIVE_LABEL_VALUE = 'user-secret-label-value';
-    const SENSITIVE_LOG_LINE = 'secret-payload-DO-NOT-LEAK';
-
-    // New-schema frame intentionally missing labelTypes and id. normalizeLokiDataFrame
-    // returns it unchanged (no Time/Line triggers the no-op branch), so isLokiFields
-    // rejects it and parseLokiLogs hits the error path we care about.
+    // New-schema frame missing labelTypes and id, so normalizeLokiDataFrame
+    // returns it as-is and isLokiFields rejects it.
     const malformedFrame = {
-      length: 1,
+      length: 0,
       refId: 'A',
       fields: [
-        {
-          name: LokiFieldNames.Labels,
-          type: FieldType.other,
-          values: [{ secretKey: SENSITIVE_LABEL_VALUE }],
-          config: {},
-          typeInfo: { frame: 'json.RawMessage' },
-        },
-        {
-          name: LokiFieldNames.TimeStamp,
-          type: FieldType.time,
-          values: [1000],
-          nanos: [0],
-          config: {},
-          typeInfo: { frame: 'time.Time' },
-        },
-        {
-          name: LokiFieldNames.Body,
-          type: FieldType.string,
-          values: [SENSITIVE_LOG_LINE],
-          config: {},
-          typeInfo: { frame: 'string' },
-        },
+        { name: LokiFieldNames.Labels, values: [] },
+        { name: LokiFieldNames.TimeStamp, values: [], nanos: [] },
+        { name: LokiFieldNames.Body, values: [] },
       ],
     } as unknown as LokiDataFrame<Record<string, string>, Record<string, string>>;
 
-    const result = parseLokiLogs(malformedFrame);
-
-    expect(result).toEqual([]);
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(parseLokiLogs(malformedFrame)).toEqual([]);
     expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to normalize LokiDataFrame fields', {
       fieldNames: [LokiFieldNames.Labels, LokiFieldNames.TimeStamp, LokiFieldNames.Body],
-      length: 1,
+      length: 0,
       refId: 'A',
     });
 
-    // Defense-in-depth: serialize the full call payload and assert no row values
-    // leaked through, in case the metadata shape gains a new key in the future.
-    const serialized = JSON.stringify(consoleErrorSpy.mock.calls);
-    expect(serialized).not.toContain(SENSITIVE_LABEL_VALUE);
-    expect(serialized).not.toContain(SENSITIVE_LOG_LINE);
+    consoleErrorSpy.mockRestore();
   });
 });
 

--- a/src/features/parseLokiLogs/parseLokiLogs.test.ts
+++ b/src/features/parseLokiLogs/parseLokiLogs.test.ts
@@ -187,6 +187,31 @@ describe(`parseLokiLogs error path`, () => {
       refId: 'A',
     });
   });
+
+  it(`does not leak row values when fields contain data`, () => {
+    // Same malformed shape as above (missing labelTypes and id) but with
+    // sentinel values populated in the rows that would represent real user
+    // log content. Demonstrates the no-leak property the way a reader
+    // naturally looks for it: rows in, rows definitely not out.
+    const SENSITIVE_LABEL_VALUE = 'should-not-leak';
+    const SENSITIVE_LOG_LINE = 'sensitive log line content';
+
+    const malformedFrame = {
+      length: 1,
+      refId: 'A',
+      fields: [
+        { name: LokiFieldNames.Labels, values: [{ secret: SENSITIVE_LABEL_VALUE }] },
+        { name: LokiFieldNames.TimeStamp, values: [1234567890], nanos: [0] },
+        { name: LokiFieldNames.Body, values: [SENSITIVE_LOG_LINE] },
+      ],
+    } as unknown as LokiDataFrame<Record<string, string>, Record<string, string>>;
+
+    parseLokiLogs(malformedFrame);
+
+    const loggedArg = JSON.stringify(consoleErrorSpy.mock.calls[0]);
+    expect(loggedArg).not.toContain(SENSITIVE_LABEL_VALUE);
+    expect(loggedArg).not.toContain(SENSITIVE_LOG_LINE);
+  });
 });
 
 describe(`normalizeLokiDataFrame`, () => {

--- a/src/features/parseLokiLogs/parseLokiLogs.ts
+++ b/src/features/parseLokiLogs/parseLokiLogs.ts
@@ -20,7 +20,6 @@ type FieldParser = Partial<Record<LokiFieldNamesOld | LokiFieldNames, (value: an
 // parser to extract individual fields before calling this function.
 export function parseLokiLogs<T, R>(dataFrame: LokiDataFrame<T, R>, parser?: FieldParser) {
   const normalizedDataFrame = normalizeLokiDataFrame(dataFrame);
-  // After normalization, fields are guaranteed to be LokiFields<T, R>
   if (!isLokiFields(normalizedDataFrame.fields)) {
     // Log error but return empty array to prevent UI crashes
     console.error('Failed to normalize LokiDataFrame fields', {

--- a/src/features/parseLokiLogs/parseLokiLogs.ts
+++ b/src/features/parseLokiLogs/parseLokiLogs.ts
@@ -23,7 +23,11 @@ export function parseLokiLogs<T, R>(dataFrame: LokiDataFrame<T, R>, parser?: Fie
   // After normalization, fields are guaranteed to be LokiFields<T, R>
   if (!isLokiFields(normalizedDataFrame.fields)) {
     // Log error but return empty array to prevent UI crashes
-    console.error('Failed to normalize LokiDataFrame fields', normalizedDataFrame);
+    console.error('Failed to normalize LokiDataFrame fields', {
+      fieldNames: normalizedDataFrame.fields.map((f) => f.name),
+      length: normalizedDataFrame.length,
+      refId: normalizedDataFrame.refId,
+    });
     return [];
   }
   const flattenedLogs = flattenLogs(normalizedDataFrame.fields, parser);


### PR DESCRIPTION
## Problem

In `src/features/parseLokiLogs/parseLokiLogs.ts`, when `isLokiFields` rejects the post-normalization frame, we log the full `normalizedDataFrame` object to the console:

```ts
console.error('Failed to normalize LokiDataFrame fields', normalizedDataFrame);
```

That object's `fields[*].values` carry the actual Loki rows — log lines, user-supplied label keys and values, ids — i.e. potential PII and customer payloads.

This isn't just a hypothetical browser-console exposure. This app initialises Faro via `src/faro.ts`, and the Faro Web SDK ships with `ConsoleInstrumentation` enabled by default. Every `console.error(..., normalizedDataFrame)` call is therefore JSON-serialised and POSTed to the Grafana-Ops Faro collector with full row contents whenever this error path fires. That's an active information-disclosure path into observability infrastructure, not a speculative screen-share risk.

## Solution

Log only schema-level metadata that's useful for diagnosing why `isLokiFields` returned false, and that can never contain row data:

```ts
console.error('Failed to normalize LokiDataFrame fields', {
  fieldNames: normalizedDataFrame.fields.map((f) => f.name),
  length: normalizedDataFrame.length,
  refId: normalizedDataFrame.refId,
});
```

- `fieldNames` are schema constants (`labels`, `timestamp`, `body`, `Time`, `Line`, `tsNs`, `labelTypes`, `id`) — never user data — and tell us exactly which required field was missing.
- `length` is the row count, useful for distinguishing "empty result" from "malformed result".
- `refId` is the query identifier (`"A"`, `"B"`, …) set by the panel/scenes layer, useful for tracing the source query.
- `field.config`, `field.values`, frame-level `meta`, and the rest of the frame are excluded.

The error message string is unchanged so existing log searches and Faro alerts keyed on it keep working. No behaviour change beyond the console payload.

## Tests

A new test in `parseLokiLogs.test.ts` covers the error path:

- Constructs a malformed-but-normalized frame (new schema, missing `labelTypes` and `id`) so `normalizeLokiDataFrame` returns it unchanged and `isLokiFields` rejects it.
- Asserts `parseLokiLogs` returns `[]`.
- Asserts `console.error` was called with exactly `{ fieldNames, length, refId }` via Jest's strict deep-equal `toHaveBeenCalledWith` — which rejects any extra keys, so the metadata shape can't silently grow to include row data without failing this test.