### PR TITLE
feat: emit event bus event when check created

### DIFF
--- a/src/data/useChecks.ts
+++ b/src/data/useChecks.ts
@@ -1,5 +1,6 @@
 import { type QueryKey, useMutation, UseMutationResult, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { isFetchError } from '@grafana/runtime';
+import { emitCheckCreatedEvent } from 'features/tracking/appEvents';
 import { trackCheckCreated, trackCheckUpdated } from 'features/tracking/checkFormEvents';
 
 import { type MutationProps } from 'data/types';
@@ -67,7 +68,10 @@ export function useCreateCheck({ eventInfo, onError, onSuccess }: MutationProps<
     },
     onSuccess: (data) => {
       onSuccess?.(data);
-      trackCheckCreated({ checkType: getCheckType(data.settings) });
+
+      const checkType = getCheckType(data.settings);
+      trackCheckCreated({ checkType });
+      emitCheckCreatedEvent({ checkType });
     },
     meta: {
       event: {

--- a/src/features/tracking/appEvents.ts
+++ b/src/features/tracking/appEvents.ts
@@ -1,0 +1,12 @@
+import { BusEventWithPayload } from '@grafana/data';
+import { getAppEvents } from '@grafana/runtime';
+
+import type { CheckType } from 'types';
+
+class SyntheticMonitoringCheckCreatedEvent extends BusEventWithPayload<{ checkType: CheckType; }> {
+  static type = 'synthetic-monitoring/check-created';
+}
+
+export const emitCheckCreatedEvent = ({ checkType }: { checkType: CheckType }) => {
+  getAppEvents().publish(new SyntheticMonitoringCheckCreatedEvent({ checkType }));
+}

--- a/src/page/NewCheck/__tests__/v2/NewCheckV2.journey.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/NewCheckV2.journey.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor, within } from '@testing-library/react';
+import { emitCheckCreatedEvent } from 'features/tracking/appEvents';
 import { trackCheckCreated } from 'features/tracking/checkFormEvents';
 import { CHECKSTER_TEST_ID, DataTestIds } from 'test/dataTestIds';
 import { BASIC_HTTP_CHECK } from 'test/fixtures/checks';
@@ -22,6 +23,10 @@ jest.mock('features/tracking/checkFormEvents', () => ({
   trackNavigateWizardForm: jest.fn(),
   trackAdhocCreated: jest.fn(),
   trackNeedHelpScriptsButtonClicked: jest.fn(),
+}));
+
+jest.mock('features/tracking/appEvents', () => ({
+  emitCheckCreatedEvent: jest.fn(),
 }));
 
 describe(`<NewCheckV2 /> journey`, () => {
@@ -302,7 +307,7 @@ describe(`<NewCheckV2 /> journey`, () => {
     expect(screen.getByTestId(CHECKSTER_TEST_ID.form.submitButton)).not.toBeDisabled();
   });
 
-  it(`should track check creation with check type`, async () => {
+  it(`should track + emit check creation with check type`, async () => {
     const { user } = await renderNewForm(CheckType.Http);
 
     await fillMandatoryFields({ user, checkType: CheckType.Http });
@@ -314,5 +319,6 @@ describe(`<NewCheckV2 /> journey`, () => {
     });
 
     expect(trackCheckCreated).toHaveBeenCalledWith({ checkType: CheckType.Http });
+    expect(emitCheckCreatedEvent).toHaveBeenCalledWith({ checkType: CheckType.Http });
   });
 });

--- a/src/test/mocks/@grafana/runtime.tsx
+++ b/src/test/mocks/@grafana/runtime.tsx
@@ -20,6 +20,14 @@ import { DataTestIds } from '../../dataTestIds';
 jest.mock('@grafana/runtime', () => {
   const actual = jest.requireActual('@grafana/runtime');
 
+  const appEvents = {
+    publish: jest.fn(),
+    subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+    getStream: jest.fn(),
+    removeAllListeners: jest.fn(),
+    newScopedBus: jest.fn(),
+  };
+
   type Location = { pathname: string; search: string; hash: string; state: unknown; key: string };
   type PathArg = string | { pathname?: string; search?: string; hash?: string };
 
@@ -136,6 +144,7 @@ jest.mock('@grafana/runtime', () => {
       get: () => Promise.resolve(new SMDataSource(SM_DATASOURCE)),
     }),
     getLocationSrv: () => ({ update: (args: any) => args }),
+    getAppEvents: () => appEvents,
     PluginPage: ({ actions, children, pageNav }: { actions: any; children: ReactNode; pageNav: NavModelItem }) => (
       <div>
         <h2>{pageNav?.text}</h2>


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new operational event fired over the event bus for when checks are created, to support [product marketing work](https://raintank-corp.slack.com/archives/C0AJVPB9S2U/p1781191475571649) (🔐) via the [global messaging feature](https://github.com/grafana/grafana-setupguide-app/blob/main/docs/global-messaging.md) (🔐), to show a toast popup for users who have created a check.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

https://github.com/user-attachments/assets/a94d65ae-869b-4b1c-b4c4-c6500af65a31
