### PR TITLE
fix: distinguish multiple notification policy trees in routing preview

### DIFF
--- a/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
@@ -44,11 +44,17 @@ const AlertRoutingPreviewContent: React.FC<AlertRoutingPreviewProps> = ({ alertT
     if (isLoading || isError || !routingTreeData?.items) {
       return [];
     }
-    // Reflect what the backend actually routes: match against every routing tree
-    // the API returns. The backend already filters trees based on the
-    // alertingMultiplePolicies feature, so the preview mirrors real delivery.
+    // SM alert rules are created without notification settings (see sm-api), so
+    // they carry no `__grafana_managed_route__` label and are always routed
+    // through the default (user-defined) tree — never through additional policy
+    // trees. Match only the default tree so the preview reflects real delivery
+    // instead of showing routes in trees the alert will never reach.
+    const defaultTree = getDefaultRoutingTree(routingTreeData.items);
+    if (!defaultTree) {
+      return [];
+    }
     try {
-      return matchInstancesToRouteTrees(routingTreeData.items, [convertLabelsToLabelPairs(alertLabels)]);
+      return matchInstancesToRouteTrees([defaultTree], [convertLabelsToLabelPairs(alertLabels)]);
     } catch (error) {
       return [];
     }

--- a/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useFormContext } from 'react-hook-form';
-import { useMatchInstancesToRouteTrees } from '@grafana/alerting';
+import { matchInstancesToRouteTrees, useMatchInstancesToRouteTrees } from '@grafana/alerting';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Icon, LoadingPlaceholder, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -15,6 +15,7 @@ import {
   encodeReceiverForUrl,
   extractMatchersFromRoutes,
   generateAlertLabels,
+  getDefaultRoutingTree,
 } from './alertRoutingUtils';
 import { RouteTreeDisplay } from './RouteTreeDisplay';
 
@@ -37,23 +38,21 @@ const AlertRoutingPreviewContent: React.FC<AlertRoutingPreviewProps> = ({ alertT
     return generateAlertLabels(alertType, { checkType, frequency, customLabels, job, instance });
   }, [alertType, checkType, frequency, customLabels, job, instance]);
 
-  const {
-    matchInstancesToRouteTrees,
-    isLoading,
-    isError,
-    currentData: routingTreeData,
-  } = useMatchInstancesToRouteTrees();
+  const { isLoading, isError, currentData: routingTreeData } = useMatchInstancesToRouteTrees();
 
   const routeMatches = useMemo(() => {
-    if (!matchInstancesToRouteTrees || isLoading || isError) {
+    if (isLoading || isError || !routingTreeData?.items) {
       return [];
     }
+    // Reflect what the backend actually routes: match against every routing tree
+    // the API returns. The backend already filters trees based on the
+    // alertingMultiplePolicies feature, so the preview mirrors real delivery.
     try {
-      return matchInstancesToRouteTrees([convertLabelsToLabelPairs(alertLabels)]);
+      return matchInstancesToRouteTrees(routingTreeData.items, [convertLabelsToLabelPairs(alertLabels)]);
     } catch (error) {
       return [];
     }
-  }, [matchInstancesToRouteTrees, isLoading, isError, alertLabels]);
+  }, [isLoading, isError, routingTreeData, alertLabels]);
 
   const highlightMatchers = useMemo(() => {
     return extractMatchersFromRoutes(routeMatches);
@@ -64,8 +63,7 @@ const AlertRoutingPreviewContent: React.FC<AlertRoutingPreviewProps> = ({ alertT
       return null;
     }
 
-    // Find the default routing tree (usually the first one)
-    const defaultTree = routingTreeData.items[0];
+    const defaultTree = getDefaultRoutingTree(routingTreeData.items);
     if (!defaultTree?.spec?.defaults) {
       return null;
     }

--- a/src/components/CheckForm/AlertsPerCheck/RouteTreeDisplay.test.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/RouteTreeDisplay.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-import { MOCK_HTTP_DURATION_ROUTE_MATCH, MOCK_PROBE_FAILED_ROUTE_MATCH } from '../../../test/fixtures/alerting';
+import {
+  MOCK_HTTP_DURATION_ROUTE_MATCH,
+  MOCK_MULTI_TREE_ROUTE_MATCH,
+  MOCK_PROBE_FAILED_ROUTE_MATCH,
+} from '../../../test/fixtures/alerting';
 import { RouteTreeDisplay } from './RouteTreeDisplay';
 
 describe('RouteTreeDisplay', () => {
@@ -78,6 +82,28 @@ describe('RouteTreeDisplay', () => {
       // Should not show any stop icons since all policies have continue=true
       const stopIcons = screen.queryAllByText('⏹️');
       expect(stopIcons.length).toBe(0);
+    });
+  });
+
+  describe('Multiple notification policy trees', () => {
+    it('labels each tree root with its tree name and only the default tree as "Default policy"', () => {
+      render(<RouteTreeDisplay routeMatch={MOCK_MULTI_TREE_ROUTE_MATCH} />);
+
+      // The default ("user-defined") tree root is still shown as "Default policy"
+      expect(screen.getByText('Default policy')).toBeInTheDocument();
+
+      // Named trees show their own name at the root rather than "Default policy"
+      expect(screen.getByText('hashicorp-vault')).toBeInTheDocument();
+      expect(screen.getByText('pam-incident-alert')).toBeInTheDocument();
+
+      // Only the pam-incident-alert tree matches a child route with a contact point
+      expect(screen.getByText('label_Environment=prod')).toBeInTheDocument();
+      expect(screen.getByText('PAM Incident Alert')).toBeInTheDocument();
+
+      // Only one contact point link, since the other two trees match only at
+      // their root with no receiver ("Sent to empty")
+      const contactPointLinks = screen.getAllByRole('link');
+      expect(contactPointLinks.length).toBe(1);
     });
   });
 });

--- a/src/components/CheckForm/AlertsPerCheck/RouteTreeDisplay.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/RouteTreeDisplay.tsx
@@ -22,12 +22,14 @@ export const RouteTreeDisplay: React.FC<RouteTreeDisplayProps> = ({ routeMatch }
       route: Route;
       level: number;
       isEffective: boolean;
+      treeName?: string;
     }> = [];
 
     const processedRouteIds = new Set<string>();
 
     routeMatch.matchedRoutes.forEach((matchedRoute) => {
       const matchingJourney = matchedRoute.matchDetails?.matchingJourney || [];
+      const treeName = matchedRoute.routeTree?.metadata?.name;
       // @ts-ignore
       // Find the effective index (the last route with a receiver, where it will get delivered)
       const effectiveIndex = matchingJourney.findLastIndex((item) => (item.route as Route).receiver);
@@ -44,6 +46,7 @@ export const RouteTreeDisplay: React.FC<RouteTreeDisplayProps> = ({ routeMatch }
             route,
             level: index, // Use journey index as hierarchy level
             isEffective,
+            treeName,
           });
         }
       });
@@ -57,7 +60,7 @@ export const RouteTreeDisplay: React.FC<RouteTreeDisplayProps> = ({ routeMatch }
   return (
     <div className={styles.routeTree}>
       {routesToRender.map((routeInfo, index) => {
-        const { route, level, isEffective } = routeInfo;
+        const { route, level, isEffective, treeName } = routeInfo;
         return (
           <div key={index} style={{ marginLeft: level * 16 }}>
             <RouteNode
@@ -65,6 +68,7 @@ export const RouteTreeDisplay: React.FC<RouteTreeDisplayProps> = ({ routeMatch }
               level={level}
               routingStops={level > 0 && !route.continue}
               isEffective={isEffective}
+              treeName={treeName}
             />
           </div>
         );
@@ -78,11 +82,12 @@ const RouteNode: React.FC<{
   level: number;
   routingStops?: boolean;
   isEffective?: boolean;
-}> = ({ route, level, routingStops, isEffective = false }) => {
+  treeName?: string;
+}> = ({ route, level, routingStops, isEffective = false, treeName }) => {
   const styles = useStyles2(getStyles);
   const hasMatchers = route.matchers && route.matchers.length > 0;
-  const isDefaultPolicy = level === 0 && !hasMatchers;
-  const policyInfo = getPolicyIdentifier(route, isDefaultPolicy);
+  const isRootPolicy = level === 0 && !hasMatchers;
+  const policyInfo = getPolicyIdentifier(route, isRootPolicy, treeName);
 
   return (
     <div className={styles.routeNode} style={{ marginLeft: level * 16 }}>

--- a/src/components/CheckForm/AlertsPerCheck/RouteTreeDisplay.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/RouteTreeDisplay.tsx
@@ -25,6 +25,9 @@ export const RouteTreeDisplay: React.FC<RouteTreeDisplayProps> = ({ routeMatch }
       treeName?: string;
     }> = [];
 
+    // Dedupe is scoped per tree: routes within a tree share root/intermediate
+    // nodes across overlapping journeys, but route ids can repeat across trees,
+    // so a global set would drop nodes (and entire trees) that reuse an id.
     const processedRouteIds = new Set<string>();
 
     routeMatch.matchedRoutes.forEach((matchedRoute) => {
@@ -36,9 +39,10 @@ export const RouteTreeDisplay: React.FC<RouteTreeDisplayProps> = ({ routeMatch }
 
       matchingJourney.forEach((journeyItem, index) => {
         const route = journeyItem.route;
+        const routeKey = `${treeName ?? ''}::${route.id}`;
 
-        if (!processedRouteIds.has(route.id)) {
-          processedRouteIds.add(route.id);
+        if (!processedRouteIds.has(routeKey)) {
+          processedRouteIds.add(routeKey);
 
           const isEffective = index === effectiveIndex;
 

--- a/src/components/CheckForm/AlertsPerCheck/alertRoutingUtils.test.ts
+++ b/src/components/CheckForm/AlertsPerCheck/alertRoutingUtils.test.ts
@@ -1,20 +1,19 @@
 import { USER_DEFINED_TREE_NAME } from '@grafana/alerting';
 
+import { routingTreeFactory } from '../../../test/factories/routingTree';
 import { getDefaultRoutingTree } from './alertRoutingUtils';
 
 describe('getDefaultRoutingTree', () => {
-  const userDefinedTree = { metadata: { name: USER_DEFINED_TREE_NAME } };
-  const namedTreeA = { metadata: { name: 'hashicorp-vault' } };
-  const namedTreeB = { metadata: { name: 'pam-incident-alert' } };
+  const userDefinedTree = routingTreeFactory.build({ metadata: { name: USER_DEFINED_TREE_NAME } });
+  const namedTreeA = routingTreeFactory.build({ metadata: { name: 'hashicorp-vault' } });
+  const namedTreeB = routingTreeFactory.build({ metadata: { name: 'pam-incident-alert' } });
 
   it('returns the user-defined tree regardless of its position in the list', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const trees = [namedTreeA, userDefinedTree, namedTreeB] as any;
+    const trees = [namedTreeA, userDefinedTree, namedTreeB];
     expect(getDefaultRoutingTree(trees)).toBe(userDefinedTree);
   });
 
   it('returns undefined when there is no user-defined tree', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(getDefaultRoutingTree([namedTreeA, namedTreeB] as any)).toBeUndefined();
+    expect(getDefaultRoutingTree([namedTreeA, namedTreeB])).toBeUndefined();
   });
 });

--- a/src/components/CheckForm/AlertsPerCheck/alertRoutingUtils.test.ts
+++ b/src/components/CheckForm/AlertsPerCheck/alertRoutingUtils.test.ts
@@ -1,0 +1,20 @@
+import { USER_DEFINED_TREE_NAME } from '@grafana/alerting';
+
+import { getDefaultRoutingTree } from './alertRoutingUtils';
+
+describe('getDefaultRoutingTree', () => {
+  const userDefinedTree = { metadata: { name: USER_DEFINED_TREE_NAME } };
+  const namedTreeA = { metadata: { name: 'hashicorp-vault' } };
+  const namedTreeB = { metadata: { name: 'pam-incident-alert' } };
+
+  it('returns the user-defined tree regardless of its position in the list', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const trees = [namedTreeA, userDefinedTree, namedTreeB] as any;
+    expect(getDefaultRoutingTree(trees)).toBe(userDefinedTree);
+  });
+
+  it('returns undefined when there is no user-defined tree', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(getDefaultRoutingTree([namedTreeA, namedTreeB] as any)).toBeUndefined();
+  });
+});

--- a/src/components/CheckForm/AlertsPerCheck/alertRoutingUtils.ts
+++ b/src/components/CheckForm/AlertsPerCheck/alertRoutingUtils.ts
@@ -2,8 +2,12 @@ import {
   type InstanceMatchResult,
   type Label as AlertingLabel,
   type LabelMatcher,
+  matchInstancesToRouteTrees,
   type Route,
+  USER_DEFINED_TREE_NAME,
 } from '@grafana/alerting';
+
+type RoutingTree = Parameters<typeof matchInstancesToRouteTrees>[0][number];
 
 import { CheckAlertType, CheckType, Label } from 'types';
 
@@ -71,9 +75,22 @@ export const encodeReceiverForUrl = (receiverName: string): string => {
   return receiverId.replace(/=+$/, '');
 };
 
-export const getPolicyIdentifier = (route: Route, isDefaultPolicy: boolean): PolicyInfo => {
-  if (isDefaultPolicy) {
-    return { text: 'Default policy', type: 'default' };
+/**
+ * Returns the default (user-defined) routing tree from the list. The routing tree
+ * API does not guarantee ordering, so the default tree is matched by name rather
+ * than assuming it is the first item.
+ */
+export const getDefaultRoutingTree = (trees: RoutingTree[]): RoutingTree | undefined => {
+  return trees.find((tree) => tree.metadata?.name === USER_DEFINED_TREE_NAME);
+};
+
+export const getPolicyIdentifier = (route: Route, isRootPolicy: boolean, treeName?: string): PolicyInfo => {
+  if (isRootPolicy) {
+    // Each routing tree has a root policy with no matchers. Only the default
+    // ("user-defined") tree should be shown as "Default policy"; named trees
+    // (available with the alertingMultiplePolicies feature) show their own name.
+    const isDefaultTree = !treeName || treeName === USER_DEFINED_TREE_NAME;
+    return { text: isDefaultTree ? 'Default policy' : treeName, type: 'default' };
   }
 
   const hasMatchers = route.matchers && route.matchers.length > 0;

--- a/src/test/factories/routingTree.ts
+++ b/src/test/factories/routingTree.ts
@@ -1,0 +1,102 @@
+import {
+  type InstanceMatchResult,
+  type Label,
+  type LabelMatcher,
+  matchInstancesToRouteTrees,
+  type RouteMatch,
+  type RouteWithID,
+  USER_DEFINED_TREE_NAME,
+} from '@grafana/alerting';
+import { Factory } from 'fishery';
+
+// The RoutingTree type isn't exported directly from @grafana/alerting, so we
+// derive it from the function that consumes a list of trees.
+type RoutingTree = Parameters<typeof matchInstancesToRouteTrees>[0][number];
+type MatchingJourneyItem = RouteMatch['matchDetails']['matchingJourney'][number];
+
+// The `Route` / `RouteWithID` types come from @grafana/alerting via type-fest's
+// `OverrideProperties`, which doesn't fully resolve in this project. As a result
+// those types collapse to `{ id; routes }` and don't expose the runtime fields
+// (`continue`, `matchers`, `receiver`, ...) the routing preview reads. We model
+// the runtime shape here and perform the single necessary cast inside
+// `buildRouteWithId`, so call sites stay fully typed and cast-free.
+interface RouteInput {
+  id?: string;
+  continue?: boolean;
+  receiver?: string;
+  matchers?: LabelMatcher[];
+  routes?: RouteInput[];
+}
+
+let routeIdSequence = 1;
+
+/**
+ * Builds a route node for a routing tree, filling in the boilerplate the type
+ * requires. Only the fields relevant to a test need to be passed.
+ */
+export const buildRouteWithId = (overrides: RouteInput = {}): RouteWithID => {
+  const route: RouteInput = {
+    id: `route-${routeIdSequence++}`,
+    continue: false,
+    matchers: [],
+    routes: [],
+    ...overrides,
+  };
+
+  return route as unknown as RouteWithID;
+};
+
+export const matchingJourneyItemFactory = Factory.define<MatchingJourneyItem>(() => ({
+  route: buildRouteWithId(),
+  matchDetails: [],
+  matched: true,
+}));
+
+interface RouteMatchTransientParams {
+  treeName: string;
+  matchingJourney: MatchingJourneyItem[];
+}
+
+/**
+ * Builds a fully-typed RouteMatch. Pass `treeName` and `matchingJourney` as
+ * transient params to describe the tree a match belongs to and the routes that
+ * were traversed; the effective (delivering) route defaults to the last item in
+ * the journey.
+ */
+export const routeMatchFactory = Factory.define<RouteMatch, RouteMatchTransientParams>(({ transientParams }) => {
+  const { treeName = USER_DEFINED_TREE_NAME, matchingJourney = [matchingJourneyItemFactory.build()] } = transientParams;
+  const effectiveRoute = matchingJourney[matchingJourney.length - 1]?.route ?? buildRouteWithId();
+
+  return {
+    route: effectiveRoute,
+    routeTree: {
+      metadata: { name: treeName },
+      expandedSpec: matchingJourney[0]?.route ?? buildRouteWithId(),
+    },
+    matchDetails: {
+      route: effectiveRoute,
+      labels: [] as Label[],
+      matchingJourney,
+    },
+  };
+});
+
+/**
+ * Builds a fully-typed RoutingTree. Tests generally only care about
+ * `metadata.name` and `spec.defaults.receiver`; this factory fills in the rest
+ * of the boilerplate the type requires so callers don't have to cast.
+ */
+export const routingTreeFactory = Factory.define<RoutingTree>(({ sequence }) => ({
+  apiVersion: 'notifications.alerting.grafana.app/v1beta1',
+  kind: 'RoutingTree',
+  metadata: { name: `routing-tree-${sequence}` },
+  spec: {
+    defaults: { receiver: 'grafana-default-email' },
+    routes: [],
+  },
+}));
+
+export const instanceMatchResultFactory = Factory.define<InstanceMatchResult>(() => ({
+  labels: [],
+  matchedRoutes: [],
+}));

--- a/src/test/fixtures/alerting.ts
+++ b/src/test/fixtures/alerting.ts
@@ -1,7 +1,13 @@
-import { type InstanceMatchResult } from '@grafana/alerting';
+import { type InstanceMatchResult, USER_DEFINED_TREE_NAME } from '@grafana/alerting';
 
 import { ListPrometheusAlertsResponse } from 'datasource/responses.types';
 
+import {
+  buildRouteWithId,
+  instanceMatchResultFactory,
+  matchingJourneyItemFactory,
+  routeMatchFactory,
+} from '../factories/routingTree';
 import {
   ALERT_PROBE_SUCCESS_RECORDING_EXPR,
   ALERT_PROBE_SUCCESS_RECORDING_METRIC,
@@ -271,59 +277,57 @@ export const MOCK_PROBE_FAILED_ROUTE_MATCH: InstanceMatchResult = {
 // named "hashicorp-vault" tree match only at their root (no receiver), while
 // the named "pam-incident-alert" tree matches a child route that delivers to a
 // contact point.
-export const MOCK_MULTI_TREE_ROUTE_MATCH: InstanceMatchResult = {
+//
+// Each tree's root reuses the same route id ("route-1") on purpose: route ids
+// are only unique within a tree, so the display must scope its dedupe per tree
+// or named trees would vanish from the preview.
+const multiTreeRootRoute = buildRouteWithId({ id: 'route-1', matchers: [], continue: false });
+
+export const MOCK_MULTI_TREE_ROUTE_MATCH: InstanceMatchResult = instanceMatchResultFactory.build({
   labels: [
     ['alertname', 'ProbeFailedExecutionsTooHigh'],
     ['label_Environment', 'prod'],
   ],
-  // Each tree's root reuses the same route id ("route-1") on purpose: route ids
-  // are only unique within a tree, so the display must scope its dedupe per tree
-  // or named trees would vanish from the preview.
   matchedRoutes: [
-    {
-      route: { id: 'route-1', matchers: [], continue: false },
-      routeTree: { metadata: { name: 'user-defined' }, expandedSpec: { id: 'route-1' } },
-      matchDetails: {
-        matchingJourney: [
-          { route: { id: 'route-1', matchers: [], continue: false }, matchDetails: [], matched: true },
-        ],
-      },
-    },
-    {
-      route: { id: 'route-1', matchers: [], continue: false },
-      routeTree: { metadata: { name: 'hashicorp-vault' }, expandedSpec: { id: 'route-1' } },
-      matchDetails: {
-        matchingJourney: [
-          { route: { id: 'route-1', matchers: [], continue: false }, matchDetails: [], matched: true },
-        ],
-      },
-    },
-    {
-      route: {
-        id: 'route-2',
-        matchers: [{ type: '=', label: 'label_Environment', value: 'prod' }],
-        continue: false,
-        receiver: 'PAM Incident Alert',
-      },
-      routeTree: { metadata: { name: 'pam-incident-alert' }, expandedSpec: { id: 'route-1' } },
-      matchDetails: {
-        matchingJourney: [
-          { route: { id: 'route-1', matchers: [], continue: false }, matchDetails: [], matched: true },
-          {
-            route: {
-              id: 'route-2',
-              matchers: [{ type: '=', label: 'label_Environment', value: 'prod' }],
-              continue: false,
-              receiver: 'PAM Incident Alert',
-            },
-            matchDetails: [],
-            matched: true,
-          },
-        ],
-      },
-    },
+    routeMatchFactory.build(
+      {},
+      {
+        transient: {
+          treeName: USER_DEFINED_TREE_NAME,
+          matchingJourney: [matchingJourneyItemFactory.build({ route: multiTreeRootRoute })],
+        },
+      }
+    ),
+    routeMatchFactory.build(
+      {},
+      {
+        transient: {
+          treeName: 'hashicorp-vault',
+          matchingJourney: [matchingJourneyItemFactory.build({ route: multiTreeRootRoute })],
+        },
+      }
+    ),
+    routeMatchFactory.build(
+      {},
+      {
+        transient: {
+          treeName: 'pam-incident-alert',
+          matchingJourney: [
+            matchingJourneyItemFactory.build({ route: multiTreeRootRoute }),
+            matchingJourneyItemFactory.build({
+              route: buildRouteWithId({
+                id: 'route-2',
+                matchers: [{ type: '=', label: 'label_Environment', value: 'prod' }],
+                continue: false,
+                receiver: 'PAM Incident Alert',
+              }),
+            }),
+          ],
+        },
+      }
+    ),
   ],
-} as unknown as InstanceMatchResult;
+});
 
 export const MOCK_HTTP_DURATION_ROUTE_MATCH: InstanceMatchResult = {
   "labels": [

--- a/src/test/fixtures/alerting.ts
+++ b/src/test/fixtures/alerting.ts
@@ -266,6 +266,62 @@ export const MOCK_PROBE_FAILED_ROUTE_MATCH: InstanceMatchResult = {
   ],
 } as unknown as InstanceMatchResult;
 
+// Mirrors the multiple-policy-trees scenario: three independent routing trees
+// are evaluated for the same alert. The default ("user-defined") tree and a
+// named "hashicorp-vault" tree match only at their root (no receiver), while
+// the named "pam-incident-alert" tree matches a child route that delivers to a
+// contact point.
+export const MOCK_MULTI_TREE_ROUTE_MATCH: InstanceMatchResult = {
+  labels: [
+    ['alertname', 'ProbeFailedExecutionsTooHigh'],
+    ['label_Environment', 'prod'],
+  ],
+  matchedRoutes: [
+    {
+      route: { id: 'route-default-root', matchers: [], continue: false },
+      routeTree: { metadata: { name: 'user-defined' }, expandedSpec: { id: 'route-default-root' } },
+      matchDetails: {
+        matchingJourney: [
+          { route: { id: 'route-default-root', matchers: [], continue: false }, matchDetails: [], matched: true },
+        ],
+      },
+    },
+    {
+      route: { id: 'route-vault-root', matchers: [], continue: false },
+      routeTree: { metadata: { name: 'hashicorp-vault' }, expandedSpec: { id: 'route-vault-root' } },
+      matchDetails: {
+        matchingJourney: [
+          { route: { id: 'route-vault-root', matchers: [], continue: false }, matchDetails: [], matched: true },
+        ],
+      },
+    },
+    {
+      route: {
+        id: 'route-pam-prod',
+        matchers: [{ type: '=', label: 'label_Environment', value: 'prod' }],
+        continue: false,
+        receiver: 'PAM Incident Alert',
+      },
+      routeTree: { metadata: { name: 'pam-incident-alert' }, expandedSpec: { id: 'route-pam-root' } },
+      matchDetails: {
+        matchingJourney: [
+          { route: { id: 'route-pam-root', matchers: [], continue: false }, matchDetails: [], matched: true },
+          {
+            route: {
+              id: 'route-pam-prod',
+              matchers: [{ type: '=', label: 'label_Environment', value: 'prod' }],
+              continue: false,
+              receiver: 'PAM Incident Alert',
+            },
+            matchDetails: [],
+            matched: true,
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as InstanceMatchResult;
+
 export const MOCK_HTTP_DURATION_ROUTE_MATCH: InstanceMatchResult = {
   "labels": [
     ["job", "test_http"], ["instance", "http://example.com"], ["check_name", "http"], ["frequency", "10000"],

--- a/src/test/fixtures/alerting.ts
+++ b/src/test/fixtures/alerting.ts
@@ -276,39 +276,42 @@ export const MOCK_MULTI_TREE_ROUTE_MATCH: InstanceMatchResult = {
     ['alertname', 'ProbeFailedExecutionsTooHigh'],
     ['label_Environment', 'prod'],
   ],
+  // Each tree's root reuses the same route id ("route-1") on purpose: route ids
+  // are only unique within a tree, so the display must scope its dedupe per tree
+  // or named trees would vanish from the preview.
   matchedRoutes: [
     {
-      route: { id: 'route-default-root', matchers: [], continue: false },
-      routeTree: { metadata: { name: 'user-defined' }, expandedSpec: { id: 'route-default-root' } },
+      route: { id: 'route-1', matchers: [], continue: false },
+      routeTree: { metadata: { name: 'user-defined' }, expandedSpec: { id: 'route-1' } },
       matchDetails: {
         matchingJourney: [
-          { route: { id: 'route-default-root', matchers: [], continue: false }, matchDetails: [], matched: true },
+          { route: { id: 'route-1', matchers: [], continue: false }, matchDetails: [], matched: true },
         ],
       },
     },
     {
-      route: { id: 'route-vault-root', matchers: [], continue: false },
-      routeTree: { metadata: { name: 'hashicorp-vault' }, expandedSpec: { id: 'route-vault-root' } },
+      route: { id: 'route-1', matchers: [], continue: false },
+      routeTree: { metadata: { name: 'hashicorp-vault' }, expandedSpec: { id: 'route-1' } },
       matchDetails: {
         matchingJourney: [
-          { route: { id: 'route-vault-root', matchers: [], continue: false }, matchDetails: [], matched: true },
+          { route: { id: 'route-1', matchers: [], continue: false }, matchDetails: [], matched: true },
         ],
       },
     },
     {
       route: {
-        id: 'route-pam-prod',
+        id: 'route-2',
         matchers: [{ type: '=', label: 'label_Environment', value: 'prod' }],
         continue: false,
         receiver: 'PAM Incident Alert',
       },
-      routeTree: { metadata: { name: 'pam-incident-alert' }, expandedSpec: { id: 'route-pam-root' } },
+      routeTree: { metadata: { name: 'pam-incident-alert' }, expandedSpec: { id: 'route-1' } },
       matchDetails: {
         matchingJourney: [
-          { route: { id: 'route-pam-root', matchers: [], continue: false }, matchDetails: [], matched: true },
+          { route: { id: 'route-1', matchers: [], continue: false }, matchDetails: [], matched: true },
           {
             route: {
-              id: 'route-pam-prod',
+              id: 'route-2',
               matchers: [{ type: '=', label: 'label_Environment', value: 'prod' }],
               continue: false,
               receiver: 'PAM Incident Alert',


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-app/issues/1733

## What this PR does / why we need it

Fixes the per-check **Alert Routing Summary** so it reflects where a synthetic-monitoring alert is *actually* delivered.

SM per-check alert rules are provisioned by the sm-api ([`newAlertRule`](https://github.com/grafana/synthetic-monitoring-api/blob/main/internal/alerts/rules.go#L768-L794)) **without any notification settings**. Because that field is empty, the rule gets no `__grafana_managed_route__` label, and Grafana Alerting routes it through the **default (`user-defined`) tree only** — it never enters additional policy trees created via the `alertingMultiplePolicies` feature.

The preview, however, matched the alert's labels against **every** routing tree returned by `listRoutingTree`. When a stack had extra policy trees, this showed matches (and contact points) in trees the alert can never reach — a false positive. Customers saw the preview claim an alert would route to a custom tree, while in reality it fell through to the default tree's receiver and the custom tree showed 0 instances.

This PR:

- Scopes the preview's matching to the **default tree** .
- Keeps the earlier improvements to `RouteTreeDisplay` (correct per-tree labelling + per-tree route de-duplication) so the component can still render multiple trees **if** SM later supports per-check policy-tree selection.

## Special notes for your reviewer

- No change to alert delivery or backend routing — this is preview/UI only.
- Why the default tree is the only one that applies to SM alerts is verified in Grafana core: a rule reaches a named tree only by carrying `__grafana_managed_route__=<tree>`, which is produced solely by a rule's notification settings (`PolicyRouting`). SM sets none, so all SM alerts use the default tree. Refs: [notifications.go](https://github.com/grafana/grafana/blob/main/pkg/services/ngalert/models/notifications.go), [merge.go](https://github.com/grafana/grafana/blob/main/pkg/services/ngalert/notifier/merge/merge.go), [Manage multiple notification policies](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/create-notification-policy/#manage-multiple-notification-policies).
