### PR TITLE
feat: Frontend Observability context for the Grafana Assistant on browser-check pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
   "dependencies": {
     "@emotion/css": "11.13.5",
     "@grafana/alerting": "13.0.2",
+    "@grafana/assistant": "0.1.25",
     "@grafana/data": "13.0.2",
     "@grafana/faro-web-sdk": "2.7.1",
     "@grafana/i18n": "13.0.2",

--- a/src/hooks/useDemAssistantContext.test.ts
+++ b/src/hooks/useDemAssistantContext.test.ts
@@ -1,33 +1,20 @@
+import { createAssistantContextItem } from '@grafana/assistant';
 import { renderHook } from '@testing-library/react';
 import { BASIC_HTTP_CHECK, COMPLEX_BROWSER_CHECK } from 'test/fixtures/checks';
 
 import { useDemAssistantContext } from './useDemAssistantContext';
 
-const mockSetPageContext = jest.fn();
-const mockCreateAssistantContextItem = jest.fn();
-
-jest.mock('@grafana/assistant', () => ({
-  useProvidePageContext: () => mockSetPageContext,
-  createAssistantContextItem: (...args: unknown[]) => {
-    mockCreateAssistantContextItem(...args);
-    return { args };
-  },
-}));
+const mockCreateAssistantContextItem = createAssistantContextItem as jest.Mock;
 
 const FRONTEND_OBSERVABILITY_SETUP_URL = '/a/grafana-kowalski-app/apps/new';
 
 interface StructuredParams {
   title: string;
-  bypassLimits?: boolean;
   data: {
     setup: { entryPoint: string };
     userBrowserChecks: Array<{ job: string; target: string }>;
     currentlyViewedCheck?: { job: string; target: string };
   };
-}
-
-function lastProvidedContext() {
-  return mockSetPageContext.mock.calls.at(-1)?.[0];
 }
 
 function structuredParams(callIndex = 0): StructuredParams {
@@ -42,14 +29,12 @@ describe('useDemAssistantContext', () => {
   it('provides no context when there are no checks', () => {
     renderHook(() => useDemAssistantContext([]));
 
-    expect(lastProvidedContext()).toEqual([]);
     expect(mockCreateAssistantContextItem).not.toHaveBeenCalled();
   });
 
   it('provides no context when the user has no browser checks', () => {
     renderHook(() => useDemAssistantContext([BASIC_HTTP_CHECK]));
 
-    expect(lastProvidedContext()).toEqual([]);
     expect(mockCreateAssistantContextItem).not.toHaveBeenCalled();
   });
 
@@ -60,7 +45,6 @@ describe('useDemAssistantContext', () => {
     expect(mockCreateAssistantContextItem.mock.calls[0][0]).toBe('structured');
 
     const params = structuredParams();
-    expect(params.bypassLimits).toBe(true);
     expect(params.data.setup.entryPoint).toBe(FRONTEND_OBSERVABILITY_SETUP_URL);
     expect(params.data.userBrowserChecks).toEqual([
       { job: COMPLEX_BROWSER_CHECK.job, target: COMPLEX_BROWSER_CHECK.target },

--- a/src/hooks/useDemAssistantContext.test.ts
+++ b/src/hooks/useDemAssistantContext.test.ts
@@ -1,0 +1,85 @@
+import { renderHook } from '@testing-library/react';
+import { BASIC_HTTP_CHECK, COMPLEX_BROWSER_CHECK } from 'test/fixtures/checks';
+
+import { useDemAssistantContext } from './useDemAssistantContext';
+
+const mockSetPageContext = jest.fn();
+const mockCreateAssistantContextItem = jest.fn();
+
+jest.mock('@grafana/assistant', () => ({
+  useProvidePageContext: () => mockSetPageContext,
+  createAssistantContextItem: (...args: unknown[]) => {
+    mockCreateAssistantContextItem(...args);
+    return { args };
+  },
+}));
+
+const FRONTEND_OBSERVABILITY_SETUP_URL = '/a/grafana-kowalski-app/apps/new';
+
+interface StructuredParams {
+  title: string;
+  bypassLimits?: boolean;
+  data: {
+    setup: { entryPoint: string };
+    userBrowserChecks: Array<{ job: string; target: string }>;
+    currentlyViewedCheck?: { job: string; target: string };
+  };
+}
+
+function lastProvidedContext() {
+  return mockSetPageContext.mock.calls.at(-1)?.[0];
+}
+
+function structuredParams(callIndex = 0): StructuredParams {
+  return mockCreateAssistantContextItem.mock.calls[callIndex][1];
+}
+
+describe('useDemAssistantContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('provides no context when there are no checks', () => {
+    renderHook(() => useDemAssistantContext([]));
+
+    expect(lastProvidedContext()).toEqual([]);
+    expect(mockCreateAssistantContextItem).not.toHaveBeenCalled();
+  });
+
+  it('provides no context when the user has no browser checks', () => {
+    renderHook(() => useDemAssistantContext([BASIC_HTTP_CHECK]));
+
+    expect(lastProvidedContext()).toEqual([]);
+    expect(mockCreateAssistantContextItem).not.toHaveBeenCalled();
+  });
+
+  it('provides Frontend Observability context with only the browser checks and the setup URL', () => {
+    renderHook(() => useDemAssistantContext([BASIC_HTTP_CHECK, COMPLEX_BROWSER_CHECK]));
+
+    expect(mockCreateAssistantContextItem).toHaveBeenCalledTimes(1);
+    expect(mockCreateAssistantContextItem.mock.calls[0][0]).toBe('structured');
+
+    const params = structuredParams();
+    expect(params.bypassLimits).toBe(true);
+    expect(params.data.setup.entryPoint).toBe(FRONTEND_OBSERVABILITY_SETUP_URL);
+    expect(params.data.userBrowserChecks).toEqual([
+      { job: COMPLEX_BROWSER_CHECK.job, target: COMPLEX_BROWSER_CHECK.target },
+    ]);
+    expect(params.data.currentlyViewedCheck).toBeUndefined();
+  });
+
+  it('marks the currently viewed check when a browser check is focused', () => {
+    renderHook(() => useDemAssistantContext([COMPLEX_BROWSER_CHECK], { focusedCheck: COMPLEX_BROWSER_CHECK }));
+
+    expect(structuredParams().data.currentlyViewedCheck).toEqual({
+      job: COMPLEX_BROWSER_CHECK.job,
+      target: COMPLEX_BROWSER_CHECK.target,
+    });
+  });
+
+  it('ignores a focused check that is not a browser check', () => {
+    renderHook(() => useDemAssistantContext([COMPLEX_BROWSER_CHECK], { focusedCheck: BASIC_HTTP_CHECK }));
+
+    expect(structuredParams().data.currentlyViewedCheck).toBeUndefined();
+  });
+});

--- a/src/hooks/useDemAssistantContext.ts
+++ b/src/hooks/useDemAssistantContext.ts
@@ -1,0 +1,106 @@
+import { useEffect, useMemo } from 'react';
+import { createAssistantContextItem, useProvidePageContext } from '@grafana/assistant';
+
+import { Check, CheckType } from 'types';
+import { getCheckType } from 'utils';
+import { PLUGIN_URL_PATH } from 'routing/constants';
+
+// Onboarding entry point for Grafana Frontend Observability ("create web app" page).
+const FRONTEND_OBSERVABILITY_SETUP_URL = '/a/grafana-kowalski-app/apps/new';
+
+// The context is registered for any Synthetic Monitoring app page where this hook is
+// mounted (today: the home, check-list, and browser check dashboard pages).
+const URL_PATTERN = `${PLUGIN_URL_PATH}**`;
+
+interface DemAssistantContextOptions {
+  // The browser check the user is currently viewing, when on a single-check page.
+  focusedCheck?: Check;
+}
+
+/**
+ * Provides the Grafana Assistant with product context describing how Synthetic Monitoring
+ * browser checks (synthetic monitoring) relate to Grafana Frontend Observability (real-user
+ * monitoring). This grounds the Assistant so that questions about the real-user side of a
+ * browser check get an accurate, useful answer, and includes the user's browser checks so the
+ * Assistant can reference them and recommend instrumenting the same URLs.
+ *
+ * The context is only registered when the user has at least one browser check, and stays
+ * dormant unless the conversation is about real-user impact.
+ */
+export function useDemAssistantContext(checks: Check[], options: DemAssistantContextOptions = {}) {
+  const { focusedCheck } = options;
+
+  const browserChecks = useMemo(
+    () => checks.filter((check) => getCheckType(check.settings) === CheckType.Browser),
+    [checks]
+  );
+
+  const focusedBrowserCheck =
+    focusedCheck && getCheckType(focusedCheck.settings) === CheckType.Browser ? focusedCheck : undefined;
+
+  const context = useMemo(() => {
+    if (browserChecks.length === 0) {
+      return [];
+    }
+
+    return [
+      createAssistantContextItem('structured', {
+        title: 'Synthetic Monitoring browser checks & Frontend Observability',
+        bypassLimits: true,
+        data: {
+          userActivity: 'The user is working with Synthetic Monitoring browser checks in Grafana Cloud.',
+          whatBrowserChecksAre:
+            'Browser checks are scripted, synthetic checks run on a schedule from Grafana probes. They ' +
+            'simulate a user journey through a web app to proactively detect when a critical flow breaks, ' +
+            'errors, or slows down — independently of real traffic.',
+          realUserCounterpart: {
+            product: 'Grafana Frontend Observability',
+            whatItIs:
+              'Real-user monitoring (RUM) for web applications. Captures how actual users experience the ' +
+              'app: Core Web Vitals, page-load and interaction performance, JavaScript errors, and the ' +
+              'geographies, browsers, and sessions involved.',
+            howItRelatesToBrowserChecks:
+              'Synthetic browser checks are the detection layer — they tell you something broke from a ' +
+              'simulated path. Frontend Observability adds the real-user layer — who was actually affected, ' +
+              'where, on what device, and what they experienced. Run together they cover both the simulated ' +
+              'and the real-user view of the same journeys, so a synthetic failure can be tied to its ' +
+              'real-world user impact.',
+            questionsItAnswers: [
+              'How many real users were affected by what a check just caught, and in which geos?',
+              'Is a failing check a real user-facing incident, or a low-impact blip?',
+              'Which pages and journeys get the most real traffic, so checks can focus there?',
+              'What did real users actually experience (errors, slow loads) around a failure?',
+            ],
+          },
+          userBrowserChecks: browserChecks.map((check) => ({ job: check.job, target: check.target })),
+          ...(focusedBrowserCheck
+            ? { currentlyViewedCheck: { job: focusedBrowserCheck.job, target: focusedBrowserCheck.target } }
+            : {}),
+          setup: {
+            // Canonical entry point for creating a Frontend Observability app. The in-product flow
+            // generates the exact Faro configuration once the user lands here.
+            entryPoint: FRONTEND_OBSERVABILITY_SETUP_URL,
+            recommendation:
+              'Recommend the user instrument the same URL their browser check monitors first — for a failed ' +
+              'check, the target of that failed check — so the synthetic check and the real-user data cover ' +
+              'the same journey.',
+          },
+          assistantGuidance:
+            'Frontend Observability is the relevant product when the user asks about real-user impact, who ' +
+            'was affected, or getting the real-user view of their browser checks — explain how it ' +
+            'complements their synthetic checks, and offer to take them to set it up. When linking or ' +
+            'navigating the user to set up, use the setup entry point URL provided in this context (the ' +
+            'create-web-app page) and let the in-product flow generate the Faro configuration; do not ' +
+            'substitute a different URL or improvise manual setup steps. Navigate only once the user ' +
+            'chooses to set it up or get started.',
+        },
+      }),
+    ];
+  }, [browserChecks, focusedBrowserCheck]);
+
+  const setPageContext = useProvidePageContext(URL_PATTERN, context);
+
+  useEffect(() => {
+    setPageContext(context);
+  }, [setPageContext, context]);
+}

--- a/src/hooks/useDemAssistantContext.ts
+++ b/src/hooks/useDemAssistantContext.ts
@@ -46,7 +46,6 @@ export function useDemAssistantContext(checks: Check[], options: DemAssistantCon
     return [
       createAssistantContextItem('structured', {
         title: 'Synthetic Monitoring browser checks & Frontend Observability',
-        bypassLimits: true,
         data: {
           userActivity: 'The user is working with Synthetic Monitoring browser checks in Grafana Cloud.',
           whatBrowserChecksAre:

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -24,6 +24,7 @@ import { useSuspenseProbes } from 'data/useProbes';
 import { useChecksReachabilitySuccessRate } from 'data/useSuccessRates';
 import { useTenantCostAttributionLabels } from 'data/useTenantCostAttributionLabels';
 import { useCheckFolderAccess } from 'hooks/useCheckFolderAccess';
+import { useDemAssistantContext } from 'hooks/useDemAssistantContext';
 import { useFeatureFlag } from 'hooks/useFeatureFlag';
 import { useQueryParametersState } from 'hooks/useQueryParametersState';
 import { ChecksEmptyState } from 'components/ChecksEmptyState';
@@ -71,6 +72,8 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
   useSuspenseProbes(); // we need to block rendering until we have the probe list so not to initially render a check list that might have probe filters
   const location = useLocation();
   const { data: checks } = useSuspenseChecks();
+
+  useDemAssistantContext(checks);
 
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
   const {

--- a/src/scenes/BrowserDashboard/BrowserDashboard.tsx
+++ b/src/scenes/BrowserDashboard/BrowserDashboard.tsx
@@ -9,6 +9,7 @@ import { getSumDurationByProbeQuery } from 'queries/sumDurationByProbe';
 
 import { Check, CheckType } from 'types';
 import { getCheckType } from 'utils';
+import { useDemAssistantContext } from 'hooks/useDemAssistantContext';
 import { MetricsByURL } from 'scenes/BrowserDashboard/MetricsByURL';
 import { WebVitalsAverageRow } from 'scenes/BrowserDashboard/WebVitalsAverageRow';
 import { WebVitalsOverTimeRow } from 'scenes/BrowserDashboard/WebVitalsOverTimeRow';
@@ -28,6 +29,8 @@ import { TimepointExplorer } from 'scenes/components/TimepointExplorer/Timepoint
 export const BrowserDashboard = ({ check }: { check: Check }) => {
   const styles = useStyles2(getStyles);
   const checkType = getCheckType(check.settings);
+
+  useDemAssistantContext([check], { focusedCheck: check });
 
   return (
     <DashboardContainer check={check} checkType={checkType}>

--- a/src/scenes/BrowserDashboard/BrowserDashboard.tsx
+++ b/src/scenes/BrowserDashboard/BrowserDashboard.tsx
@@ -9,6 +9,7 @@ import { getSumDurationByProbeQuery } from 'queries/sumDurationByProbe';
 
 import { Check, CheckType } from 'types';
 import { getCheckType } from 'utils';
+import { useChecks } from 'data/useChecks';
 import { useDemAssistantContext } from 'hooks/useDemAssistantContext';
 import { MetricsByURL } from 'scenes/BrowserDashboard/MetricsByURL';
 import { WebVitalsAverageRow } from 'scenes/BrowserDashboard/WebVitalsAverageRow';
@@ -27,10 +28,11 @@ import { UptimeStat } from 'scenes/Common/UptimeStatViz';
 import { TimepointExplorer } from 'scenes/components/TimepointExplorer/TimepointExplorer';
 
 export const BrowserDashboard = ({ check }: { check: Check }) => {
+  const { data: checks = [] } = useChecks();
   const styles = useStyles2(getStyles);
   const checkType = getCheckType(check.settings);
 
-  useDemAssistantContext([check], { focusedCheck: check });
+  useDemAssistantContext(checks, { focusedCheck: check });
 
   return (
     <DashboardContainer check={check} checkType={checkType}>

--- a/src/scenes/Summary/SummaryDashboard.tsx
+++ b/src/scenes/Summary/SummaryDashboard.tsx
@@ -15,6 +15,7 @@ import { Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { Check } from 'types';
+import { useDemAssistantContext } from 'hooks/useDemAssistantContext';
 import { useMetricsDS } from 'hooks/useMetricsDS';
 import { AddNewCheckButton } from 'components/AddNewCheckButton';
 import { ChecksEmptyState } from 'components/ChecksEmptyState';
@@ -38,6 +39,8 @@ const SummaryDashboardContent = ({ checks }: SummaryDashboardProps) => {
   const annotations = useSummaryDashboardAnnotations();
   const scene = useSceneContext();
   const [filtersAdded, setFiltersAdded] = useState(false);
+
+  useDemAssistantContext(checks);
 
   const labelKeys = useMemo(() => {
     return checks.reduce<Set<string>>((acc, check) => {

--- a/src/test/jest-setup.tsx
+++ b/src/test/jest-setup.tsx
@@ -57,6 +57,7 @@ global.ResizeObserver = jest.fn(() => ({
   disconnect: jest.fn(),
 }));
 
+import 'test/mocks/@grafana/assistant';
 import 'test/mocks/@grafana/runtime';
 import 'test/mocks/@grafana/ui';
 import 'test/mocks/components/SimpleMap';

--- a/src/test/mocks/@grafana/assistant.tsx
+++ b/src/test/mocks/@grafana/assistant.tsx
@@ -1,0 +1,4 @@
+jest.mock('@grafana/assistant', () => ({
+  useProvidePageContext: jest.fn(() => jest.fn()),
+  createAssistantContextItem: jest.fn((type, params) => ({ type, ...params })),
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1380,6 +1380,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@grafana/assistant@npm:0.1.25":
+  version: 0.1.25
+  resolution: "@grafana/assistant@npm:0.1.25"
+  peerDependencies:
+    "@emotion/css": ">=11.0.0"
+    "@grafana/data": ">=12.1.0"
+    "@grafana/runtime": ">=12.1.0"
+    "@grafana/scenes": ">=5.41.0"
+    "@grafana/schema": ">=12.1.0"
+    "@grafana/ui": ">=12.1.0"
+    react: ">=18.0.0"
+    rxjs: ">=7.0.0"
+  checksum: 10c0/87ccb59650e17f66a09f2d069ea467a03d22a2b4e8e727c9bc06d7555743117889352965a3da341848fcfaf3f52b8afea1905f31b4601111baaf92f82ee1bd51
+  languageName: node
+  linkType: hard
+
 "@grafana/data@npm:13.0.2":
   version: 13.0.2
   resolution: "@grafana/data@npm:13.0.2"
@@ -13782,6 +13798,7 @@ __metadata:
     "@emotion/css": "npm:11.13.5"
     "@faker-js/faker": "npm:10.1.0"
     "@grafana/alerting": "npm:13.0.2"
+    "@grafana/assistant": "npm:0.1.25"
     "@grafana/data": "npm:13.0.2"
     "@grafana/eslint-config": "npm:9.0.0"
     "@grafana/faro-web-sdk": "npm:2.7.1"


### PR DESCRIPTION
## What

Adds a `useDemAssistantContext` hook that registers structured Grafana Assistant **page context** on the pages where users work with browser checks — the home, check-list, and browser check dashboard pages. The context describes how Synthetic Monitoring browser checks (synthetic monitoring) relate to Grafana Frontend Observability (real-user monitoring), includes the user's own browser checks, and points at the Frontend Observability setup entry point.

It is only registered when the user has at least one browser check, and on the single-check dashboard it also flags the currently viewed check.

## Why

Browser checks tell you a synthetic path broke, but not who was affected or what real users experienced. When a user asks the Grafana Assistant about the real-user side of a browser check, it previously had to guess. This gives the Assistant accurate, grounded product context so it can explain how Frontend Observability complements their checks and reference their actual checks.

## How it works

- `src/hooks/useDemAssistantContext.ts` builds a single `structured` context item via `@grafana/assistant` and registers it with `useProvidePageContext`.
- Mounted in `SummaryDashboard` (home), `CheckList` (checks), and `BrowserDashboard` (check dashboard, which passes the focused check).
- Gated on the presence of browser checks — no context is registered otherwise.

## Testing

- Unit tests in `useDemAssistantContext.test.ts` cover the gating, that only browser checks are included, that the setup URL is present, and the focused-check behaviour.
- Manual: on the home or checks page with at least one browser check, open the Assistant and ask about the real-user impact of a browser check — it should reference your checks and link the Frontend Observability setup page. With no browser checks, no context is registered.

## Dependencies

Adds `@grafana/assistant`.