### PR TITLE
fix: detect logs retention period from Loki instead of hardcoding it

### DIFF
--- a/src/data/useLogsRetention.test.ts
+++ b/src/data/useLogsRetention.test.ts
@@ -1,0 +1,114 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { apiRoute } from 'test/handlers';
+import { createWrapper } from 'test/render';
+import { server } from 'test/server';
+
+import { Result } from 'test/handlers/types';
+
+import {
+  parseGoDuration,
+  parseMaxQueryLookback,
+  REF_ID_LOGS_RETENTION_CANARY,
+  useLogsRetentionPeriod,
+} from './useLogsRetention';
+
+const MILLISECONDS_IN_HOUR = 60 * 60 * 1000;
+const STANDARD_RETENTION_PERIOD = 31 * 24 * MILLISECONDS_IN_HOUR;
+const NINETY_DAYS_IN_HOURS = 2160;
+
+const MAX_QUERY_LOOKBACK_ERROR_MESSAGE = `this data is no longer available, it is past now - max_query_lookback (${NINETY_DAYS_IN_HOURS}h0m0s)`;
+
+function mockCanaryQuery(result: Result<unknown>) {
+  server.use(
+    apiRoute(`getHttpDashboard`, {
+      result: () => result,
+    })
+  );
+}
+
+describe(`useLogsRetentionPeriod`, () => {
+  it(`returns the retention period parsed from Loki's max_query_lookback error`, async () => {
+    mockCanaryQuery({
+      status: 400,
+      json: {
+        results: {
+          [REF_ID_LOGS_RETENTION_CANARY]: {
+            error: MAX_QUERY_LOOKBACK_ERROR_MESSAGE,
+            status: 400,
+          },
+        },
+      },
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useLogsRetentionPeriod(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.retentionPeriod).toBe(NINETY_DAYS_IN_HOURS * MILLISECONDS_IN_HOUR);
+  });
+
+  it(`returns null when no lookback limit is enforced (query succeeds)`, async () => {
+    mockCanaryQuery({
+      json: {
+        results: {
+          [REF_ID_LOGS_RETENTION_CANARY]: {
+            frames: [],
+          },
+        },
+      },
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useLogsRetentionPeriod(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.retentionPeriod).toBe(null);
+  });
+
+  it(`falls back to the standard retention period when the canary query fails unexpectedly`, async () => {
+    mockCanaryQuery({
+      status: 500,
+      json: {
+        message: `something went wrong`,
+      },
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useLogsRetentionPeriod(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.retentionPeriod).toBe(STANDARD_RETENTION_PERIOD);
+  });
+});
+
+describe(`parseMaxQueryLookback`, () => {
+  it(`extracts the duration from the error message`, () => {
+    expect(parseMaxQueryLookback(MAX_QUERY_LOOKBACK_ERROR_MESSAGE)).toBe(NINETY_DAYS_IN_HOURS * MILLISECONDS_IN_HOUR);
+  });
+
+  it(`returns null when the message doesn't contain a lookback limit`, () => {
+    expect(parseMaxQueryLookback(`some other error`)).toBe(null);
+  });
+
+  it(`returns null when the duration can't be parsed`, () => {
+    expect(parseMaxQueryLookback(`it is past now - max_query_lookback (not a duration)`)).toBe(null);
+  });
+});
+
+describe(`parseGoDuration`, () => {
+  it.each([
+    [`2160h`, 2160 * MILLISECONDS_IN_HOUR],
+    [`744h0m0s`, 744 * MILLISECONDS_IN_HOUR],
+    [`1.5h`, 1.5 * MILLISECONDS_IN_HOUR],
+    [`30m`, 30 * 60 * 1000],
+    [`90s`, 90 * 1000],
+    [`500ms`, 500],
+    [`1h30m`, 1.5 * MILLISECONDS_IN_HOUR],
+  ])(`parses %s`, (duration, expected) => {
+    expect(parseGoDuration(duration)).toBe(expected);
+  });
+
+  it(`returns null for unparseable input`, () => {
+    expect(parseGoDuration(`nonsense`)).toBe(null);
+  });
+});

--- a/src/data/useLogsRetention.ts
+++ b/src/data/useLogsRetention.ts
@@ -1,22 +1,148 @@
+import { useQuery } from '@tanstack/react-query';
 import { config } from '@grafana/runtime';
+import { queryLoki } from 'features/queryDatasources/queryLoki';
 
-import { UnixTimestamp } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
+import { useLogsDS } from 'hooks/useLogsDS';
+
+export const REF_ID_LOGS_RETENTION_CANARY = 'logsRetentionCanary';
 
 const FREE_TRIAL_RETENTION_DAYS = 14;
 const STANDARD_RETENTION_DAYS = 31;
 
-// todo: this is a temporary solution to get the logs retention period.
-// really we should get this from gcom or another endpoint
-// some clients will have custom retention periods which makes this unreliable
-export function useLogsRetentionPeriod(from: UnixTimestamp) {
+const MILLISECONDS_IN_DAY = 24 * 60 * 60 * 1000;
+
+// the canary query needs to target a window older than any retention period we could realistically
+// encounter so that Loki is guaranteed to reject it when a lookback limit is enforced
+const CANARY_END_OFFSET = 10 * 365 * MILLISECONDS_IN_DAY;
+const CANARY_WINDOW = 60 * 1000;
+
+// https://grafana.com/docs/loki/latest/query/troubleshoot-query/#error-data-is-no-longer-available
+export const MAX_QUERY_LOOKBACK_ERROR = 'it is past now - max_query_lookback';
+
+export type LogsRetention =
+  | { type: 'known'; periodMs: number }
+  // no lookback limit is enforced for the tenant so we can't infer retention from Loki.
+  // Consumers should query the requested range and let the returned data speak for itself.
+  | { type: 'unknown' };
+
+interface UseLogsRetentionPeriodResult {
+  isLoading: boolean;
+  // null when retention couldn't be determined and no clamping should be applied
+  retentionPeriod: number | null;
+}
+
+// There is no endpoint available to plugins which exposes a tenant's logs retention period
+// (it lives in gcom). Instead we send a "canary" query to the Loki datasource that is deliberately
+// far outside any plausible retention period: Loki rejects queries that fall entirely outside
+// `max_query_lookback` with an error message containing the configured limit, which Grafana Cloud
+// keeps in step with the tenant's retention period. The rejection is the answer we're after --
+// the query never returns any data.
+export function useLogsRetentionPeriod(): UseLogsRetentionPeriodResult {
+  const logsDS = useLogsDS();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['logsRetention', logsDS?.uid],
+    queryFn: () => fetchLogsRetentionFromLoki({ uid: logsDS!.uid, type: logsDS!.type }),
+    enabled: Boolean(logsDS),
+    staleTime: Infinity,
+    gcTime: Infinity,
+    retry: false,
+  });
+
+  if (!data) {
+    // while the canary query is in flight (or if it failed unexpectedly) fall back to the assumed values
+    return { retentionPeriod: getFallbackRetentionPeriod(), isLoading };
+  }
+
+  return {
+    retentionPeriod: data.type === 'known' ? data.periodMs : null,
+    isLoading: false,
+  };
+}
+
+export function getFallbackRetentionPeriod() {
   // @ts-expect-error - Cloud Free is not defined in the config but it is what is present for Free trial accounts and free tier accounts
   const isFree = config.buildInfo.edition === `Cloud Free`;
   const days = isFree ? FREE_TRIAL_RETENTION_DAYS : STANDARD_RETENTION_DAYS;
 
-  const HOURS_IN_DAY = 24;
-  const MINUTES_IN_HOUR = 60;
-  const SECONDS_IN_MINUTE = 60;
-  const MILLISECONDS_IN_SECOND = 1000;
+  return days * MILLISECONDS_IN_DAY;
+}
 
-  return days * HOURS_IN_DAY * MINUTES_IN_HOUR * SECONDS_IN_MINUTE * MILLISECONDS_IN_SECOND;
+async function fetchLogsRetentionFromLoki(datasource: { uid: string; type: string }): Promise<LogsRetention> {
+  const end = Date.now() - CANARY_END_OFFSET;
+
+  try {
+    // the selector just needs to be syntactically valid -- the query frontend rejects
+    // the query based on its time range before any log data is read
+    await queryLoki({
+      datasource,
+      query: `{job=~".+"}`,
+      start: end - CANARY_WINDOW,
+      end,
+      refId: REF_ID_LOGS_RETENTION_CANARY,
+    });
+  } catch (error) {
+    const message = extractErrorMessage(error);
+
+    if (message.includes(MAX_QUERY_LOOKBACK_ERROR)) {
+      const periodMs = parseMaxQueryLookback(message);
+
+      if (periodMs !== null) {
+        return { type: 'known', periodMs };
+      }
+    }
+
+    throw error;
+  }
+
+  return { type: 'unknown' };
+}
+
+// errors from /api/ds/query can surface the Loki error in the top-level message
+// or nested in the per-refId results
+export function extractErrorMessage(error: unknown): string {
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (!error || typeof error !== 'object') {
+    return '';
+  }
+
+  const { message, data } = error as {
+    message?: string;
+    data?: { message?: string; results?: Record<string, { error?: string }> };
+  };
+  const resultErrors = Object.values(data?.results ?? {}).map((result) => result?.error);
+
+  return [message, data?.message, ...resultErrors].filter(Boolean).join('\n');
+}
+
+// e.g. "this data is no longer available, it is past now - max_query_lookback (2160h)"
+export function parseMaxQueryLookback(message: string): number | null {
+  const match = message.match(/max_query_lookback \(([^)]+)\)/);
+
+  if (!match) {
+    return null;
+  }
+
+  return parseGoDuration(match[1]);
+}
+
+const UNIT_TO_MS: Record<string, number> = {
+  h: 60 * 60 * 1000,
+  m: 60 * 1000,
+  s: 1000,
+  ms: 1,
+};
+
+// Loki reports the lookback limit in Go's duration format, e.g. "744h" or "2160h0m0s"
+export function parseGoDuration(duration: string): number | null {
+  const matches = [...duration.matchAll(/(\d+(?:\.\d+)?)(ms|h|m|s)/g)];
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  return matches.reduce((total, [, value, unit]) => total + Number(value) * UNIT_TO_MS[unit], 0);
 }

--- a/src/scenes/components/TimepointExplorer/TimepointExplorer.context.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointExplorer.context.tsx
@@ -114,9 +114,14 @@ export const TimepointExplorerProvider = ({ children, check }: TimepointExplorer
   const checkCreation = Math.ceil(check.created!) * 1000;
   const [timeRange] = useTimeRange();
   const timeRangeRef = useRef<TimeRange>(timeRange);
-  const logsRetentionPeriod = useLogsRetentionPeriod(timeRange.from.valueOf());
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- update date.now when timerange changes
-  const logsRetentionFrom = useMemo(() => Date.now() - logsRetentionPeriod, [logsRetentionPeriod, timeRange]);
+  const { retentionPeriod: logsRetentionPeriod, isLoading: isLogsRetentionLoading } = useLogsRetentionPeriod();
+  const logsRetentionFrom = useMemo(
+    // a null retention period means it couldn't be determined, so we don't clamp the time range
+    // and let Loki return whatever data it still has
+    () => (logsRetentionPeriod === null ? 0 : Date.now() - logsRetentionPeriod),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- update date.now when timerange changes
+    [logsRetentionPeriod, timeRange]
+  );
   const explorerTimeFrom = getExplorerTimeFrom({
     checkCreation,
     logsRetentionFrom,
@@ -223,7 +228,8 @@ export const TimepointExplorerProvider = ({ children, check }: TimepointExplorer
     timeRange: miniMapCurrentPageTimeRange,
   });
 
-  const isLoading = isCheckConfigsLoading || isExecutionDurationLogsLoading || isMaxProbeDurationLoading;
+  const isLoading =
+    isLogsRetentionLoading || isCheckConfigsLoading || isExecutionDurationLogsLoading || isMaxProbeDurationLoading;
   const isFetching = isCheckConfigsFetching || isExecutionDurationLogsFetching || isMaxProbeDurationFetching;
   const isError = isCheckConfigsError || isExecutionDurationLogsError || isMaxProbeDurationError;
 


### PR DESCRIPTION
Addresses: https://github.com/grafana/synthetic-monitoring-app/issues/1588

## Problem

The Timepoint Explorer assumed every org has a logs retention period of 31 days (14 for free tier). For orgs with custom retention policies (> 31 days), the explorer refused to display anything older than 31 days and rendered an "Out of retention period" annotation instead — even though Loki returns the data when queried. There is no endpoint available to plugins which exposes a tenant's actual retention period (it lives in gcom), which is why the values were hardcoded.

## Solution

Instead of hardcoding the retention period, we now infer it from Loki itself. On mount the explorer sends a single "canary" query to the logs datasource with a time range that is deliberately far outside any plausible retention period (a 1-minute window 10 years in the past, cached for the session):

- **Loki rejects the query** with `this data is no longer available, it is past now - max_query_lookback (2160h)` — we parse the configured limit from the error message and use it as the retention period. Grafana Cloud keeps `max_query_lookback` in step with the tenant's retention, so custom retention orgs now get an accurate boundary. The rejection is deterministic when the whole range is out of bounds ([Loki docs](https://grafana.com/docs/loki/latest/query/troubleshoot-query/#error-data-is-no-longer-available)).
- **The query succeeds** (no lookback limit enforced for the tenant) — the explorer applies no clamping at all: it queries the full requested time range, renders whatever data Loki returns, and shows "No data" for the rest.
- **Anything else fails** — we fall back to the previous hardcoded values, so behaviour is never worse than before.

This is the same `max_query_lookback` error message the assertions table already parses for its "beyond retention" warning.

## Trade-offs and notes for reviewers

- On tenants where `max_query_lookback` is not enforced, the explorer can no longer distinguish "out of retention" from "no data" — old empty ranges show the "No data" annotation rather than "Out of retention period". This is the agreed fallback from the issue discussion.
- The canary query runs once per session and is cheap: it never returns data, as it is rejected by the query frontend before touching storage.

## Testing

- Unit tests cover the three canary outcomes (parsed limit, no limit enforced, unexpected failure) plus the error-message and Go-duration parsing.
- Verified manually against a real stack without `max_query_lookback` enforcement: a 90-day range now renders timepoints across the full range with "No data" where logs no longer exist, instead of cutting off at 31 days.
- Not yet verified against a tenant that both enforces `max_query_lookback` and has custom retention (the scenario from the original escalation) — reviewer with access to such a stack welcome.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Timepoint Explorer bounds log queries and retention UX (including no clamp when lookback is not enforced); failures fall back to prior hardcoded limits.
> 
> **Overview**
> Replaces **hardcoded** 14/31-day logs retention with a **session-cached Loki canary query** that probes `max_query_lookback`, so Timepoint Explorer can honor **custom retention** instead of falsely marking older data as out of retention.
> 
> `useLogsRetentionPeriod` no longer takes a time-range argument; it returns `{ retentionPeriod, isLoading }`. When Loki rejects the canary with the documented lookback error, the limit is parsed from Go duration strings; when the query succeeds, `retentionPeriod` is **null** and the explorer **does not clamp** the range. Unexpected failures still use the previous free/standard day fallbacks while loading or on error.
> 
> Timepoint Explorer waits on retention loading, treats **null** retention as “no clamp” (`logsRetentionFrom` → 0), and adds unit tests for the three canary outcomes plus parsing helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bbb062c17821308377de136f7492f1fe63c59c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->