### PR TITLE
feat: add check type to analytics events for check dashboards and timepoint explorer

### DIFF
--- a/src/features/tracking/checkDashboardEvents.ts
+++ b/src/features/tracking/checkDashboardEvents.ts
@@ -1,0 +1,17 @@
+import { createSMEventFactory, TrackingEventProps } from 'features/tracking/utils';
+
+import { CheckType } from 'types';
+
+const checkDashboardEvents = createSMEventFactory('check_dashboard');
+
+interface CheckDashboardViewed extends TrackingEventProps {
+  /** The type of check the dashboard belongs to. */
+  checkType: CheckType;
+  /** Whether the check had any failed executions in the queried time period. Undefined when uptime could not be determined. */
+  hasFailures?: boolean;
+  /** The uptime percentage (0-100) of the check over the queried time period. Undefined when uptime could not be determined. */
+  uptime?: number;
+}
+
+/** Tracks when a check dashboard is viewed. */
+export const trackCheckDashboardViewed = checkDashboardEvents<CheckDashboardViewed>('viewed');

--- a/src/features/tracking/timepointExplorerEvents.ts
+++ b/src/features/tracking/timepointExplorerEvents.ts
@@ -1,11 +1,14 @@
 import { createSMEventFactory, TrackingEventProps } from 'features/tracking/utils';
 
+import { CheckType } from 'types';
 import { LogsView } from 'scenes/components/LogsRenderer/LogsViewSelect';
 import { TimepointStatus, ViewMode } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
 
 const timepointExplorerEvents = createSMEventFactory('timepoint_explorer');
 
 interface ViewToggle extends TrackingEventProps {
+  /** The type of check being explored. */
+  checkType: CheckType;
   /** The view type. */
   viewMode: ViewMode;
 }
@@ -14,6 +17,8 @@ interface ViewToggle extends TrackingEventProps {
 export const trackViewToggle = timepointExplorerEvents<ViewToggle>('view_toggle');
 
 interface MiniMapSectionClicked extends TrackingEventProps {
+  /** The type of check being explored. */
+  checkType: CheckType;
   /** The index of the section of the mini map that was clicked. */
   index: number;
   /** The UI component that was clicked. */
@@ -24,6 +29,8 @@ interface MiniMapSectionClicked extends TrackingEventProps {
 export const trackMiniMapSectionClicked = timepointExplorerEvents<MiniMapSectionClicked>('mini_map_section_clicked');
 
 interface MiniMapPageChange extends TrackingEventProps {
+  /** The type of check being explored. */
+  checkType: CheckType;
   /** The index of the page that was clicked. */
   index: number;
 }
@@ -32,6 +39,8 @@ interface MiniMapPageChange extends TrackingEventProps {
 export const trackMiniMapPageClicked = timepointExplorerEvents<MiniMapPageChange>('mini_map_page_clicked');
 
 export interface TimepointDetailsClick extends TrackingEventProps {
+  /** The type of check being explored. */
+  checkType: CheckType;
   /** The UI component that was clicked. */
   component: 'tooltip' | 'reachability-entry' | 'viewer-tab' | 'uptime-entry' | 'pending-entry';
   /** The status of the Timepoint List entry that was clicked. */
@@ -42,6 +51,8 @@ export interface TimepointDetailsClick extends TrackingEventProps {
 export const trackTimepointDetailsClicked = timepointExplorerEvents<TimepointDetailsClick>('timepoint_click');
 
 interface TimepointVizLegendClicked extends TrackingEventProps {
+  /** The type of check being explored. */
+  checkType: CheckType;
   /** The viz options that were toggled. */
   vizOptions: string;
 }
@@ -51,6 +62,8 @@ export const trackTimepointVizLegendToggled =
   timepointExplorerEvents<TimepointVizLegendClicked>('timepoint_viz_legend_toggled');
 
 interface TimepointVizLegendColorClicked extends TrackingEventProps {
+  /** The type of check being explored. */
+  checkType: CheckType;
   /** The color of the viz option that was clicked. */
   color: string;
   /** The viz option that was clicked. */
@@ -63,6 +76,8 @@ export const trackTimepointVizLegendColorClicked = timepointExplorerEvents<Timep
 );
 
 interface TimepointViewerActionClicked extends TrackingEventProps {
+  /** The type of check being explored. */
+  checkType: CheckType;
   /** The action that was clicked. */
   action: 'previous-timepoint' | 'next-timepoint' | 'view-explore-logs' | 'view-explore-metrics';
 }
@@ -81,6 +96,8 @@ interface TraceIconClicked extends TrackingEventProps {
 export const trackTraceIconClicked = timepointExplorerEvents<TraceIconClicked>('trace_icon_clicked');
 
 interface TimepointViewerLogsViewToggled extends TrackingEventProps {
+  /** The type of check being explored. */
+  checkType: CheckType;
   /** The action that was clicked. */
   action: LogsView;
 }

--- a/src/scenes/Common/DashboardContainer.tsx
+++ b/src/scenes/Common/DashboardContainer.tsx
@@ -1,10 +1,12 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect, useRef } from 'react';
 import { PluginPage } from '@grafana/runtime';
 import { CustomVariable, QueryVariable, SceneContextProvider } from '@grafana/scenes-react';
 import { VariableHide, VariableRefresh } from '@grafana/schema';
 import { Stack } from '@grafana/ui';
+import { trackCheckDashboardViewed } from 'features/tracking/checkDashboardEvents';
 
 import { Check, CheckType } from 'types';
+import { useCheckUptimeSuccessRate } from 'data/useSuccessRates';
 import { useMetricsDS } from 'hooks/useMetricsDS';
 import { DEFAULT_QUERY_FROM_TIME } from 'components/constants';
 import { useDashboardContainerAnnotations } from 'scenes/Common/DashboardContainer.hooks';
@@ -16,9 +18,28 @@ interface DashboardContainerProps extends PropsWithChildren {
   checkType: CheckType;
 }
 
+const useTrackCheckDashboardViewed = (check: Check, checkType: CheckType) => {
+  const { data: uptime, isSuccess, isError } = useCheckUptimeSuccessRate(check);
+  const trackedCheckId = useRef<Check['id']>(undefined);
+
+  useEffect(() => {
+    if (trackedCheckId.current === check.id || (!isSuccess && !isError)) {
+      return;
+    }
+
+    trackedCheckId.current = check.id;
+    trackCheckDashboardViewed({
+      checkType,
+      hasFailures: typeof uptime === 'number' ? uptime < 1 : undefined,
+      uptime: typeof uptime === 'number' ? Math.round(uptime * 10000) / 100 : undefined,
+    });
+  }, [check.id, checkType, uptime, isSuccess, isError]);
+};
+
 export const DashboardContainer = ({ check, checkType, children }: DashboardContainerProps) => {
   const metricsDS = useMetricsDS();
   const annotations = useDashboardContainerAnnotations(check);
+  useTrackCheckDashboardViewed(check, checkType);
 
   return (
     <SceneContextProvider timeRange={{ from: `now-${DEFAULT_QUERY_FROM_TIME}`, to: 'now' }} withQueryController>

--- a/src/scenes/components/TimepointExplorer/TimepointExplorer.context.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointExplorer.context.tsx
@@ -13,7 +13,8 @@ import { useTimeRange } from '@grafana/scenes-react';
 import { useTheme2 } from '@grafana/ui';
 import { trackTimepointVizLegendToggled, trackViewToggle } from 'features/tracking/timepointExplorerEvents';
 
-import { Check } from 'types';
+import { Check, CheckType } from 'types';
+import { getCheckType } from 'utils';
 import { useLogsRetentionPeriod } from 'data/useLogsRetention';
 import { useSceneVar } from 'scenes/Common/useSceneVar';
 import {
@@ -65,6 +66,7 @@ interface TimepointExplorerContextType {
   alertEvents: CheckEvent[];
   check: Check;
   checkConfigs: CheckConfig[];
+  checkType: CheckType;
   checkEvents: CheckEvent[];
   currentAdjustedTime: UnixTimestamp;
   explorerTimeFrom: UnixTimestamp;
@@ -111,6 +113,7 @@ interface TimepointExplorerProviderProps extends PropsWithChildren {
 }
 
 export const TimepointExplorerProvider = ({ children, check }: TimepointExplorerProviderProps) => {
+  const checkType = getCheckType(check.settings);
   const checkCreation = Math.ceil(check.created!) * 1000;
   const [timeRange] = useTimeRange();
   const timeRangeRef = useRef<TimeRange>(timeRange);
@@ -239,10 +242,13 @@ export const TimepointExplorerProvider = ({ children, check }: TimepointExplorer
     setMiniMapCurrentSectionIndex(0);
   }, []);
 
-  const handleViewModeChange = useCallback((viewMode: ViewMode) => {
-    trackViewToggle({ viewMode });
-    setViewMode(viewMode);
-  }, []);
+  const handleViewModeChange = useCallback(
+    (viewMode: ViewMode) => {
+      trackViewToggle({ checkType, viewMode });
+      setViewMode(viewMode);
+    },
+    [checkType]
+  );
 
   const handleViewerStateChange = useCallback((state: ViewerState) => {
     setViewerState(state);
@@ -283,27 +289,31 @@ export const TimepointExplorerProvider = ({ children, check }: TimepointExplorer
     [listWidth, handleTimepointDisplayCountChange]
   );
 
-  const handleVizDisplayChange = useCallback((display: TimepointStatus, usedModifier: boolean) => {
-    setVizDisplay((prev) => {
-      const isSelected = prev.includes(display);
-      const allSelected = prev.length === VIZ_DISPLAY_OPTIONS.length;
-      let newVizDisplay = [display];
+  const handleVizDisplayChange = useCallback(
+    (display: TimepointStatus, usedModifier: boolean) => {
+      setVizDisplay((prev) => {
+        const isSelected = prev.includes(display);
+        const allSelected = prev.length === VIZ_DISPLAY_OPTIONS.length;
+        let newVizDisplay = [display];
 
-      if (usedModifier) {
-        newVizDisplay = isSelected ? prev.filter((value) => value !== display) : [...prev, display];
-      }
+        if (usedModifier) {
+          newVizDisplay = isSelected ? prev.filter((value) => value !== display) : [...prev, display];
+        }
 
-      if (isSelected && !allSelected) {
-        newVizDisplay = VIZ_DISPLAY_OPTIONS;
-      }
+        if (isSelected && !allSelected) {
+          newVizDisplay = VIZ_DISPLAY_OPTIONS;
+        }
 
-      trackTimepointVizLegendToggled({
-        vizOptions: newVizDisplay.sort().join(','),
+        trackTimepointVizLegendToggled({
+          checkType,
+          vizOptions: newVizDisplay.sort().join(','),
+        });
+
+        return newVizDisplay;
       });
-
-      return newVizDisplay;
-    });
-  }, []);
+    },
+    [checkType]
+  );
 
   const handleVizOptionChange = useCallback((display: TimepointStatus, color: string) => {
     setVizOptions((prev) => {
@@ -353,6 +363,7 @@ export const TimepointExplorerProvider = ({ children, check }: TimepointExplorer
       check,
       checkConfigs,
       checkEvents,
+      checkType,
       currentAdjustedTime,
       explorerTimeFrom,
       handleHoverStateChange,
@@ -395,6 +406,7 @@ export const TimepointExplorerProvider = ({ children, check }: TimepointExplorer
     check,
     checkConfigs,
     checkEvents,
+    checkType,
     currentAdjustedTime,
     explorerTimeFrom,
     handleHoverStateChange,

--- a/src/scenes/components/TimepointExplorer/TimepointListEntryBar.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointListEntryBar.tsx
@@ -38,7 +38,7 @@ export const TimepointListEntryBar = ({
   timepoint,
 }: TimepointListEntryPendingProps) => {
   const statefulTimepoint = useStatefulTimepoint(timepoint);
-  const { handleViewerStateChange, handleSetScrollToViewer, yAxisMax, viewerState, timepointWidth, vizDisplay } = useTimepointExplorerContext();
+  const { checkType, handleViewerStateChange, handleSetScrollToViewer, yAxisMax, viewerState, timepointWidth, vizDisplay } = useTimepointExplorerContext();
   const selectedProbeNames = useSelectedProbeNames(statefulTimepoint);
 
   const height = getEntryHeight(statefulTimepoint.maxProbeDuration, yAxisMax);
@@ -50,12 +50,13 @@ export const TimepointListEntryBar = ({
 
   const handleViewerStateClick = useCallback(() => {
     trackTimepointDetailsClicked({
+      checkType,
       component: analyticsEventName,
       status,
     });
     handleSetScrollToViewer(true);
     handleViewerStateChange([timepoint, probeNameToView, 0]);
-  }, [analyticsEventName, status, timepoint, probeNameToView, handleViewerStateChange, handleSetScrollToViewer]);
+  }, [analyticsEventName, checkType, status, timepoint, probeNameToView, handleViewerStateChange, handleSetScrollToViewer]);
 
   if (!vizDisplay.includes(status)) {
     return <div />;

--- a/src/scenes/components/TimepointExplorer/TimepointListEntryReachability.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointListEntryReachability.tsx
@@ -31,6 +31,7 @@ const ICON_MAP: Record<number, IconName> = {
 
 export const TimepointListEntryReachability = ({ timepoint }: TimepointListEntryProps) => {
   const {
+    checkType,
     handleHoverStateChange,
     handleSetScrollToViewer,
     handleViewerStateChange,
@@ -63,13 +64,14 @@ export const TimepointListEntryReachability = ({ timepoint }: TimepointListEntry
   const handleProbeClick = useCallback(
     (probeName: string, index: number) => {
       trackTimepointDetailsClicked({
+        checkType,
         component: 'reachability-entry',
         status: statefulTimepoint.status,
       });
       handleSetScrollToViewer(true);
       handleViewerStateChange([statefulTimepoint, probeName, index]);
     },
-    [statefulTimepoint, handleViewerStateChange, handleSetScrollToViewer]
+    [checkType, statefulTimepoint, handleViewerStateChange, handleSetScrollToViewer]
   );
 
   if (!executionsToRender.length) {

--- a/src/scenes/components/TimepointExplorer/TimepointListEntryTooltip.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointListEntryTooltip.tsx
@@ -24,7 +24,7 @@ interface TimepointListEntryTooltipProps {
 
 export const TimepointListEntryTooltip = ({ timepoint }: TimepointListEntryTooltipProps) => {
   const styles = useStyles2(getStyles);
-  const { currentAdjustedTime, handleHoverStateChange, handleSetScrollToViewer, handleViewerStateChange, hoveredState, viewerState } =
+  const { checkType, currentAdjustedTime, handleHoverStateChange, handleSetScrollToViewer, handleViewerStateChange, hoveredState, viewerState } =
     useTimepointExplorerContext();
 
   const statefulTimepoint = useStatefulTimepoint(timepoint);
@@ -45,13 +45,14 @@ export const TimepointListEntryTooltip = ({ timepoint }: TimepointListEntryToolt
   const handleProbeClick = useCallback(
     (probeName: string, index: number) => {
       trackTimepointDetailsClicked({
+        checkType,
         component: 'tooltip',
         status: statefulTimepoint.status,
       });
       handleSetScrollToViewer(true);
       handleViewerStateChange([statefulTimepoint, probeName, index]);
     },
-    [statefulTimepoint, handleViewerStateChange, handleSetScrollToViewer]
+    [checkType, statefulTimepoint, handleViewerStateChange, handleSetScrollToViewer]
   );
 
   return (

--- a/src/scenes/components/TimepointExplorer/TimepointListVizLegend.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointListVizLegend.tsx
@@ -12,17 +12,18 @@ import { TimepointVizItem } from 'scenes/components/TimepointExplorer/TimepointV
 
 export const TimepointListVizLegend = () => {
   const styles = useStyles2(getStyles);
-  const { handleVizDisplayChange, vizDisplay, vizOptions, handleVizOptionChange } = useTimepointExplorerContext();
+  const { checkType, handleVizDisplayChange, vizDisplay, vizOptions, handleVizOptionChange } = useTimepointExplorerContext();
 
   const handleVizOptionClick = useCallback(
     (status: TimepointStatus, color: string) => {
       trackTimepointVizLegendColorClicked({
+        checkType,
         vizOption: status,
         color,
       });
       handleVizOptionChange(status, color);
     },
-    [handleVizOptionChange]
+    [checkType, handleVizOptionChange]
   );
 
   return (

--- a/src/scenes/components/TimepointExplorer/TimepointMinimap.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointMinimap.tsx
@@ -26,6 +26,7 @@ const BUTTON_SPACE = GAP_PX + BUTTON_WIDTH;
 
 export const TimepointMinimap = () => {
   const {
+    checkType,
     handleMiniMapPageChange,
     handleMiniMapSectionChange,
     miniMapCurrentPage,
@@ -50,6 +51,7 @@ export const TimepointMinimap = () => {
             const index = isLastSection ? 0 : miniMapCurrentSectionIndex + 1;
 
             trackMiniMapSectionClicked({
+              checkType,
               index,
               component: 'left-arrow',
             });
@@ -71,6 +73,7 @@ export const TimepointMinimap = () => {
             const index = isFirstSection ? MAX_MINIMAP_SECTIONS - 1 : miniMapCurrentSectionIndex - 1;
 
             trackMiniMapSectionClicked({
+              checkType,
               index,
               component: 'right-arrow',
             });
@@ -177,7 +180,7 @@ interface MiniMapPaginationProps {
 }
 
 const MiniMapPagination = ({ miniMapCurrentPage, miniMapPages }: MiniMapPaginationProps) => {
-  const { handleMiniMapPageChange } = useTimepointExplorerContext();
+  const { checkType, handleMiniMapPageChange } = useTimepointExplorerContext();
   const numberOfPages = miniMapPages.length;
   const currentPage = numberOfPages - miniMapCurrentPage;
 
@@ -185,11 +188,12 @@ const MiniMapPagination = ({ miniMapCurrentPage, miniMapPages }: MiniMapPaginati
     (page: number) => {
       const index = numberOfPages - page;
       trackMiniMapPageClicked({
+        checkType,
         index,
       });
       handleMiniMapPageChange(index);
     },
-    [handleMiniMapPageChange, numberOfPages]
+    [checkType, handleMiniMapPageChange, numberOfPages]
   );
 
   return <Pagination currentPage={currentPage} numberOfPages={numberOfPages} onNavigate={handleNavigate} />;

--- a/src/scenes/components/TimepointExplorer/TimepointMinimapSection.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointMinimapSection.tsx
@@ -24,6 +24,7 @@ interface MiniMapSectionProps {
 
 export const TimepointMiniMapSection = ({ index, miniMapWidth, section }: MiniMapSectionProps) => {
   const {
+    checkType,
     handleMiniMapSectionChange,
     isCheckCreationWithinTimeRange,
     miniMapCurrentPageSections,
@@ -44,11 +45,12 @@ export const TimepointMiniMapSection = ({ index, miniMapWidth, section }: MiniMa
 
   const handleMiniMapSectionClick = useCallback(() => {
     trackMiniMapSectionClicked({
+      checkType,
       index,
       component: 'section',
     });
     handleMiniMapSectionChange(index);
-  }, [index, handleMiniMapSectionChange]);
+  }, [checkType, index, handleMiniMapSectionChange]);
 
   const padStart = renderingStrategy === 'start' && isCheckCreationWithinTimeRange;
 

--- a/src/scenes/components/TimepointExplorer/TimepointViewer.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointViewer.tsx
@@ -20,7 +20,7 @@ import { TimepointViewerActions } from 'scenes/components/TimepointExplorer/Time
 import { TimepointViewerExecutions } from 'scenes/components/TimepointExplorer/TimepointViewerExecutions';
 
 export const TimepointViewer = () => {
-  const { isInitialised, viewerState, shouldScrollToViewer, handleSetScrollToViewer } = useTimepointExplorerContext();
+  const { checkType, isInitialised, viewerState, shouldScrollToViewer, handleSetScrollToViewer } = useTimepointExplorerContext();
   const [logsView, setLogsView] = useState<LogsView>(LOGS_VIEW_OPTIONS[0].value);
   const [viewerTimepoint, viewerProbeName] = viewerState;
   const styles = useStyles2(getStyles);
@@ -36,12 +36,16 @@ export const TimepointViewer = () => {
     }
   }, [shouldScrollToViewer, viewerTimepoint, handleSetScrollToViewer]);
 
-  const handleChangeLogsView = useCallback((view: LogsView) => {
-    trackTimepointViewerLogsViewToggled({
-      action: view,
-    });
-    setLogsView(view);
-  }, []);
+  const handleChangeLogsView = useCallback(
+    (view: LogsView) => {
+      trackTimepointViewerLogsViewToggled({
+        checkType,
+        action: view,
+      });
+      setLogsView(view);
+    },
+    [checkType]
+  );
 
   return (
     <div ref={containerRef} className={styles.container} data-testid={DataTestIds.TimepointViewer}>

--- a/src/scenes/components/TimepointExplorer/TimepointViewerActions.hooks.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointViewerActions.hooks.tsx
@@ -22,7 +22,7 @@ interface Action {
 export function useTimepointViewerActions(timepoint: StatelessTimepoint) {
   const logsDS = useLogsDS();
   const metricsDS = useMetricsDS();
-  const { check, currentAdjustedTime, handleViewerStateChange, listLogsMap, viewerState, timepoints } =
+  const { check, checkType, currentAdjustedTime, handleViewerStateChange, listLogsMap, viewerState, timepoints } =
     useTimepointExplorerContext();
   const [_, viewerProbeName] = viewerState;
   const logsQuery = { expr: `{job="${check.job}", instance="${check.target}", probe="${viewerProbeName}"} | logfmt` };
@@ -53,10 +53,11 @@ export function useTimepointViewerActions(timepoint: StatelessTimepoint) {
       const probeName = getProbeNameToUse(probeVar, statefulPrevTimepoint);
       handleViewerStateChange([prevTimepoint, probeName, 0]);
       trackTimepointViewerActionClicked({
+        checkType,
         action: 'previous-timepoint',
       });
     }
-  }, [prevTimepoint, listLogsMap, probeVar, handleViewerStateChange]);
+  }, [checkType, prevTimepoint, listLogsMap, probeVar, handleViewerStateChange]);
 
   const handleNextTimepoint = useCallback(() => {
     if (nextTimepoint) {
@@ -64,10 +65,11 @@ export function useTimepointViewerActions(timepoint: StatelessTimepoint) {
       const probeName = getProbeNameToUse(probeVar, statefulNextTimepoint);
       handleViewerStateChange([nextTimepoint, probeName, 0]);
       trackTimepointViewerActionClicked({
+        checkType,
         action: 'next-timepoint',
       });
     }
-  }, [nextTimepoint, listLogsMap, probeVar, handleViewerStateChange]);
+  }, [checkType, nextTimepoint, listLogsMap, probeVar, handleViewerStateChange]);
 
   return useMemo<Action[]>(
     () => [
@@ -89,6 +91,7 @@ export function useTimepointViewerActions(timepoint: StatelessTimepoint) {
         href: exploreLogsURL,
         onClick: () => {
           trackTimepointViewerActionClicked({
+            checkType,
             action: 'view-explore-logs',
           });
         },
@@ -99,11 +102,12 @@ export function useTimepointViewerActions(timepoint: StatelessTimepoint) {
         href: exploreMetricsURL,
         onClick: () => {
           trackTimepointViewerActionClicked({
+            checkType,
             action: 'view-explore-metrics',
           });
         },
       },
     ],
-    [prevTimepoint, nextTimepoint, exploreLogsURL, exploreMetricsURL, handleNextTimepoint, handlePreviousTimepoint]
+    [checkType, prevTimepoint, nextTimepoint, exploreLogsURL, exploreMetricsURL, handleNextTimepoint, handlePreviousTimepoint]
   );
 }

--- a/src/scenes/components/TimepointExplorer/TimepointViewerExecutions.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointViewerExecutions.tsx
@@ -37,7 +37,7 @@ export const TimepointViewerExecutions = ({
   probeNameToView,
   timepoint,
 }: TimepointViewerExecutionsProps) => {
-  const { handleHoverStateChange, handleViewerStateChange } = useTimepointExplorerContext();
+  const { checkType, handleHoverStateChange, handleViewerStateChange } = useTimepointExplorerContext();
   const tabsToRender = useTimepointViewerExecutions({
     isLoading,
     pendingProbeNames,
@@ -49,11 +49,12 @@ export const TimepointViewerExecutions = ({
     (probeName: string, status: TimepointStatus) => {
       handleViewerStateChange([timepoint, probeName, 0]);
       trackTimepointDetailsClicked({
+        checkType,
         component: 'viewer-tab',
         status,
       });
     },
-    [handleViewerStateChange, timepoint]
+    [checkType, handleViewerStateChange, timepoint]
   );
 
   return (


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds check-type context to our RudderStack analytics so downstream consumers can
segment dashboard engagement by check type — specifically to power an upcoming
SM → Frontend Observability campaign targeting users who create browser checks or
experience browser check failures.

Two changes:

1. **`checkType` added to all timepoint explorer events** (`timepoint_click`,
   `view_toggle`, mini map, viz legend, viewer actions, logs view toggle). The check
   type is derived once in `TimepointExplorerProvider` and exposed via context. This
   makes `timepoint_click` with `status: 'failure'` + `checkType: 'browser'` usable as
   a "user investigated a failed browser check" signal.

2. **New `synthetic-monitoring_check_dashboard_viewed` event**, fired once per check
   dashboard view from `DashboardContainer` (covers all 8 check type dashboards) with:
   - `checkType`
   - `hasFailures` — whether uptime was below 100% over the dashboard's default 3h window
   - `uptime` — the uptime percentage itself

   It reuses the existing `useCheckUptimeSuccessRate` query and waits for it to settle
   before firing; a ref guard on the check id prevents duplicate events from refetch
   intervals. If the uptime query errors, the event still fires with `hasFailures`/`uptime`
   undefined so the view itself is never lost.

**Which issue(s) this PR fixes**:

n/a — supports the SM → FEO campaign (no tracked issue)

**Special notes for your reviewer**:

- `trace_icon_clicked` is the one timepoint explorer event intentionally left without
  `checkType`: it fires from `LogsRenderer`, which also renders in the Checkster ad-hoc
  test panel outside the `TimepointExplorerProvider`.
- No behavioural/UI changes — analytics only, so no screenshots.
- Verified with `yarn typecheck`, `yarn lint` (no new warnings), and the TimepointExplorer
  test suite (60 passing). No existing tests cover `DashboardContainer` or the tracking
  modules.
- This PR was prepped with claude code/fable 5. I dont know the innnerworkings of rudderstack nor have a good way to test that it works correctly!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation with no UI or auth changes; the dashboard hook waits on an existing uptime query before emitting.
> 
> **Overview**
> Adds **`checkType`** (and related context) to RudderStack events so engagement can be segmented by check type—for example browser-check failures in Timepoint Explorer.
> 
> **Check dashboard:** Introduces `trackCheckDashboardViewed` and fires it once per check from `DashboardContainer` after `useCheckUptimeSuccessRate` succeeds or errors, with optional `hasFailures` and `uptime` (percent). A ref on check id avoids duplicate events on refetch.
> 
> **Timepoint Explorer:** Derives `checkType` once in `TimepointExplorerProvider`, exposes it on context, and passes it into existing trackers (view toggle, mini map, viz legend, timepoint clicks, viewer actions, logs view). **`trace_icon_clicked`** is unchanged (no `checkType`) because it can fire outside that provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ac58387d360784b1d75fc15460be4615ed7e810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->