### PR TITLE
fix: home summary panels show no data with label filters applied

### DIFF
--- a/src/scenes/Summary/SummaryErrorPctgViz.tsx
+++ b/src/scenes/Summary/SummaryErrorPctgViz.tsx
@@ -46,6 +46,7 @@ export const SummaryErrorPctgViz = () => {
     by (job, instance)`;
 
   const dataProvider = useQueryRunner({
+    datasource: { uid: '-- Mixed --', type: 'datasource' },
     queries: [
       {
         exemplar: true,
@@ -54,9 +55,9 @@ export const SummaryErrorPctgViz = () => {
         interval: '1m',
         legendFormat: '{{job}}/{{ instance }}',
         refId: 'A',
+        datasource: metricsDS,
       },
     ],
-    datasource: metricsDS,
   });
 
   const viz = VizConfigBuilders.timeseries()

--- a/src/scenes/Summary/SummaryLatencyViz.tsx
+++ b/src/scenes/Summary/SummaryLatencyViz.tsx
@@ -47,6 +47,7 @@ export const SummaryLatencyViz = () => {
   `;
 
   const dataProvider = useQueryRunner({
+    datasource: { uid: '-- Mixed --', type: 'datasource' },
     queries: [
       {
         expr: query,
@@ -54,9 +55,9 @@ export const SummaryLatencyViz = () => {
         interval: '1m',
         legendFormat: '{{job}}/{{ instance }}',
         refId: 'A',
+        datasource: metricsDS,
       },
     ],
-    datasource: metricsDS,
   });
 
   const viz = VizConfigBuilders.timeseries()


### PR DESCRIPTION
Addresses: https://github.com/grafana/support-escalations/issues/23098

## Problem

On the Synthetic Monitoring home page, the **All check error percentage** and **All latency** panels showed "No data" whenever a custom label filter was applied (e.g. `env = prod`), even though matching checks existed and other panels on the page (such as the checks table) displayed data correctly. Removing the filter brought the panels back, making the behaviour confusing and eroding trust in the dashboard.

## Solution

The custom label filter is only meaningful for the check metadata metric and was never intended to be applied to the underlying probe result metrics. These two panels were unintentionally having the filter applied everywhere, which filtered their data down to nothing. The panels now apply the filter only where it belongs, so they populate correctly with or without a filter selected.

Made with [Cursor](https://cursor.com)