### PR TITLE
fix: prevent sensitive data leaking through Faro error reports

### DIFF
--- a/src/faro.test.ts
+++ b/src/faro.test.ts
@@ -1,0 +1,57 @@
+import { faro } from '@grafana/faro-web-sdk';
+
+import { FaroEvent, reportError } from 'faro';
+
+const mockPushError = jest.fn();
+
+beforeEach(() => {
+  // faro is a getter-backed singleton that lazily initialises api after initializeFaro().
+  // In tests we haven't called initializeFaro(), so api is undefined.
+  // @ts-expect-error — partial mock: only pushError is needed for reportError tests
+  faro.api = { pushError: mockPushError };
+});
+
+describe(`reportError`, () => {
+  it(`should pass an Error instance through to pushError unchanged`, () => {
+    const err = new Error('something broke');
+    reportError(err, FaroEvent.Init);
+
+    expect(mockPushError).toHaveBeenCalledWith(err, { type: FaroEvent.Init });
+  });
+
+  it(`should wrap a string message in an Error before sending`, () => {
+    reportError('bad request', FaroEvent.CreateCheck);
+
+    const [sentError, meta] = mockPushError.mock.calls[0];
+    expect(sentError).toBeInstanceOf(Error);
+    expect(sentError.message).toBe('bad request');
+    expect(meta).toEqual({ type: FaroEvent.CreateCheck });
+  });
+
+  it(`should not serialize arbitrary objects into the error message`, () => {
+    const payload = { data: { msg: 'ok' }, secret: 'should-not-appear' };
+    // @ts-expect-error — verifying runtime safety for callers that bypass type checks
+    reportError(payload, FaroEvent.Init);
+
+    const [sentError] = mockPushError.mock.calls[0];
+    expect(sentError).toBeInstanceOf(Error);
+    expect(sentError.message).not.toContain('should-not-appear');
+    expect(sentError.message).not.toContain('"data"');
+  });
+
+  it(`should accept a call without a FaroEvent type`, () => {
+    reportError('no type');
+
+    const [sentError, meta] = mockPushError.mock.calls[0];
+    expect(sentError.message).toBe('no type');
+    expect(meta).toEqual({ type: undefined });
+  });
+
+  it(`should swallow exceptions from pushError`, () => {
+    mockPushError.mockImplementationOnce(() => {
+      throw new Error('faro is down');
+    });
+
+    expect(() => reportError('test')).not.toThrow();
+  });
+});

--- a/src/faro.ts
+++ b/src/faro.ts
@@ -1,4 +1,4 @@
-import { faro, isError, isObject } from '@grafana/faro-web-sdk';
+import { faro, isError } from '@grafana/faro-web-sdk';
 import { config } from '@grafana/runtime';
 
 export enum FaroEvent {
@@ -61,17 +61,14 @@ export function reportEvent(type: FaroEvent, info: Record<string, string> = {}) 
   }
 }
 
-function sanitizeError(error: Error | Object | string) {
+function sanitizeError(error: Error | string): Error {
   if (isError(error)) {
     return error;
   }
-  if (isObject(error)) {
-    return new Error(JSON.stringify(error));
-  }
-  return new Error(error);
+  return new Error(String(error));
 }
 
-export function reportError(error: Error | Object | string, type?: FaroEvent) {
+export function reportError(error: Error | string, type?: FaroEvent) {
   const valToSend = sanitizeError(error);
   try {
     faro.api.pushError(valToSend, { type });

--- a/src/hooks/useAppInitializer.ts
+++ b/src/hooks/useAppInitializer.ts
@@ -198,9 +198,10 @@ export const useAppInitializer = (redirectTo?: AppRoutes) => {
       }
     } catch (e) {
       const err = e as SubmissionErrorWrapper;
-      setError(err.data?.msg ?? err.data?.err ?? 'Something went wrong');
+      const message = err.data?.msg ?? err.data?.err ?? 'Something went wrong';
+      setError(message);
       setLoading(false);
-      reportError(err.data?.msg ?? err.data?.err ?? err, FaroEvent.Init);
+      reportError(message, FaroEvent.Init);
     }
   };
 


### PR DESCRIPTION
## Problem

The `reportError` function in `faro.ts` accepted arbitrary objects (`Error | Object | string`) and serialised them with `JSON.stringify` before sending to Faro. This meant any caller that passed a full error response object — including API responses containing tokens, credentials, or internal data — would have its entire contents logged as a Faro error.

One active caller in `useAppInitializer.ts` had a `?? err` fallback that passed the entire `SubmissionErrorWrapper` object (including `err.data`) to `reportError` when both `.msg` and `.err` were falsy.

## Solution

Narrowed the `reportError` and `sanitizeError` signatures from `Error | Object | string` to `Error | string`, removing the `JSON.stringify` branch entirely. If a non-Error, non-string value reaches `sanitizeError` at runtime (bypassing TypeScript), `String()` produces `[object Object]` rather than dumping the object's contents.

Fixed the `useAppInitializer.ts` catch block to extract the message string before calling `reportError`, falling back to `'Something went wrong'` instead of the raw error object.

Added tests covering the key security properties: Error passthrough, string wrapping, object rejection, optional type parameter, and exception swallowing.