### PR TITLE
fix: use prerelease-inclusive semver range for grafanaDependency

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -283,7 +283,7 @@
     }
   ],
   "dependencies": {
-    "grafanaDependency": ">=12.4.0"
+    "grafanaDependency": ">=12.4.0-0"
   },
   "languages": ["en-US", "es-ES"]
 }


### PR DESCRIPTION
## Problem

Every publish to the dev catalog has been failing since June 11, when the Grafana plugin catalog API began enforcing that Grafana-owned plugins declare prerelease-inclusive version ranges. Our `grafanaDependency` of `>=12.4.0` does not match prerelease Grafana builds (e.g. `12.5.0-pre`) under semver rules, so the publish step on every merge to main is rejected with:

> Grafana-owned plugins must use prerelease-inclusive semver ranges. Change ">=12.4.0" to ">=12.4.0-0" in grafanaDependency to include prerelease versions.

This means no new versions of the plugin are reaching the dev catalog, and Grafana dev/ops environments (which run prerelease Grafana builds) would consider the plugin incompatible.

## Solution

Update `grafanaDependency` in `src/plugin.json` from `>=12.4.0` to `>=12.4.0-0`. The `-0` suffix is the lowest possible prerelease identifier, so the range matches `12.4.0` and everything after it, including prereleases of later versions. This satisfies the new catalog validation and unblocks publishing to the dev catalog.

## Notes

This is a metadata-only change with no runtime behaviour to test, so no tests are included.