### PR TITLE
chore(analytics): remove unused RudderStack events (overspend cleanup)

### DIFF
--- a/docs/analytics/analytics-events.md
+++ b/docs/analytics/analytics-events.md
@@ -108,16 +108,6 @@ Tracks when the 'need help writing scripts' button is clicked.
 | ------ | -------- | -------------------------------- |
 | source | `string` | The source of the clicked button |
 
-#### synthetic-monitoring_check_form_feature_tab_changed
-
-Tracks when a feature tab is changed.
-
-##### Properties
-
-| name  | type     | description                   |
-| ----- | -------- | ----------------------------- |
-| label | `string` | The label of the feature tab. |
-
 #### synthetic-monitoring_check_form_k6_channel_selected
 
 Tracks when a k6 version channel is selected.
@@ -132,30 +122,6 @@ Tracks when a k6 version channel is selected.
 #### synthetic-monitoring_check_form_k6_channel_retry_clicked
 
 Tracks when the retry button is clicked after k6 channels fail to load.
-
-#### synthetic-monitoring_check_form_terraform_format_changed
-
-Tracks when the Terraform format is changed.
-
-##### Properties
-
-| name   | type              | description                                    |
-| ------ | ----------------- | ---------------------------------------------- |
-| format | `"hcl" \| "json"` | The format that was switched to (hcl or json). |
-
-#### synthetic-monitoring_check_form_terraform_config_copied
-
-Tracks when Terraform configuration is copied.
-
-##### Properties
-
-| name   | type              | description                                    |
-| ------ | ----------------- | ---------------------------------------------- |
-| format | `"hcl" \| "json"` | The format that was switched to (hcl or json). |
-
-#### synthetic-monitoring_check_form_terraform_full_config_clicked
-
-Tracks when the full configuration link is clicked.
 
 #### synthetic-monitoring_check_form_example_script_selected
 
@@ -176,18 +142,6 @@ Tracks when an example script is copied in the check form.
 | name   | type     | description                                          |
 | ------ | -------- | ---------------------------------------------------- |
 | script | `string` | The value identifier of the selected example script. |
-
-### check_list
-
-#### synthetic-monitoring_check_list_duplicate_check_button_clicked
-
-Tracks when the duplicate check button is clicked.
-
-##### Properties
-
-| name      | type                                                                                                     | description                         |
-| --------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| checkType | `"browser" \| "dns" \| "grpc" \| "http" \| "multihttp" \| "ping" \| "scripted" \| "tcp" \| "traceroute"` | The type of check being duplicated. |
 
 ### feature_feedback
 
@@ -281,27 +235,6 @@ Tracks when an alert is selected from the per-check alerts list
 | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
 | name | `"ProbeFailedExecutionsTooHigh" \| "TLSTargetCertificateCloseToExpiring" \| "HTTPRequestDurationTooHighAvg" \| "PingRequestDurationTooHighAvg" \| "DNSRequestDurationTooHighAvg"` | The name of the alert |
 
-#### synthetic-monitoring_per_check_alerts_unselect_alert
-
-Tracks when an alert is unselected from the per-check alerts list
-
-##### Properties
-
-| name | type                                                                                                                                                                              | description           |
-| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| name | `"ProbeFailedExecutionsTooHigh" \| "TLSTargetCertificateCloseToExpiring" \| "HTTPRequestDurationTooHighAvg" \| "PingRequestDurationTooHighAvg" \| "DNSRequestDurationTooHighAvg"` | The name of the alert |
-
-#### synthetic-monitoring_per_check_alerts_change_period
-
-Tracks when the period of an alert is changed
-
-##### Properties
-
-| name   | type                                                                                                                                                                              | description             |
-| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| name   | `"ProbeFailedExecutionsTooHigh" \| "TLSTargetCertificateCloseToExpiring" \| "HTTPRequestDurationTooHighAvg" \| "PingRequestDurationTooHighAvg" \| "DNSRequestDurationTooHighAvg"` | The name of the alert   |
-| period | `string`                                                                                                                                                                          | The period of the alert |
-
 #### synthetic-monitoring_per_check_alerts_change_threshold
 
 Tracks when the threshold of an alert is changed
@@ -312,17 +245,6 @@ Tracks when the threshold of an alert is changed
 | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
 | name      | `"ProbeFailedExecutionsTooHigh" \| "TLSTargetCertificateCloseToExpiring" \| "HTTPRequestDurationTooHighAvg" \| "PingRequestDurationTooHighAvg" \| "DNSRequestDurationTooHighAvg"` | The name of the alert      |
 | threshold | `string`                                                                                                                                                                          | The threshold of the alert |
-
-#### synthetic-monitoring_per_check_alerts_routing_preview_toggled
-
-Tracks when the routing preview is toggled for an alert
-
-##### Properties
-
-| name   | type                                                                                                                                                                              | description                                          |
-| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| name   | `"ProbeFailedExecutionsTooHigh" \| "TLSTargetCertificateCloseToExpiring" \| "HTTPRequestDurationTooHighAvg" \| "PingRequestDurationTooHighAvg" \| "DNSRequestDurationTooHighAvg"` | The name of the alert                                |
-| action | `"show" \| "hide"`                                                                                                                                                                | Whether the routing preview is being shown or hidden |
 
 #### synthetic-monitoring_per_check_alerts_creation_success
 
@@ -370,69 +292,6 @@ Tracks when the hide screenshots toggle is changed.
 | name   | type            | description                         |
 | ------ | --------------- | ----------------------------------- |
 | hidden | `false \| true` | Whether screenshots are now hidden. |
-
-### secrets_management
-
-#### synthetic-monitoring_secrets_management_create_secret_button_clicked
-
-Tracks when the create secret button is clicked.
-
-##### Properties
-
-| name     | type                                                                 | description                                                       |
-| -------- | -------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| source   | `"check_editor_sidepanel_feature_tabs" \| "config_page_secrets_tab"` | The source context where the secrets management UI is being used. |
-| location | `"empty_state" \| "header_action"`                                   | The location where the create button was clicked.                 |
-
-#### synthetic-monitoring_secrets_management_edit_secret_button_clicked
-
-Tracks when the edit secret button is clicked.
-
-##### Properties
-
-| name   | type                                                                 | description                                                       |
-| ------ | -------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| source | `"check_editor_sidepanel_feature_tabs" \| "config_page_secrets_tab"` | The source context where the secrets management UI is being used. |
-
-#### synthetic-monitoring_secrets_management_delete_secret_button_clicked
-
-Tracks when the delete secret button is clicked.
-
-##### Properties
-
-| name   | type                                                                 | description                                                       |
-| ------ | -------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| source | `"check_editor_sidepanel_feature_tabs" \| "config_page_secrets_tab"` | The source context where the secrets management UI is being used. |
-
-#### synthetic-monitoring_secrets_management_secret_created
-
-Tracks when a secret is successfully created.
-
-##### Properties
-
-| name   | type                                                                 | description                                                       |
-| ------ | -------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| source | `"check_editor_sidepanel_feature_tabs" \| "config_page_secrets_tab"` | The source context where the secrets management UI is being used. |
-
-#### synthetic-monitoring_secrets_management_secret_updated
-
-Tracks when a secret is successfully updated.
-
-##### Properties
-
-| name   | type                                                                 | description                                                       |
-| ------ | -------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| source | `"check_editor_sidepanel_feature_tabs" \| "config_page_secrets_tab"` | The source context where the secrets management UI is being used. |
-
-#### synthetic-monitoring_secrets_management_secret_deleted
-
-Tracks when a secret is successfully deleted.
-
-##### Properties
-
-| name   | type                                                                 | description                                                       |
-| ------ | -------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| source | `"check_editor_sidepanel_feature_tabs" \| "config_page_secrets_tab"` | The source context where the secrets management UI is being used. |
 
 ### testing_synthetics_landing
 
@@ -566,16 +425,6 @@ Tracks when a Timepoint Viewer action is clicked
 | --------- | -------------------------------------------------------------------------------------------------------- | --------------------------------- |
 | checkType | `"browser" \| "dns" \| "grpc" \| "http" \| "multihttp" \| "ping" \| "scripted" \| "tcp" \| "traceroute"` | The type of check being explored. |
 | action    | `"previous-timepoint" \| "next-timepoint" \| "view-explore-logs" \| "view-explore-metrics"`              | The action that was clicked.      |
-
-#### synthetic-monitoring_timepoint_explorer_trace_icon_clicked
-
-Tracks when a trace icon is clicked in the log view.
-
-##### Properties
-
-| name   | type                     | description                                        |
-| ------ | ------------------------ | -------------------------------------------------- |
-| action | `"expand" \| "collapse"` | Whether the trace panel was expanded or collapsed. |
 
 #### synthetic-monitoring_timepoint_explorer_timepoint_viewer_logs_view_toggled
 

--- a/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertItem.tsx
@@ -3,7 +3,6 @@ import { useFormContext } from 'react-hook-form';
 import { GrafanaTheme2, urlUtil } from '@grafana/data';
 import { Button, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
-import { trackRoutingPreviewToggled } from 'features/tracking/perCheckAlertsEvents';
 
 import { CheckAlertType, CheckFormValuesWithAlert } from 'types';
 import { useMetricsDS } from 'hooks/useMetricsDS';
@@ -111,10 +110,6 @@ export const AlertItem = ({
             onClick={() => {
               const newShowRouting = !showRouting;
               setShowRouting(newShowRouting);
-              trackRoutingPreviewToggled({
-                name: alert.type,
-                action: newShowRouting ? 'show' : 'hide',
-              });
             }}
             className={styles.routingToggle}
           >

--- a/src/components/CheckForm/AlertsPerCheck/FailedExecutionsAlert.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/FailedExecutionsAlert.tsx
@@ -14,7 +14,7 @@ import {
   useStyles2,
 } from '@grafana/ui';
 import { getTotalChecksPerPeriod } from 'checkUsageCalc';
-import { trackChangePeriod, trackSelectAlert, trackUnSelectAlert } from 'features/tracking/perCheckAlertsEvents';
+import { trackSelectAlert } from 'features/tracking/perCheckAlertsEvents';
 import pluralize from 'pluralize';
 import { CHECKSTER_TEST_ID } from 'test/dataTestIds';
 
@@ -45,7 +45,6 @@ export const FailedExecutionsAlert = ({
   const handleToggleAlert = (type: CheckAlertType) => {
     onSelectionChange(type);
     if (selected) {
-      trackUnSelectAlert({ name: type });
     } else {
       trackSelectAlert({ name: type });
     }
@@ -131,7 +130,6 @@ export const FailedExecutionsAlert = ({
             maxWidth={10}
             onChange={({ value = null }: { value?: string | null }) => {
               periodField.onChange(value);
-              trackChangePeriod({ name: alert.type, period: value ?? '' });
               // clear threshold error if new period is valid
               revalidateForm<CheckFormValuesWithAlert<typeof alert.type>>(`alerts.${alert.type}`);
             }}

--- a/src/components/CheckForm/AlertsPerCheck/RequestDurationTooHighAvgAlert.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/RequestDurationTooHighAvgAlert.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
   useStyles2,
 } from '@grafana/ui';
-import { trackChangePeriod, trackSelectAlert, trackUnSelectAlert } from 'features/tracking/perCheckAlertsEvents';
+import { trackSelectAlert } from 'features/tracking/perCheckAlertsEvents';
 import { CHECKSTER_TEST_ID } from 'test/dataTestIds';
 
 import { CheckAlertType, CheckFormValues } from 'types';
@@ -41,7 +41,6 @@ export const RequestDurationTooHighAvgAlert = ({
   const handleToggleAlert = (type: CheckAlertType) => {
     onSelectionChange(type);
     if (selected) {
-      trackUnSelectAlert({ name: type });
     } else {
       trackSelectAlert({ name: type });
     }
@@ -107,7 +106,6 @@ export const RequestDurationTooHighAvgAlert = ({
             onChange={(option: { value?: string | null }) => {
               const value = option.value ?? null;
               periodField.onChange(value);
-              trackChangePeriod({ name: alert.type, period: value ?? '' });
               // clear threshold error if new period is valid
               revalidateForm<CheckFormValues>(`alerts.${alert.type}`);
             }}

--- a/src/components/CheckForm/AlertsPerCheck/TLSTargetCertificateCloseToExpiringAlert.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/TLSTargetCertificateCloseToExpiringAlert.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
   useStyles2,
 } from '@grafana/ui';
-import { trackChangeThreshold, trackSelectAlert, trackUnSelectAlert } from 'features/tracking/perCheckAlertsEvents';
+import { trackChangeThreshold, trackSelectAlert } from 'features/tracking/perCheckAlertsEvents';
 import { useDebounceCallback } from 'usehooks-ts';
 import { CHECKSTER_TEST_ID } from 'test/dataTestIds';
 
@@ -38,7 +38,6 @@ export const TLSTargetCertificateCloseToExpiringAlert = ({
   const handleToggleAlert = (type: CheckAlertType) => {
     onSelectionChange(type);
     if (selected) {
-      trackUnSelectAlert({ name: type });
     } else {
       trackSelectAlert({ name: type });
     }

--- a/src/components/Checkster/contexts/FeatureTabsContext.tsx
+++ b/src/components/Checkster/contexts/FeatureTabsContext.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, PropsWithChildren, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { trackFeatureTabChanged } from 'features/tracking/checkFormEvents';
 
 import { FeatureTabConfig, FeatureTabLabel } from '../types';
 import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
@@ -57,7 +56,6 @@ export function FeatureTabsContextProvider({ children }: PropsWithChildren) {
 
   const handleSetActive = useCallback((label: FeatureTabLabel, highlight = false) => {
     setActiveLabel(label);
-    trackFeatureTabChanged({ source: 'check_editor_sidepanel_feature_tabs', label });
 
     if (highlight) {
       setHighlightedTab(label);

--- a/src/components/Checkster/feature/terraform/TerraformPanel.tsx
+++ b/src/components/Checkster/feature/terraform/TerraformPanel.tsx
@@ -3,11 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data';
 import { ClipboardButton, Tab, TabContent, TabsBar, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
-import {
-  trackTerraformConfigCopied,
-  trackTerraformFormatChanged,
-  trackTerraformFullConfigClicked,
-} from 'features/tracking/checkFormEvents';
+
 import { highlight, languages } from 'prismjs';
 import { CHECKSTER_TEST_ID } from 'test/dataTestIds';
 
@@ -35,16 +31,13 @@ export function TerraformPanel() {
 
   const handleFormatChange = (format: TerraformFormat) => {
     setActiveFormat(format);
-    trackTerraformFormatChanged({ format });
   };
 
   const handleCopy = () => {
-    trackTerraformConfigCopied({ format: activeFormat });
     return content;
   };
 
   const handleFullConfigClick = () => {
-    trackTerraformFullConfigClicked();
   };
 
   const content = activeFormat === 'hcl' ? hclConfig : jsonConfig;

--- a/src/features/tracking/checkFormEvents.ts
+++ b/src/features/tracking/checkFormEvents.ts
@@ -48,14 +48,6 @@ export const trackNeedHelpScriptsButtonClicked = checkFormEvents<NeedHelpScripts
   'need_help_scripts_button_clicked'
 );
 
-interface FeatureTabChanged extends TrackingEventProps {
-  /** The label of the feature tab. */
-  label: FeatureTabLabel;
-}
-
-/** Tracks when a feature tab is changed. */
-export const trackFeatureTabChanged = checkFormEvents<FeatureTabChanged>('feature_tab_changed');
-
 interface K6ChannelSelected extends TrackingEventProps {
   /** The type of check. */
   checkType: CheckType;
@@ -68,19 +60,6 @@ export const trackK6ChannelSelected = checkFormEvents<K6ChannelSelected>('k6_cha
 
 /** Tracks when the retry button is clicked after k6 channels fail to load. */
 export const trackK6ChannelRetryClicked = checkFormEvents('k6_channel_retry_clicked');
-interface TerraformFormatChanged extends TrackingEventProps {
-  /** The format that was switched to (hcl or json). */
-  format: 'hcl' | 'json';
-}
-
-/** Tracks when the Terraform format is changed. */
-export const trackTerraformFormatChanged = checkFormEvents<TerraformFormatChanged>('terraform_format_changed');
-
-/** Tracks when Terraform configuration is copied. */
-export const trackTerraformConfigCopied = checkFormEvents<TerraformFormatChanged>('terraform_config_copied');
-
-/** Tracks when the full configuration link is clicked. */
-export const trackTerraformFullConfigClicked = checkFormEvents('terraform_full_config_clicked');
 
 interface ExampleScriptEvent extends TrackingEventProps {
   /** The value identifier of the selected example script. */

--- a/src/features/tracking/checkListEvents.ts
+++ b/src/features/tracking/checkListEvents.ts
@@ -4,12 +4,3 @@ import { CheckType } from 'types';
 
 const checkListEvents = createSMEventFactory('check_list');
 
-interface DuplicateCheckButtonClicked extends TrackingEventProps {
-  /** The type of check being duplicated. */
-  checkType: CheckType;
-}
-
-/** Tracks when the duplicate check button is clicked. */
-export const trackDuplicateCheckButtonClicked = checkListEvents<DuplicateCheckButtonClicked>(
-  'duplicate_check_button_clicked'
-);

--- a/src/features/tracking/perCheckAlertsEvents.ts
+++ b/src/features/tracking/perCheckAlertsEvents.ts
@@ -9,13 +9,6 @@ interface PerCheckAlertEvent extends TrackingEventProps {
   name: CheckAlertType;
 }
 
-interface PerCheckAlertChangePeriod extends TrackingEventProps {
-  /** The name of the alert */
-  name: CheckAlertType;
-  /** The period of the alert */
-  period: string;
-}
-
 interface PerCheckAlertChangeThreshold extends TrackingEventProps {
   /** The name of the alert */
   name: CheckAlertType;
@@ -23,27 +16,11 @@ interface PerCheckAlertChangeThreshold extends TrackingEventProps {
   threshold: string;
 }
 
-interface PerCheckAlertRoutingPreviewToggled extends TrackingEventProps {
-  /** The name of the alert */
-  name: CheckAlertType;
-  /** Whether the routing preview is being shown or hidden */
-  action: 'show' | 'hide';
-}
-
 /** Tracks when an alert is selected from the per-check alerts list */
 export const trackSelectAlert = perCheckAlertEvents<PerCheckAlertEvent>('select_alert');
 
-/** Tracks when an alert is unselected from the per-check alerts list */
-export const trackUnSelectAlert = perCheckAlertEvents<PerCheckAlertEvent>('unselect_alert');
-
-/** Tracks when the period of an alert is changed */
-export const trackChangePeriod = perCheckAlertEvents<PerCheckAlertChangePeriod>('change_period');
-
 /** Tracks when the threshold of an alert is changed */
 export const trackChangeThreshold = perCheckAlertEvents<PerCheckAlertChangeThreshold>('change_threshold');
-
-/** Tracks when the routing preview is toggled for an alert */
-export const trackRoutingPreviewToggled = perCheckAlertEvents<PerCheckAlertRoutingPreviewToggled>('routing_preview_toggled');
 
 /** Tracks when an alert is created successfully */
 export const trackAlertCreationSuccess = perCheckAlertEvents<PerCheckAlertEvent>('creation_success');

--- a/src/features/tracking/secretsManagementEvents.ts
+++ b/src/features/tracking/secretsManagementEvents.ts
@@ -4,35 +4,3 @@ import { SecretsManagementSource } from 'page/ConfigPageLayout/tabs/SecretsManag
 
 const secretsManagementEvents = createSMEventFactory('secrets_management');
 
-interface CreateSecretButtonClicked extends TrackingEventProps {
-  /** The source context where the secrets management UI is being used. */
-  source: SecretsManagementSource;
-  /** The location where the create button was clicked. */
-  location: 'empty_state' | 'header_action';
-}
-
-/** Tracks when the create secret button is clicked. */
-export const trackCreateSecretButtonClicked =
-  secretsManagementEvents<CreateSecretButtonClicked>('create_secret_button_clicked');
-
-interface SecretsManagementEvent extends TrackingEventProps {
-  /** The source context where the secrets management UI is being used. */
-  source: SecretsManagementSource;
-}
-
-/** Tracks when the edit secret button is clicked. */
-export const trackEditSecretButtonClicked =
-  secretsManagementEvents<SecretsManagementEvent>('edit_secret_button_clicked');
-
-/** Tracks when the delete secret button is clicked. */
-export const trackDeleteSecretButtonClicked =
-  secretsManagementEvents<SecretsManagementEvent>('delete_secret_button_clicked');
-
-/** Tracks when a secret is successfully created. */
-export const trackSecretCreated = secretsManagementEvents<SecretsManagementEvent>('secret_created');
-
-/** Tracks when a secret is successfully updated. */
-export const trackSecretUpdated = secretsManagementEvents<SecretsManagementEvent>('secret_updated');
-
-/** Tracks when a secret is successfully deleted. */
-export const trackSecretDeleted = secretsManagementEvents<SecretsManagementEvent>('secret_deleted');

--- a/src/features/tracking/timepointExplorerEvents.ts
+++ b/src/features/tracking/timepointExplorerEvents.ts
@@ -87,14 +87,6 @@ export const trackTimepointViewerActionClicked = timepointExplorerEvents<Timepoi
   'timepoint_viewer_action_clicked'
 );
 
-interface TraceIconClicked extends TrackingEventProps {
-  /** Whether the trace panel was expanded or collapsed. */
-  action: 'expand' | 'collapse';
-}
-
-/** Tracks when a trace icon is clicked in the log view. */
-export const trackTraceIconClicked = timepointExplorerEvents<TraceIconClicked>('trace_icon_clicked');
-
 interface TimepointViewerLogsViewToggled extends TrackingEventProps {
   /** The type of check being explored. */
   checkType: CheckType;

--- a/src/page/CheckList/components/CheckItemActionButtons.tsx
+++ b/src/page/CheckList/components/CheckItemActionButtons.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { ConfirmModal, IconButton, LinkButton, useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
-import { trackDuplicateCheckButtonClicked } from 'features/tracking/checkListEvents';
+
 import { DataTestIds } from 'test/dataTestIds';
 
 import { Check } from 'types';
@@ -107,7 +107,6 @@ export const CheckItemActionButtons = ({
         tooltip="Duplicate check"
         disabled={!canWriteChecks}
         onClick={() => {
-          trackDuplicateCheckButtonClicked({ checkType: getCheckType(check.settings) });
         }}
         variant="secondary"
         fill="text"

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretEditModal.tsx
@@ -4,7 +4,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, Field, IconButton, Input, Modal, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
-import { trackSecretCreated, trackSecretUpdated } from 'features/tracking/secretsManagementEvents';
+
 import { DataTestIds } from 'test/dataTestIds';
 
 import { Secret, SecretsManagementSource } from './types';
@@ -130,9 +130,7 @@ export function SecretEditModal({ open, name, onDismiss, existingNames = [], sou
       onSuccess() {
         setSaveError(null);
         if (isNewSecret) {
-          trackSecretCreated({ source });
         } else {
-          trackSecretUpdated({ source });
         }
         onDismiss();
       },

--- a/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
+++ b/src/page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI.tsx
@@ -1,12 +1,6 @@
 import React, { useState } from 'react';
 import { Button, ConfirmModal, EmptyState } from '@grafana/ui';
 import { css } from '@emotion/css';
-import {
-  trackCreateSecretButtonClicked,
-  trackDeleteSecretButtonClicked,
-  trackEditSecretButtonClicked,
-  trackSecretDeleted,
-} from 'features/tracking/secretsManagementEvents';
 
 import { SecretsManagementSource, SecretWithUuid } from './types';
 import { getUserPermissions } from 'data/permissions';
@@ -34,19 +28,16 @@ export function SecretsManagementUI({ source }: SecretsManagementUIProps) {
   const existingNames = secrets?.map((secret) => secret.name) ?? [];
 
   const handleAddSecret = (location: 'empty_state' | 'header_action') => {
-    trackCreateSecretButtonClicked({ source, location });
     setEditMode(SECRETS_EDIT_MODE_ADD);
   };
 
   const handleEditSecret = (name?: string) => {
     if (name) {
-      trackEditSecretButtonClicked({ source });
     }
     setEditMode(name ?? false);
   };
 
   const handleDeleteSecret = (name: string) => {
-    trackDeleteSecretButtonClicked({ source });
     const secret = secrets?.find((s) => s.name === name);
     if (secret) {
       setDeleteMode(secret);
@@ -139,7 +130,6 @@ export function SecretsManagementUI({ source }: SecretsManagementUIProps) {
           if (deleteMode) {
             deleteSecret.mutate(deleteMode.name, {
               onSuccess: () => {
-                trackSecretDeleted({ source });
               },
             });
           }

--- a/src/scenes/components/LogsRenderer/LogLine.tsx
+++ b/src/scenes/components/LogsRenderer/LogLine.tsx
@@ -4,7 +4,6 @@ import { dateTimeFormat, GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
 import { MSG_STRINGS_HTTP } from 'features/parseCheckLogs/checkLogs.constants.msgs';
-import { trackTraceIconClicked } from 'features/tracking/timepointExplorerEvents';
 
 import { HTTPResponseTimingsLog } from 'features/parseCheckLogs/checkLogs.types.http';
 import { LokiFieldNames, ParsedLokiRecord } from 'features/parseLokiLogs/parseLokiLogs.types';
@@ -77,7 +76,6 @@ export const LogLine = ({ log, mainKey, hasTraceColumn }: LogLineProps) => {
   }, [isAwaitingPropagation, logTimestamp]);
 
   const handleToggle = useCallback(() => {
-    trackTraceIconClicked({ action: expanded ? 'collapse' : 'expand' });
     setExpanded((prev) => !prev);
   }, [expanded]);
 


### PR DESCRIPTION
## Remove unused RudderStack events (overspend cleanup)

We are overspending on RudderStack: the events below are **still being ingested into BigQuery** (and incurring ingestion + storage cost) but are **not consumed by any query, dbt model, or dashboard** in the last **180 days**. Only events whose tables are at least **90 days old** were considered, so freshly instrumented events are excluded.

Combined these events account for **~1.15 GB** of RudderStack event storage with ongoing ingestion. Dropping the instrumentation stops the spend at the source.

Detected automatically by the `data_governance` unused-event detector. cc @grafana/synthetic-monitoring-fe

### Removed in this PR (15 events)

| Event | Events / 30d | Table size (GB) | Last consumed | Status |
| --- | ---: | ---: | --- | --- |
| `synthetic-monitoring_check_form_feature_tab_changed` | 4,795 | 0.05 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_per_check_alerts_routing_preview_toggled` | 1,544 | 0.01 | 2026-01-20 | STALE |
| `synthetic-monitoring_per_check_alerts_change_period` | 1,274 | 0.02 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_check_list_duplicate_check_button_clicked` | 999 | 0.01 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_per_check_alerts_unselect_alert` | 775 | 0.01 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_check_form_terraform_format_changed` | 399 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_secrets_management_create_secret_button_clicked` | 395 | 0.01 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_secrets_management_edit_secret_button_clicked` | 380 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_secrets_management_secret_created` | 313 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_secrets_management_secret_updated` | 192 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_check_form_terraform_config_copied` | 167 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_secrets_management_delete_secret_button_clicked` | 110 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_secrets_management_secret_deleted` | 107 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_check_form_terraform_full_config_clicked` | 26 | 0.0 | never (in lookback) | NEVER_QUERIED |
| `synthetic-monitoring_timepoint_explorer_trace_icon_clicked` | 7 | 0.0 | 2026-03-30 | STALE |

For these, the event definition, its props interface, imports, and bare call sites were removed automatically.

### Also flagged — needs manual removal (4 events)

These are equally unused, but their call sites are not simple statements (JSX prop values, callback arguments, or test mocks), so they were left untouched to avoid breaking code. Please remove them in a follow-up:

- `synthetic-monitoring_check_form_navigate_wizard_form_button_clicked` (27,142 events/30d, 0.83 GB)
  - `src/page/NewCheck/__tests__/v2/NewCheckV2.journey.test.tsx:23` — test: `trackNavigateWizardForm: jest.fn(),`
  - `src/page/EditCheck/__tests__/v2/EditCheckV2.test.tsx:23` — test: `trackNavigateWizardForm: jest.fn(),`
- `synthetic-monitoring_check_form_check_updated` (11,751 events/30d, 0.17 GB)
  - `src/page/NewCheck/__tests__/v2/NewCheckV2.journey.test.tsx:22` — test: `trackCheckUpdated: jest.fn(),`
  - `src/page/EditCheck/__tests__/v2/EditCheckV2.test.tsx:3` — test: `import { trackCheckUpdated } from 'features/tracking/checkFormEvents';`
  - `src/page/EditCheck/__tests__/v2/EditCheckV2.test.tsx:22` — test: `trackCheckUpdated: jest.fn(),`
  - `src/page/EditCheck/__tests__/v2/EditCheckV2.test.tsx:116` — test: `expect(trackCheckUpdated).toHaveBeenCalledWith({ checkType: CheckType.Dns });`
- `synthetic-monitoring_per_check_alerts_change_threshold` (2,123 events/30d, 0.04 GB)
  - `src/components/CheckForm/AlertsPerCheck/ThresholdSelector.tsx:24` — jsx_or_arg: `const debouncedTrackChangeThreshold = useDebounceCallback(trackChangeThreshold, 750);`
  - `src/components/CheckForm/AlertsPerCheck/TLSTargetCertificateCloseToExpiringAlert.tsx:52` — jsx_or_arg: `const debouncedTrackChangeThreshold = useDebounceCallback(trackChangeThreshold, 750);`
- `synthetic-monitoring_check_form_k6_channel_retry_clicked` (1 events/30d, 0.0 GB)
  - `src/components/CheckEditor/FormComponents/K6ChannelSelect.tsx:25` — jsx_or_arg: `onRetry={trackK6ChannelRetryClicked}`

### Notes for reviewers

- Analytics doc regenerated via: **markdown strip (fallback)**.
- Automated removal can leave empty blocks or unused helpers behind — please run `yarn build:analytics-events`, `yarn lint --fix`, and typecheck before merging.
- **Caveat**: consumption is measured at table/view-reference level. An event queried *only* via `stg_rudderstack__tracks WHERE event_name = ...` can appear unused. Please confirm none of these are consumed that way before merging.

_Opened as a draft for owning-team review._