### PR TITLE
fix: allow check deletion with folder Edit permission

### DIFF
--- a/src/data/folderPermissions.test.ts
+++ b/src/data/folderPermissions.test.ts
@@ -164,11 +164,11 @@ describe('computeCheckPermissions', () => {
       });
     });
 
-    it('SM writer + folder Edit → can read + write, not delete', () => {
+    it('SM writer + folder Edit → full access (folder Edit grants delete, same as dashboards)', () => {
       expect(computeCheckPermissions(smWriter(), FOLDER_EDITOR)).toEqual({
         canRead: true,
         canWrite: true,
-        canDelete: false,
+        canDelete: true,
       });
     });
 

--- a/src/data/folderPermissions.ts
+++ b/src/data/folderPermissions.ts
@@ -103,10 +103,13 @@ export function isCheckVisible(folderStatus: CheckFolderStatus): boolean {
  * Implements the combined permission model:
  *   effective = min(SM RBAC, folder permission)
  *
- * Folder permission mapping (SLO model):
- *   - Folder View  (canEdit=false) → check READ
- *   - Folder Edit  (canEdit=true)  → check READ + WRITE
- *   - Folder Admin (canAdmin=true) → check READ + WRITE + DELETE
+ * Folder permission mapping (same as Grafana dashboards, where folder Edit
+ * grants dashboards:delete):
+ *   - Folder View (canEdit=false) → check READ
+ *   - Folder Edit (canEdit=true)  → check READ + WRITE + DELETE
+ *
+ * Deleting the folder itself is gated separately on the folder's canDelete
+ * flag (folders:delete), not handled here.
  *
  * Special cases:
  *   - no-folder-context / orphaned → SM RBAC only (no folder restriction)
@@ -137,7 +140,7 @@ export function computeCheckPermissions(
       return {
         canRead: smPerms.canReadChecks,
         canWrite: smPerms.canWriteChecks && folderStatus.permissions.canEdit,
-        canDelete: smPerms.canDeleteChecks && folderStatus.permissions.canAdmin,
+        canDelete: smPerms.canDeleteChecks && folderStatus.permissions.canEdit,
       };
 
     case 'forbidden':

--- a/src/page/CheckList/CheckList.folderPermissions.test.tsx
+++ b/src/page/CheckList/CheckList.folderPermissions.test.tsx
@@ -120,14 +120,14 @@ describe('CheckList - Folder Permissions', () => {
         expect(toggleButton).toBeDisabled();
       });
 
-      it('enables edit but disables delete for checks in an editable folder (folder Edit, no Admin)', async () => {
+      it('enables edit and delete for checks in an editable folder (folder Edit grants delete, same as dashboards)', async () => {
         await renderCheckList([CHECK_IN_PRODUCTION]);
 
         await waitFor(() => {
           expect(screen.getByLabelText('Edit check')).not.toHaveAttribute('aria-disabled', 'true');
         });
 
-        expect(screen.getByLabelText('Delete check')).toBeDisabled();
+        expect(screen.getByLabelText('Delete check')).not.toBeDisabled();
         expect(screen.getByLabelText('Disable check')).not.toBeDisabled();
       });
 


### PR DESCRIPTION
## Problem

Users with folder Edit permission (e.g. Grafana Editors, who get Edit on folders by default) could not delete checks in Synthetic Monitoring — the delete action was grayed out, both for individual checks and for the bulk "delete folder + checks" flow.

This was inconsistent with the rest of Grafana: an Editor can delete a folder and the dashboards inside it from the Dashboards page, but couldn't do the equivalent in SM.

The original implementation gated check deletion on folder Admin (`canAdmin`), based on the [Folder access control docs](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/folder-access-control/), which list `folders:delete` as an Admin-only action. That page turns out to be inaccurate: Grafana's actual access control definitions in [`ossaccesscontrol/folder.go`](https://github.com/grafana/grafana/blob/main/pkg/services/accesscontrol/ossaccesscontrol/folder.go) include `folders:delete` (and `dashboards:delete`) in the **Edit** action set, which is also what the [org roles table](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/#organization-roles) documents ("Add, edit, delete folders" — Editor: yes). 

Thanks to @d0ugal for pointing out the discrepancy.

## Solution

Align the check permission model with Grafana's dashboards model: folder Edit now grants check delete.

The combined model `effective = min(SM RBAC, folder permission)` is unchanged — SM RBAC (`checks:delete`) is still required, and a user without it cannot delete checks regardless of folder permission. The folder-side gate simply moved from Admin to Edit:

| Folder permission | Check access (before) | Check access (after) |
| --- | --- | --- |
| View | read | read |
| Edit | read + write | read + write + **delete** |
| Admin | read + write + delete | read + write + delete |

Deleting the folder itself is unaffected: it remains gated on the folder's `canDelete` flag (`folders:delete`) returned by the Grafana folder API, so the protected default SM folder still cannot be deleted.

With this change, an Editor who selects all checks in a folder gets the full "Delete folder + checks" flow, matching the behaviour they already have on the Dashboards page.

## Testing

- Updated unit tests in `folderPermissions.test.ts` (folder Edit now grants delete; SM RBAC ceiling cases unchanged)
- Updated integration test in `CheckList.folderPermissions.test.tsx` (delete button enabled in an editable folder)
- Verified manually as a Grafana Editor: check deletion and folder deletion now work in SM, consistent with Dashboards

https://github.com/user-attachments/assets/8f7f1bb7-44a9-4f6c-80a8-dfdf4c90f8f0

