### PR TITLE
fix(feature): ppdate cost attribution feature flag

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -746,7 +746,7 @@ export enum HTTPCompressionAlgo {
 }
 
 export enum FeatureName {
-  CALs = 'synthetic-monitoring-cals',
+  CALs = 'synthetic-monitoring-cost-attribution',
   Folders = 'synthetic-monitoring-folders',
   GRPCChecks = 'grpc-checks',
   Screenshots = 'synthetic-monitoring-screenshots',


### PR DESCRIPTION
We should align with the CMAB feature flag value for cost attribution so only one feature flag needs to be enabled to support both in public preview. In CMAB it is defined as `synthetic-monitoring-cost-attribution`: https://github.com/grafana/grafana-cmab-app/blob/fix/remove-sm-cal-app-ff/src/utils/featureToggles.ts#L12-L12

This updates our cost attribution feature flag to match CMAB's. Existing environments with CAL's enabled will become disabled, but since that is mostly dev I believe that's acceptable.

- relates https://github.com/grafana/synthetic-monitoring/issues/370
