### PR TITLE
fix: Use `contents: write` in validate_main.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
-      contents: read # write is only needed if we publish docs to the website.
+      contents: write # write is only needed if we publish docs to the website, which we don't, but the workflow won't work without this.
       id-token: write
       attestations: write
       pull-requests: read

--- a/.github/workflows/validate_main.yml
+++ b/.github/workflows/validate_main.yml
@@ -14,7 +14,7 @@ jobs:
     # Documentation: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
-      contents: read # write is only needed if we publish docs to the website.
+      contents: write # write is only needed if we publish docs to the website, which we don't, but the workflow won't work without this.
       id-token: write
       attestations: write
     with:


### PR DESCRIPTION
plugin-ci-workflows/cd.yml won't work unless you have `contents: write` permission. We don't need it because we don't publish docs to the website, but we must have it, otherwise this won't work.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
