### PR TITLE
fix: address folder view UI feedback

### DIFF
--- a/src/hooks/useChecksByFolder.ts
+++ b/src/hooks/useChecksByFolder.ts
@@ -63,7 +63,8 @@ export function collectAllChecks(node: FolderNode): Check[] {
 export function buildChecksByFolder(
   checks: Check[],
   folders: GrafanaFolder[],
-  defaultFolderUid?: string
+  defaultFolderUid?: string,
+  reverseFolderSort?: boolean
 ): ChecksByFolder {
   const foldersById = new Map(folders.map((f) => [f.uid, f]));
   const nodeMap = new Map<string, FolderNode>();
@@ -127,7 +128,8 @@ export function buildChecksByFolder(
   const sortByTitle = (a: FolderNode, b: FolderNode) => {
     const titleA = a.folder?.title ?? a.folderUid;
     const titleB = b.folder?.title ?? b.folderUid;
-    return titleA.localeCompare(titleB);
+    const result = titleA.localeCompare(titleB);
+    return reverseFolderSort ? -result : result;
   };
 
   const sortNodes = (nodes: FolderNode[]) => {

--- a/src/locales/en-US/grafana-synthetic-monitoring-app.json
+++ b/src/locales/en-US/grafana-synthetic-monitoring-app.json
@@ -29,7 +29,7 @@
       "deselectAll": "Deselect all",
       "selectAll": "Select all",
       "selectAllAriaLabel": "Select all",
-      "setThresholds": "Set Thresholds",
+      "setThresholds": "Set thresholds",
       "sortOptions": {
         "ascExecutions": "Asc. Executions",
         "ascReachability": "Asc. Reachability",

--- a/src/page/CheckList/CheckList.folderView.test.tsx
+++ b/src/page/CheckList/CheckList.folderView.test.tsx
@@ -131,6 +131,24 @@ describe('buildChecksByFolder', () => {
     expect(titles).toEqual(sorted);
   });
 
+  test('reverses folder sort order when reverseFolderSort is true', () => {
+    const { folderTree: aToZ } = buildChecksByFolder([CHECK_IN_PRODUCTION], MOCK_FOLDERS, DEFAULT_FOLDER.uid, false);
+    const { folderTree: zToA } = buildChecksByFolder([CHECK_IN_PRODUCTION], MOCK_FOLDERS, DEFAULT_FOLDER.uid, true);
+
+    const titlesAZ = aToZ.map((n) => n.folder?.title ?? n.folderUid);
+    const titlesZA = zToA.map((n) => n.folder?.title ?? n.folderUid);
+
+    const nonEmptyAZ = aToZ.filter((n) => n.checks.length > 0).map((n) => n.folder?.title);
+    const nonEmptyZA = zToA.filter((n) => n.checks.length > 0).map((n) => n.folder?.title);
+    expect(nonEmptyZA).toEqual([...nonEmptyAZ].reverse());
+
+    const emptyAZ = aToZ.filter((n) => n.checks.length === 0).map((n) => n.folder?.title);
+    const emptyZA = zToA.filter((n) => n.checks.length === 0).map((n) => n.folder?.title);
+    expect(emptyZA).toEqual([...emptyAZ].reverse());
+
+    expect(titlesZA).not.toEqual(titlesAZ);
+  });
+
   test('returns orphaned nodes when folders list is empty', () => {
     const { folderTree, rootChecks } = buildChecksByFolder(FOLDER_CHECKS, []);
 

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -298,6 +298,7 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
           onSelectChecks={handleSelectChecks}
           onDeselectChecks={handleDeselectChecks}
           selectedCheckIds={selectedCheckIds}
+          sortType={sortType}
         />
       ) : (
         <div>

--- a/src/page/CheckList/components/BulkActions.tsx
+++ b/src/page/CheckList/components/BulkActions.tsx
@@ -45,6 +45,7 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
       <div className={styles.buttonGroup}>
         {checks.length > 0 && (
           <ButtonCascader
+            variant="secondary"
             options={[
               {
                 label: 'Add probes',
@@ -61,7 +62,7 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
               setBulkEditAction(action);
             }}
           >
-            Bulk Edit Probes
+            Bulk edit probes
           </ButtonCascader>
         )}
         {isFoldersEnabled && (
@@ -78,7 +79,7 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
         )}
         <Button
           type="button"
-          variant="primary"
+          variant="secondary"
           fill="text"
           onClick={enableChecks}
           disabled={!canWriteAll}

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -4,7 +4,7 @@ import { Button, Checkbox, ConfirmModal, Icon, IconButton, Pagination, Spinner, 
 import { css } from '@emotion/css';
 
 import { CheckListViewType } from 'page/CheckList/CheckList.types';
-import { Check, CheckType, GrafanaFolder, Label } from 'types';
+import { Check, CheckSort, CheckType, GrafanaFolder, Label } from 'types';
 import { useCheckFolderStatus } from 'contexts/CheckFolderAccessContext';
 import { CheckRuntimeAlertStates, getCheckRuntimeAlertState } from 'data/useCheckAlertStates';
 import { useDeleteFolder } from 'data/useFolders';
@@ -31,6 +31,7 @@ interface CheckListFolderViewProps {
   onSelectChecks: (checkIds: number[]) => void;
   onDeselectChecks: (checkIds: number[]) => void;
   selectedCheckIds: Set<number>;
+  sortType: CheckSort;
 }
 
 export function CheckListFolderView({
@@ -50,20 +51,22 @@ export function CheckListFolderView({
   onSelectChecks,
   onDeselectChecks,
   selectedCheckIds,
+  sortType,
 }: CheckListFolderViewProps) {
   const styles = useStyles2(getStyles);
+  const reverseFolderSort = sortType === CheckSort.ZToA;
   const { folderTree, rootChecks } = useMemo(
-    () => buildChecksByFolder(checks, folders, defaultFolderUid),
-    [checks, folders, defaultFolderUid]
+    () => buildChecksByFolder(checks, folders, defaultFolderUid, reverseFolderSort),
+    [checks, folders, defaultFolderUid, reverseFolderSort]
   );
 
   const defaultFolderNode: FolderNode | null = useMemo(() => {
-    if (rootChecks.length === 0) {
+    if (!defaultFolderUid) {
       return null;
     }
-    const folder = defaultFolderUid ? foldersMap.get(defaultFolderUid) : undefined;
+    const folder = foldersMap.get(defaultFolderUid);
     return {
-      folderUid: defaultFolderUid ?? '__default__',
+      folderUid: defaultFolderUid,
       folder: folder ? { ...folder, title: `${folder.title} (default)` } : undefined,
       folderPath: folder?.title ?? 'Default folder',
       checks: rootChecks,

--- a/src/page/CheckList/components/CheckListHeader.tsx
+++ b/src/page/CheckList/components/CheckListHeader.tsx
@@ -119,7 +119,7 @@ export const CheckListHeader = ({
             />
             {canWriteThresholds && (
               <Button variant="secondary" fill="outline" onClick={() => setShowThresholdModal((v) => !v)}>
-                <Trans i18nKey="checkList.header.setThresholds">Set Thresholds</Trans>
+                <Trans i18nKey="checkList.header.setThresholds">Set thresholds</Trans>
               </Button>
             )}
             {canWriteChecks && (


### PR DESCRIPTION
## Summary
- Normalize button casing to sentence case ("Bulk edit probes", "Set thresholds") for consistency with the rest of the UI
- Change "Bulk edit probes" cascader from primary (blue) to secondary variant, and demote the Enable button from primary to secondary so no single bulk action is visually prioritized
- Always show the default "Grafana Synthetic Monitoring (default)" folder in folder view, even when it has 0 checks, for a more consistent experience
- Wire the A-Z / Z-A sort toggle to folder ordering so switching between them visibly reorders folders (previously only affected check order within folders)

Addresses feedback from https://docs.google.com/document/d/19MkPT09vozOgjI5ISv6GhyCWHYpuZKomTn7-9RAJ6Ks/edit?tab=t.0

<img width="2227" height="331" alt="image" src="https://github.com/user-attachments/assets/ec9ebd0c-8ea7-4429-b067-3e1301f47adf" />

https://github.com/user-attachments/assets/6e81bc59-e4d6-42ee-a242-6cb6d8d321df




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to check-list folder view sorting, default-folder display, and button styling/copy, with unit test coverage for reversed folder sort.
> 
> **Overview**
> **Folder view behavior** now follows the header **A–Z / Z–A** sort for **folder title ordering** (via a new `reverseFolderSort` flag on `buildChecksByFolder`), while keeping the existing rule that folders with checks appear before empty ones. The **default Synthetic Monitoring folder** is always rendered when a default folder UID exists, including when it has **zero** checks (previously it could be omitted when there were no root checks).
> 
> **Check list UI** updates normalize copy to **sentence case** (“Bulk edit probes”, “Set thresholds”) and adjust bulk actions so **Bulk edit probes** and **Enable** use **secondary** styling instead of primary, avoiding a single highlighted bulk action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933d9b6bd7c5ddd35bb0147353f002aee7574e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->