### PR TITLE
fix: automerge deployment prs for ops and prod

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
       trigger-argo: ${{ github.event.inputs.branch == 'main' }}
       argo-workflow-slack-channel: '#sm-ops-deploys'
 
-      auto-merge-environments: dev, ops
+      auto-merge-environments: dev,ops,prod
 
       # https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs
       node-version: 22


### PR DESCRIPTION
## Problem

When the release workflows were last reworked (#1689), the shared CD workflow was bumped from `plugin-ci-workflows@v6.0.0` to `@v8.0.1`. The `auto-merge-environments` input was carried over unchanged as `dev, ops`, but the newer version evaluates that value strictly, so the deployment_tools PRs for `ops` and `prod` releases stopped auto-merging — they now have to be merged manually, slowing down releases and creating room for human error. Only `dev` auto-merges.

There are two problems with the current `auto-merge-environments: dev, ops` value in `publish.yml`:

1. **A stray space after the comma.** The shared `cd.yml` workflow converts this list for Argo by literally replacing commas with `+` (`${VALUE//,/+}`), producing `dev+ ops`. The Argo template then evaluates `auto_merge_environments | split('+')`, yielding `["dev", " ops"]`. The membership check `env.name in [...]` compares against `" ops"` (with a leading space), which never matches `ops` — so even though `ops` looked like it was in the list, it never auto-merged.
2. **`prod` was missing entirely** from the list, so prod PRs were never eligible to auto-merge.

The same runtime expression in the Argo template drives the `auto-merge/` branch prefix, the `[Auto-Merge]` title prefix, and the auto-merge behaviour itself — which is why the dev PR visibly differs from the ops/prod PRs.

## Solution

Set `auto-merge-environments: dev,ops,prod` to configure auto-merge for all environments — removing the space (to match the no-space, comma-separated format used by the shared workflow defaults) and adding `prod`. After this change, the `dev`, `ops`, and `prod` deployment_tools PRs all auto-merge once their CI passes, restoring the behaviour we had before #1689.

## Notes

Auto-merging the PR is independent of the Argo rollout approval (`auto-approve-durations`, which is not set here). `prod` will still require a manual "Resume" in the Argo UI to actually roll out; this PR only restores automatic merging of the version-bump PR.