### PR TITLE
feat: add tracking for script examples and screenshots interactions

### DIFF
--- a/src/components/Checkster/components/ScriptExamples.tsx
+++ b/src/components/Checkster/components/ScriptExamples.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import { trackExampleScriptCopied, trackExampleScriptSelected } from 'features/tracking/checkFormEvents';
 
 import { CodeSnippetTab } from '../../CodeSnippet/CodeSnippet.types';
 
@@ -25,5 +26,15 @@ export function ScriptExamples({ examples }: ScriptExamplesProps) {
     ];
   }, [examples]);
 
-  return <CodeSnippet hideHeader canCopy dedent tabs={tabs} lang="js" />;
+  const handleGroupChange = useCallback((script: string) => {
+    trackExampleScriptSelected({ script });
+  }, []);
+
+  const handleCopy = useCallback((script: string) => {
+    trackExampleScriptCopied({ script });
+  }, []);
+
+  return (
+    <CodeSnippet hideHeader canCopy dedent tabs={tabs} lang="js" onGroupChange={handleGroupChange} onCopy={handleCopy} />
+  );
 }

--- a/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.tsx
@@ -87,6 +87,8 @@ export const CodeSnippet = ({
     return tab;
   }, [hasGroups, activeGroup, tab]);
 
+  const resolvedGroup = hasGroups ? activeGroup ?? tab.groups[0]?.value : undefined;
+
   useEffect(() => {
     if (hasGroups && tab.selected) {
       setActiveGroup(tab.selected);
@@ -132,9 +134,8 @@ export const CodeSnippet = ({
         <div className={cx(styles.codeWrapper, className)}>
           {hasGroups && (
             <div className={styles.tabGroup}>
-              {tab.groups.map((group, index) => {
-                const isGroupActive =
-                  !tab.groups.some((item) => item.value === activeGroup) && !index ? true : activeGroup === group.value;
+              {tab.groups.map((group) => {
+                const isGroupActive = resolvedGroup === group.value;
                 return (
                   <CodeSnippetGroup
                     key={`${tab.value}-${group.value}`}
@@ -156,7 +157,7 @@ export const CodeSnippet = ({
           {canCopy && (
             <CopyToClipboardButton
               data={snippet ?? ''}
-              onCopy={onCopy && activeGroup ? () => onCopy(activeGroup) : undefined}
+              onCopy={onCopy && resolvedGroup ? () => onCopy(resolvedGroup) : undefined}
             />
           )}
         </div>

--- a/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Badge, ClipboardButton, Tab, TabsBar, useStyles2 } from '@grafana/ui';
 import { cx } from '@emotion/css';
 import { highlight, languages } from 'prismjs';
@@ -40,13 +40,14 @@ const CodeSnippetGroup = ({ active = false, group, onClick }: CodeSnippetGroupPr
   );
 };
 
-const CopyToClipboardButton = (data: string) => {
+const CopyToClipboardButton = ({ data, onCopy }: { data: string; onCopy?: () => void }) => {
   return (
     <ClipboardButton
       icon="clipboard-alt"
       variant="secondary"
       size="sm"
       getText={() => data ?? ''}
+      onClipboardCopy={onCopy}
       data-cy="copy-agent-install"
     >
       Copy
@@ -62,12 +63,22 @@ export const CodeSnippet = ({
   tabs = [],
   className,
   hideHeader,
+  onGroupChange,
+  onCopy,
 }: CodeSnippetProps) => {
   const [activeTab, setActiveTab] = useState<string | undefined>(initialTab);
   const [activeGroup, setActiveGroup] = useState<string | undefined>();
   const styles = useStyles2(getStyles);
   const tab = getTab(activeTab, tabs);
   const hasGroups = tab && 'groups' in tab;
+
+  const handleGroupChange = useCallback(
+    (groupValue: string) => {
+      setActiveGroup(groupValue);
+      onGroupChange?.(groupValue);
+    },
+    [onGroupChange]
+  );
   const snippetTab = useMemo(() => {
     if (hasGroups) {
       return getTab(activeGroup, tab.groups);
@@ -129,7 +140,7 @@ export const CodeSnippet = ({
                     key={`${tab.value}-${group.value}`}
                     group={group}
                     active={isGroupActive}
-                    onClick={setActiveGroup}
+                    onClick={handleGroupChange}
                   />
                 );
               })}
@@ -141,7 +152,14 @@ export const CodeSnippet = ({
             data-cy="agent-install"
           />
         </div>
-        <div className={styles.buttonWrapper}>{canCopy && CopyToClipboardButton(snippet ?? '')}</div>
+        <div className={styles.buttonWrapper}>
+          {canCopy && (
+            <CopyToClipboardButton
+              data={snippet ?? ''}
+              onCopy={onCopy && activeGroup ? () => onCopy(activeGroup) : undefined}
+            />
+          )}
+        </div>
       </section>
     </SnippetWindow>
   );

--- a/src/components/CodeSnippet/CodeSnippet.types.ts
+++ b/src/components/CodeSnippet/CodeSnippet.types.ts
@@ -29,6 +29,8 @@ export interface CodeSnippetProps {
   height?: string;
   className?: string;
   hideHeader?: boolean;
+  onGroupChange?: (groupValue: string) => void;
+  onCopy?: (groupValue: string) => void;
 }
 
 export interface CodeSnippetTabProps {

--- a/src/features/tracking/checkFormEvents.ts
+++ b/src/features/tracking/checkFormEvents.ts
@@ -81,3 +81,14 @@ export const trackTerraformConfigCopied = checkFormEvents<TerraformFormatChanged
 
 /** Tracks when the full configuration link is clicked. */
 export const trackTerraformFullConfigClicked = checkFormEvents('terraform_full_config_clicked');
+
+interface ExampleScriptEvent extends TrackingEventProps {
+  /** The value identifier of the selected example script. */
+  script: string;
+}
+
+/** Tracks when an example script is selected in the check form. */
+export const trackExampleScriptSelected = checkFormEvents<ExampleScriptEvent>('example_script_selected');
+
+/** Tracks when an example script is copied in the check form. */
+export const trackExampleScriptCopied = checkFormEvents<ExampleScriptEvent>('example_script_copied');

--- a/src/features/tracking/screenshotEvents.ts
+++ b/src/features/tracking/screenshotEvents.ts
@@ -1,0 +1,25 @@
+import { createSMEventFactory, TrackingEventProps } from 'features/tracking/utils';
+
+const screenshotEvents = createSMEventFactory('screenshots');
+
+interface ScreenshotExpandedEvent extends TrackingEventProps {
+  /** Whether the screenshot has a caption. */
+  hasCaption: boolean;
+  /** The source type of the screenshot. */
+  source: 'base64' | 'url';
+}
+
+/** Tracks when a screenshot thumbnail is clicked to expand. */
+export const trackScreenshotExpanded = screenshotEvents<ScreenshotExpandedEvent>('expanded');
+
+/** Tracks when an expanded screenshot modal is dismissed. */
+export const trackScreenshotDismissed = screenshotEvents('dismissed');
+
+interface HideScreenshotsToggledEvent extends TrackingEventProps {
+  /** Whether screenshots are now hidden. */
+  hidden: boolean;
+}
+
+/** Tracks when the hide screenshots toggle is changed. */
+export const trackHideScreenshotsToggled = screenshotEvents<HideScreenshotsToggledEvent>('hide_toggled');
+

--- a/src/scenes/components/LogsRenderer/LogsEvent.tsx
+++ b/src/scenes/components/LogsRenderer/LogsEvent.tsx
@@ -1,7 +1,8 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Badge, Switch, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { trackHideScreenshotsToggled } from 'features/tracking/screenshotEvents';
 
 import { LokiFieldNames, UnknownParsedLokiRecord } from 'features/parseLokiLogs/parseLokiLogs.types';
 import { FeatureName } from 'types';
@@ -28,6 +29,12 @@ export const LogsEvent = <T extends UnknownParsedLokiRecord>({
   const { isEnabled: screenshotsEnabled } = useFeatureFlag(FeatureName.Screenshots);
 
   const [hideScreenshots, setHideScreenshots] = useState(false);
+
+  const handleToggleHideScreenshots = useCallback((e: React.FormEvent<HTMLInputElement>) => {
+    const hidden = e.currentTarget.checked;
+    trackHideScreenshotsToggled({ hidden });
+    setHideScreenshots(hidden);
+  }, []);
 
   const screenshotUUIDs = useMemo(
     () => (screenshotsEnabled ? extractScreenshotUUIDs(logs, mainKey) : []),
@@ -88,7 +95,7 @@ export const LogsEvent = <T extends UnknownParsedLokiRecord>({
         <div className={styles.filterBar}>
           <Badge text="NEW" color="orange" />
           <label className={styles.filterLabel}>
-            <Switch checked={hideScreenshots} onChange={(e) => setHideScreenshots(e.currentTarget.checked)} />
+            <Switch checked={hideScreenshots} onChange={handleToggleHideScreenshots} />
             <span>hide screenshots</span>
           </label>
         </div>

--- a/src/scenes/components/LogsRenderer/screenshots/ScreenshotThumbnail.tsx
+++ b/src/scenes/components/LogsRenderer/screenshots/ScreenshotThumbnail.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Modal, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { trackScreenshotDismissed, trackScreenshotExpanded } from 'features/tracking/screenshotEvents';
 
 import { sanitizeScreenshotSrc } from './screenshots.utils';
 
@@ -17,6 +18,16 @@ export const ScreenshotThumbnail = ({ base64, url, caption }: ScreenshotThumbnai
   const src = sanitizeScreenshotSrc(url, base64);
   const alt = caption || 'Screenshot';
 
+  const handleExpand = useCallback(() => {
+    trackScreenshotExpanded({ hasCaption: !!caption, source: url ? 'url' : 'base64' });
+    setIsModalOpen(true);
+  }, [caption, url]);
+
+  const handleDismiss = useCallback(() => {
+    trackScreenshotDismissed();
+    setIsModalOpen(false);
+  }, []);
+
   if (!src) {
     return null;
   }
@@ -28,7 +39,7 @@ export const ScreenshotThumbnail = ({ base64, url, caption }: ScreenshotThumbnai
         <button
           type="button"
           className={styles.thumbnailButton}
-          onClick={() => setIsModalOpen(true)}
+          onClick={handleExpand}
           aria-label={`View full size: ${alt}`}
         >
           <img src={src} alt={alt} className={styles.thumbnail} />
@@ -38,7 +49,7 @@ export const ScreenshotThumbnail = ({ base64, url, caption }: ScreenshotThumbnai
         <Modal
           title={caption ? `Screenshot: ${caption}` : 'Screenshot'}
           isOpen={true}
-          onDismiss={() => setIsModalOpen(false)}
+          onDismiss={handleDismiss}
           className={styles.modalOverride}
           contentClassName={styles.modalContent}
         >


### PR DESCRIPTION
## Summary

The screenshots feature shipped without any interaction tracking. This PR adds analytics events so we can understand how users interact with screenshots and example scripts.

### Screenshot events (`screenshots`)
- `expanded` — thumbnail clicked to open the full-size modal (tracks `hasCaption` and `source` as `base64` | `url`)
- `dismissed` — screenshot modal closed
- `hide_toggled` — "hide screenshots" switch toggled (tracks `hidden` boolean)

### Check form events (`check_form`)
- `example_script_selected` — example script selected in the side panel (tracks `script` name)
- `example_script_copied` — example script copied via the copy button (tracks `script` name)

## Changes

- **New file:** `screenshotEvents.ts` — screenshot-specific tracking events
- **Updated:** `checkFormEvents.ts` — added example script selected/copied events
- **Updated:** `ScreenshotThumbnail.tsx` — wired expand/dismiss tracking
- **Updated:** `LogsEvent.tsx` — wired hide toggle tracking
- **Updated:** `CodeSnippet.tsx` / `CodeSnippet.types.ts` — added optional `onGroupChange` and `onCopy` callback props
- **Updated:** `ScriptExamples.tsx` — passes tracking callbacks into `CodeSnippet`

