### PR TITLE
fix(ci): harden auto-label_pr workflow

### DIFF
--- a/.github/workflows/auto-label_pr.yml
+++ b/.github/workflows/auto-label_pr.yml
@@ -5,19 +5,27 @@ permissions: {}
 
 on:
   pull_request:
+    branches:
+      - main
 
 jobs:
   label-by-title:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-small
     permissions:
       contents: none
+      id-token: write      # mint token
       pull-requests: write # needed to add labels to PRs
     steps:
-      # This needs a step to mint a token from GATB. Pass to github-script
-      # action so that it can write to PRs.
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        with:
+          github_app: synthetic-monitoring-ci
+
       - name: Label PR based on title
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
+          github-token: ${{ steps.get-github-app-token.outputs.token }}
           script: |
             const title = context.payload.pull_request && context.payload.pull_request.title || '';
             // Mapping: regex -> label name (aligned with conventional commits & release-please)


### PR DESCRIPTION
* Restrict the auto-label_pr workflow to pull requests targeting main so it does not run for unrelated branches
* Switch to self-hosted runner
* Mint a scoped GitHub App token via the shared create-github-app-token action (synthetic-monitoring-ci) instead of relying on the default GITHUB_TOKEN

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
