### PR TITLE
fix: gracefully degrade when user lacks folders permissions

### DIFF
--- a/src/components/Checkster/components/form/generic/GenericNameValueField.test.tsx
+++ b/src/components/Checkster/components/form/generic/GenericNameValueField.test.tsx
@@ -33,8 +33,7 @@ jest.mock('data/useDefaultFolder', () => ({
   useDefaultFolder: jest.fn(() => ({
     defaultFolder: undefined,
     defaultFolderUid: undefined,
-    isLoading: false,
-    isError: false,
+    status: 'available',
   })),
 }));
 

--- a/src/contexts/CheckFolderAccessContext.tsx
+++ b/src/contexts/CheckFolderAccessContext.tsx
@@ -11,6 +11,7 @@ interface CheckFolderAccessContextValue {
   visibleChecks: Check[];
   getPermissions: (check: Pick<Check, 'folderUid'>) => CheckPermissions;
   getFolderStatus: (check: Pick<Check, 'folderUid'>) => CheckFolderStatus;
+  isFoldersAvailable: boolean;
 }
 
 const CheckFolderAccessContext = createContext<CheckFolderAccessContextValue | null>(null);
@@ -64,4 +65,8 @@ export function useBulkCheckPermissions(checks: Array<Pick<Check, 'folderUid'>>)
     canWriteAll: checks.every((check) => getPermissions(check).canWrite),
     canDeleteAll: checks.every((check) => getPermissions(check).canDelete),
   };
+}
+
+export function useIsFoldersAvailable() {
+  return useCheckFolderAccessContext().isFoldersAvailable;
 }

--- a/src/data/useDefaultFolder.ts
+++ b/src/data/useDefaultFolder.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getBackendSrv } from '@grafana/runtime';
+import { getBackendSrv, isFetchError } from '@grafana/runtime';
 import { firstValueFrom } from 'rxjs';
 
 import { GrafanaFolder } from 'types';
@@ -8,6 +8,24 @@ import { fetchFolderByUid, fetchFolders, folderQueryKeys } from 'data/useFolders
 
 import { DEFAULT_FOLDER_TITLE, DEFAULT_FOLDER_UID, FOLDERS_STALE_TIME } from './folders.constants';
 
+export class FolderNotProvisionedError extends Error {
+  constructor() {
+    super('Default Synthetic Monitoring folder not found and user lacks folders:create permission');
+    this.name = 'FolderNotProvisionedError';
+  }
+}
+
+/**
+ * Single source of truth for the default folder's availability.
+ *
+ * - `loading`: the query is still resolving.
+ * - `available`: the default folder loaded successfully.
+ * - `not-provisioned`: the folder does not exist and the user cannot create it.
+ * - `permission-denied`: the user lacks folders:read.
+ * - `error`: any other failure (server error, create denied, etc.).
+ */
+export type FolderStatus = 'loading' | 'available' | 'not-provisioned' | 'permission-denied' | 'error';
+
 /**
  * Resolves the default SM folder with permission fields (canSave, canEdit, etc.).
  *
@@ -15,15 +33,20 @@ import { DEFAULT_FOLDER_TITLE, DEFAULT_FOLDER_UID, FOLDERS_STALE_TIME } from './
  * because only the detail endpoint returns permission fields. Falls back to
  * searching by title if the known UID is not found. If the folder doesn't exist
  * at all and the user has folders:create permission, auto-creates it.
+ *
+ * A 403 is re-thrown immediately so callers can detect a permissions gap
+ * rather than wastefully trying to list/create the folder.
  */
 export function useDefaultFolder(enabled = true) {
-  const { data: defaultFolder, isLoading, isError, refetch } = useQuery({
+  const { data: defaultFolder, isLoading, isError, error, refetch } = useQuery({
     queryKey: [...folderQueryKeys.all, 'default'] as const,
     queryFn: async (): Promise<GrafanaFolder> => {
       try {
         return await fetchFolderByUid(DEFAULT_FOLDER_UID);
-      } catch {
-        // UID not found — fall back to searching by title
+      } catch (err) {
+        if (isFetchError(err) && err.status === 403) {
+          throw err;
+        }
       }
 
       const folders = await fetchFolders();
@@ -33,17 +56,30 @@ export function useDefaultFolder(enabled = true) {
       }
 
       if (!getUserPermissions().canCreateFolders) {
-        throw new Error('Default Synthetic Monitoring folder not found and user lacks folders:create permission');
+        throw new FolderNotProvisionedError();
       }
 
-      return firstValueFrom(
-        getBackendSrv().fetch<GrafanaFolder>({
-          method: 'POST',
-          url: '/api/folders',
-          data: { title: DEFAULT_FOLDER_TITLE },
-          showErrorAlert: false,
-        })
-      ).then((res) => res.data);
+      try {
+        return await firstValueFrom(
+          getBackendSrv().fetch<GrafanaFolder>({
+            method: 'POST',
+            url: '/api/folders',
+            data: { title: DEFAULT_FOLDER_TITLE },
+            showErrorAlert: false,
+          })
+        ).then((res) => res.data);
+      } catch (err) {
+        // A 403 on create means this user effectively cannot provision the
+        // folder (the RBAC flag passed but the server denied it). The end
+        // state is the same as "not provisioned" -- someone with working
+        // folders:create must initialize it -- so surface that banner rather
+        // than a Retry that cannot succeed. Other failures (e.g. 500) are
+        // transient and fall through to the generic error banner.
+        if (isFetchError(err) && err.status === 403) {
+          throw new FolderNotProvisionedError();
+        }
+        throw new Error('Failed to create default Synthetic Monitoring folder');
+      }
     },
     staleTime: FOLDERS_STALE_TIME,
     refetchOnWindowFocus: false,
@@ -51,11 +87,38 @@ export function useDefaultFolder(enabled = true) {
     enabled,
   });
 
+  const status = getFolderStatus({ isLoading, isError, error });
+
   return {
     defaultFolder,
     defaultFolderUid: defaultFolder?.uid,
     isLoading,
     isError,
+    status,
     refetch,
   };
+}
+
+function getFolderStatus({
+  isLoading,
+  isError,
+  error,
+}: {
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+}): FolderStatus {
+  if (isLoading) {
+    return 'loading';
+  }
+  if (!isError) {
+    return 'available';
+  }
+  if (error instanceof FolderNotProvisionedError) {
+    return 'not-provisioned';
+  }
+  if (isFetchError(error) && error.status === 403) {
+    return 'permission-denied';
+  }
+  return 'error';
 }

--- a/src/data/useFolders.ts
+++ b/src/data/useFolders.ts
@@ -120,7 +120,11 @@ export function getFolderPath(folder: GrafanaFolder, allFoldersMap: Map<string, 
  */
 export function useAllFolders() {
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
-  const { defaultFolder, defaultFolderUid, isLoading: isDefaultLoading, isError: isDefaultError } = useDefaultFolder(isFoldersEnabled);
+  const {
+    defaultFolder,
+    defaultFolderUid,
+    status: folderStatus,
+  } = useDefaultFolder(isFoldersEnabled);
   const {
     data: childFolders = [],
     isLoading: isChildrenLoading,
@@ -136,15 +140,24 @@ export function useAllFolders() {
 
   const foldersMap = useMemo(() => new Map(folders.map((f) => [f.uid, f])), [folders]);
 
-  const isError = isDefaultError || isChildrenError;
+  // Folder availability is driven solely by the default folder. A child-folder
+  // failure is a partial error surfaced inside the folder view (foldersError),
+  // not a reason to disable folder grouping and access control entirely.
+  // While loading we treat folders as available (optimistic) so access control
+  // applies as soon as data arrives, instead of briefly showing every check.
+  const isFoldersAvailable =
+    isFoldersEnabled && (folderStatus === 'available' || folderStatus === 'loading');
+  const isError = isChildrenError;
   const refetch = () => queryClient.invalidateQueries({ queryKey: folderQueryKeys.all });
 
   return {
     folders,
     foldersMap,
     defaultFolderUid,
-    isLoading: isDefaultLoading || isChildrenLoading,
+    isLoading: folderStatus === 'loading' || isChildrenLoading,
     isError,
+    folderStatus,
+    isFoldersAvailable,
     refetch,
   };
 }

--- a/src/hooks/useCheckFolderAccess.ts
+++ b/src/hooks/useCheckFolderAccess.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { Check, FeatureName } from 'types';
-import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
+import { Check } from 'types';
 import {
   CheckFolderStatus,
   CheckPermissions,
@@ -22,11 +21,14 @@ import { useAllFolders } from 'data/useFolders';
  *      shown only after confirming 404 (orphaned). Forbidden folders stay hidden.
  *   4. Computes effective permissions per check (combined model)
  *
+ * When the feature flag is on but folder data failed to load (e.g. missing
+ * folders:read permission), falls back to pre-folders behaviour: all checks
+ * visible, SM RBAC only.
+ *
  * Returns visibleChecks (filtered) and getPermissions (lookup function).
  */
 export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks: T[]) {
-  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
-  const { folders: allFolders, defaultFolderUid } = useAllFolders();
+  const { folders: allFolders, defaultFolderUid, isFoldersAvailable } = useAllFolders();
 
   const accessibleFolderUids = useMemo(
     () => new Set(allFolders.map((f) => f.uid)),
@@ -34,7 +36,7 @@ export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks:
   );
 
   const folderUids = useMemo(() => {
-    if (!isFoldersEnabled) {
+    if (!isFoldersAvailable) {
       return [];
     }
     const uids = new Set<string>();
@@ -48,13 +50,13 @@ export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks:
     });
     allFolders.forEach((folder) => uids.add(folder.uid));
     return [...uids];
-  }, [checks, allFolders, isFoldersEnabled, defaultFolderUid]);
+  }, [checks, allFolders, isFoldersAvailable, defaultFolderUid]);
 
   const { folderDetailsByUid } = useFolderPermissions(folderUids);
   const smPerms = useUserPermissions();
 
   const visibleChecks = useMemo(() => {
-    if (!isFoldersEnabled) {
+    if (!isFoldersAvailable) {
       return checks;
     }
 
@@ -68,13 +70,13 @@ export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks:
       }
       return folderDetailsByUid.get(effectiveUid)?.type === 'orphaned';
     });
-  }, [checks, isFoldersEnabled, accessibleFolderUids, folderDetailsByUid, defaultFolderUid]);
+  }, [checks, isFoldersAvailable, accessibleFolderUids, folderDetailsByUid, defaultFolderUid]);
 
   const getFolderStatus = useCallback(
     (check: Pick<Check, 'folderUid'>): CheckFolderStatus => {
-      return resolveCheckFolderStatus(check, folderDetailsByUid, isFoldersEnabled, defaultFolderUid);
+      return resolveCheckFolderStatus(check, folderDetailsByUid, isFoldersAvailable, defaultFolderUid);
     },
-    [folderDetailsByUid, isFoldersEnabled, defaultFolderUid]
+    [folderDetailsByUid, isFoldersAvailable, defaultFolderUid]
   );
 
   const getPermissions = useCallback(
@@ -88,5 +90,6 @@ export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks:
     visibleChecks,
     getPermissions,
     getFolderStatus,
+    isFoldersAvailable,
   };
 }

--- a/src/page/CheckList/CheckList.folderPermissions.test.tsx
+++ b/src/page/CheckList/CheckList.folderPermissions.test.tsx
@@ -153,6 +153,211 @@ describe('CheckList - Folder Permissions', () => {
     });
   });
 
+  describe('graceful degradation — folders enabled but user lacks folders:read', () => {
+    beforeEach(() => mockFeatureToggles({ [FeatureName.Folders]: true }));
+
+    const renderWithFolders403 = async (checks: Check[] = ALL_CHECKS) => {
+      server.use(
+        apiRoute(`listChecks`, {
+          result: () => ({ json: checks }),
+        }),
+        apiRoute(`listProbes`, {
+          result: () => ({ json: [PRIVATE_PROBE, PUBLIC_PROBE] }),
+        }),
+        apiRoute(`getFolder`, {
+          result: () => ({ status: 403, json: { message: 'Access denied' } }),
+        }),
+        apiRoute(`listFolders`, {
+          result: () => ({ status: 403, json: { message: 'Access denied' } }),
+        })
+      );
+
+      return render(<CheckList />, {
+        route: AppRoutes.Checks,
+        path: generateRoutePath(AppRoutes.Checks),
+      });
+    };
+
+    it('shows all checks including those with folderUids', async () => {
+      await renderWithFolders403();
+      await screen.findByText(/Folder features are unavailable/);
+      expect(screen.getByText('Production HTTP check')).toBeInTheDocument();
+      expect(screen.getByText('Staging DNS check')).toBeInTheDocument();
+      expect(screen.getByText('Forbidden folder check')).toBeInTheDocument();
+      expect(screen.getByText('Unassigned check')).toBeInTheDocument();
+    });
+
+    it('uses SM RBAC for action buttons (folder permissions do not apply)', async () => {
+      await renderWithFolders403([CHECK_IN_READONLY_FOLDER]);
+      const editButton = await screen.findByLabelText('Edit check');
+      const deleteButton = screen.getByLabelText('Delete check');
+
+      expect(editButton).not.toHaveAttribute('aria-disabled', 'true');
+      expect(deleteButton).not.toBeDisabled();
+    });
+
+    it('shows a dismissible permission banner for 403', async () => {
+      const { user } = await renderWithFolders403();
+      const alert = await screen.findByText(/Folder features are unavailable/);
+      expect(alert).toBeInTheDocument();
+      expect(screen.getByText(/folders:read/)).toBeInTheDocument();
+
+      const closeButton = screen.getByLabelText('Close alert');
+      await user.click(closeButton);
+      expect(screen.queryByText(/Folder features are unavailable/)).not.toBeInTheDocument();
+    });
+
+    it('shows a creation-needed banner when the default folder does not exist', async () => {
+      server.use(
+        apiRoute(`listChecks`, {
+          result: () => ({ json: ALL_CHECKS }),
+        }),
+        apiRoute(`listProbes`, {
+          result: () => ({ json: [PRIVATE_PROBE, PUBLIC_PROBE] }),
+        }),
+        apiRoute(`getFolder`, {
+          result: () => ({ status: 404, json: { message: 'Folder not found' } }),
+        }),
+        apiRoute(`listFolders`, {
+          result: () => ({ json: [] }),
+        })
+      );
+
+      render(<CheckList />, {
+        route: AppRoutes.Checks,
+        path: generateRoutePath(AppRoutes.Checks),
+      });
+
+      expect(await screen.findByText(/has not been created yet/)).toBeInTheDocument();
+    });
+
+    it('hides the folder view option in the view switcher', async () => {
+      await renderWithFolders403();
+      await screen.findByText('Production HTTP check');
+      expect(screen.queryByLabelText('Folder view')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('graceful degradation — folders enabled but server returns 500', () => {
+    beforeEach(() => mockFeatureToggles({ [FeatureName.Folders]: true }));
+
+    const renderWithFolders500 = async (checks: Check[] = ALL_CHECKS) => {
+      server.use(
+        apiRoute(`listChecks`, {
+          result: () => ({ json: checks }),
+        }),
+        apiRoute(`listProbes`, {
+          result: () => ({ json: [PRIVATE_PROBE, PUBLIC_PROBE] }),
+        }),
+        apiRoute(`getFolder`, {
+          result: () => ({ status: 500, json: { message: 'Internal server error' } }),
+        }),
+        apiRoute(`listFolders`, {
+          result: () => ({ status: 500, json: { message: 'Internal server error' } }),
+        })
+      );
+
+      return render(<CheckList />, {
+        route: AppRoutes.Checks,
+        path: generateRoutePath(AppRoutes.Checks),
+      });
+    };
+
+    it('shows the error banner (not the permission banner) for non-403 failures', async () => {
+      await renderWithFolders500();
+      const errorAlert = await screen.findByText(/Failed to load folder information/);
+      expect(errorAlert).toBeInTheDocument();
+      expect(screen.getByText(/Something went wrong while loading folders/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+
+      expect(screen.queryByText(/folders:read/)).not.toBeInTheDocument();
+    });
+
+    it('shows all checks despite the folder error', async () => {
+      await renderWithFolders500();
+      await screen.findByText(/Failed to load folder information/);
+      expect(screen.getByText('Production HTTP check')).toBeInTheDocument();
+      expect(screen.getByText('Staging DNS check')).toBeInTheDocument();
+      expect(screen.getByText('Forbidden folder check')).toBeInTheDocument();
+      expect(screen.getByText('Unassigned check')).toBeInTheDocument();
+    });
+
+    it('uses SM RBAC for action buttons when folders error', async () => {
+      await renderWithFolders500([CHECK_IN_READONLY_FOLDER]);
+      const editButton = await screen.findByLabelText('Edit check');
+      const deleteButton = screen.getByLabelText('Delete check');
+
+      expect(editButton).not.toHaveAttribute('aria-disabled', 'true');
+      expect(deleteButton).not.toBeDisabled();
+    });
+  });
+
+  describe('graceful degradation — folder creation denied (403 on create)', () => {
+    beforeEach(() => mockFeatureToggles({ [FeatureName.Folders]: true }));
+
+    // jest.replaceProperty is reset in afterEach in jest-setup.js
+    const grantFoldersCreate = () => {
+      const runtime = require('@grafana/runtime');
+      jest.replaceProperty(runtime, 'config', {
+        ...runtime.config,
+        bootData: {
+          ...runtime.config.bootData,
+          user: {
+            ...runtime.config.bootData.user,
+            permissions: {
+              ...runtime.config.bootData.user.permissions,
+              'folders:create': true,
+            },
+          },
+        },
+      });
+    };
+
+    const renderWithCreateDenied = () => {
+      server.use(
+        apiRoute(`listChecks`, {
+          result: () => ({ json: ALL_CHECKS }),
+        }),
+        apiRoute(`listProbes`, {
+          result: () => ({ json: [PRIVATE_PROBE, PUBLIC_PROBE] }),
+        }),
+        apiRoute(`getFolder`, {
+          result: () => ({ status: 404, json: { message: 'Folder not found' } }),
+        }),
+        apiRoute(`listFolders`, {
+          result: () => ({ json: [] }),
+        }),
+        apiRoute(`createFolder`, {
+          result: () => ({ status: 403, json: { message: 'Access denied' } }),
+        })
+      );
+
+      return render(<CheckList />, {
+        route: AppRoutes.Checks,
+        path: generateRoutePath(AppRoutes.Checks),
+      });
+    };
+
+    it('shows the creation-needed banner (not the permission or generic error banner) when creation is denied', async () => {
+      grantFoldersCreate();
+      renderWithCreateDenied();
+
+      expect(await screen.findByText(/has not been created yet/)).toBeInTheDocument();
+      expect(screen.queryByText(/folders:read/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Failed to load folder information/)).not.toBeInTheDocument();
+    });
+
+    it('still shows all checks without folder grouping', async () => {
+      grantFoldersCreate();
+      renderWithCreateDenied();
+
+      await screen.findByText(/has not been created yet/);
+      expect(screen.getByText('Production HTTP check')).toBeInTheDocument();
+      expect(screen.getByText('Forbidden folder check')).toBeInTheDocument();
+      expect(screen.getByText('Unassigned check')).toBeInTheDocument();
+    });
+  });
+
   describe('with folders feature disabled', () => {
     it('shows all checks regardless of folderUid', async () => {
       await renderCheckList();

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -38,6 +38,7 @@ import { matchesAllFilters } from 'page/CheckList/CheckList.utils';
 import { CheckListFolderView } from 'page/CheckList/components/CheckListFolderView';
 import { CheckListHeader } from 'page/CheckList/components/CheckListHeader';
 import { CheckListItem } from 'page/CheckList/components/CheckListItem';
+import { FolderErrorBanner, FolderNotProvisionedBanner, FolderPermissionBanner } from 'page/CheckList/components/FolderBanners';
 
 export const CheckList = () => {
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
@@ -72,7 +73,16 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
   const { data: checks } = useSuspenseChecks();
 
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
-  const { folders: allFolders, foldersMap, defaultFolderUid, isLoading: isFoldersLoading, isError: isFoldersError, refetch: refetchFolders } = useAllFolders();
+  const {
+    folders: allFolders,
+    foldersMap,
+    defaultFolderUid,
+    isLoading: isFoldersLoading,
+    isError: isFoldersError,
+    folderStatus,
+    isFoldersAvailable,
+    refetch: refetchFolders,
+  } = useAllFolders();
   const {
     data: checkAlertStates = {},
     isFetched: isAlertStatesFetched,
@@ -86,6 +96,12 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
   const { isEnabled: isCALsEnabled } = useFeatureFlag(FeatureName.CALs);
   const { data: calData } = useTenantCostAttributionLabels();
   const calNames = useMemo(() => (isCALsEnabled ? calData?.names ?? [] : []), [isCALsEnabled, calData?.names]);
+
+  // When folders are unavailable, fall back to card view synchronously so the
+  // folder view never renders, while preserving the user's stored preference
+  // (so folder view returns automatically if folders become available again).
+  const effectiveViewType =
+    viewType === CheckListViewType.Folder && !isFoldersAvailable ? CheckListViewType.Card : viewType;
 
   // Animate the initial alert-based reorder only once, when alert states first arrive.
   // Subsequent refetches re-sort silently to avoid distracting repeated animations.
@@ -129,15 +145,16 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
           ? ({ label: status.label, value: status.value } as CheckFiltersType['status'])
           : CHECK_LIST_STATUS_OPTIONS[0],
       probes,
-      folders: isFoldersEnabled ? folders : [],
+      folders: isFoldersAvailable ? folders : [],
     }),
-    [labels, search, type, alerts, status, probes, folders, isFoldersEnabled]
+    [labels, search, type, alerts, status, probes, folders, isFoldersAvailable]
   );
 
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedCheckIds, setSelectedChecksIds] = useState<Set<number>>(new Set());
+  const [folderBannerDismissed, setFolderBannerDismissed] = useState(false);
   const styles = useStyles2(getStyles);
-  const CHECKS_PER_PAGE = viewType === CheckListViewType.Card ? CHECKS_PER_PAGE_CARD : CHECKS_PER_PAGE_LIST;
+  const CHECKS_PER_PAGE = effectiveViewType === CheckListViewType.Card ? CHECKS_PER_PAGE_CARD : CHECKS_PER_PAGE_LIST;
 
   const filteredChecks = filterChecks(checks, checkFiltersWithStatus, defaultFolderUid);
   const sortedChecks = sortChecks(filteredChecks, sortType, reachabilitySuccessRates, checkAlertStates, applyAlertSort);
@@ -258,6 +275,8 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
     return <ChecksEmptyState />;
   }
 
+  const foldersUnavailable = isFoldersEnabled && !isFoldersLoading && !isFoldersAvailable;
+
   return (
     <CheckFolderAccessValueProvider value={folderAccess}>
       <CheckListHeader
@@ -266,6 +285,7 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
         currentPageChecks={currentPageChecks}
         folders={allFolders}
         defaultFolderUid={defaultFolderUid}
+        isFoldersAvailable={isFoldersAvailable}
         onChangeView={handleChangeViewType}
         onFilterChange={handleFilterChange}
         onSelectAll={handleSelectAll}
@@ -274,13 +294,27 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
         onDelete={handleUnselectAll}
         selectedCheckIds={selectedCheckIds}
         sortType={sortType}
-        viewType={viewType}
+        viewType={effectiveViewType}
         alertStatesFetching={isAlertStatesFetching}
         alertStatesError={isAlertStatesError}
         onRetryAlertStates={refetchAlertStates}
         calNames={calNames}
       />
-      {viewType === CheckListViewType.Folder ? (
+      {foldersUnavailable && (
+        // The error banner is actionable (Retry) and not dismissible, so it
+        // always shows. The info banners are dismissible for the session.
+        folderStatus === 'error' ? (
+          <FolderErrorBanner onRetry={refetchFolders} />
+        ) : (
+          !folderBannerDismissed &&
+          (folderStatus === 'not-provisioned' ? (
+            <FolderNotProvisionedBanner onDismiss={() => setFolderBannerDismissed(true)} />
+          ) : (
+            <FolderPermissionBanner onDismiss={() => setFolderBannerDismissed(true)} />
+          ))
+        )
+      )}
+      {effectiveViewType === CheckListViewType.Folder ? (
         <CheckListFolderView
           checks={visibleChecks}
           folders={allFolders}
@@ -315,7 +349,7 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
                   onToggleCheckbox={handleCheckSelect}
                   runtimeAlertState={getCheckRuntimeAlertState(checkAlertStates, check)}
                   selected={selectedCheckIds.has(check.id!)}
-                  viewType={viewType}
+                  viewType={effectiveViewType}
                 />
                 </div>
               ))}

--- a/src/page/CheckList/components/BulkActions.hooks.ts
+++ b/src/page/CheckList/components/BulkActions.hooks.ts
@@ -1,8 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { Check, FeatureName } from 'types';
+import { Check } from 'types';
 import { useBulkCheckPermissions } from 'contexts/CheckFolderAccessContext';
-import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 import { useBulkDeleteChecks, useBulkUpdateChecks } from 'data/useChecks';
 import { useDeleteFolder } from 'data/useFolders';
 import { showAlert } from 'data/utils';
@@ -16,10 +15,10 @@ interface UseBulkActionsOptions {
   checks: Check[];
   onResolved: () => void;
   deleteFolder?: DeleteFolderTarget;
+  isFoldersAvailable: boolean;
 }
 
-export function useBulkActions({ checks, onResolved, deleteFolder }: UseBulkActionsOptions) {
-  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
+export function useBulkActions({ checks, onResolved, deleteFolder, isFoldersAvailable }: UseBulkActionsOptions) {
   const { canWriteAll, canDeleteAll } = useBulkCheckPermissions(checks);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showMoveToFolderModal, setShowMoveToFolderModal] = useState(false);
@@ -85,7 +84,7 @@ export function useBulkActions({ checks, onResolved, deleteFolder }: UseBulkActi
   }, [deleteFolder, checksLabel]);
 
   return {
-    isFoldersEnabled,
+    isFoldersAvailable,
     canWriteAll,
     canDeleteAll,
     showDeleteModal,

--- a/src/page/CheckList/components/BulkActions.tsx
+++ b/src/page/CheckList/components/BulkActions.tsx
@@ -4,6 +4,7 @@ import { Button, ButtonCascader, ConfirmModal, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { Check } from 'types';
+import { useIsFoldersAvailable } from 'contexts/CheckFolderAccessContext';
 import { BulkActionsModal } from 'page/CheckList/components/BulkActionsModal';
 import { BulkMoveToFolderModal } from 'page/CheckList/components/BulkMoveToFolderModal';
 
@@ -22,8 +23,8 @@ enum BulkAction {
 export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
   const styles = useStyles2(getStyles);
   const [bulkEditAction, setBulkEditAction] = useState<BulkAction | null>(null);
+  const isFoldersAvailable = useIsFoldersAvailable();
   const {
-    isFoldersEnabled,
     canWriteAll,
     canDeleteAll,
     showDeleteModal,
@@ -35,7 +36,7 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
     disableChecks,
     deleteChecks,
     deleteModalProps,
-  } = useBulkActions({ checks, onResolved });
+  } = useBulkActions({ checks, onResolved, isFoldersAvailable });
 
   return (
     <>
@@ -65,7 +66,7 @@ export const BulkActions = ({ checks, onResolved }: BulkActionsProps) => {
             Bulk edit probes
           </ButtonCascader>
         )}
-        {isFoldersEnabled && (
+        {isFoldersAvailable && (
           <Button
             type="button"
             variant="secondary"

--- a/src/page/CheckList/components/CheckFilters.tsx
+++ b/src/page/CheckList/components/CheckFilters.tsx
@@ -6,8 +6,7 @@ import { css, cx } from '@emotion/css';
 import { DataTestIds } from 'test/dataTestIds';
 
 import { CheckAlertsFilter, CheckFiltersType, CheckTypeFilter, FilterType, ProbeFilter } from 'page/CheckList/CheckList.types';
-import { Check, FeatureName, GrafanaFolder } from 'types';
-import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
+import { Check, GrafanaFolder } from 'types';
 import { useExtendedProbes } from 'data/useProbes';
 import { useCheckTypeOptions } from 'hooks/useCheckTypeOptions';
 import { CHECK_LIST_STATUS_OPTIONS } from 'page/CheckList/CheckList.constants';
@@ -20,6 +19,7 @@ interface CheckFiltersProps {
   checkFilters: CheckFiltersType;
   folders?: GrafanaFolder[];
   defaultFolderUid?: string;
+  isFoldersAvailable?: boolean;
   includeStatus?: boolean;
   calNames?: string[];
   className?: string;
@@ -32,6 +32,7 @@ export function CheckFilters({
   checkFilters,
   folders = [],
   defaultFolderUid,
+  isFoldersAvailable = false,
   includeStatus = true,
   calNames,
   className,
@@ -87,8 +88,6 @@ export function CheckFilters({
         value: probe.id!,
       }));
   }, [probes]);
-
-  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
 
   const folderOptions: Array<ComboboxOption<string>> = useMemo(() => {
     return folders.map((folder) => ({
@@ -232,7 +231,7 @@ export function CheckFilters({
               isClearable
             />
           </Field>
-          {isFoldersEnabled && (
+          {isFoldersAvailable && (
             <Field
               label={t('checkFilters.folders', 'Folders')}
               htmlFor="check-folder-filter"

--- a/src/page/CheckList/components/CheckListHeader.tsx
+++ b/src/page/CheckList/components/CheckListHeader.tsx
@@ -21,6 +21,7 @@ type CheckListHeaderProps = {
   currentPageChecks: Check[];
   folders?: GrafanaFolder[];
   defaultFolderUid?: string;
+  isFoldersAvailable: boolean;
   onChangeView: (viewType: CheckListViewType) => void;
   onDelete: () => void;
   onFilterChange: (filters: CheckFiltersType, type: FilterType) => void;
@@ -69,6 +70,7 @@ export const CheckListHeader = ({
   currentPageChecks,
   folders,
   defaultFolderUid,
+  isFoldersAvailable,
   onChangeView,
   onDelete,
   onFilterChange,
@@ -113,6 +115,7 @@ export const CheckListHeader = ({
               checkFilters={checkFilters}
               folders={folders}
               defaultFolderUid={defaultFolderUid}
+              isFoldersAvailable={isFoldersAvailable}
               onChange={onFilterChange}
               calNames={calNames}
               className={styles.filters}
@@ -144,7 +147,7 @@ export const CheckListHeader = ({
             {selectedCheckIds.size > 0 ? (
               <BulkActions checks={selectedChecks} onResolved={onDelete} />
             ) : (
-              <CheckListViewSwitcher onChange={onChangeView} viewType={viewType} />
+              <CheckListViewSwitcher onChange={onChangeView} viewType={viewType} isFoldersAvailable={isFoldersAvailable} />
             )}
           </div>
 

--- a/src/page/CheckList/components/CheckListViewSwitcher.tsx
+++ b/src/page/CheckList/components/CheckListViewSwitcher.tsx
@@ -2,8 +2,6 @@ import React, { useMemo } from 'react';
 import { RadioButtonGroup } from '@grafana/ui';
 
 import { CheckListViewType } from 'page/CheckList/CheckList.types';
-import { FeatureName } from 'types';
-import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 
 const BASE_VIEW_TYPE_OPTIONS = [
   { description: 'Card view', value: CheckListViewType.Card, icon: 'check-square' },
@@ -15,16 +13,16 @@ const FOLDER_VIEW_OPTION = { description: 'Folder view', value: CheckListViewTyp
 interface CheckListViewSwitcherProps {
   viewType: CheckListViewType;
   onChange: (viewType: CheckListViewType) => void;
+  isFoldersAvailable: boolean;
 }
 
-export function CheckListViewSwitcher({ viewType, onChange }: CheckListViewSwitcherProps) {
-  const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
+export function CheckListViewSwitcher({ viewType, onChange, isFoldersAvailable }: CheckListViewSwitcherProps) {
   const options = useMemo(() => {
-    if (isFoldersEnabled) {
+    if (isFoldersAvailable) {
       return [FOLDER_VIEW_OPTION, ...BASE_VIEW_TYPE_OPTIONS];
     }
     return BASE_VIEW_TYPE_OPTIONS;
-  }, [isFoldersEnabled]);
+  }, [isFoldersAvailable]);
 
   return (
     <RadioButtonGroup

--- a/src/page/CheckList/components/FolderBanners.tsx
+++ b/src/page/CheckList/components/FolderBanners.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Alert } from '@grafana/ui';
+
+import { ErrorAlert } from 'components/ErrorAlert';
+
+export function FolderNotProvisionedBanner({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <Alert severity="info" title="Folder features are unavailable" onRemove={onDismiss}>
+      Checks are organized inside a <strong>Grafana Synthetic Monitoring</strong> folder, but it has not been created yet. A user with <code>folders:create</code> permission needs to open Synthetic Monitoring to initialize the default folder. Checks are shown without folder grouping.
+    </Alert>
+  );
+}
+
+export function FolderPermissionBanner({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <Alert severity="info" title="Folder features are unavailable" onRemove={onDismiss}>
+      You lack the required <code>folders:read</code> permission. Contact your organization administrator to update your role. Checks are shown without folder grouping.
+    </Alert>
+  );
+}
+
+export function FolderErrorBanner({ onRetry }: { onRetry: () => void }) {
+  return (
+    <ErrorAlert
+      title="Failed to load folder information"
+      content="Something went wrong while loading folders. Checks are shown without folder grouping."
+      buttonText="Retry"
+      onClick={onRetry}
+    />
+  );
+}

--- a/src/page/CheckList/components/FolderBulkActions.tsx
+++ b/src/page/CheckList/components/FolderBulkActions.tsx
@@ -4,6 +4,7 @@ import { ConfirmModal, IconButton, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { Check } from 'types';
+import { useIsFoldersAvailable } from 'contexts/CheckFolderAccessContext';
 import { BulkMoveToFolderModal } from 'page/CheckList/components/BulkMoveToFolderModal';
 
 import { DeleteFolderTarget, useBulkActions } from './BulkActions.hooks';
@@ -16,8 +17,8 @@ interface FolderBulkActionsProps {
 
 export function FolderBulkActions({ checks, onResolved, deleteFolder }: FolderBulkActionsProps) {
   const styles = useStyles2(getStyles);
+  const isFoldersAvailable = useIsFoldersAvailable();
   const {
-    isFoldersEnabled,
     canWriteAll,
     canDeleteAll,
     showDeleteModal,
@@ -29,11 +30,11 @@ export function FolderBulkActions({ checks, onResolved, deleteFolder }: FolderBu
     disableChecks,
     deleteChecks,
     deleteModalProps,
-  } = useBulkActions({ checks, onResolved, deleteFolder });
+  } = useBulkActions({ checks, onResolved, deleteFolder, isFoldersAvailable });
 
   return (
     <div className={styles.container}>
-      {isFoldersEnabled && (
+      {isFoldersAvailable && (
         <IconButton
           name="folder"
           aria-label="Move to folder"


### PR DESCRIPTION
## Problem

The **Grafana Synthetic Monitoring** folder is the default folder used by alerting rules and, with the folders feature flag, also used to group checks. When a user opens Synthetic Monitoring for the first time on a stack where this folder does not yet exist, the app auto-creates it. However, if the user lacks `folders:create` permission, the auto-creation fails and the app hides all checks with no explanation.

Users who permanently lack `folders:read` would also hit this problem without self-resolution, as they cannot access the folder even after it has been created by someone else.

## Solution

In this PR we add a fallback for when the default folder is unavailable. Instead of hiding checks, the app loads the check list without folder grouping and displays an info banner explaining what needs to happen:

- **Folder not provisioned**: tells the user the **Grafana Synthetic Monitoring** folder has not been created yet and that a user with `folders:create` permission needs to open Synthetic Monitoring to initialize it.
- **Missing folders:read**: tells the user they lack the required permission and should contact their organization administrator.

<img width="2256" height="794" alt="image" src="https://github.com/user-attachments/assets/a6e691cb-3970-4d9d-98a3-406a7b5ade8f" />

<img width="2264" height="775" alt="image" src="https://github.com/user-attachments/assets/8932d13f-053c-42e9-b843-73e6de4078af" />