### PR TITLE
fix: allow editing checks when users lack folders:read permissions

### DIFF
--- a/src/data/useDefaultFolder.ts
+++ b/src/data/useDefaultFolder.ts
@@ -83,6 +83,15 @@ export function useDefaultFolder(enabled = true) {
     },
     staleTime: FOLDERS_STALE_TIME,
     refetchOnWindowFocus: false,
+    // Once this query has settled (success or error) we must not re-fetch it
+    // every time a new observer mounts. With no data and a 403 error, React
+    // Query's `shouldLoadOnMount` is gated by `retryOnMount` (not
+    // `refetchOnMount`); leaving it at the default `true` makes each newly
+    // mounted consumer (e.g. the check form mounting once access falls back to
+    // SM RBAC) re-issue the 403. That re-fetch flips `folderStatus`
+    // loading->error, which remounts consumers, which re-fetch again: an
+    // infinite request loop. Errors here are surfaced with an explicit Retry.
+    retryOnMount: false,
     retry: false,
     enabled,
   });

--- a/src/data/useFolderPermissions.ts
+++ b/src/data/useFolderPermissions.ts
@@ -51,6 +51,12 @@ export function useFolderPermissions(folderUids: string[]) {
       queryKey: ['folders', 'detail', uid] as const,
       queryFn: () => fetchFolderByUid(uid),
       staleTime: FOLDERS_STALE_TIME,
+      // Don't re-issue a settled-error request every time a new observer
+      // mounts. A 403/404 folder has no data, so React Query's
+      // `shouldLoadOnMount` is governed by `retryOnMount`; leaving it `true`
+      // makes each remount re-fetch, which can drive an infinite request loop
+      // when the folder set churns. See useDefaultFolder for the full rationale.
+      retryOnMount: false,
       retry: (failureCount: number, error: unknown) => {
         if (isFetchError(error) && (error.status === 403 || error.status === 404)) {
           return false;

--- a/src/hooks/useCheckFolderAccess.ts
+++ b/src/hooks/useCheckFolderAccess.ts
@@ -28,7 +28,7 @@ import { useAllFolders } from 'data/useFolders';
  * Returns visibleChecks (filtered) and getPermissions (lookup function).
  */
 export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks: T[]) {
-  const { folders: allFolders, defaultFolderUid, isFoldersAvailable } = useAllFolders();
+  const { folders: allFolders, defaultFolderUid, isFoldersAvailable, folderStatus } = useAllFolders();
 
   const accessibleFolderUids = useMemo(
     () => new Set(allFolders.map((f) => f.uid)),
@@ -91,5 +91,12 @@ export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks:
     getPermissions,
     getFolderStatus,
     isFoldersAvailable,
+    // True while the default folder request is still in flight. During this
+    // window isFoldersAvailable is optimistically `true`, so a check whose
+    // folder has already resolved to `forbidden` would compute canRead=false
+    // even when the eventual state is the fallback (default folder 403 ->
+    // no-folder-context). Consumers that gate navigation on canRead must wait
+    // for this to settle to avoid a premature, irreversible redirect.
+    isResolving: folderStatus === 'loading',
   };
 }

--- a/src/page/DashboardPage.tsx
+++ b/src/page/DashboardPage.tsx
@@ -22,11 +22,20 @@ function DashboardPageContent() {
   const { id } = useParams<CheckPageParams>();
   const check = checks.find((check) => String(check.id) === id);
 
-  const { getPermissions } = useCheckFolderAccess(check ? [check] : []);
+  const { getPermissions, isResolving: isResolvingFolders } = useCheckFolderAccess(check ? [check] : []);
   const permissions = getPermissions({ folderUid: check?.folderUid });
 
   if (!isLoading && !check) {
     return <CheckNotFound />;
+  }
+
+  // Wait for folder access to settle before evaluating the canRead redirect.
+  // During the optimistic loading window a check whose folder has returned 403
+  // resolves to `forbidden` (canRead=false) and would redirect prematurely,
+  // even when the eventual state is the fallback (canRead=true). See
+  // useCheckFolderAccess for details.
+  if (isResolvingFolders) {
+    return <Spinner />;
   }
 
   if (!permissions.canRead) {

--- a/src/page/EditCheck/EditCheckV2.tsx
+++ b/src/page/EditCheck/EditCheckV2.tsx
@@ -26,7 +26,7 @@ export const EditCheckV2 = () => {
   const check = checks?.find((c) => c.id === Number(id));
   const urlSearchParams = useURLSearchParams();
 
-  const { getPermissions } = useCheckFolderAccess(check ? [check] : []);
+  const { getPermissions, isResolving: isResolvingFolders } = useCheckFolderAccess(check ? [check] : []);
   const permissions = getPermissions({ folderUid: check?.folderUid });
 
   const handleSubmit = useHandleSubmitCheckster(check);
@@ -48,8 +48,13 @@ export const EditCheckV2 = () => {
 
   const isReady = !isLoading;
 
-  // Only show spinner for the initial fetch.
-  if (isLoading && !isFetched) {
+  // Only show spinner for the initial fetch, or while folder access is still
+  // resolving. We must not evaluate the canRead redirect until the default
+  // folder request has settled: during that optimistic window a check whose
+  // folder has already returned 403 resolves to `forbidden` (canRead=false)
+  // and would trigger an irreversible redirect, even when the eventual state
+  // is the fallback (default folder 403 -> no-folder-context -> canRead=true).
+  if ((isLoading && !isFetched) || isResolvingFolders) {
     return <CenteredSpinner />;
   }
 

--- a/src/page/EditCheck/__tests__/v2/EditCheckV2.test.tsx
+++ b/src/page/EditCheck/__tests__/v2/EditCheckV2.test.tsx
@@ -141,6 +141,26 @@ describe(`<EditCheckV2 />`, () => {
         });
       });
 
+      it('falls back to SM RBAC and loads the editable form when the user lacks folders:read (default folder 403)', async () => {
+        // When the default folder itself returns 403 the user has no
+        // folders:read, so access control falls back to SM RBAC. A check whose
+        // own folder also returns 403 must still load (and be editable) rather
+        // than redirecting out of the edit page mid-load (the premature-redirect
+        // race that otherwise cancels the in-flight request and loops).
+        server.use(
+          apiRoute('getFolder', {
+            result: async () => ({ status: 403, json: { message: 'Access denied' } }),
+          })
+        );
+
+        await renderEditPage(CHECK_IN_FORBIDDEN_FOLDER);
+
+        await waitFor(() => screen.getByTestId(DataTestIds.PageReady), { timeout: 10000 });
+
+        const jobNameInput = await screen.findByLabelText('Job name', { exact: false });
+        expect(jobNameInput).not.toBeDisabled();
+      });
+
       it('disables the form for a check in a read-only folder', async () => {
         await renderEditPage(CHECK_IN_READONLY_FOLDER);
 


### PR DESCRIPTION
## Problem

Users with `checks:write` but without `folders:read` could not edit their synthetic checks. Clicking **Edit** on an accessible check bounced them straight back to the timepoint explorer.

This affected customers managing permissions via Terraform/custom roles (e.g. teams granted SM check permissions but not folder permissions), who had no easy way to re-grant `folders:read` across every stack. The graceful-degradation fallback shipped in #1739 was meant to cover exactly this case, but the edit page never reached it.

## Solution

The edit page now waits for folder access to finish resolving before it decides whether to redirect. Previously it evaluated the check's read permission while folder data was still loading — and during the optimistic loading window a check whose folder returned `403` briefly looked forbidden, triggering an irreversible redirect out of the edit page before the SM-RBAC fallback could take over.

With the redirect now gated on folder access settling, a user who lacks `folders:read` lands on the editable form (SM-RBAC only) as intended, instead of being sent to the timepoint explorer.

In the recording, I'm loading the app as a user without `folders:read` access, but with `checks:read` and `checks:write`. This allows me to edit a check, and doesn't use the new folders view.

https://github.com/user-attachments/assets/b6c54c66-c798-48a6-a929-ef1cb14f093e




