### PR TITLE
fix: handle spread operator in browser script options validation

### DIFF
--- a/src/schemas/forms/script/parser.ts
+++ b/src/schemas/forms/script/parser.ts
@@ -1,4 +1,4 @@
-import { Node, ObjectExpression, parse, Property } from 'acorn';
+import { Node, ObjectExpression, parse, Property, SpreadElement } from 'acorn';
 import { simple as walk, SimpleVisitors } from 'acorn-walk';
 
 export function parseScript(script: string) {
@@ -17,16 +17,52 @@ interface ExtractOptionsState {
   options: ObjectExpression | null;
 }
 
-function getPropertyValueByPath(obj: ObjectExpression, path: string[]): any {
+export type ObjectDeclarations = Map<string, ObjectExpression>;
+
+// a spread is resolvable when it references an object literal declared in the same script
+function resolveSpreadTarget(spread: SpreadElement, declarations: ObjectDeclarations): ObjectExpression | undefined {
+  return spread.argument.type === 'Identifier' ? declarations.get(spread.argument.name) : undefined;
+}
+
+// resolves the effective list of properties of an object expression, expanding spreads
+// of locally declared objects (e.g. `{ ...defaultOptions }`) so their properties are visible.
+// `expanding` guards against circular references, e.g. `const a = { ...a }`
+function expandProperties(
+  obj: ObjectExpression,
+  declarations: ObjectDeclarations,
+  expanding: Set<ObjectExpression> = new Set()
+): Property[] {
+  if (expanding.has(obj)) {
+    return [];
+  }
+  expanding.add(obj);
+
+  const properties = obj.properties.flatMap((prop): Property[] => {
+    if (prop.type === 'Property') {
+      return [prop];
+    }
+
+    const resolved = resolveSpreadTarget(prop, declarations);
+    return resolved ? expandProperties(resolved, declarations, expanding) : [];
+  });
+
+  expanding.delete(obj);
+
+  return properties;
+}
+
+function getPropertyValueByPath(obj: ObjectExpression, path: string[], declarations: ObjectDeclarations): any {
   let current: any = obj;
   for (const key of path) {
-    if (current.type !== 'ObjectExpression') {
+    if (current?.type !== 'ObjectExpression') {
       return undefined;
     }
 
-    const property = current.properties.find(
-      (prop: Property) => prop.key.type === 'Identifier' && prop.key.name === key
-    );
+    const properties = expandProperties(current, declarations);
+    // search from the end so later properties win, matching spread/override semantics
+    const property = properties
+      .reverse()
+      .find((prop: Property) => prop.key.type === 'Identifier' && prop.key.name === key);
     if (property?.value.type === 'ObjectExpression') {
       current = property.value;
     } else if (property?.value.type === 'Literal') {
@@ -60,18 +96,62 @@ const optionExportMatcher: SimpleVisitors<{ options: ObjectExpression | null }> 
   },
 };
 
-export function getProperty(objectExpression: ObjectExpression, propPath: string[]) {
-  const scenarios = getPropertyValueByPath(objectExpression, ['scenarios']);
+export function getProperty(objectExpression: ObjectExpression, propPath: string[], declarations: ObjectDeclarations) {
+  const scenarios = getPropertyValueByPath(objectExpression, ['scenarios'], declarations);
   if (!scenarios || scenarios.type !== 'ObjectExpression') {
-    return false;
+    return undefined;
   }
 
-  for (const scenario of scenarios.properties) {
-    if (scenario.key.type === 'Identifier') {
-      const propValue = getPropertyValueByPath(scenario.value, propPath);
+  for (const scenario of expandProperties(scenarios, declarations)) {
+    if (scenario.key.type === 'Identifier' && scenario.value.type === 'ObjectExpression') {
+      const propValue = getPropertyValueByPath(scenario.value, propPath, declarations);
       return propValue;
     }
   }
+}
+
+// true when the object (or any nested object, following resolvable spreads) contains a spread
+// we can't statically resolve, e.g. `...importedOptions` or `...buildOptions()`
+export function containsUnresolvableSpread(
+  objectExpression: ObjectExpression,
+  declarations: ObjectDeclarations,
+  seen: Set<ObjectExpression> = new Set()
+): boolean {
+  if (seen.has(objectExpression)) {
+    return false;
+  }
+  seen.add(objectExpression);
+
+  return objectExpression.properties.some((prop) => {
+    if (prop.type === 'SpreadElement') {
+      const resolved = resolveSpreadTarget(prop, declarations);
+      return resolved ? containsUnresolvableSpread(resolved, declarations, seen) : true;
+    }
+
+    if (prop.value.type === 'ObjectExpression') {
+      return containsUnresolvableSpread(prop.value, declarations, seen);
+    }
+
+    return false;
+  });
+}
+
+const objectDeclarationMatcher: SimpleVisitors<ObjectDeclarations> = {
+  VariableDeclaration(node, state) {
+    for (const declaration of node.declarations) {
+      if (declaration.id.type === 'Identifier' && declaration.init?.type === 'ObjectExpression') {
+        state.set(declaration.id.name, declaration.init);
+      }
+    }
+  },
+};
+
+export function collectObjectDeclarations(program: Node): ObjectDeclarations {
+  const declarations: ObjectDeclarations = new Map();
+
+  walk(program, objectDeclarationMatcher, undefined, declarations);
+
+  return declarations;
 }
 
 interface ImportBrowserState {

--- a/src/schemas/forms/script/parser.ts
+++ b/src/schemas/forms/script/parser.ts
@@ -48,7 +48,21 @@ function expandProperties(
 
   expanding.delete(obj);
 
-  return properties;
+  return dedupeProperties(properties);
+}
+
+// when the same key appears multiple times (e.g. provided by a spread and overridden
+// explicitly) only the last occurrence applies, matching JavaScript spread semantics
+function dedupeProperties(properties: Property[]): Property[] {
+  const lastByName = new Map<string, Property>();
+
+  for (const prop of properties) {
+    if (prop.key.type === 'Identifier') {
+      lastByName.set(prop.key.name, prop);
+    }
+  }
+
+  return properties.filter((prop) => prop.key.type !== 'Identifier' || lastByName.get(prop.key.name) === prop);
 }
 
 function getPropertyValueByPath(obj: ObjectExpression, path: string[], declarations: ObjectDeclarations): any {
@@ -59,10 +73,7 @@ function getPropertyValueByPath(obj: ObjectExpression, path: string[], declarati
     }
 
     const properties = expandProperties(current, declarations);
-    // search from the end so later properties win, matching spread/override semantics
-    const property = properties
-      .reverse()
-      .find((prop: Property) => prop.key.type === 'Identifier' && prop.key.name === key);
+    const property = properties.find((prop: Property) => prop.key.type === 'Identifier' && prop.key.name === key);
     if (property?.value.type === 'ObjectExpression') {
       current = property.value;
     } else if (property?.value.type === 'Literal') {

--- a/src/schemas/forms/script/validation.test.ts
+++ b/src/schemas/forms/script/validation.test.ts
@@ -189,6 +189,70 @@ describe('validateBrowserScript', () => {
     expect(runValidation(script)).toEqual([]);
   });
 
+  it('lets an explicit scenario override one provided by a spread inside the scenarios object', () => {
+    const script = `
+      import { browser } from 'k6/browser';
+
+      const defaultScenarios = {
+        ui: {
+          executor: 'shared-iterations',
+          options: {},
+        },
+      };
+
+      export const options = {
+        scenarios: {
+          ...defaultScenarios,
+          ui: {
+            executor: 'shared-iterations',
+            options: {
+              browser: {
+                type: 'chromium',
+              },
+            },
+          },
+        },
+      };
+
+      export default async function () {}
+    `;
+
+    expect(runValidation(script)).toEqual([]);
+  });
+
+  it('errors when an explicit scenario overrides a valid one from a spread with invalid options', () => {
+    const script = `
+      import { browser } from 'k6/browser';
+
+      const defaultScenarios = {
+        ui: {
+          executor: 'shared-iterations',
+          options: {
+            browser: {
+              type: 'chromium',
+            },
+          },
+        },
+      };
+
+      export const options = {
+        scenarios: {
+          ...defaultScenarios,
+          ui: {
+            executor: 'shared-iterations',
+            options: {},
+          },
+        },
+      };
+
+      export default async function () {}
+    `;
+
+    expect(runValidation(script)).toEqual([
+      expect.objectContaining({ message: 'Script must set the type to chromium in the browser options.' }),
+    ]);
+  });
+
   it('errors with a clear message when the exported options contain a spread it cannot resolve', () => {
     const script = `
       import { browser } from 'k6/browser';

--- a/src/schemas/forms/script/validation.test.ts
+++ b/src/schemas/forms/script/validation.test.ts
@@ -1,0 +1,307 @@
+import { RefinementCtx } from 'zod';
+
+import { UNRESOLVABLE_SPREAD_MESSAGE, validateBrowserScript } from './validation';
+
+const VALID_BROWSER_SCRIPT = `
+import { browser } from 'k6/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+}
+`;
+
+const SPREAD_OPTIONS_BROWSER_SCRIPT = `
+import { browser } from 'k6/browser';
+
+const defaultOptions = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+};
+
+export const options = {
+  ...defaultOptions,
+  syntheticMonitoring: {
+    job: 'my job',
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+}
+`;
+
+const NESTED_SPREAD_OPTIONS_BROWSER_SCRIPT = `
+import { browser } from 'k6/browser';
+
+const browserOptions = {
+  browser: {
+    type: 'chromium',
+  },
+};
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        ...browserOptions,
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+}
+`;
+
+function runValidation(script: string) {
+  const issues: Array<{ message?: string }> = [];
+  const context = {
+    addIssue: (issue: { message?: string }) => {
+      issues.push(issue);
+    },
+    path: [],
+  } as unknown as RefinementCtx;
+
+  validateBrowserScript(script, context);
+
+  return issues;
+}
+
+describe('validateBrowserScript', () => {
+  it('passes for a valid browser script', () => {
+    expect(runValidation(VALID_BROWSER_SCRIPT)).toEqual([]);
+  });
+
+  it('resolves a spread of a locally declared object in the exported options', () => {
+    expect(runValidation(SPREAD_OPTIONS_BROWSER_SCRIPT)).toEqual([]);
+  });
+
+  it('resolves a spread of a locally declared object in a nested options object', () => {
+    expect(runValidation(NESTED_SPREAD_OPTIONS_BROWSER_SCRIPT)).toEqual([]);
+  });
+
+  it('errors when a resolved spread is missing the chromium browser type', () => {
+    const script = `
+      import { browser } from 'k6/browser';
+
+      const defaultOptions = {
+        scenarios: {
+          ui: {
+            executor: 'shared-iterations',
+          },
+        },
+      };
+
+      export const options = {
+        ...defaultOptions,
+      };
+
+      export default async function () {}
+    `;
+
+    expect(runValidation(script)).toEqual([
+      expect.objectContaining({ message: 'Script must set the type to chromium in the browser options.' }),
+    ]);
+  });
+
+  it('errors when a scenario from a resolved spread defines a duration', () => {
+    const script = `
+      import { browser } from 'k6/browser';
+
+      const defaultOptions = {
+        scenarios: {
+          ui: {
+            executor: 'shared-iterations',
+            duration: '1m',
+            options: {
+              browser: {
+                type: 'chromium',
+              },
+            },
+          },
+        },
+      };
+
+      export const options = {
+        ...defaultOptions,
+      };
+
+      export default async function () {}
+    `;
+
+    expect(runValidation(script)).toEqual([
+      expect.objectContaining({ message: "Script can't define a duration value for this check" }),
+    ]);
+  });
+
+  it('lets later properties override earlier spreads', () => {
+    const script = `
+      import { browser } from 'k6/browser';
+
+      const defaultOptions = {
+        scenarios: {
+          ui: {
+            executor: 'shared-iterations',
+          },
+        },
+      };
+
+      export const options = {
+        ...defaultOptions,
+        scenarios: {
+          ui: {
+            executor: 'shared-iterations',
+            options: {
+              browser: {
+                type: 'chromium',
+              },
+            },
+          },
+        },
+      };
+
+      export default async function () {}
+    `;
+
+    expect(runValidation(script)).toEqual([]);
+  });
+
+  it('errors with a clear message when the exported options contain a spread it cannot resolve', () => {
+    const script = `
+      import { browser } from 'k6/browser';
+      import { defaultOptions } from './config';
+
+      export const options = {
+        ...defaultOptions,
+      };
+
+      export default async function () {}
+    `;
+
+    expect(runValidation(script)).toEqual([expect.objectContaining({ message: UNRESOLVABLE_SPREAD_MESSAGE })]);
+  });
+
+  it('passes when an unresolvable spread is present but the browser options are explicitly defined', () => {
+    const script = `
+      import { browser } from 'k6/browser';
+      import { defaultOptions } from './config';
+
+      export const options = {
+        ...defaultOptions,
+        scenarios: {
+          ui: {
+            executor: 'shared-iterations',
+            options: {
+              browser: {
+                type: 'chromium',
+              },
+            },
+          },
+        },
+      };
+
+      export default async function () {}
+    `;
+
+    expect(runValidation(script)).toEqual([]);
+  });
+
+  it('errors when the browser type is not chromium', () => {
+    const script = VALID_BROWSER_SCRIPT.replace(`chromium`, `firefox`);
+
+    expect(runValidation(script)).toEqual([
+      expect.objectContaining({ message: 'Script must set the type to chromium in the browser options.' }),
+    ]);
+  });
+
+  it('errors when the script does not export any options', () => {
+    const script = `
+      import { browser } from 'k6/browser';
+
+      export default async function () {}
+    `;
+
+    expect(runValidation(script)).toEqual([
+      expect.objectContaining({ message: 'Script does not export any options.' }),
+    ]);
+  });
+
+  it('errors when a scenario defines a duration', () => {
+    const script = VALID_BROWSER_SCRIPT.replace(
+      `executor: 'shared-iterations',`,
+      `executor: 'shared-iterations', duration: '1m',`
+    );
+
+    expect(runValidation(script)).toEqual([
+      expect.objectContaining({ message: "Script can't define a duration value for this check" }),
+    ]);
+  });
+
+  it('errors when a scenario defines vus > 1', () => {
+    const script = VALID_BROWSER_SCRIPT.replace(
+      `executor: 'shared-iterations',`,
+      `executor: 'shared-iterations', vus: 2,`
+    );
+
+    expect(runValidation(script)).toEqual([
+      expect.objectContaining({ message: "Script can't define vus > 1 for this check" }),
+    ]);
+  });
+
+  it('errors when a scenario defines iterations > 1', () => {
+    const script = VALID_BROWSER_SCRIPT.replace(
+      `executor: 'shared-iterations',`,
+      `executor: 'shared-iterations', iterations: 2,`
+    );
+
+    expect(runValidation(script)).toEqual([
+      expect.objectContaining({ message: "Script can't define iterations > 1 for this check" }),
+    ]);
+  });
+
+  it(`errors when the script does not import { browser } from 'k6/browser'`, () => {
+    const script = `
+      export const options = {
+        scenarios: {
+          ui: {
+            executor: 'shared-iterations',
+            options: {
+              browser: {
+                type: 'chromium',
+              },
+            },
+          },
+        },
+      };
+
+      export default async function () {}
+    `;
+
+    expect(runValidation(script)).toEqual([
+      expect.objectContaining({ message: "Script must import { browser } from 'k6/browser'" }),
+    ]);
+  });
+});

--- a/src/schemas/forms/script/validation.ts
+++ b/src/schemas/forms/script/validation.ts
@@ -1,9 +1,19 @@
 import { RefinementCtx } from 'zod';
 
-import { extractImportStatement, extractOptionsExport, getProperty, parseScript } from './parser';
+import {
+  collectObjectDeclarations,
+  containsUnresolvableSpread,
+  extractImportStatement,
+  extractOptionsExport,
+  getProperty,
+  parseScript,
+} from './parser';
 import { K6_EXTENSION_MESSAGE, K6_PRAGMA_MESSAGE, validateK6Restrictions } from './rules';
 
 const MAX_SCRIPT_IN_KB = 128;
+
+export const UNRESOLVABLE_SPREAD_MESSAGE =
+  'Script options contain a spread that can not be verified. Define the browser options inline, e.g. options: { browser: { type: "chromium" } }.';
 
 function validateScriptPragmasAndExtensions(script: string, context: RefinementCtx): void {
   const validation = validateK6Restrictions(script, parseScript);
@@ -57,15 +67,27 @@ export function validateBrowserScript(script: string, context: RefinementCtx) {
     });
   }
 
-  const hasChromium = getProperty(options, ['options', 'browser', 'type']) === 'chromium';
+  // spreads of locally declared objects (e.g. `{ ...defaultOptions }`) are resolved so their
+  // properties are validated too
+  const declarations = collectObjectDeclarations(program);
+  const hasChromium = getProperty(options, ['options', 'browser', 'type'], declarations) === 'chromium';
   if (!hasChromium) {
+    // spreads we can't resolve statically (e.g. imported values) hide the browser options
+    // from analysis, so explain why the requirement can't be verified
+    if (containsUnresolvableSpread(options, declarations)) {
+      return context.addIssue({
+        code: 'custom',
+        message: UNRESOLVABLE_SPREAD_MESSAGE,
+      });
+    }
+
     return context.addIssue({
       code: 'custom',
       message: 'Script must set the type to chromium in the browser options.',
     });
   }
 
-  const hasInvalidDuration = getProperty(options, ['duration']) !== undefined;
+  const hasInvalidDuration = getProperty(options, ['duration'], declarations) !== undefined;
   if (hasInvalidDuration) {
     return context.addIssue({
       code: 'custom',
@@ -73,16 +95,16 @@ export function validateBrowserScript(script: string, context: RefinementCtx) {
     });
   }
 
-  const vus = getProperty(options, ['vus']);
-  const hasInvaludVus = vus !== undefined && vus !== 1;
-  if (hasInvaludVus) {
+  const vus = getProperty(options, ['vus'], declarations);
+  const hasInvalidVus = vus !== undefined && vus !== 1;
+  if (hasInvalidVus) {
     return context.addIssue({
       code: 'custom',
       message: "Script can't define vus > 1 for this check",
     });
   }
 
-  const iterations = getProperty(options, ['iterations']);
+  const iterations = getProperty(options, ['iterations'], declarations);
   const hasInvalidIterations = iterations !== undefined && iterations !== 1;
   if (hasInvalidIterations) {
     return context.addIssue({


### PR DESCRIPTION
## Problem

Browser check scripts that build their exported `options` with a spread operator (e.g. `export const options = { ...defaultOptions }`) crash the check form with an uncaught `TypeError: Cannot read properties of undefined (reading 'type')`. The error is thrown on every validation pass, which makes it impossible to update or save the check.

The crash happens because the static script analysis assumes every entry in an object literal is a regular property, but spread elements have no `key` node.

## Solution

The script parser is now spread-aware:

- Spreads of objects declared in the same script are resolved, so their contents are validated exactly as if they were written inline — including the required chromium browser type and the `duration`/`vus`/`iterations` restrictions. Later properties correctly override earlier spreads, matching JavaScript semantics.
- Spreads that can't be statically resolved (e.g. computed values) fail validation with a clear message asking the user to define the browser options inline, instead of throwing.
- Circular references between spread objects are guarded against, so they can't hang or crash the form either.

## Testing

Added a unit test suite for `validateBrowserScript` covering all validation paths: valid scripts, resolved spreads (passing and failing), spread override semantics, unresolvable spreads, and the pre-existing rules (chromium type, duration, vus, iterations, browser import).

**Before**


https://github.com/user-attachments/assets/ae99ccbf-e56b-44cd-aa89-bbe4dbcb82b6



**After**

https://github.com/user-attachments/assets/6f45c9f1-d602-4349-bc90-0d97778586a3


