### PR TITLE
fix: add plugin-version-suffix to dev deployments

### DIFF
--- a/.github/workflows/validate_main.yml
+++ b/.github/workflows/validate_main.yml
@@ -34,6 +34,10 @@ jobs:
 
       environment: dev
 
+      # Append commit SHA so each merge to main publishes a unique version
+      # to the dev catalog and GCS, instead of colliding with the released version.
+      plugin-version-suffix: ${{ github.sha }}
+
       docs-only: false
 
       scopes: universal


### PR DESCRIPTION
## Problem

After merging #1689 and #1705, every merge to main tries to publish the plugin to the dev catalog and GCS using the raw version from `plugin.json` (e.g. `1.51.0`) without a commit SHA suffix. This causes two issues:

- **Catalog publish fails** because the version already exists
- **GCS artifact is overwritten** at the same path as the released version, since both dev and prod share the same bucket (`integration-artifacts`)

## Solution

Add `plugin-version-suffix: ${{ github.sha }}` to the `cd` job, matching what the [old `push.yml` had](https://github.com/grafana/synthetic-monitoring-app/blob/14c3fea2f1b5eab9b62cbcb1bbabd48bf2587203/.github/workflows/push.yml#L70)