### PR TITLE
feat: reference secrets from HTTP check credential fields

### DIFF
--- a/src/components/Checkster/components/form/FormHttpBasicAuthField.tsx
+++ b/src/components/Checkster/components/form/FormHttpBasicAuthField.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
-import { Input, Stack } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Input, Stack, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 
 import { CheckFormFieldPath } from '../../types';
 import { CheckFormValues } from 'types';
@@ -8,7 +10,7 @@ import { useDOMId } from 'hooks/useDOMId';
 
 import { getFieldErrorProps } from '../../utils/form';
 import { StyledField } from '../ui/StyledField';
-import { FormSecretOrPlaintextField } from './FormSecretOrPlaintextField';
+import { FormSecretOrPlaintextField, useSecretsFieldEnabled } from './FormSecretOrPlaintextField';
 
 interface FormHttpBasicAuthFieldProps {
   field: CheckFormFieldPath;
@@ -16,6 +18,7 @@ interface FormHttpBasicAuthFieldProps {
 
 export function FormHttpBasicAuthField({ field }: FormHttpBasicAuthFieldProps) {
   const usernameInputId = useDOMId();
+  const styles = useStyles2(getStyles);
 
   const {
     register,
@@ -23,14 +26,21 @@ export function FormHttpBasicAuthField({ field }: FormHttpBasicAuthFieldProps) {
   } = useFormContext<CheckFormValues>();
   const usernameField = `${field}.username` as any; // TODO: Fix `any` usage
   const passwordField = `${field}.password` as any;
+
+  // When the Password field shows the Value/Secret toggle, its label row is
+  // taller than a plain label. Reserve the same height on the Username label so
+  // the two inputs stay top-aligned regardless of any error/hint below either.
+  const secretsEnabled = useSecretsFieldEnabled(true);
+
   return (
-    <Stack direction="row" gap={1}>
+    <Stack direction="row" gap={1} alignItems="flex-start">
       {/* TODO: Seems to be required if one of the other is not empty? */}
       <StyledField
         grow
         label="Username"
         required
         htmlFor={usernameInputId}
+        className={secretsEnabled ? styles.matchToggleLabelHeight : undefined}
         {...getFieldErrorProps(errors, usernameField)}
       >
         <Input id={usernameInputId} {...register(usernameField)} disabled={disabled} />
@@ -40,3 +50,13 @@ export function FormHttpBasicAuthField({ field }: FormHttpBasicAuthFieldProps) {
     </Stack>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  // Match FormSecretOrPlaintextField's label-row height (the sm RadioButtonGroup)
+  // so the Username input lines up with the Password input beside it.
+  matchToggleLabelHeight: css({
+    '& > div:first-child': {
+      minHeight: theme.spacing(3),
+    },
+  }),
+});

--- a/src/components/Checkster/components/form/FormHttpBasicAuthField.tsx
+++ b/src/components/Checkster/components/form/FormHttpBasicAuthField.tsx
@@ -7,8 +7,8 @@ import { CheckFormValues } from 'types';
 import { useDOMId } from 'hooks/useDOMId';
 
 import { getFieldErrorProps } from '../../utils/form';
-import { PasswordInput } from '../PasswordInput';
 import { StyledField } from '../ui/StyledField';
+import { FormSecretOrPlaintextField } from './FormSecretOrPlaintextField';
 
 interface FormHttpBasicAuthFieldProps {
   field: CheckFormFieldPath;
@@ -16,7 +16,6 @@ interface FormHttpBasicAuthFieldProps {
 
 export function FormHttpBasicAuthField({ field }: FormHttpBasicAuthFieldProps) {
   const usernameInputId = useDOMId();
-  const passwordInputId = useDOMId();
 
   const {
     register,
@@ -36,15 +35,8 @@ export function FormHttpBasicAuthField({ field }: FormHttpBasicAuthFieldProps) {
       >
         <Input id={usernameInputId} {...register(usernameField)} disabled={disabled} />
       </StyledField>
-      <StyledField
-        grow
-        htmlFor={passwordInputId}
-        label="Password"
-        required
-        {...getFieldErrorProps(errors, passwordField)}
-      >
-        <PasswordInput id={passwordInputId} {...register(passwordField)} disabled={disabled} />
-      </StyledField>
+      {/* Only the password is resolved by the agent, so only it can reference a secret. */}
+      <FormSecretOrPlaintextField grow field={passwordField} label="Password" required variant="password" allowSecrets />
     </Stack>
   );
 }

--- a/src/components/Checkster/components/form/FormHttpBearerTokenField.tsx
+++ b/src/components/Checkster/components/form/FormHttpBearerTokenField.tsx
@@ -1,29 +1,13 @@
 import React from 'react';
-import { useFormContext } from 'react-hook-form';
 
 import { CheckFormFieldPath } from '../../types';
-import { CheckFormValues } from 'types';
-import { useDOMId } from 'hooks/useDOMId';
 
-import { getFieldErrorProps } from '../../utils/form';
-import { PasswordInput } from '../PasswordInput';
-import { StyledField } from '../ui/StyledField';
+import { FormSecretOrPlaintextField } from './FormSecretOrPlaintextField';
 
 interface FormHttpBearerTokenFieldProps {
   field: CheckFormFieldPath;
 }
 
 export function FormHttpBearerTokenField({ field }: FormHttpBearerTokenFieldProps) {
-  const {
-    register,
-    formState: { errors, disabled },
-  } = useFormContext<CheckFormValues>();
-
-  const inputId = useDOMId();
-
-  return (
-    <StyledField label="Token" required htmlFor={inputId} {...getFieldErrorProps(errors, field)}>
-      <PasswordInput id={inputId} {...register(field)} disabled={disabled} />
-    </StyledField>
-  );
+  return <FormSecretOrPlaintextField field={field} label="Token" required variant="password" allowSecrets />;
 }

--- a/src/components/Checkster/components/form/FormSecretOrPlaintextField.test.tsx
+++ b/src/components/Checkster/components/form/FormSecretOrPlaintextField.test.tsx
@@ -115,3 +115,18 @@ it('clears a secret reference when switching to Value mode so it is not saved as
   expect(screen.getByRole('radio', { name: 'Value' })).toBeChecked();
   expect(screen.getByTestId(TestFormTestId.Value)).not.toHaveTextContent('secrets.test-secret-1');
 });
+
+it('links to the secrets config page in secret mode when no secrets exist', async () => {
+  (useSecrets as jest.Mock).mockReturnValue({ data: [], isLoading: false });
+  const user = formTestRenderer(FormSecretOrPlaintextField, {
+    field: FIELD,
+    label: 'Token',
+    variant: 'password',
+    allowSecrets: true,
+  });
+
+  await user.click(screen.getByRole('radio', { name: 'Secret' }));
+
+  const link = screen.getByRole('link', { name: /Create one in Config/i });
+  expect(link).toHaveAttribute('href', expect.stringContaining('/config/secrets'));
+});

--- a/src/components/Checkster/components/form/FormSecretOrPlaintextField.test.tsx
+++ b/src/components/Checkster/components/form/FormSecretOrPlaintextField.test.tsx
@@ -1,4 +1,7 @@
-import { screen } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MOCKED_SECRETS } from 'test/fixtures/secrets';
 import { runTestAsSecretsNoAccess, runTestAsSecretsReadOnly, selectOption } from 'test/utils';
 
@@ -129,4 +132,58 @@ it('links to the secrets config page in secret mode when no secrets exist', asyn
 
   const link = screen.getByRole('link', { name: /Create one in Config/i });
   expect(link).toHaveAttribute('href', expect.stringContaining('/config/secrets'));
+});
+
+it('keeps an existing secret reference in the submitted values when secrets are unavailable', async () => {
+  // Secrets UI unavailable -> the read-only plaintext fallback renders. A disabled
+  // input would be dropped from React Hook Form's submit payload; read-only is not.
+  runTestAsSecretsNoAccess();
+  const onSubmit = jest.fn();
+  const user = userEvent.setup();
+
+  function Harness() {
+    const methods = useForm({ defaultValues: { settings: { http: { bearerToken: '${secrets.test-secret-1}' } } } });
+    return (
+      <FormProvider {...methods}>
+        <form onSubmit={methods.handleSubmit(onSubmit)}>
+          <FormSecretOrPlaintextField field={FIELD} label="Token" variant="password" allowSecrets />
+          <button type="submit">Save</button>
+        </form>
+      </FormProvider>
+    );
+  }
+
+  render(<Harness />);
+  await user.click(screen.getByRole('button', { name: 'Save' }));
+
+  expect(onSubmit).toHaveBeenCalledTimes(1);
+  expect(onSubmit.mock.calls[0][0]).toMatchObject({
+    settings: { http: { bearerToken: '${secrets.test-secret-1}' } },
+  });
+});
+
+it('reverts to Value mode when the form is reset to an empty value', async () => {
+  const user = userEvent.setup();
+
+  function Harness() {
+    const methods = useForm({ defaultValues: { settings: { http: { bearerToken: '${secrets.test-secret-1}' } } } });
+    return (
+      <FormProvider {...methods}>
+        <FormSecretOrPlaintextField field={FIELD} label="Token" variant="password" allowSecrets />
+        <button type="button" onClick={() => methods.reset({ settings: { http: { bearerToken: '' } } })}>
+          Reset form
+        </button>
+      </FormProvider>
+    );
+  }
+
+  render(<Harness />);
+  // Starts in Secret mode because the field holds a reference.
+  expect(screen.getByRole('radio', { name: 'Secret' })).toBeChecked();
+
+  await user.click(screen.getByRole('button', { name: 'Reset form' }));
+
+  // A reset that empties the field must return the control to Value mode, not
+  // leave an empty Secret picker.
+  expect(screen.getByRole('radio', { name: 'Value' })).toBeChecked();
 });

--- a/src/components/Checkster/components/form/FormSecretOrPlaintextField.test.tsx
+++ b/src/components/Checkster/components/form/FormSecretOrPlaintextField.test.tsx
@@ -187,3 +187,22 @@ it('reverts to Value mode when the form is reset to an empty value', async () =>
   // leave an empty Secret picker.
   expect(screen.getByRole('radio', { name: 'Value' })).toBeChecked();
 });
+
+it('keeps Value mode usable when the secrets list fails to load', () => {
+  // Value mode never calls the secrets API, so a failing secrets-list request
+  // (which the Secret-mode error boundary would otherwise surface) must not
+  // block plaintext entry.
+  (useSecrets as jest.Mock).mockImplementation(() => {
+    throw new Error('failed to load secrets');
+  });
+
+  formTestRenderer(FormSecretOrPlaintextField, {
+    field: FIELD,
+    label: 'Token',
+    variant: 'password',
+    allowSecrets: true,
+  });
+
+  expect(screen.getByRole('radio', { name: 'Value' })).toBeChecked();
+  expect(screen.getByLabelText('Token')).toBeEnabled();
+});

--- a/src/components/Checkster/components/form/FormSecretOrPlaintextField.test.tsx
+++ b/src/components/Checkster/components/form/FormSecretOrPlaintextField.test.tsx
@@ -1,0 +1,117 @@
+import { screen } from '@testing-library/react';
+import { MOCKED_SECRETS } from 'test/fixtures/secrets';
+import { runTestAsSecretsNoAccess, runTestAsSecretsReadOnly, selectOption } from 'test/utils';
+
+import { useSecrets } from 'data/useSecrets';
+import { useFeatureFlag } from 'hooks/useFeatureFlag';
+
+import { formTestRenderer, TestFormTestId } from './__test__/formTestRenderer';
+import { FormSecretOrPlaintextField } from './FormSecretOrPlaintextField';
+
+jest.mock('data/useSecrets', () => ({ useSecrets: jest.fn() }));
+jest.mock('hooks/useFeatureFlag', () => ({ useFeatureFlag: jest.fn() }));
+
+const FIELD = 'settings.http.bearerToken';
+
+function mockFlag(isEnabled: boolean) {
+  (useFeatureFlag as jest.Mock).mockReturnValue({ isEnabled, isReady: true });
+}
+
+beforeEach(() => {
+  (useSecrets as jest.Mock).mockReturnValue({ data: MOCKED_SECRETS, isLoading: false });
+  mockFlag(true);
+  runTestAsSecretsReadOnly();
+});
+
+it('shows the Value/Secret toggle when secrets are available', () => {
+  formTestRenderer(FormSecretOrPlaintextField, { field: FIELD, label: 'Token', variant: 'password', allowSecrets: true });
+
+  expect(screen.getByRole('radio', { name: 'Value' })).toBeInTheDocument();
+  expect(screen.getByRole('radio', { name: 'Secret' })).toBeInTheDocument();
+});
+
+it('hides the toggle when allowSecrets is false', () => {
+  formTestRenderer(FormSecretOrPlaintextField, {
+    field: FIELD,
+    label: 'Token',
+    variant: 'password',
+    allowSecrets: false,
+  });
+
+  expect(screen.queryByRole('radio', { name: 'Secret' })).not.toBeInTheDocument();
+});
+
+it('hides the toggle when the feature flag is off', () => {
+  mockFlag(false);
+  formTestRenderer(FormSecretOrPlaintextField, { field: FIELD, label: 'Token', variant: 'password', allowSecrets: true });
+
+  expect(screen.queryByRole('radio', { name: 'Secret' })).not.toBeInTheDocument();
+});
+
+it('hides the toggle when the user cannot read secrets', () => {
+  runTestAsSecretsNoAccess();
+  formTestRenderer(FormSecretOrPlaintextField, { field: FIELD, label: 'Token', variant: 'password', allowSecrets: true });
+
+  expect(screen.queryByRole('radio', { name: 'Secret' })).not.toBeInTheDocument();
+});
+
+it('writes a ${secrets.<name>} reference into the field when a secret is picked', async () => {
+  const user = formTestRenderer(FormSecretOrPlaintextField, {
+    field: FIELD,
+    label: 'Token',
+    variant: 'password',
+    allowSecrets: true,
+  });
+
+  await user.click(screen.getByRole('radio', { name: 'Secret' }));
+  // The option's accessible name includes its description, so match on a substring.
+  await selectOption(user, { label: 'Token', option: /test-secret-1/ });
+
+  expect(screen.getByTestId(TestFormTestId.Value)).toHaveTextContent('${secrets.test-secret-1}');
+});
+
+it('starts in secret mode when the field already holds a reference', () => {
+  formTestRenderer(
+    FormSecretOrPlaintextField,
+    { field: FIELD, label: 'Token', variant: 'password', allowSecrets: true },
+    { settings: { http: { bearerToken: '${secrets.test-secret-1}' } } }
+  );
+
+  expect(screen.getByRole('radio', { name: 'Secret' })).toBeChecked();
+  expect(screen.getByDisplayValue('test-secret-1')).toBeInTheDocument();
+});
+
+it('switches to secret mode and keeps the reference when a ${secrets.<name>} value is entered in Value mode', async () => {
+  const user = formTestRenderer(FormSecretOrPlaintextField, {
+    field: FIELD,
+    label: 'Token',
+    variant: 'password',
+    allowSecrets: true,
+  });
+
+  expect(screen.getByRole('radio', { name: 'Value' })).toBeChecked();
+
+  const input = screen.getByLabelText('Token');
+  await user.click(input);
+  await user.paste('${secrets.test-secret-1}');
+
+  // A reference must flip the control to secret mode instead of staying on a
+  // masked value input, and it must not be dropped.
+  expect(await screen.findByRole('radio', { name: 'Secret' })).toBeChecked();
+  expect(screen.getByTestId(TestFormTestId.Value)).toHaveTextContent('${secrets.test-secret-1}');
+});
+
+it('clears a secret reference when switching to Value mode so it is not saved as plaintext', async () => {
+  const user = formTestRenderer(
+    FormSecretOrPlaintextField,
+    { field: FIELD, label: 'Token', variant: 'password', allowSecrets: true },
+    { settings: { http: { bearerToken: '${secrets.test-secret-1}' } } }
+  );
+
+  expect(screen.getByRole('radio', { name: 'Secret' })).toBeChecked();
+
+  await user.click(screen.getByRole('radio', { name: 'Value' }));
+
+  expect(screen.getByRole('radio', { name: 'Value' })).toBeChecked();
+  expect(screen.getByTestId(TestFormTestId.Value)).not.toHaveTextContent('secrets.test-secret-1');
+});

--- a/src/components/Checkster/components/form/FormSecretOrPlaintextField.tsx
+++ b/src/components/Checkster/components/form/FormSecretOrPlaintextField.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { Combobox, ComboboxOption, Input, RadioButtonGroup, Stack, TextArea } from '@grafana/ui';
-import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Combobox, ComboboxOption, Input, Label, RadioButtonGroup, Text, TextArea, TextLink, useStyles2 } from '@grafana/ui';
+import { css, cx } from '@emotion/css';
 
 import { CheckFormFieldPath } from '../../types';
 import { CheckFormValues, FeatureName } from 'types';
+import { AppRoutes } from 'routing/types';
+import { getRoute } from 'routing/utils';
 import { useUserPermissions } from 'data/permissions';
 import { useSecrets } from 'data/useSecrets';
 import { useDOMId } from 'hooks/useDOMId';
@@ -45,10 +48,20 @@ export interface FormSecretOrPlaintextFieldProps {
  * form field. The `secretManagerEnabled` flag is not exposed here — it is
  * inferred from field values at serialization time.
  */
-export function FormSecretOrPlaintextField(props: FormSecretOrPlaintextFieldProps) {
+/**
+ * Whether a credential field can reference a secret: the field opts in via
+ * `allowSecrets`, the feature flag is on, and the user can read secrets. Exported
+ * so a sibling plain field (e.g. the basic-auth username) can match this field's
+ * taller, toggle-carrying label row when the toggle is shown.
+ */
+export function useSecretsFieldEnabled(allowSecrets?: boolean): boolean {
   const { isEnabled } = useFeatureFlag(FeatureName.SecretsManagement);
   const { canReadSecrets } = useUserPermissions();
-  const secretsAvailable = Boolean(props.allowSecrets && isEnabled && canReadSecrets);
+  return Boolean(allowSecrets && isEnabled && canReadSecrets);
+}
+
+export function FormSecretOrPlaintextField(props: FormSecretOrPlaintextFieldProps) {
+  const secretsAvailable = useSecretsFieldEnabled(props.allowSecrets);
 
   if (!secretsAvailable) {
     return <PlaintextField {...props} />;
@@ -98,7 +111,17 @@ function PlaintextField({ field, label, description, required, variant, rows, pl
   );
 }
 
-function SecretOrPlaintextField({ field, label, description, required, variant, rows, placeholder, grow }: FormSecretOrPlaintextFieldProps) {
+function SecretOrPlaintextField({
+  field,
+  label,
+  description,
+  required,
+  variant,
+  rows,
+  placeholder,
+  grow,
+}: FormSecretOrPlaintextFieldProps) {
+  const styles = useStyles2(getStyles);
   const {
     register,
     setValue,
@@ -148,44 +171,83 @@ function SecretOrPlaintextField({ field, label, description, required, variant, 
     options.push({ label: `${selectedSecret} (not found)`, value: selectedSecret });
   }
 
+  const hasNoSecrets = !isLoading && secrets.length === 0;
+
   return (
-    <StyledField
-      grow={grow}
-      label={label}
-      description={description}
-      required={required}
-      htmlFor={id}
-      {...getFieldErrorProps(errors, field)}
-    >
-      <Stack direction="row" gap={1} alignItems="flex-start">
+    <div className={cx(styles.wrapper, { [styles.grow]: grow })}>
+      <div className={styles.header}>
+        <Label htmlFor={id} description={description} className={styles.label}>
+          {label}
+          {required ? ' *' : ''}
+        </Label>
         <RadioButtonGroup<FieldMode>
+          size="sm"
           options={MODE_OPTIONS}
           value={mode}
           onChange={handleModeChange}
           disabled={disabled}
         />
-        <div className={css({ flexGrow: 1, minWidth: 0 })}>
-          {mode === 'secret' ? (
-            <Combobox<string>
-              id={id}
-              options={options}
-              value={selectedSecret ?? null}
-              disabled={disabled}
-              placeholder={isLoading ? 'Loading secrets...' : 'Select a secret'}
-              onChange={(option) => {
-                const name = typeof option === 'string' ? option : option?.value;
-                if (name) {
-                  setValue(field, buildSecretRef(name), { shouldDirty: true });
-                }
-              }}
-            />
-          ) : variant === 'textarea' ? (
-            <TextArea id={id} rows={rows ?? 3} placeholder={placeholder} disabled={disabled} aria-label={label} {...register(field)} />
-          ) : (
-            <PasswordInput id={id} placeholder={placeholder} disabled={disabled} {...register(field)} />
-          )}
-        </div>
-      </Stack>
-    </StyledField>
+      </div>
+      <StyledField htmlFor={id} {...getFieldErrorProps(errors, field)}>
+        {mode === 'secret' ? (
+          <Combobox<string>
+            id={id}
+            options={options}
+            value={selectedSecret ?? null}
+            disabled={disabled}
+            placeholder={isLoading ? 'Loading secrets...' : 'Select a secret'}
+            onChange={(option) => {
+              const name = typeof option === 'string' ? option : option?.value;
+              if (name) {
+                setValue(field, buildSecretRef(name), { shouldDirty: true });
+              }
+            }}
+          />
+        ) : variant === 'textarea' ? (
+          <TextArea
+            id={id}
+            rows={rows ?? 3}
+            placeholder={placeholder}
+            disabled={disabled}
+            aria-label={label}
+            {...register(field)}
+          />
+        ) : (
+          <PasswordInput id={id} placeholder={placeholder} disabled={disabled} {...register(field)} />
+        )}
+      </StyledField>
+
+      {mode === 'secret' && hasNoSecrets && (
+        <Text variant="bodySmall" color="secondary">
+          No secrets available.{' '}
+          <TextLink href={`${getRoute(AppRoutes.Config)}/secrets`} variant="bodySmall">
+            Create one in Config
+          </TextLink>
+        </Text>
+      )}
+    </div>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+  }),
+  grow: css({
+    flexGrow: 1,
+  }),
+  header: css({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1),
+    // The sm RadioButtonGroup is theme.spacing(3) tall; pin the row to it so a
+    // sibling plain field can match this height and keep both inputs aligned.
+    minHeight: theme.spacing(3),
+  }),
+  label: css({
+    marginBottom: 0,
+  }),
+});

--- a/src/components/Checkster/components/form/FormSecretOrPlaintextField.tsx
+++ b/src/components/Checkster/components/form/FormSecretOrPlaintextField.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { Combobox, ComboboxOption, Input, RadioButtonGroup, Stack, TextArea } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { CheckFormFieldPath } from '../../types';
+import { CheckFormValues, FeatureName } from 'types';
+import { useUserPermissions } from 'data/permissions';
+import { useSecrets } from 'data/useSecrets';
+import { useDOMId } from 'hooks/useDOMId';
+import { useFeatureFlag } from 'hooks/useFeatureFlag';
+import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
+
+import { getFieldErrorProps } from '../../utils/form';
+import { buildSecretRef, isSecretRef, parseSecretName } from '../../utils/secrets';
+import { PasswordInput } from '../PasswordInput';
+import { StyledField } from '../ui/StyledField';
+
+type FieldMode = 'plaintext' | 'secret';
+
+const MODE_OPTIONS: Array<{ label: string; value: FieldMode }> = [
+  { label: 'Value', value: 'plaintext' },
+  { label: 'Secret', value: 'secret' },
+];
+
+export interface FormSecretOrPlaintextFieldProps {
+  field: CheckFormFieldPath;
+  label?: string;
+  description?: string;
+  required?: boolean;
+  /** Plaintext render mode: masked single-line input, or a multi-line textarea (certs/keys). */
+  variant: 'password' | 'textarea';
+  rows?: number;
+  placeholder?: string;
+  /** Whether this field is eligible for secret references at all (HTTP only today). */
+  allowSecrets?: boolean;
+  /** Forwarded to the underlying field wrapper so the control can grow in a row. */
+  grow?: boolean;
+}
+
+/**
+ * A credential field that can hold either a plaintext value or a reference to a
+ * secret (`${secrets.<name>}`). When secrets are available it renders a
+ * "Value / Secret" toggle; picking a secret writes the reference into the same
+ * form field. The `secretManagerEnabled` flag is not exposed here — it is
+ * inferred from field values at serialization time.
+ */
+export function FormSecretOrPlaintextField(props: FormSecretOrPlaintextFieldProps) {
+  const { isEnabled } = useFeatureFlag(FeatureName.SecretsManagement);
+  const { canReadSecrets } = useUserPermissions();
+  const secretsAvailable = Boolean(props.allowSecrets && isEnabled && canReadSecrets);
+
+  if (!secretsAvailable) {
+    return <PlaintextField {...props} />;
+  }
+
+  return (
+    <QueryErrorBoundary
+      title="Error loading secrets"
+      content="Failed to load secrets. Please check your connection and try again."
+    >
+      <SecretOrPlaintextField {...props} />
+    </QueryErrorBoundary>
+  );
+}
+
+/**
+ * Plaintext-only render (secrets unavailable). If the field already holds a
+ * secret reference (e.g. the check was created elsewhere), show it in a disabled
+ * input so the reference is preserved on save rather than silently dropped.
+ */
+function PlaintextField({ field, label, description, required, variant, rows, placeholder, grow }: FormSecretOrPlaintextFieldProps) {
+  const {
+    register,
+    watch,
+    formState: { errors, disabled },
+  } = useFormContext<CheckFormValues>();
+  const id = useDOMId();
+  const holdsSecret = isSecretRef(watch(field) as string | undefined);
+
+  return (
+    <StyledField
+      grow={grow}
+      label={label}
+      description={holdsSecret ? 'This field references a secret. Enable secrets management to edit it.' : description}
+      required={required}
+      htmlFor={id}
+      {...getFieldErrorProps(errors, field)}
+    >
+      {holdsSecret ? (
+        <Input id={id} type="text" disabled {...register(field)} />
+      ) : variant === 'textarea' ? (
+        <TextArea id={id} rows={rows ?? 3} placeholder={placeholder} disabled={disabled} aria-label={label} {...register(field)} />
+      ) : (
+        <PasswordInput id={id} placeholder={placeholder} disabled={disabled} {...register(field)} />
+      )}
+    </StyledField>
+  );
+}
+
+function SecretOrPlaintextField({ field, label, description, required, variant, rows, placeholder, grow }: FormSecretOrPlaintextFieldProps) {
+  const {
+    register,
+    setValue,
+    watch,
+    formState: { errors, disabled },
+  } = useFormContext<CheckFormValues>();
+  const id = useDOMId();
+  const value = watch(field) as string | undefined;
+
+  // Seed the mode from the current value, then keep it in sync when the value
+  // changes externally (e.g. after the form is reset with new check data, or a
+  // ${secrets.*} reference is pasted into the value input): a secret reference
+  // must show the secret picker, not a masked input. An empty value keeps the
+  // current mode, so switching to "Secret" to pick a secret does not
+  // immediately flip back to "Value".
+  const [mode, setMode] = useState<FieldMode>(() => (isSecretRef(value) ? 'secret' : 'plaintext'));
+
+  useEffect(() => {
+    if (isSecretRef(value)) {
+      setMode('secret');
+    } else if (value) {
+      setMode('plaintext');
+    }
+  }, [value]);
+
+  const { data: secrets = [], isLoading } = useSecrets(true);
+
+  const handleModeChange = (next: FieldMode) => {
+    setMode(next);
+    // Only clear a value that belongs to the *other* mode, so we never persist a
+    // plaintext token in "Secret" mode (or vice versa). A value that already
+    // matches the target mode — e.g. an existing ${secrets.*} reference when
+    // switching to "Secret" — is preserved rather than dropped.
+    if ((next === 'secret') !== isSecretRef(value)) {
+      setValue(field, '', { shouldDirty: true });
+    }
+  };
+
+  const selectedSecret = parseSecretName(value);
+  const options: Array<ComboboxOption<string>> = secrets.map((secret) => ({
+    label: secret.name,
+    value: secret.name,
+    description: secret.description,
+  }));
+  // Surface a referenced-but-missing secret so its value is not silently lost.
+  if (selectedSecret && !options.some((option) => option.value === selectedSecret)) {
+    options.push({ label: `${selectedSecret} (not found)`, value: selectedSecret });
+  }
+
+  return (
+    <StyledField
+      grow={grow}
+      label={label}
+      description={description}
+      required={required}
+      htmlFor={id}
+      {...getFieldErrorProps(errors, field)}
+    >
+      <Stack direction="row" gap={1} alignItems="flex-start">
+        <RadioButtonGroup<FieldMode>
+          options={MODE_OPTIONS}
+          value={mode}
+          onChange={handleModeChange}
+          disabled={disabled}
+        />
+        <div className={css({ flexGrow: 1, minWidth: 0 })}>
+          {mode === 'secret' ? (
+            <Combobox<string>
+              id={id}
+              options={options}
+              value={selectedSecret ?? null}
+              disabled={disabled}
+              placeholder={isLoading ? 'Loading secrets...' : 'Select a secret'}
+              onChange={(option) => {
+                const name = typeof option === 'string' ? option : option?.value;
+                if (name) {
+                  setValue(field, buildSecretRef(name), { shouldDirty: true });
+                }
+              }}
+            />
+          ) : variant === 'textarea' ? (
+            <TextArea id={id} rows={rows ?? 3} placeholder={placeholder} disabled={disabled} aria-label={label} {...register(field)} />
+          ) : (
+            <PasswordInput id={id} placeholder={placeholder} disabled={disabled} {...register(field)} />
+          )}
+        </div>
+      </Stack>
+    </StyledField>
+  );
+}

--- a/src/components/Checkster/components/form/FormSecretOrPlaintextField.tsx
+++ b/src/components/Checkster/components/form/FormSecretOrPlaintextField.tsx
@@ -68,14 +68,7 @@ export function FormSecretOrPlaintextField(props: FormSecretOrPlaintextFieldProp
     return <PlaintextField {...props} />;
   }
 
-  return (
-    <QueryErrorBoundary
-      title="Error loading secrets"
-      content="Failed to load secrets. Please check your connection and try again."
-    >
-      <SecretOrPlaintextField {...props} />
-    </QueryErrorBoundary>
-  );
+  return <SecretOrPlaintextField {...props} />;
 }
 
 /**
@@ -157,8 +150,6 @@ function SecretOrPlaintextField({
     }
   }, [value]);
 
-  const { data: secrets = [], isLoading } = useSecrets(true);
-
   const handleModeChange = (next: FieldMode) => {
     setMode(next);
     // Only clear a value that belongs to the *other* mode, so we never persist a
@@ -169,19 +160,6 @@ function SecretOrPlaintextField({
       setValue(field, '', { shouldDirty: true });
     }
   };
-
-  const selectedSecret = parseSecretName(value);
-  const options: Array<ComboboxOption<string>> = secrets.map((secret) => ({
-    label: secret.name,
-    value: secret.name,
-    description: secret.description,
-  }));
-  // Surface a referenced-but-missing secret so its value is not silently lost.
-  if (selectedSecret && !options.some((option) => option.value === selectedSecret)) {
-    options.push({ label: `${selectedSecret} (not found)`, value: selectedSecret });
-  }
-
-  const hasNoSecrets = !isLoading && secrets.length === 0;
 
   return (
     <div className={cx(styles.wrapper, { [styles.grow]: grow })}>
@@ -200,19 +178,15 @@ function SecretOrPlaintextField({
       </div>
       <StyledField htmlFor={id} {...getFieldErrorProps(errors, field)}>
         {mode === 'secret' ? (
-          <Combobox<string>
-            id={id}
-            options={options}
-            value={selectedSecret ?? null}
-            disabled={disabled}
-            placeholder={isLoading ? 'Loading secrets...' : 'Select a secret'}
-            onChange={(option) => {
-              const name = typeof option === 'string' ? option : option?.value;
-              if (name) {
-                setValue(field, buildSecretRef(name), { shouldDirty: true });
-              }
-            }}
-          />
+          // Scope the secrets fetch (and its error boundary) to Secret mode only,
+          // so a failing secrets-list request never blocks plaintext entry in
+          // Value mode.
+          <QueryErrorBoundary
+            title="Error loading secrets"
+            content="Failed to load secrets. Please check your connection and try again."
+          >
+            <SecretPicker id={id} field={field} value={value} disabled={disabled} />
+          </QueryErrorBoundary>
         ) : variant === 'textarea' ? (
           <TextArea
             id={id}
@@ -226,16 +200,70 @@ function SecretOrPlaintextField({
           <PasswordInput id={id} placeholder={placeholder} disabled={disabled} {...register(field)} />
         )}
       </StyledField>
-
-      {mode === 'secret' && hasNoSecrets && (
-        <Text variant="bodySmall" color="secondary">
-          No secrets available.{' '}
-          <TextLink href={`${getRoute(AppRoutes.Config)}/secrets`} variant="bodySmall">
-            Create one in Config
-          </TextLink>
-        </Text>
-      )}
     </div>
+  );
+}
+
+/**
+ * The Secret-mode control: a combobox of available secrets. Isolated into its
+ * own component so `useSecrets` (and the surrounding error boundary) only mount
+ * in Secret mode — a secrets-list failure must not take down Value-mode
+ * plaintext entry.
+ */
+function SecretPicker({
+  id,
+  field,
+  value,
+  disabled,
+}: {
+  id: string;
+  field: CheckFormFieldPath;
+  value: string | undefined;
+  disabled?: boolean;
+}) {
+  const styles = useStyles2(getStyles);
+  const { setValue } = useFormContext<CheckFormValues>();
+  const { data: secrets = [], isLoading } = useSecrets(true);
+
+  const selectedSecret = parseSecretName(value);
+  const options: Array<ComboboxOption<string>> = secrets.map((secret) => ({
+    label: secret.name,
+    value: secret.name,
+    description: secret.description,
+  }));
+  // Surface a referenced-but-missing secret so its value is not silently lost.
+  if (selectedSecret && !options.some((option) => option.value === selectedSecret)) {
+    options.push({ label: `${selectedSecret} (not found)`, value: selectedSecret });
+  }
+
+  const hasNoSecrets = !isLoading && secrets.length === 0;
+
+  return (
+    <>
+      <Combobox<string>
+        id={id}
+        options={options}
+        value={selectedSecret ?? null}
+        disabled={disabled}
+        placeholder={isLoading ? 'Loading secrets...' : 'Select a secret'}
+        onChange={(option) => {
+          const name = typeof option === 'string' ? option : option?.value;
+          if (name) {
+            setValue(field, buildSecretRef(name), { shouldDirty: true });
+          }
+        }}
+      />
+      {hasNoSecrets && (
+        <div className={styles.hint}>
+          <Text variant="bodySmall" color="secondary">
+            No secrets available.{' '}
+            <TextLink href={`${getRoute(AppRoutes.Config)}/secrets`} variant="bodySmall">
+              Create one in Config
+            </TextLink>
+          </Text>
+        </div>
+      )}
+    </>
   );
 }
 
@@ -259,5 +287,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   label: css({
     marginBottom: 0,
+  }),
+  hint: css({
+    marginTop: theme.spacing(0.5),
   }),
 });

--- a/src/components/Checkster/components/form/FormSecretOrPlaintextField.tsx
+++ b/src/components/Checkster/components/form/FormSecretOrPlaintextField.tsx
@@ -3,6 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Combobox, ComboboxOption, Input, Label, RadioButtonGroup, Text, TextArea, TextLink, useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
+import { get } from 'lodash';
 
 import { CheckFormFieldPath } from '../../types';
 import { CheckFormValues, FeatureName } from 'types';
@@ -42,13 +43,6 @@ export interface FormSecretOrPlaintextFieldProps {
 }
 
 /**
- * A credential field that can hold either a plaintext value or a reference to a
- * secret (`${secrets.<name>}`). When secrets are available it renders a
- * "Value / Secret" toggle; picking a secret writes the reference into the same
- * form field. The `secretManagerEnabled` flag is not exposed here — it is
- * inferred from field values at serialization time.
- */
-/**
  * Whether a credential field can reference a secret: the field opts in via
  * `allowSecrets`, the feature flag is on, and the user can read secrets. Exported
  * so a sibling plain field (e.g. the basic-auth username) can match this field's
@@ -60,6 +54,13 @@ export function useSecretsFieldEnabled(allowSecrets?: boolean): boolean {
   return Boolean(allowSecrets && isEnabled && canReadSecrets);
 }
 
+/**
+ * A credential field that can hold either a plaintext value or a reference to a
+ * secret (`${secrets.<name>}`). When secrets are available it renders a
+ * "Value / Secret" toggle; picking a secret writes the reference into the same
+ * form field. The `secretManagerEnabled` flag is not exposed here — it is
+ * inferred from field values at serialization time.
+ */
 export function FormSecretOrPlaintextField(props: FormSecretOrPlaintextFieldProps) {
   const secretsAvailable = useSecretsFieldEnabled(props.allowSecrets);
 
@@ -79,8 +80,8 @@ export function FormSecretOrPlaintextField(props: FormSecretOrPlaintextFieldProp
 
 /**
  * Plaintext-only render (secrets unavailable). If the field already holds a
- * secret reference (e.g. the check was created elsewhere), show it in a disabled
- * input so the reference is preserved on save rather than silently dropped.
+ * secret reference (e.g. the check was created elsewhere), show it read-only so
+ * the reference is preserved on save rather than silently dropped.
  */
 function PlaintextField({ field, label, description, required, variant, rows, placeholder, grow }: FormSecretOrPlaintextFieldProps) {
   const {
@@ -101,7 +102,10 @@ function PlaintextField({ field, label, description, required, variant, rows, pl
       {...getFieldErrorProps(errors, field)}
     >
       {holdsSecret ? (
-        <Input id={id} type="text" disabled {...register(field)} />
+        // Read-only, not disabled: React Hook Form omits disabled registered
+        // fields from the submitted values, which would drop the very reference
+        // this fallback is meant to preserve.
+        <Input id={id} type="text" readOnly {...register(field)} />
       ) : variant === 'textarea' ? (
         <TextArea id={id} rows={rows ?? 3} placeholder={placeholder} disabled={disabled} aria-label={label} {...register(field)} />
       ) : (
@@ -126,19 +130,25 @@ function SecretOrPlaintextField({
     register,
     setValue,
     watch,
-    formState: { errors, disabled },
+    formState: { errors, disabled, defaultValues },
   } = useFormContext<CheckFormValues>();
   const id = useDOMId();
   const value = watch(field) as string | undefined;
+  const defaultValue = get(defaultValues, field) as string | undefined;
 
-  // Seed the mode from the current value, then keep it in sync when the value
-  // changes externally (e.g. after the form is reset with new check data, or a
-  // ${secrets.*} reference is pasted into the value input): a secret reference
-  // must show the secret picker, not a masked input. An empty value keeps the
-  // current mode, so switching to "Secret" to pick a secret does not
-  // immediately flip back to "Value".
   const [mode, setMode] = useState<FieldMode>(() => (isSecretRef(value) ? 'secret' : 'plaintext'));
 
+  // Re-derive the mode from the current value on mount and whenever the form is
+  // reset (this field's default value changes). This returns an emptied field to
+  // Value mode after a reset rather than leaving an empty Secret picker behind.
+  useEffect(() => {
+    setMode(isSecretRef(value) ? 'secret' : 'plaintext');
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- runs on reset (defaultValue); reads the latest value intentionally
+  }, [defaultValue]);
+
+  // A ${secrets.*} reference typed/pasted while in Value mode must flip to Secret
+  // mode; a plaintext value flips back. An empty value keeps the current mode so
+  // switching to Secret to pick a secret does not immediately bounce to Value.
   useEffect(() => {
     if (isSecretRef(value)) {
       setMode('secret');

--- a/src/components/Checkster/components/form/FormTLSConfigField.tsx
+++ b/src/components/Checkster/components/form/FormTLSConfigField.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { Stack } from '@grafana/ui';
 
-import { TLSBaseFieldPath } from '../../types';
+import { CheckFormFieldPath, TLSBaseFieldPath } from '../../types';
 
 import { FIELD_SPACING } from '../../constants';
 import { GenericCheckboxField } from './generic/GenericCheckboxField';
 import { GenericInputField } from './generic/GenericInputField';
 import { GenericTextareaField } from './generic/GenericTextareaField';
+import { FormSecretOrPlaintextField } from './FormSecretOrPlaintextField';
 
 interface FormTLSConfigFieldProps {
   field: TLSBaseFieldPath; // TODO: This should be a narrow type (that validates that the path has TLS config child paths)
   useTLS?: true; // gRPC + TCP (leave undefined for HTTP)
+  allowSecrets?: boolean; // HTTP only: allow cert/key fields to reference a secret
 }
 
 type TLSConfigKey = 'serverName' | 'insecureSkipVerify' | 'caCert' | 'clientCert' | 'clientKey';
@@ -19,13 +21,28 @@ function getTLSConfigField(settingsField: TLSBaseFieldPath, name: TLSConfigKey) 
   return `${settingsField}.tlsConfig.${name}` as const;
 }
 
-export function FormTLSConfigField({ field, useTLS }: FormTLSConfigFieldProps) {
+export function FormTLSConfigField({ field, useTLS, allowSecrets }: FormTLSConfigFieldProps) {
   const tlsField = `${field}.tls` as any; // TODO: `tls` is missing in `settings.http`, better typing?
   const insecureSkipVerify = getTLSConfigField(field, 'insecureSkipVerify');
   const serverName = getTLSConfigField(field, 'serverName');
   const caCert = getTLSConfigField(field, 'caCert');
   const clientCert = getTLSConfigField(field, 'clientCert');
   const clientKey = getTLSConfigField(field, 'clientKey');
+
+  const renderCert = (certField: CheckFormFieldPath, label: string, description: string, placeholder: string) =>
+    allowSecrets ? (
+      <FormSecretOrPlaintextField
+        field={certField}
+        label={label}
+        description={description}
+        variant="textarea"
+        rows={3}
+        placeholder={placeholder}
+        allowSecrets
+      />
+    ) : (
+      <GenericTextareaField field={certField} label={label} description={description} rows={3} placeholder={placeholder} />
+    );
 
   return (
     <Stack direction="column" gap={FIELD_SPACING}>
@@ -43,33 +60,30 @@ export function FormTLSConfigField({ field, useTLS }: FormTLSConfigFieldProps) {
         description="Used to verify the hostname for the targets"
         placeholder="grafana.com"
       />
-      <GenericTextareaField
-        field={caCert}
-        label="CA certificate"
-        description="Certificate must be in PEM format."
-        rows={3}
-        placeholder={`-----BEGIN CERTIFICATE-----
+      {renderCert(
+        caCert,
+        'CA certificate',
+        'Certificate must be in PEM format.',
+        `-----BEGIN CERTIFICATE-----
 ...
------END CERTIFICATE-----`}
-      />
-      <GenericTextareaField
-        field={clientCert}
-        label="Client certificate"
-        description="The client cert file for the targets. The certificate must be in PEM format."
-        rows={3}
-        placeholder={`-----BEGIN CERTIFICATE-----
+-----END CERTIFICATE-----`
+      )}
+      {renderCert(
+        clientCert,
+        'Client certificate',
+        'The client cert file for the targets. The certificate must be in PEM format.',
+        `-----BEGIN CERTIFICATE-----
 ...
------END CERTIFICATE-----`}
-      />
-      <GenericTextareaField
-        field={clientKey}
-        label="Client key"
-        description="The client key file for the targets. The key must be in PEM format."
-        rows={3}
-        placeholder={`----BEGIN PRIVATE KEY-----
+-----END CERTIFICATE-----`
+      )}
+      {renderCert(
+        clientKey,
+        'Client key',
+        'The client key file for the targets. The key must be in PEM format.',
+        `----BEGIN PRIVATE KEY-----
 ...
------END PRIVATE KEY-----`}
-      />
+-----END PRIVATE KEY-----`
+      )}
     </Stack>
   );
 }

--- a/src/components/Checkster/components/form/layouts/HttpCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/HttpCheckContent.tsx
@@ -105,7 +105,7 @@ export function HttpCheckContent() {
 
           <FormTabContent label="TLS">
             {/* TODO: This is not super transparent */}
-            <FormTLSConfigField field="settings.http" />
+            <FormTLSConfigField field="settings.http" allowSecrets />
           </FormTabContent>
 
           <FormTabContent label="Proxy">

--- a/src/components/Checkster/transformations/toFormValues.http.test.ts
+++ b/src/components/Checkster/transformations/toFormValues.http.test.ts
@@ -1,0 +1,31 @@
+import { HTTPCheck } from 'types';
+import { toBase64 } from 'utils';
+import { FALLBACK_CHECK_HTTP } from 'components/constants';
+
+import { getHTTPCheckFormValues } from './toFormValues.http';
+
+function httpCheckWith(http: Partial<HTTPCheck['settings']['http']>): HTTPCheck {
+  return {
+    ...FALLBACK_CHECK_HTTP,
+    settings: { http: { ...FALLBACK_CHECK_HTTP.settings.http, ...http } },
+  };
+}
+
+describe('getHTTPCheckFormValues — secret references', () => {
+  it('keeps a bearer-token secret reference verbatim in form values', () => {
+    const fv = getHTTPCheckFormValues(httpCheckWith({ bearerToken: '${secrets.tok}', secretManagerEnabled: true }));
+    expect(fv.settings.http.bearerToken).toBe('${secrets.tok}');
+  });
+
+  it('decodes a base64-wrapped TLS cert secret reference back to the literal', () => {
+    const fv = getHTTPCheckFormValues(
+      httpCheckWith({ tlsConfig: { caCert: toBase64('${secrets.ca}') }, secretManagerEnabled: true })
+    );
+    expect(fv.settings.http.tlsConfig?.caCert).toBe('${secrets.ca}');
+  });
+
+  it('never leaks secretManagerEnabled into form values', () => {
+    const fv = getHTTPCheckFormValues(httpCheckWith({ bearerToken: '${secrets.tok}', secretManagerEnabled: true }));
+    expect('secretManagerEnabled' in fv.settings.http).toBe(false);
+  });
+});

--- a/src/components/Checkster/transformations/toFormValues.http.ts
+++ b/src/components/Checkster/transformations/toFormValues.http.ts
@@ -41,6 +41,9 @@ export function getHttpSettingsForm(settings: HTTPCheck['settings']): HttpSettin
     noFollowRedirects,
     tlsConfig,
     compression,
+    // Dropped from form values: the UI infers it from field values on save, so
+    // it must never leak into the form (it is Omit-ted from HttpSettingsFormValues).
+    secretManagerEnabled,
     ...rest
   } = httpSettings;
 

--- a/src/components/Checkster/transformations/toFormValues.utils.ts
+++ b/src/components/Checkster/transformations/toFormValues.utils.ts
@@ -5,6 +5,7 @@ import {
   PredefinedAlertInterface,
 } from 'components/CheckForm/AlertsPerCheck/AlertsPerCheck.constants';
 
+import { isSecretRef } from '../utils/secrets';
 import { getCheckAlertsFormValues } from './toFormValues.alerts';
 
 export const getTlsConfigFormValues = (tlsConfig?: TLSConfig) => {
@@ -26,6 +27,11 @@ const getDecodedIfPEM = (cert = '') => {
   const decoded = fromBase64(cert);
   if (decoded === undefined) {
     return cert;
+  }
+  // A secret reference is stored base64-encoded on the wire (like any PEM); decode
+  // it back to the literal `${secrets.*}` so the field re-hydrates into secret mode.
+  if (isSecretRef(decoded)) {
+    return decoded;
   }
   if (decoded.indexOf('BEGIN') > 0) {
     return decoded;

--- a/src/components/Checkster/transformations/toPayload.http.test.ts
+++ b/src/components/Checkster/transformations/toPayload.http.test.ts
@@ -1,0 +1,41 @@
+import { FALLBACK_CHECK_HTTP } from 'components/constants';
+
+import { getHTTPCheckFormValues } from './toFormValues.http';
+import { getHTTPPayload } from './toPayload.http';
+
+// A valid HTTP form-values object derived from the fallback check; individual
+// credential fields are overridden per test.
+function baseFormValues() {
+  return getHTTPCheckFormValues(FALLBACK_CHECK_HTTP);
+}
+
+describe('getHTTPPayload — secretManagerEnabled inference', () => {
+  it('is omitted when no credential field references a secret', () => {
+    const payload = getHTTPPayload(baseFormValues());
+    expect(payload.settings.http.secretManagerEnabled).toBeUndefined();
+  });
+
+  it('is true when the bearer token references a secret', () => {
+    const fv = baseFormValues();
+    fv.settings.http.bearerToken = '${secrets.my-token}';
+    expect(getHTTPPayload(fv).settings.http.secretManagerEnabled).toBe(true);
+  });
+
+  it('is true when the basic-auth password references a secret', () => {
+    const fv = baseFormValues();
+    fv.settings.http.basicAuth = { username: 'admin', password: '${secrets.pw}' };
+    expect(getHTTPPayload(fv).settings.http.secretManagerEnabled).toBe(true);
+  });
+
+  it('is not set when only the username looks like a secret reference', () => {
+    const fv = baseFormValues();
+    fv.settings.http.basicAuth = { username: '${secrets.user}', password: 'plaintext' };
+    expect(getHTTPPayload(fv).settings.http.secretManagerEnabled).toBeUndefined();
+  });
+
+  it.each(['caCert', 'clientCert', 'clientKey'] as const)('is true when TLS %s references a secret', (key) => {
+    const fv = baseFormValues();
+    fv.settings.http.tlsConfig = { [key]: '${secrets.cert}' };
+    expect(getHTTPPayload(fv).settings.http.secretManagerEnabled).toBe(true);
+  });
+});

--- a/src/components/Checkster/transformations/toPayload.http.ts
+++ b/src/components/Checkster/transformations/toPayload.http.ts
@@ -9,6 +9,7 @@ import {
 } from 'types';
 import { FALLBACK_CHECK_HTTP } from 'components/constants';
 
+import { isSecretRef } from '../utils/secrets';
 import { getBasePayloadValuesFromForm, getTlsConfigFromFormValues } from './toPayload.utils';
 
 export function getHTTPPayload(formValues: CheckFormValuesHttp): HTTPCheck {
@@ -35,11 +36,26 @@ function getHttpSettingsPayload(settings: Partial<HttpSettingsFormValues> | unde
   const { sslOptions, regexValidations, followRedirects, tlsConfig, ...restToKeep } = settings;
   const transformedTlsConfig = getTlsConfigFromFormValues(tlsConfig);
 
+  // Infer the per-check secret-manager flag from the credential fields rather
+  // than exposing a toggle: if any field the agent resolves holds a
+  // `${secrets.*}` reference, the check opts in to resolution. Computed from the
+  // pre-transform form values so the scan sees the literal reference (TLS certs
+  // are base64-encoded downstream). Username is excluded — the agent resolves
+  // only the basic-auth password. Omitted when false so checks that don't use
+  // secrets keep an unchanged payload (the API treats absent as false).
+  const secretManagerEnabled =
+    isSecretRef(settings.bearerToken) ||
+    isSecretRef(settings.basicAuth?.password) ||
+    isSecretRef(tlsConfig?.caCert) ||
+    isSecretRef(tlsConfig?.clientCert) ||
+    isSecretRef(tlsConfig?.clientKey);
+
   return sanitize({
     ...restToKeep,
     ...sslConfig,
     ...validationRegexes,
     ...transformedTlsConfig,
+    ...(secretManagerEnabled ? { secretManagerEnabled: true } : {}),
     noFollowRedirects: !followRedirects,
     method: settings?.method ?? FALLBACK_CHECK_HTTP.settings.http.method,
     headers: formattedHeaders,

--- a/src/components/Checkster/utils/secrets.test.ts
+++ b/src/components/Checkster/utils/secrets.test.ts
@@ -1,0 +1,36 @@
+import { buildSecretRef, isSecretRef, parseSecretName } from './secrets';
+
+describe('isSecretRef', () => {
+  it.each([
+    ['${secrets.my-token}', true],
+    ['prefix ${secrets.db-password} suffix', true],
+    ['${secrets.a}', true],
+    ['plain-value', false],
+    ['', false],
+    ['${vars.something}', false],
+    [undefined, false],
+  ])('isSecretRef(%p) === %p', (value, expected) => {
+    expect(isSecretRef(value as string | undefined)).toBe(expected);
+  });
+});
+
+describe('parseSecretName', () => {
+  it('extracts the secret name', () => {
+    expect(parseSecretName('${secrets.my-token}')).toBe('my-token');
+  });
+
+  it('returns undefined for a non-reference', () => {
+    expect(parseSecretName('plain')).toBeUndefined();
+    expect(parseSecretName(undefined)).toBeUndefined();
+  });
+});
+
+describe('buildSecretRef', () => {
+  it('builds a reference from a name', () => {
+    expect(buildSecretRef('my-token')).toBe('${secrets.my-token}');
+  });
+
+  it('round-trips with parseSecretName', () => {
+    expect(parseSecretName(buildSecretRef('some-name'))).toBe('some-name');
+  });
+});

--- a/src/components/Checkster/utils/secrets.ts
+++ b/src/components/Checkster/utils/secrets.ts
@@ -1,0 +1,34 @@
+/**
+ * Helpers for the `${secrets.<name>}` reference syntax used to point a check's
+ * credential fields at a secret stored in Grafana Secrets Manager. The agent
+ * resolves these references at check-execution time; the frontend only needs to
+ * write, detect, and parse them. Mirror of the agent-side interpolation regex
+ * (`internal/prober/interpolation`).
+ */
+export const SECRET_REF_REGEX = /\$\{secrets\.([^}]*)\}/;
+
+/**
+ * Whether a field value is a secret reference (e.g. `${secrets.my-token}`).
+ */
+export function isSecretRef(value?: string): boolean {
+  return typeof value === 'string' && SECRET_REF_REGEX.test(value);
+}
+
+/**
+ * Extract the secret name from a reference, or `undefined` if the value is not
+ * a reference.
+ */
+export function parseSecretName(value?: string): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const match = value.match(SECRET_REF_REGEX);
+  return match ? match[1] : undefined;
+}
+
+/**
+ * Build a secret reference from a secret name.
+ */
+export function buildSecretRef(name: string): string {
+  return `\${secrets.${name}}`;
+}

--- a/src/schemas/general/TLSConfig.test.ts
+++ b/src/schemas/general/TLSConfig.test.ts
@@ -1,0 +1,43 @@
+import { tlsConfigSchema } from './TLSConfig';
+
+const VALID_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIJAK. . .example. . .
+-----END CERTIFICATE-----`;
+
+const VALID_KEY_PEM = `-----BEGIN PRIVATE KEY-----
+MIIBkTCB+wIJAK. . .example. . .
+-----END PRIVATE KEY-----`;
+
+describe('tlsConfigSchema', () => {
+  it('accepts a secret reference for the cert and key fields', () => {
+    const result = tlsConfigSchema.safeParse({
+      caCert: '${secrets.ca}',
+      clientCert: '${secrets.client-cert}',
+      clientKey: '${secrets.client-key}',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid PEM certificates and keys', () => {
+    const result = tlsConfigSchema.safeParse({
+      caCert: VALID_CERT_PEM,
+      clientCert: VALID_CERT_PEM,
+      clientKey: VALID_KEY_PEM,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a certificate that is neither PEM nor a secret reference', () => {
+    const result = tlsConfigSchema.safeParse({ caCert: 'not-a-cert' });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a client key that is neither PEM nor a secret reference', () => {
+    const result = tlsConfigSchema.safeParse({ clientKey: 'not-a-key' });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/schemas/general/TLSConfig.ts
+++ b/src/schemas/general/TLSConfig.ts
@@ -1,6 +1,7 @@
 import { z, ZodType } from 'zod';
 
 import { TLSConfig } from 'types';
+import { isSecretRef } from 'components/Checkster/utils/secrets';
 
 const PEM_HEADER = '-----BEGIN CERTIFICATE-----';
 const PEM_FOOTER = '-----END CERTIFICATE-----';
@@ -37,6 +38,10 @@ function validateTLSCACert(caCert?: string) {
     return true;
   }
 
+  if (isSecretRef(caCert)) {
+    return true;
+  }
+
   if (caCert.indexOf(PEM_HEADER) < 0 || caCert.indexOf(PEM_FOOTER) < 0) {
     return false;
   }
@@ -49,6 +54,10 @@ function validateTLSClientCert(clientCert?: string) {
     return true;
   }
 
+  if (isSecretRef(clientCert)) {
+    return true;
+  }
+
   if (clientCert.indexOf(PEM_HEADER) < 0 || clientCert.indexOf(PEM_FOOTER) < 0) {
     return false;
   }
@@ -58,6 +67,10 @@ function validateTLSClientCert(clientCert?: string) {
 
 function validateTLSClientKey(clientKey?: string) {
   if (!clientKey) {
+    return true;
+  }
+
+  if (isSecretRef(clientKey)) {
     return true;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,11 @@ export interface HttpSettings {
   bearerToken?: string;
   basicAuth?: BasicAuth;
 
+  // When true, the agent resolves `${secrets.*}` references in this check's
+  // credential fields. Inferred by the UI from field values, never shown to the
+  // user, so it is intentionally excluded from `HttpSettingsFormValues`.
+  secretManagerEnabled?: boolean;
+
   // validations
   failIfSSL?: boolean;
   failIfNotSSL?: boolean;
@@ -259,6 +264,7 @@ export interface HttpSettingsFormValues
     | 'failIfHeaderNotMatchesRegexp'
     | 'noFollowRedirects'
     | 'compression'
+    | 'secretManagerEnabled'
   > {
   sslOptions: HttpSslOption;
   headers?: HttpHeaderFormValue[];


### PR DESCRIPTION
Add UI to reference Grafana Secrets Manager secrets from the HTTP check credential fields, alongside the existing plaintext inputs.

- New FormSecretOrPlaintextField: a credential field with a "Value / Secret" toggle. In value mode it renders the usual masked input or textarea; in secret mode it renders a Combobox of available secrets and stores a ${secrets.<name>} reference in the same form field. It is gated by the SecretsManagement feature flag and the read-secrets permission; when unavailable it falls back to a plaintext-only input, showing an existing secret reference disabled so it is preserved rather than silently dropped on save. The toggle is laid out inline, next to a growing input wrapper, so it reads and behaves like a real toggle rather than sitting on top of the field.
- Wire it into the HTTP auth fields: bearer token, basic-auth password, and the TLS config cert/key/CA (enabled via allowSecrets on FormTLSConfigField from HttpCheckContent). FormHttpAuthenticationField is restructured accordingly.
- Add secret-reference utilities (isSecretRef, buildSecretRef, parseSecretName) and the form/payload transformations: secretManager- Enabled is inferred from the field values on save (toPayload) and dropped from the form values (toFormValues) so it never leaks into the form.
- Add tests for the utilities, the transformations, and the component.

Fixes: #570
Part-of: grafana/synthetic-monitoring#628.

### No secrets
<img width="1193" height="319" alt="Screenshot 2026-07-14 at 10 25 42 AM" src="https://github.com/user-attachments/assets/a94b15b9-d508-447c-aee8-2771fe5e31a7" />
<img width="1197" height="590" alt="Screenshot 2026-07-14 at 10 25 49 AM" src="https://github.com/user-attachments/assets/8951cccd-5272-40fa-a62f-24438c907b75" />

### Secrets selected
<img width="1195" height="361" alt="Screenshot 2026-07-14 at 10 19 09 AM" src="https://github.com/user-attachments/assets/89373c3f-6ad7-4100-88bd-9ea4bfe576d9" />
<img width="1206" height="496" alt="Screenshot 2026-07-14 at 10 19 15 AM" src="https://github.com/user-attachments/assets/f1ef3954-612a-4a62-b8ed-5296bc11585e" />
