### PR TITLE
POC: Extend CheckV2 to allow prefilled the Check data

### DIFF
--- a/src/components/Checkster/contexts/ChecksterContext.tsx
+++ b/src/components/Checkster/contexts/ChecksterContext.tsx
@@ -66,6 +66,7 @@ export interface ChecksterProviderProps extends PropsWithChildren {
   check?: Check;
   checkType?: CheckType;
   isDuplicate?: boolean;
+  isPrefilled?: boolean;
 }
 
 interface StashedValues {
@@ -103,6 +104,7 @@ export function ChecksterProvider({
   onCheckTypeChange,
   disabled = false,
   isDuplicate = false,
+  isPrefilled = false,
 }: PropsWithChildren<ChecksterProviderProps>) {
   const check = isCheck(externalCheck) ? externalCheck : undefined;
   const { data: probesWithMetadata = [] } = useProbesWithMetadata();
@@ -227,6 +229,10 @@ export function ChecksterProvider({
     if (isDuplicate) {
       formMethods.setValue('job', `${check?.job} (Copy)`, { shouldDirty: true });
       formNavigation.completeAllSteps();
+    }
+    if (isPrefilled) {
+      formMethods.reset(getDefaultFormValues(checkType), { keepValues: true });
+      formMethods.setValue('job', formMethods.getValues('job'), { shouldDirty: true });
     }
     // only do this on mount so it doesn't trigger when the check is updated
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/page/NewCheck/NewCheckV2.test.tsx
+++ b/src/page/NewCheck/NewCheckV2.test.tsx
@@ -1,8 +1,13 @@
 import React, { ReactNode } from 'react';
+import { useLocation } from 'react-router';
 import { screen, waitFor } from '@testing-library/react';
+import { CHECKSTER_TEST_ID, DataTestIds } from 'test/dataTestIds';
+import { PRIVATE_PROBE } from 'test/fixtures/probes';
 import { render } from 'test/render';
 
-import { Check, CheckType, CheckTypeGroup, IpVersion } from '../../types';
+import { Check, CheckType, CheckTypeGroup, HttpMethod, IpVersion } from '../../types';
+import { AppRoutes } from 'routing/types';
+import { generateRoutePath, getRoute } from 'routing/utils';
 
 import { Checkster } from '../../components/Checkster';
 import { PluginPageNotFound } from '../NotFound';
@@ -17,6 +22,8 @@ enum NewCheckTestIds {
 function ReadyComponent({ children }: { children: ReactNode }) {
   return <div data-testid={NewCheckTestIds.Ready}>{children}</div>;
 }
+
+const { Checkster: RealCheckster } = jest.requireActual('components/Checkster');
 
 jest.mock('components/Checkster', () => ({
   Checkster: jest.fn().mockImplementation(() => (
@@ -33,6 +40,14 @@ jest.mock('page/NotFound', () => ({
     </ReadyComponent>
   )),
 }));
+
+jest.mock('react-router', () => {
+  const actual = jest.requireActual('react-router');
+  return {
+    ...actual,
+    useLocation: jest.fn((...args: unknown[]) => actual.useLocation(...args)),
+  };
+});
 
 async function renderNewCheck(options?: any) {
   const result = render(<NewCheckV2 />, options);
@@ -67,6 +82,35 @@ describe('<NewCheckV2 />', () => {
     await renderNewCheck();
     expect(screen.getByTestId(NewCheckTestIds.PluginPageNotFound)).toBeInTheDocument();
     expect(PluginPageNotFound).toHaveBeenCalledTimes(1);
+  });
+
+  it('enables Save without user interaction when a valid draft is prefilled', async () => {
+    const PREFILLED_JOB = 'assistant-prefill-test';
+    const prefilledCheck = {
+      job: PREFILLED_JOB,
+      target: 'https://grafana.com/',
+      enabled: true,
+      probes: [PRIVATE_PROBE.id],
+      labels: [],
+      settings: { http: { method: HttpMethod.Get } },
+    } as unknown as Check;
+
+    (Checkster as jest.Mock).mockImplementation(RealCheckster);
+    (useLocation as jest.Mock).mockImplementation(() => ({
+      state: { prefilledCheck },
+    }));
+
+    render(<NewCheckV2 />, {
+      path: `${generateRoutePath(AppRoutes.NewCheck)}/api-endpoint?checkType=${CheckType.Http}`,
+      route: `${getRoute(AppRoutes.NewCheck)}/:checkTypeGroup`,
+    });
+
+    await waitFor(() => expect(screen.getByTestId(DataTestIds.PageReady)).toBeInTheDocument(), {
+      timeout: 10000,
+    });
+
+    expect(screen.getByLabelText(/Job name/)).toHaveValue(PREFILLED_JOB);
+    expect(await screen.findByTestId(CHECKSTER_TEST_ID.form.submitButton)).toBeEnabled();
   });
 });
 

--- a/src/page/NewCheck/NewCheckV2.test.tsx
+++ b/src/page/NewCheck/NewCheckV2.test.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { useLocation } from 'react-router';
 import { screen, waitFor } from '@testing-library/react';
-import { CHECKSTER_TEST_ID, DataTestIds } from 'test/dataTestIds';
+import { CHECKSTER_TEST_ID } from 'test/dataTestIds';
 import { PRIVATE_PROBE } from 'test/fixtures/probes';
 import { render } from 'test/render';
 
@@ -105,11 +105,7 @@ describe('<NewCheckV2 />', () => {
       route: `${getRoute(AppRoutes.NewCheck)}/:checkTypeGroup`,
     });
 
-    await waitFor(() => expect(screen.getByTestId(DataTestIds.PageReady)).toBeInTheDocument(), {
-      timeout: 10000,
-    });
-
-    expect(screen.getByLabelText(/Job name/)).toHaveValue(PREFILLED_JOB);
+    expect(await screen.findByLabelText(/Job name/)).toHaveValue(PREFILLED_JOB);
     expect(await screen.findByTestId(CHECKSTER_TEST_ID.form.submitButton)).toBeEnabled();
   });
 });

--- a/src/page/NewCheck/NewCheckV2.test.tsx
+++ b/src/page/NewCheck/NewCheckV2.test.tsx
@@ -2,11 +2,11 @@ import React, { ReactNode } from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { render } from 'test/render';
 
-import { CheckTypeGroup } from '../../types';
+import { Check, CheckType, CheckTypeGroup, IpVersion } from '../../types';
 
 import { Checkster } from '../../components/Checkster';
 import { PluginPageNotFound } from '../NotFound';
-import { NewCheckV2 } from './NewCheckV2';
+import { mergePrefilledCheck, NewCheckV2 } from './NewCheckV2';
 
 enum NewCheckTestIds {
   Ready = 'NewCheck.Ready',
@@ -67,5 +67,52 @@ describe('<NewCheckV2 />', () => {
     await renderNewCheck();
     expect(screen.getByTestId(NewCheckTestIds.PluginPageNotFound)).toBeInTheDocument();
     expect(PluginPageNotFound).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('mergePrefilledCheck (prefilled draft handling)', () => {
+  const draftBase = {
+    job: 'my-check',
+    target: 'https://example.com',
+    enabled: true,
+    probes: [],
+    labels: [],
+  } as unknown as Check;
+
+  it('fills required settings defaults omitted by the draft (HTTP ipVersion)', () => {
+    const result = mergePrefilledCheck(
+      { ...draftBase, settings: { http: { method: 'GET' } } } as unknown as Check,
+      CheckType.Http
+    );
+    const http = (result.settings as Record<string, any>).http;
+    expect(http.method).toBe('GET');
+    expect(http.ipVersion).toBe(IpVersion.V4);
+    expect(result.job).toBe('my-check');
+    expect(result.target).toBe('https://example.com');
+  });
+
+  it('normalizes a legacy `k6` settings key to `scripted`', () => {
+    const result = mergePrefilledCheck(
+      { ...draftBase, settings: { k6: { script: 'export default () => {};' } } } as unknown as Check,
+      CheckType.Http
+    );
+    expect(result.settings).toHaveProperty('scripted');
+    expect(result.settings).not.toHaveProperty('k6');
+    expect((result.settings as Record<string, any>).scripted.script).toBe('export default () => {};');
+  });
+
+  it('uses the fallback check type when the draft has no settings', () => {
+    const result = mergePrefilledCheck({ ...draftBase } as unknown as Check, CheckType.Browser);
+    expect(result.settings).toHaveProperty('browser');
+    expect(result.settings).not.toHaveProperty('http');
+  });
+
+  it('uses the fallback check type when settings is empty (does not default to HTTP)', () => {
+    const result = mergePrefilledCheck(
+      { ...draftBase, settings: {} } as unknown as Check,
+      CheckType.Scripted
+    );
+    expect(result.settings).toHaveProperty('scripted');
+    expect(result.settings).not.toHaveProperty('http');
   });
 });

--- a/src/page/NewCheck/NewCheckV2.tsx
+++ b/src/page/NewCheck/NewCheckV2.tsx
@@ -132,6 +132,7 @@ export function NewCheckV2() {
           onCheckTypeChange={handleCheckTypeChange}
           check={initialCheck}
           isDuplicate={!!duplicateCheck}
+          isPrefilled={!duplicateCheck && !!prefilledCheck}
         >
           <Checkster onSave={handleSubmit} />
         </ChecksterProvider>

--- a/src/page/NewCheck/NewCheckV2.tsx
+++ b/src/page/NewCheck/NewCheckV2.tsx
@@ -6,8 +6,8 @@ import { TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { DataTestIds } from 'test/dataTestIds';
 
-import { CheckFormPageParams, CheckType } from 'types';
-import { createNavModel } from 'utils';
+import { Check, CheckFormPageParams, CheckType } from 'types';
+import { createNavModel, getCheckType } from 'utils';
 import { AppRoutes } from 'routing/types';
 import { generateRoutePath, getRoute } from 'routing/utils';
 import { useProbes } from 'data/useProbes';
@@ -21,10 +21,37 @@ import { useDuplicateCheck } from 'page/NewCheck/NewCheckV2.hooks';
 import { PluginPageNotFound } from 'page/NotFound';
 
 import { CenteredSpinner } from '../../components/CenteredSpinner';
-import { CHECK_TYPE_GROUP_DEFAULT_CHECK } from '../../components/Checkster/constants';
+import { CHECK_TYPE_GROUP_DEFAULT_CHECK, DEFAULT_CHECK_CONFIG_MAP } from '../../components/Checkster/constants';
 import { getUserPermissions } from '../../data/permissions';
 
 const CHECK_TYPE_PARAM_NAME = 'checkType';
+
+/**
+ * A pre-filled check draft (e.g. from the Grafana Assistant deep-link) may only
+ * set a few fields. Merge it over the check type's default config so required
+ * settings the caller omitted (e.g. HTTP `ipVersion`) are still present —
+ * otherwise the form fails validation on an off-screen field and Save silently
+ * does nothing.
+ */
+function mergePrefilledCheck(prefill: Check): Check {
+  const checkType = getCheckType(prefill.settings);
+  const base = checkType ? DEFAULT_CHECK_CONFIG_MAP[checkType] : undefined;
+  if (!base) {
+    return prefill;
+  }
+  const settingsKey = Object.keys(prefill.settings ?? {})[0];
+  const baseSettings = base.settings as Record<string, unknown>;
+  const prefillSettings = (prefill.settings ?? {}) as Record<string, unknown>;
+  const mergedSettings = settingsKey
+    ? {
+        [settingsKey]: {
+          ...(baseSettings[settingsKey] as Record<string, unknown>),
+          ...(prefillSettings[settingsKey] as Record<string, unknown>),
+        },
+      }
+    : base.settings;
+  return { ...base, ...prefill, settings: mergedSettings } as Check;
+}
 
 export function NewCheckV2() {
   const [params] = useSearchParams({});
@@ -45,6 +72,10 @@ export function NewCheckV2() {
   ]);
 
   const location = useLocation();
+  // The Grafana Assistant can deep-link here with a pre-filled check draft in
+  // router state so the user only has to review and click Create.
+  const prefilledCheck = (location.state as { prefilledCheck?: Check } | null)?.prefilledCheck;
+  const initialCheck = duplicateCheck ?? (prefilledCheck ? mergePrefilledCheck(prefilledCheck) : undefined);
 
   const handleSubmit = useHandleSubmitCheckster();
   const handleCheckTypeChange = useCallback(
@@ -85,7 +116,7 @@ export function NewCheckV2() {
           checkType={checkType || CHECK_TYPE_GROUP_DEFAULT_CHECK[group.value]}
           disabled={isOverlimit || !canWriteChecks}
           onCheckTypeChange={handleCheckTypeChange}
-          check={duplicateCheck}
+          check={initialCheck}
           isDuplicate={!!duplicateCheck}
         >
           <Checkster onSave={handleSubmit} />

--- a/src/page/NewCheck/NewCheckV2.tsx
+++ b/src/page/NewCheck/NewCheckV2.tsx
@@ -33,24 +33,33 @@ const CHECK_TYPE_PARAM_NAME = 'checkType';
  * otherwise the form fails validation on an off-screen field and Save silently
  * does nothing.
  */
-function mergePrefilledCheck(prefill: Check): Check {
-  const checkType = getCheckType(prefill.settings);
-  const base = checkType ? DEFAULT_CHECK_CONFIG_MAP[checkType] : undefined;
+export function mergePrefilledCheck(prefill: Check, fallbackType: CheckType): Check {
+  // getCheckType throws on undefined settings and silently defaults empty settings
+  // to HTTP, so fall back to the route's check type when the draft has no settings.
+  const hasSettings = !!prefill.settings && Object.keys(prefill.settings).length > 0;
+  const checkType = hasSettings ? getCheckType(prefill.settings) : fallbackType;
+
+  const base = DEFAULT_CHECK_CONFIG_MAP[checkType];
   if (!base) {
     return prefill;
   }
-  const settingsKey = Object.keys(prefill.settings ?? {})[0];
+
+  // Merge under the CANONICAL settings key from the default config (e.g. `scripted`),
+  // reading the draft's settings value by position so a legacy `k6` key still lands
+  // on the right key instead of producing an invalid `settings: { k6: ... }`.
+  const canonicalKey = Object.keys(base.settings)[0];
   const baseSettings = base.settings as Record<string, unknown>;
-  const prefillSettings = (prefill.settings ?? {}) as Record<string, unknown>;
-  const mergedSettings = settingsKey
-    ? {
-        [settingsKey]: {
-          ...(baseSettings[settingsKey] as Record<string, unknown>),
-          ...(prefillSettings[settingsKey] as Record<string, unknown>),
-        },
-      }
-    : base.settings;
-  return { ...base, ...prefill, settings: mergedSettings } as Check;
+  const draftValue = hasSettings
+    ? (Object.values(prefill.settings as Record<string, unknown>)[0] as Record<string, unknown>)
+    : {};
+
+  return {
+    ...base,
+    ...prefill,
+    settings: {
+      [canonicalKey]: { ...(baseSettings[canonicalKey] as Record<string, unknown>), ...draftValue },
+    },
+  } as unknown as Check;
 }
 
 export function NewCheckV2() {
@@ -75,7 +84,9 @@ export function NewCheckV2() {
   // The Grafana Assistant can deep-link here with a pre-filled check draft in
   // router state so the user only has to review and click Create.
   const prefilledCheck = (location.state as { prefilledCheck?: Check } | null)?.prefilledCheck;
-  const initialCheck = duplicateCheck ?? (prefilledCheck ? mergePrefilledCheck(prefilledCheck) : undefined);
+  const fallbackCheckType = checkType ?? (group ? CHECK_TYPE_GROUP_DEFAULT_CHECK[group.value] : CheckType.Http);
+  const initialCheck =
+    duplicateCheck ?? (prefilledCheck ? mergePrefilledCheck(prefilledCheck, fallbackCheckType) : undefined);
 
   const handleSubmit = useHandleSubmitCheckster();
   const handleCheckTypeChange = useCallback(
@@ -87,7 +98,10 @@ export function NewCheckV2() {
     [location.pathname, urlSearchParams]
   );
 
-  const isOverlimit = useIsOverlimit(false, checkType);
+  // Prefill deep-links may omit ?checkType=, so fall back to the actual check's type
+  // to keep the type-specific (browser/scripted) limit checks accurate.
+  const effectiveCheckType = checkType ?? (initialCheck ? getCheckType(initialCheck.settings) : undefined);
+  const isOverlimit = useIsOverlimit(false, effectiveCheckType);
   const { canWriteChecks } = getUserPermissions();
 
   const isLoading = (isLoadingProbes && !isProbesFetched) || isOverlimit === null || isLoadingDuplicateCheck;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends `CheckV2` to allow prefilling the SM Check data.

**Which issue(s) this PR fixes**:

Allows Grafana Assistant to prefill the SM Check data.

