### PR TITLE
chore(eslint): warn on console.* in src/ production code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ const config = defineConfig([
     },
     rules: {
       'custom-plugin/tracking-event-creation': 'error',
+      'no-console': ['warn', {}],
       'no-redeclare': 'off', // we use typescript's 'no-redeclare' rule instead
       '@typescript-eslint/no-redeclare': ['error'],
       '@typescript-eslint/no-deprecated': 'error',
@@ -108,6 +109,21 @@ const config = defineConfig([
         project: './tsconfig.json',
         tsconfigRootDir: __dirname,
       },
+    },
+  },
+  {
+    // Tests and test infrastructure routinely use console.* for legitimate
+    // reasons (silenceErrors wrapper, msw handler logging, debug helpers).
+    // scripts/ is unaffected because the src/-scoped rule block above never
+    // matches it in the first place.
+    files: [
+      'src/**/*.test.{ts,tsx}',
+      'src/**/__tests__/**/*.{ts,tsx}',
+      'src/**/__test__/**/*.{ts,tsx}',
+      'src/test/**/*.{ts,tsx}',
+    ],
+    rules: {
+      'no-console': 'off',
     },
   },
 ]);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ const config = defineConfig([
     },
     rules: {
       'custom-plugin/tracking-event-creation': 'error',
+      // {} resets upstream allow list; do not simplify to 'warn' (see eslint-config base)
       'no-console': ['warn', {}],
       'no-redeclare': 'off', // we use typescript's 'no-redeclare' rule instead
       '@typescript-eslint/no-redeclare': ['error'],
@@ -112,10 +113,7 @@ const config = defineConfig([
     },
   },
   {
-    // Tests and test infrastructure routinely use console.* for legitimate
-    // reasons (silenceErrors wrapper, msw handler logging, debug helpers).
-    // scripts/ is unaffected because the src/-scoped rule block above never
-    // matches it in the first place.
+    // Tests legitimately use console.* (silenceErrors, msw handlers, debug helpers).
     files: [
       'src/**/*.test.{ts,tsx}',
       'src/**/__tests__/**/*.{ts,tsx}',


### PR DESCRIPTION
## Problem

`@grafana/eslint-config` ships `no-console` with an `allow` list covering `error`, `log`, `warn`, and `info`, which makes the rule effectively a no-op. Console calls in `src/` production code land with zero feedback at lint time.

## Solution

Override `no-console` in our `src/`-scoped flat-config block so every console method warns, with a test-files override that exempts tests. `scripts/` is unaffected (already outside our lint scope).

Severity is `warn`, so CI is not affected. Surfaces 13 existing call-sites for per-call-site triage in follow-ups.