### PR TITLE
fix: grant cd.yml required permissions in workflow callers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
-      contents: read # write is only needed if we publish docs to the website.
+      contents: write
       id-token: write
       attestations: write
       pull-requests: read

--- a/.github/workflows/validate_main.yml
+++ b/.github/workflows/validate_main.yml
@@ -14,9 +14,10 @@ jobs:
     # Documentation: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
-      contents: read # write is only needed if we publish docs to the website.
+      contents: write
       id-token: write
       attestations: write
+      pull-requests: read
     with:
       branch: main
 


### PR DESCRIPTION
## Problem

After merging #1689, the `validate_main.yml` workflow fails on every push to main with:

> Error calling workflow 'grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1'.
> The workflow is requesting 'contents: write, pull-requests: read', but is only allowed 'contents: read, pull-requests: none'.

This means auto-deployment to dev is broken. The `publish.yml` manual deployment workflow has the same `contents: read` issue and would fail when triggered.

## Solution

Grant the permissions that [`cd.yml@v8.0.1` declares at its workflow level](https://github.com/grafana/plugin-ci-workflows/blob/ci-cd-workflows/v8.0.1/.github/workflows/cd.yml#L552):

- `contents: write` — required because `cd.yml` creates git tags and drafts GitHub releases on prod deploys. GitHub validates permissions at parse time regardless of target environment.
- `pull-requests: read` — required by `cd.yml` internally.

Changes:
- **`validate_main.yml`**: `contents: read` → `write`, added `pull-requests: read`
- **`publish.yml`**: `contents: read` → `write`

## Additional context

The `deployment_tools` repo config at `terraform/repositories/synthetic-monitoring-app/github-app-configs/config.yaml` still references the deleted `push.yml`. This should be updated separately to point to the new workflow names.