### PR TITLE
fix: allow Grafana-org git dependencies in Yarn hardened mode

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,7 @@
-approvedGitRepositories: []
+approvedGitRepositories:
+  - "https://github.com/grafana/*"
+  - "ssh://git@github.com/grafana/*"
+  - "git@github.com:grafana/*"
 
 enableScripts: false
 


### PR DESCRIPTION
## Problem

Renovate PRs (e.g. #1708) fail all CI checks because `yarn install --immutable` is blocked in Yarn's hardened mode. Hardened mode is auto-enabled for external/bot PRs and enforces the `approvedGitRepositories` setting, which was configured as an empty list `[]`. This blocks `react-data-grid`, a transitive git dependency from `@grafana/ui`, causing every downstream check (tests, build, lint, i18n, terraform validation) to fail.

## Solution

Update `approvedGitRepositories` in `.yarnrc.yml` to allow git dependencies from the `grafana` GitHub org. This is the minimum scope needed to unblock transitive git dependencies from first-party Grafana packages while still blocking all external git dependencies.

<img width="829" height="495" alt="image" src="https://github.com/user-attachments/assets/86aaf96f-1b0b-4497-8098-cb9e2b27cc68" />
