### PR TITLE
feat: show empty folders in check list folder view

### DIFF
--- a/src/hooks/useCheckFolderAccess.ts
+++ b/src/hooks/useCheckFolderAccess.ts
@@ -46,8 +46,9 @@ export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks:
         uids.add(check.folderUid);
       }
     });
+    allFolders.forEach((folder) => uids.add(folder.uid));
     return [...uids];
-  }, [checks, isFoldersEnabled, defaultFolderUid]);
+  }, [checks, allFolders, isFoldersEnabled, defaultFolderUid]);
 
   const { folderDetailsByUid } = useFolderPermissions(folderUids);
   const smPerms = useUserPermissions();

--- a/src/hooks/useChecksByFolder.ts
+++ b/src/hooks/useChecksByFolder.ts
@@ -96,6 +96,12 @@ export function buildChecksByFolder(
     getOrCreateNode(check.folderUid).checks.push(check);
   });
 
+  folders.forEach((folder) => {
+    if (!isDefaultFolder(folder.uid)) {
+      getOrCreateNode(folder.uid);
+    }
+  });
+
   nodeMap.forEach((node) => {
     let current = node.folder;
     while (current?.parentUid && !isDefaultFolder(current.parentUid)) {
@@ -118,12 +124,19 @@ export function buildChecksByFolder(
     }
   });
 
+  const sortByTitle = (a: FolderNode, b: FolderNode) => {
+    const titleA = a.folder?.title ?? a.folderUid;
+    const titleB = b.folder?.title ?? b.folderUid;
+    return titleA.localeCompare(titleB);
+  };
+
   const sortNodes = (nodes: FolderNode[]) => {
-    nodes.sort((a, b) => {
-      const titleA = a.folder?.title ?? a.folderUid;
-      const titleB = b.folder?.title ?? b.folderUid;
-      return titleA.localeCompare(titleB);
-    });
+    const withChecks = nodes.filter((n) => getTotalCheckCount(n) > 0).sort(sortByTitle);
+    const empty = nodes.filter((n) => getTotalCheckCount(n) === 0).sort(sortByTitle);
+
+    nodes.length = 0;
+    nodes.push(...withChecks, ...empty);
+
     nodes.forEach((n) => sortNodes(n.children));
   };
   sortNodes(rootNodes);

--- a/src/page/CheckList/CheckList.folderView.test.tsx
+++ b/src/page/CheckList/CheckList.folderView.test.tsx
@@ -166,25 +166,30 @@ describe('CheckList - Folder View Integration', () => {
       expect(screen.getAllByText('0 checks').length).toBeGreaterThan(0);
     });
 
-    test('empty folders show a disabled checkbox and a delete button', async () => {
-      await renderCheckList([CHECK_IN_PRODUCTION]);
+    test('selecting an empty folder reveals the delete action', async () => {
+      const { user } = await renderCheckList([CHECK_IN_PRODUCTION]);
 
       expect(await screen.findByText('Staging')).toBeInTheDocument();
 
-      const emptyCheckbox = screen.getByLabelText('Staging (empty)');
-      expect(emptyCheckbox).toBeDisabled();
+      const emptyCheckbox = screen.getByLabelText('Select folder Staging');
+      expect(emptyCheckbox).toBeEnabled();
+      expect(screen.queryByRole('button', { name: 'Delete folder' })).not.toBeInTheDocument();
 
-      const deleteButtons = screen.getAllByRole('button', { name: 'Delete folder' });
-      expect(deleteButtons.length).toBeGreaterThan(0);
+      await user.click(emptyCheckbox);
+      expect(screen.getByRole('button', { name: 'Delete folder' })).toBeInTheDocument();
     });
 
-    test('folders with checks show an enabled checkbox', async () => {
-      await renderCheckList([CHECK_IN_PRODUCTION]);
+    test('deselecting an empty folder hides the delete action', async () => {
+      const { user } = await renderCheckList([CHECK_IN_PRODUCTION]);
 
-      expect(await screen.findByText('Production')).toBeInTheDocument();
+      expect(await screen.findByText('Staging')).toBeInTheDocument();
 
-      const checkbox = screen.getByLabelText('Select all checks in Production');
-      expect(checkbox).toBeEnabled();
+      const emptyCheckbox = screen.getByLabelText('Select folder Staging');
+      await user.click(emptyCheckbox);
+      expect(screen.getByRole('button', { name: 'Delete folder' })).toBeInTheDocument();
+
+      await user.click(emptyCheckbox);
+      expect(screen.queryByRole('button', { name: 'Delete folder' })).not.toBeInTheDocument();
     });
   });
 

--- a/src/page/CheckList/CheckList.folderView.test.tsx
+++ b/src/page/CheckList/CheckList.folderView.test.tsx
@@ -165,6 +165,27 @@ describe('CheckList - Folder View Integration', () => {
       expect(screen.getByText('Staging')).toBeInTheDocument();
       expect(screen.getAllByText('0 checks').length).toBeGreaterThan(0);
     });
+
+    test('empty folders show a disabled checkbox and a delete button', async () => {
+      await renderCheckList([CHECK_IN_PRODUCTION]);
+
+      expect(await screen.findByText('Staging')).toBeInTheDocument();
+
+      const emptyCheckbox = screen.getByLabelText('Staging (empty)');
+      expect(emptyCheckbox).toBeDisabled();
+
+      const deleteButtons = screen.getAllByRole('button', { name: 'Delete folder' });
+      expect(deleteButtons.length).toBeGreaterThan(0);
+    });
+
+    test('folders with checks show an enabled checkbox', async () => {
+      await renderCheckList([CHECK_IN_PRODUCTION]);
+
+      expect(await screen.findByText('Production')).toBeInTheDocument();
+
+      const checkbox = screen.getByLabelText('Select all checks in Production');
+      expect(checkbox).toBeEnabled();
+    });
   });
 
   describe('with folders feature disabled', () => {

--- a/src/page/CheckList/CheckList.folderView.test.tsx
+++ b/src/page/CheckList/CheckList.folderView.test.tsx
@@ -8,7 +8,7 @@ import {
   CHECK_WITH_ORPHANED_FOLDER,
   CHECK_WITHOUT_FOLDER,
 } from 'test/fixtures/folderChecks';
-import { DEFAULT_FOLDER, FOLDER_PRODUCTION, FOLDER_STAGING, MOCK_FOLDERS } from 'test/fixtures/folders';
+import { DEFAULT_FOLDER, FOLDER_DELETABLE, FOLDER_PRODUCTION, FOLDER_READONLY, FOLDER_STAGING, MOCK_FOLDERS } from 'test/fixtures/folders';
 import { PRIVATE_PROBE, PUBLIC_PROBE } from 'test/fixtures/probes';
 import { apiRoute } from 'test/handlers';
 import { render } from 'test/render';
@@ -99,6 +99,38 @@ describe('buildChecksByFolder', () => {
     expect(rootChecks).toHaveLength(0);
   });
 
+  test('includes empty folders in the tree', () => {
+    const { folderTree } = buildChecksByFolder([CHECK_IN_PRODUCTION], MOCK_FOLDERS, DEFAULT_FOLDER.uid);
+
+    const allUids = collectAllFolderUids(folderTree);
+    expect(allUids).toContain(FOLDER_PRODUCTION.uid);
+    expect(allUids).toContain(FOLDER_STAGING.uid);
+    expect(allUids).toContain(FOLDER_READONLY.uid);
+    expect(allUids).toContain(FOLDER_DELETABLE.uid);
+  });
+
+  test('sorts empty folders after folders with checks', () => {
+    const { folderTree } = buildChecksByFolder([CHECK_IN_PRODUCTION], MOCK_FOLDERS, DEFAULT_FOLDER.uid);
+
+    const titles = folderTree.map((n) => n.folder?.title);
+    const productionIndex = titles.indexOf(FOLDER_PRODUCTION.title);
+    const emptyFolderTitles = [FOLDER_STAGING.title, FOLDER_READONLY.title, FOLDER_DELETABLE.title];
+    const emptyIndices = emptyFolderTitles.map((t) => titles.indexOf(t));
+
+    emptyIndices.forEach((emptyIdx) => {
+      expect(emptyIdx).toBeGreaterThan(productionIndex);
+    });
+  });
+
+  test('sorts empty folders alphabetically among themselves', () => {
+    const { folderTree } = buildChecksByFolder([CHECK_IN_PRODUCTION], MOCK_FOLDERS, DEFAULT_FOLDER.uid);
+
+    const emptyNodes = folderTree.filter((n) => n.checks.length === 0 && n.children.length === 0);
+    const titles = emptyNodes.map((n) => n.folder?.title ?? n.folderUid);
+    const sorted = [...titles].sort((a, b) => a.localeCompare(b));
+    expect(titles).toEqual(sorted);
+  });
+
   test('returns orphaned nodes when folders list is empty', () => {
     const { folderTree, rootChecks } = buildChecksByFolder(FOLDER_CHECKS, []);
 
@@ -124,6 +156,14 @@ describe('CheckList - Folder View Integration', () => {
       await renderCheckList(FOLDER_CHECKS, 'view=folder');
 
       expect(await screen.findByText(/Folders/)).toBeInTheDocument();
+    });
+
+    test('shows empty folders with 0 checks', async () => {
+      await renderCheckList([CHECK_IN_PRODUCTION]);
+
+      expect(await screen.findByText('Production')).toBeInTheDocument();
+      expect(screen.getByText('Staging')).toBeInTheDocument();
+      expect(screen.getAllByText('0 checks').length).toBeGreaterThan(0);
     });
   });
 

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Checkbox, Icon, Pagination, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
-import { css } from '@emotion/css';
+import { Button, Checkbox, ConfirmModal, Icon, IconButton, Pagination, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import { css, cx } from '@emotion/css';
 
 import { CheckListViewType } from 'page/CheckList/CheckList.types';
 import { Check, CheckType, GrafanaFolder, Label } from 'types';
 import { useCheckFolderStatus } from 'contexts/CheckFolderAccessContext';
 import { CheckRuntimeAlertStates, getCheckRuntimeAlertState } from 'data/useCheckAlertStates';
+import { useDeleteFolder } from 'data/useFolders';
 import { buildChecksByFolder, collectAllCheckIds, collectAllChecks, collectAllFolderUids, FolderNode, getTotalCheckCount } from 'hooks/useChecksByFolder';
 import { Feedback } from 'components/Feedback';
 import { CHECKS_PER_PAGE_CARD } from 'page/CheckList/CheckList.constants';
@@ -118,6 +119,9 @@ export function CheckListFolderView({
     selectedCheckIds,
   };
 
+  const foldersWithChecks = useMemo(() => folderTree.filter((n) => getTotalCheckCount(n) > 0), [folderTree]);
+  const emptyFolders = useMemo(() => folderTree.filter((n) => getTotalCheckCount(n) === 0), [folderTree]);
+
   const hasAnyContent = folderTree.length > 0 || defaultFolderNode !== null;
 
   return (
@@ -153,7 +157,7 @@ export function CheckListFolderView({
             </Stack>
           </div>
 
-          {folderTree.map((node) => (
+          {foldersWithChecks.map((node) => (
             <FolderTreeBranch
               key={node.folderUid}
               node={node}
@@ -176,6 +180,18 @@ export function CheckListFolderView({
               onRetryFolders={onRetryFolders}
             />
           )}
+
+          {emptyFolders.map((node) => (
+            <FolderTreeBranch
+              key={node.folderUid}
+              node={node}
+              depth={0}
+              collapsedFolders={collapsedFolders}
+              toggleFolder={toggleFolder}
+              checkItemProps={checkItemProps}
+              onRetryFolders={onRetryFolders}
+            />
+          ))}
         </div>
       )}
 
@@ -234,6 +250,20 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
     ? { uid: node.folderUid, title: node.folder?.title ?? node.folderUid }
     : undefined;
 
+  const isEmpty = totalChecks === 0;
+  const canDeleteEmptyFolder = isEmpty && folderCanDelete && !node.isDefault && !node.isOrphaned;
+  const [showDeleteEmptyFolderModal, setShowDeleteEmptyFolderModal] = useState(false);
+  const { mutateAsync: deleteFolderAsync } = useDeleteFolder();
+
+  const handleDeleteEmptyFolder = async () => {
+    try {
+      await deleteFolderAsync(node.folderUid);
+    } catch {
+      // Folder deletion failed — modal closes, folder stays visible
+    }
+    setShowDeleteEmptyFolderModal(false);
+  };
+
   const handleFolderSelectAll = () => {
     if (isAllInFolderSelected) {
       checkItemProps.onDeselectChecks(allFolderCheckIds);
@@ -249,16 +279,15 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
   return (
     <div className={isRoot ? styles.folderGroup : styles.nestedFolder}>
       <div className={isRoot ? styles.folderHeaderRoot : styles.folderHeaderNested}>
-        {totalChecks > 0 && (
-          <Checkbox
-            aria-label={`Select all checks in ${node.folder?.title ?? 'folder'}`}
-            checked={isAllInFolderSelected}
-            indeterminate={isSomeInFolderSelected}
-            onChange={handleFolderSelectAll}
-          />
-        )}
+        <Checkbox
+          aria-label={isEmpty ? `${node.folder?.title ?? 'folder'} (empty)` : `Select all checks in ${node.folder?.title ?? 'folder'}`}
+          checked={!isEmpty && isAllInFolderSelected}
+          indeterminate={!isEmpty && isSomeInFolderSelected}
+          onChange={handleFolderSelectAll}
+          disabled={isEmpty}
+        />
         <button
-          className={styles.folderToggle}
+          className={cx(styles.folderToggle, isEmpty && styles.folderToggleMuted)}
           onClick={() => toggleFolder(node.folderUid)}
           aria-expanded={isExpanded}
           aria-label={`${isExpanded ? 'Collapse' : 'Expand'} folder ${node.folder?.title ?? node.folderUid}`}
@@ -309,6 +338,28 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
             />
             <span className={styles.selectedCount}>{selectedCount} selected</span>
           </div>
+        )}
+        {canDeleteEmptyFolder && (
+          <>
+            <IconButton
+              name="trash-alt"
+              aria-label="Delete folder"
+              tooltip="Delete folder"
+              size="sm"
+              variant="destructive"
+              onClick={(e) => { e.stopPropagation(); setShowDeleteEmptyFolderModal(true); }}
+            />
+            {showDeleteEmptyFolderModal && (
+              <ConfirmModal
+                isOpen={showDeleteEmptyFolderModal}
+                title={`Delete folder "${node.folder?.title ?? node.folderUid}"`}
+                body="This will delete the empty folder. This action cannot be undone."
+                confirmText="Delete folder"
+                onConfirm={handleDeleteEmptyFolder}
+                onDismiss={() => setShowDeleteEmptyFolderModal(false)}
+              />
+            )}
+          </>
         )}
       </div>
 
@@ -452,6 +503,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
       outline: `2px solid ${theme.colors.primary.border}`,
       outlineOffset: 2,
       borderRadius: theme.shape.radius.default,
+    },
+  }),
+  folderToggleMuted: css({
+    color: theme.colors.text.secondary,
+    '&:hover': {
+      color: theme.colors.text.primary,
     },
   }),
   folderActions: css({

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Button, Checkbox, ConfirmModal, Icon, IconButton, Pagination, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 
 import { CheckListViewType } from 'page/CheckList/CheckList.types';
 import { Check, CheckType, GrafanaFolder, Label } from 'types';
@@ -252,6 +252,7 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
 
   const isEmpty = totalChecks === 0;
   const canDeleteEmptyFolder = isEmpty && folderCanDelete && !node.isDefault && !node.isOrphaned;
+  const [emptyFolderSelected, setEmptyFolderSelected] = useState(false);
   const [showDeleteEmptyFolderModal, setShowDeleteEmptyFolderModal] = useState(false);
   const { mutateAsync: deleteFolderAsync } = useDeleteFolder();
 
@@ -262,9 +263,14 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
       // Folder deletion failed — modal closes, folder stays visible
     }
     setShowDeleteEmptyFolderModal(false);
+    setEmptyFolderSelected(false);
   };
 
   const handleFolderSelectAll = () => {
+    if (isEmpty) {
+      setEmptyFolderSelected((prev) => !prev);
+      return;
+    }
     if (isAllInFolderSelected) {
       checkItemProps.onDeselectChecks(allFolderCheckIds);
     } else {
@@ -276,18 +282,19 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
     checkItemProps.onDeselectChecks(allFolderCheckIds);
   };
 
+  const showActions = isEmpty ? emptyFolderSelected : selectedCount > 0;
+
   return (
     <div className={isRoot ? styles.folderGroup : styles.nestedFolder}>
       <div className={isRoot ? styles.folderHeaderRoot : styles.folderHeaderNested}>
         <Checkbox
-          aria-label={isEmpty ? `${node.folder?.title ?? 'folder'} (empty)` : `Select all checks in ${node.folder?.title ?? 'folder'}`}
-          checked={!isEmpty && isAllInFolderSelected}
+          aria-label={isEmpty ? `Select folder ${node.folder?.title ?? 'folder'}` : `Select all checks in ${node.folder?.title ?? 'folder'}`}
+          checked={isEmpty ? emptyFolderSelected : isAllInFolderSelected}
           indeterminate={!isEmpty && isSomeInFolderSelected}
           onChange={handleFolderSelectAll}
-          disabled={isEmpty}
         />
         <button
-          className={cx(styles.folderToggle, isEmpty && styles.folderToggleMuted)}
+          className={styles.folderToggle}
           onClick={() => toggleFolder(node.folderUid)}
           aria-expanded={isExpanded}
           aria-label={`${isExpanded ? 'Collapse' : 'Expand'} folder ${node.folder?.title ?? node.folderUid}`}
@@ -329,7 +336,7 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
             </span>
           </Stack>
         </button>
-        {selectedCount > 0 && (
+        {showActions && !isEmpty && (
           <div className={styles.folderActions}>
             <FolderBulkActions
               checks={selectedChecksInFolder}
@@ -339,8 +346,8 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
             <span className={styles.selectedCount}>{selectedCount} selected</span>
           </div>
         )}
-        {canDeleteEmptyFolder && (
-          <>
+        {showActions && canDeleteEmptyFolder && (
+          <div className={styles.folderActions}>
             <IconButton
               name="trash-alt"
               aria-label="Delete folder"
@@ -349,6 +356,7 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
               variant="destructive"
               onClick={(e) => { e.stopPropagation(); setShowDeleteEmptyFolderModal(true); }}
             />
+            <span className={styles.selectedCount}>1 selected</span>
             {showDeleteEmptyFolderModal && (
               <ConfirmModal
                 isOpen={showDeleteEmptyFolderModal}
@@ -359,7 +367,7 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
                 onDismiss={() => setShowDeleteEmptyFolderModal(false)}
               />
             )}
-          </>
+          </div>
         )}
       </div>
 
@@ -503,12 +511,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
       outline: `2px solid ${theme.colors.primary.border}`,
       outlineOffset: 2,
       borderRadius: theme.shape.radius.default,
-    },
-  }),
-  folderToggleMuted: css({
-    color: theme.colors.text.secondary,
-    '&:hover': {
-      color: theme.colors.text.primary,
     },
   }),
   folderActions: css({


### PR DESCRIPTION
## Problem

Empty folders were invisible in the check list folder view. Users had no way to see or clean up folders that no longer contained any checks, leading to clutter in Grafana's folder structure that could only be managed outside of Synthetic Monitoring.

## Summary

- **Show empty folders** in the check list folder view. They appear below the default folder, sorted alphabetically after folders that contain checks.
- **Delete empty folders** via a trash icon button on the folder row. Clicking it opens a confirmation modal. Only shown when the user has Grafana-level `canDelete` permission on the folder.


<img width="2236" height="413" alt="image" src="https://github.com/user-attachments/assets/1f911a3e-6871-4b8f-bc61-06ec5d4bd967" />
<img width="2215" height="422" alt="image" src="https://github.com/user-attachments/assets/266a74e3-a82d-4197-8980-383d4200e149" />


https://github.com/user-attachments/assets/b5b9db71-0ea5-4335-bfea-0795ab1756ae



