### PR TITLE
feat: exclude execution_id in timepoint explorer

### DIFF
--- a/src/scenes/components/LogsRenderer/UniqueLogLabels.utils.ts
+++ b/src/scenes/components/LogsRenderer/UniqueLogLabels.utils.ts
@@ -12,6 +12,7 @@ export function uniqueLabels(log: ParsedLokiRecord<Record<string, string>, Recor
       !LOG_LABELS_SM.includes(key) &&
       !TRACE_LABEL_NAMES.has(key) &&
       key !== 'msg' &&
+      key !== 'execution_id' &&
       !key.includes(`_extracted`) &&
       !key.includes(`label_`) &&
       key !== 'time' &&


### PR DESCRIPTION
https://github.com/grafana/sm-k6-runner/pull/1018
https://github.com/grafana/synthetic-monitoring-agent/pull/1853

When these two PRs land we will have the execution ID available in the logs. It's very noisy in the time point explorer so is worth excluding by default. This is deliberately a very small scoped PR, the main FE O11y integration PR will come about as a follow up.

**Before**
<img width="1439" height="1123" alt="image" src="https://github.com/user-attachments/assets/491faeae-2c95-48a8-95cc-b1f572855df6" />

**After**
<img width="1439" height="1084" alt="image" src="https://github.com/user-attachments/assets/6187a005-fdeb-45ec-b979-c6b57c378f0b" />
