### PR TITLE
feat: distinguish missing Faro sessions from uninstrumented checks

### DIFF
--- a/src/scenes/components/TimepointExplorer/FrontendO11yButton.test.tsx
+++ b/src/scenes/components/TimepointExplorer/FrontendO11yButton.test.tsx
@@ -11,6 +11,7 @@ import { RumAvailability } from 'scenes/components/TimepointExplorer/TimepointVi
 const mockUseFaroSessionLink = jest.fn();
 const mockMarkRumPresent = jest.fn();
 const mockUseStatefulTimepoint = jest.fn();
+const mockUseSelectedProbeNames = jest.fn();
 
 jest.mock('scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks', () => ({
   useFaroSessionLink: (args: unknown) => mockUseFaroSessionLink(args),
@@ -18,6 +19,7 @@ jest.mock('scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks'
 
 jest.mock('scenes/components/TimepointExplorer/TimepointExplorer.hooks', () => ({
   useStatefulTimepoint: (timepoint: unknown) => mockUseStatefulTimepoint(timepoint),
+  useSelectedProbeNames: (timepoint: unknown) => mockUseSelectedProbeNames(timepoint),
 }));
 
 jest.mock('hooks/useLogsDS', () => ({
@@ -46,6 +48,7 @@ const mockedUseTimepointExplorerContext = useTimepointExplorerContext as jest.Mo
 function setupContext({
   rumAvailability = 'unknown' as RumAvailability,
   viewerState = [timepoint, 'probe-a', 0] as const,
+  currentAdjustedTime = timepoint.adjustedTime + 60_000,
 } = {}) {
   mockedUseTimepointExplorerContext.mockReturnValue({
     check: COMPLEX_BROWSER_CHECK,
@@ -53,12 +56,14 @@ function setupContext({
     viewerState,
     rumAvailability,
     markRumPresent: mockMarkRumPresent,
+    currentAdjustedTime,
   });
 }
 
 describe('FrontendO11yButton', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseSelectedProbeNames.mockReturnValue(['probe-a']);
     mockUseStatefulTimepoint.mockReturnValue({
       ...timepoint,
       status: 'success',
@@ -121,6 +126,47 @@ describe('FrontendO11yButton', () => {
     expect(screen.queryByText('Add RUM to your app')).not.toBeInTheDocument();
   });
 
+  it('shows Waiting for session while Faro lookup is in flight and RUM is present', async () => {
+    mockUseFaroSessionLink.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isFetched: false,
+      isError: false,
+      isSuccess: false,
+    });
+    setupContext({ rumAvailability: 'present' });
+
+    render(<FrontendO11yButton timepoint={timepoint} />);
+
+    expect(await screen.findByText('Waiting for session')).toBeInTheDocument();
+  });
+
+  it('shows Waiting for session when the selected probe is pending and RUM is present', async () => {
+    mockUseStatefulTimepoint.mockReturnValue({
+      ...timepoint,
+      status: 'pending',
+      maxProbeDuration: 1000,
+      probeResults: {},
+    });
+    mockUseFaroSessionLink.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isFetched: false,
+      isError: false,
+      isSuccess: false,
+    });
+    setupContext({
+      rumAvailability: 'present',
+      currentAdjustedTime: timepoint.adjustedTime,
+    });
+
+    render(<FrontendO11yButton timepoint={timepoint} />);
+
+    expect(await screen.findByText('Waiting for session')).toBeInTheDocument();
+  });
+
   it('renders nothing when the Faro lookup errors', async () => {
     mockUseFaroSessionLink.mockReturnValue({
       data: undefined,
@@ -135,10 +181,11 @@ describe('FrontendO11yButton', () => {
 
     expect(screen.queryByText('Add RUM to your app')).not.toBeInTheDocument();
     expect(screen.queryByText('No session for this run')).not.toBeInTheDocument();
+    expect(screen.queryByText('Waiting for session')).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /view frontend session/i })).not.toBeInTheDocument();
   });
 
-  it('renders a spinner while the Faro lookup is in flight', async () => {
+  it('renders a spinner while the Faro lookup is in flight and RUM is not present', async () => {
     mockUseFaroSessionLink.mockReturnValue({
       data: undefined,
       isLoading: true,
@@ -147,11 +194,13 @@ describe('FrontendO11yButton', () => {
       isError: false,
       isSuccess: false,
     });
+    setupContext({ rumAvailability: 'unknown' });
 
     render(<FrontendO11yButton timepoint={timepoint} />);
 
     expect(screen.queryByText('Add RUM to your app')).not.toBeInTheDocument();
     expect(screen.queryByText('No session for this run')).not.toBeInTheDocument();
+    expect(screen.queryByText('Waiting for session')).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /view frontend session/i })).not.toBeInTheDocument();
   });
 
@@ -177,6 +226,7 @@ describe('FrontendO11yButton', () => {
 
     expect(screen.queryByText('Add RUM to your app')).not.toBeInTheDocument();
     expect(screen.queryByText('No session for this run')).not.toBeInTheDocument();
+    expect(screen.queryByText('Waiting for session')).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /view frontend session/i })).not.toBeInTheDocument();
   });
 });

--- a/src/scenes/components/TimepointExplorer/FrontendO11yButton.test.tsx
+++ b/src/scenes/components/TimepointExplorer/FrontendO11yButton.test.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { COMPLEX_BROWSER_CHECK } from 'test/fixtures/checks';
+import { render } from 'test/render';
+
+import { CheckType } from 'types';
+import { FrontendO11yButton } from 'scenes/components/TimepointExplorer/FrontendO11yButton';
+import { StatelessTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
+import { RumAvailability } from 'scenes/components/TimepointExplorer/TimepointViewerFaroSession.utils';
+
+const mockUseFaroSessionLink = jest.fn();
+const mockMarkRumPresent = jest.fn();
+const mockUseStatefulTimepoint = jest.fn();
+
+jest.mock('scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks', () => ({
+  useFaroSessionLink: (args: unknown) => mockUseFaroSessionLink(args),
+}));
+
+jest.mock('scenes/components/TimepointExplorer/TimepointExplorer.hooks', () => ({
+  useStatefulTimepoint: (timepoint: unknown) => mockUseStatefulTimepoint(timepoint),
+}));
+
+jest.mock('hooks/useLogsDS', () => ({
+  useLogsDS: () => ({ uid: 'loki-uid' }),
+}));
+
+const timepoint: StatelessTimepoint = {
+  adjustedTime: 1_700_000_000_000,
+  timepointDuration: 1_000,
+  index: 0,
+  config: {
+    frequency: 60_000,
+    from: 1_700_000_000_000,
+    to: 1_700_000_060_000,
+  },
+};
+
+jest.mock('scenes/components/TimepointExplorer/TimepointExplorer.context', () => ({
+  useTimepointExplorerContext: jest.fn(),
+}));
+
+import { useTimepointExplorerContext } from 'scenes/components/TimepointExplorer/TimepointExplorer.context';
+
+const mockedUseTimepointExplorerContext = useTimepointExplorerContext as jest.Mock;
+
+function setupContext({
+  rumAvailability = 'unknown' as RumAvailability,
+  viewerState = [timepoint, 'probe-a', 0] as const,
+} = {}) {
+  mockedUseTimepointExplorerContext.mockReturnValue({
+    check: COMPLEX_BROWSER_CHECK,
+    checkType: CheckType.Browser,
+    viewerState,
+    rumAvailability,
+    markRumPresent: mockMarkRumPresent,
+  });
+}
+
+describe('FrontendO11yButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseStatefulTimepoint.mockReturnValue({
+      ...timepoint,
+      status: 'success',
+      maxProbeDuration: 1000,
+      probeResults: {
+        'probe-a': [{ labels: { execution_id: 'exec-1' } }],
+      },
+    });
+    setupContext();
+  });
+
+  it('renders the session link when a Faro session is available', async () => {
+    mockUseFaroSessionLink.mockReturnValue({
+      data: { href: '/a/grafana-kowalski-app/apps/2/sessions/abc', appId: '2', sessionId: 'abc' },
+      isLoading: false,
+      isFetching: false,
+      isFetched: true,
+      isError: false,
+      isSuccess: true,
+    });
+
+    render(<FrontendO11yButton timepoint={timepoint} />);
+
+    expect(await screen.findByRole('link', { name: /view frontend session/i })).toHaveAttribute(
+      'href',
+      '/a/grafana-kowalski-app/apps/2/sessions/abc'
+    );
+  });
+
+  it('shows Add RUM when the lookup succeeds empty and RUM is not known present', async () => {
+    mockUseFaroSessionLink.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isFetching: false,
+      isFetched: true,
+      isError: false,
+      isSuccess: true,
+    });
+    setupContext({ rumAvailability: 'unknown' });
+
+    render(<FrontendO11yButton timepoint={timepoint} />);
+
+    expect(await screen.findByText('Add RUM to your app')).toBeInTheDocument();
+  });
+
+  it('shows No session for this run when RUM is present but this execution has none', async () => {
+    mockUseFaroSessionLink.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isFetching: false,
+      isFetched: true,
+      isError: false,
+      isSuccess: true,
+    });
+    setupContext({ rumAvailability: 'present' });
+
+    render(<FrontendO11yButton timepoint={timepoint} />);
+
+    expect(await screen.findByText('No session for this run')).toBeInTheDocument();
+    expect(screen.queryByText('Add RUM to your app')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the Faro lookup errors', async () => {
+    mockUseFaroSessionLink.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isFetched: true,
+      isError: true,
+      isSuccess: false,
+    });
+
+    render(<FrontendO11yButton timepoint={timepoint} />);
+
+    expect(screen.queryByText('Add RUM to your app')).not.toBeInTheDocument();
+    expect(screen.queryByText('No session for this run')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /view frontend session/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a spinner while the Faro lookup is in flight', async () => {
+    mockUseFaroSessionLink.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isFetched: false,
+      isError: false,
+      isSuccess: false,
+    });
+
+    render(<FrontendO11yButton timepoint={timepoint} />);
+
+    expect(screen.queryByText('Add RUM to your app')).not.toBeInTheDocument();
+    expect(screen.queryByText('No session for this run')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /view frontend session/i })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the selected execution has no execution id', async () => {
+    mockUseStatefulTimepoint.mockReturnValue({
+      ...timepoint,
+      status: 'success',
+      maxProbeDuration: 1000,
+      probeResults: {
+        'probe-a': [{ labels: {} }],
+      },
+    });
+    mockUseFaroSessionLink.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isFetched: false,
+      isError: false,
+      isSuccess: false,
+    });
+
+    render(<FrontendO11yButton timepoint={timepoint} />);
+
+    expect(screen.queryByText('Add RUM to your app')).not.toBeInTheDocument();
+    expect(screen.queryByText('No session for this run')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /view frontend session/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/scenes/components/TimepointExplorer/FrontendO11yButton.tsx
+++ b/src/scenes/components/TimepointExplorer/FrontendO11yButton.tsx
@@ -8,12 +8,8 @@ import { getCheckType } from 'utils';
 import { useLogsDS } from 'hooks/useLogsDS';
 import { DocsLink } from 'components/DocsLink';
 import { useTimepointExplorerContext } from 'scenes/components/TimepointExplorer/TimepointExplorer.context';
-import {
-  useSelectedProbeNames,
-  useStatefulTimepoint,
-} from 'scenes/components/TimepointExplorer/TimepointExplorer.hooks';
+import { useStatefulTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.hooks';
 import { StatelessTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
-import { getCouldBePending, getPendingProbeNames } from 'scenes/components/TimepointExplorer/TimepointExplorer.utils';
 import { useFaroSessionLink } from 'scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks';
 
 type FaroActionStatus = 'no-session' | 'available';
@@ -31,16 +27,13 @@ const FRONTEND_OBSERVABILITY_DOCS_LINK =
 export const FrontendO11yButton = ({ timepoint }: { timepoint: StatelessTimepoint }) => {
   const styles = useStyles2(() => ({
     italic: css({ fontStyle: 'italic' }),
+    muted: css({ fontStyle: 'italic', opacity: 0.7 }),
   }));
-  const { check, checkType, viewerState, currentAdjustedTime } = useTimepointExplorerContext();
+  const { check, checkType, viewerState, rumAvailability, markRumPresent } = useTimepointExplorerContext();
   const [, viewerProbeName, viewerExecutionIndex] = viewerState;
   const logsDS = useLogsDS();
   const isBrowserCheck = getCheckType(check.settings) === CheckType.Browser;
   const statefulTimepoint = useStatefulTimepoint(timepoint);
-  const selectedProbeNames = useSelectedProbeNames(statefulTimepoint);
-  const couldBePending = getCouldBePending(timepoint, currentAdjustedTime);
-  const pendingProbeNames = couldBePending ? getPendingProbeNames({ statefulTimepoint, selectedProbeNames }) : [];
-  const isSelectedProbePending = viewerProbeName !== undefined && pendingProbeNames.includes(viewerProbeName);
 
   const selectedExecution =
     viewerProbeName !== undefined && viewerExecutionIndex !== undefined
@@ -52,54 +45,71 @@ export const FrontendO11yButton = ({ timepoint }: { timepoint: StatelessTimepoin
   const {
     data: faroSession,
     isLoading: isFaroLoading,
-    isFetched: isFaroFetched,
+    isFetching: isFaroFetching,
+    isError: isFaroError,
+    isSuccess: isFaroSuccess,
   } = useFaroSessionLink({
     executionId: executionId ?? '',
     from: timepoint.adjustedTime,
     to: timepoint.adjustedTime + timepoint.timepointDuration + timepoint.config.frequency,
     enabled: canQueryFaro,
+    onSuccess: (session) => {
+      if (session?.href) {
+        markRumPresent();
+      }
+    },
   });
 
   const faroAction = useMemo<FaroAction | null>(() => {
-    if (!selectedExecution?.labels.execution_id) {
+    if (!executionId) {
       return null;
     }
 
-    if (!faroSession?.href) {
+    if (faroSession?.href) {
       return {
-        status: 'no-session',
-        tooltip: 'No Frontend Observability session was found for this execution',
+        status: 'available',
+        href: faroSession.href,
+        tooltip: 'View Frontend Observability session',
+        onClick: () => {
+          trackTimepointViewerActionClicked({
+            checkType,
+            action: 'view-frontend-observability-session',
+          });
+        },
       };
     }
 
     return {
-      status: 'available',
-      href: faroSession.href,
-      tooltip: 'View Frontend Observability session',
-      onClick: () => {
-        trackTimepointViewerActionClicked({
-          checkType,
-          action: 'view-frontend-observability-session',
-        });
-      },
+      status: 'no-session',
+      tooltip: 'No Frontend Observability session was found for this execution',
     };
-  }, [selectedExecution, faroSession?.href, checkType]);
+  }, [executionId, faroSession?.href, checkType]);
 
   // Frontend Observability only applies to browser checks.
-  if (
-    !isBrowserCheck ||
-    isSelectedProbePending ||
-    !faroAction ||
-    (faroAction.status === 'no-session' && !isFaroFetched)
-  ) {
+  if (!isBrowserCheck || !faroAction || isFaroError) {
     return null;
   }
 
-  if (canQueryFaro && (isFaroLoading || !isFaroFetched)) {
+  // Prefer a spinner over flashing empty/Add-RUM states, and over briefly
+  // showing the previous execution's session while the new lookup is in flight.
+  if (canQueryFaro && (isFaroLoading || isFaroFetching)) {
     return <Spinner />;
   }
 
   if (faroAction.status === 'no-session') {
+    // Only treat a completed successful empty lookup as "no session".
+    if (!isFaroSuccess) {
+      return null;
+    }
+
+    if (rumAvailability === 'present') {
+      return (
+        <Tooltip content="No Frontend Observability session was found for this execution.">
+          <div className={styles.muted}>No session for this run</div>
+        </Tooltip>
+      );
+    }
+
     return (
       <Tooltip content="Add Frontend Observability to your application to start monitoring frontend performance and get insights into user experience.">
         <div className={styles.italic}>

--- a/src/scenes/components/TimepointExplorer/FrontendO11yButton.tsx
+++ b/src/scenes/components/TimepointExplorer/FrontendO11yButton.tsx
@@ -84,7 +84,7 @@ export const FrontendO11yButton = ({ timepoint }: { timepoint: StatelessTimepoin
   // Prefer a spinner over flashing empty/Add-RUM states, and over briefly
   // showing the previous execution's session while the new lookup is in flight.
   if (isFaroInFlight) {
-    return <Tooltip content="Looking for Frontend Observability session..."><Spinner /></Tooltip>;
+    return <Tooltip content="Looking for Frontend Observability session..."><span><Spinner /></span></Tooltip>;
   }
 
   if (faroSession?.href) {

--- a/src/scenes/components/TimepointExplorer/FrontendO11yButton.tsx
+++ b/src/scenes/components/TimepointExplorer/FrontendO11yButton.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
-import { LinkButton, Spinner, Tooltip, useStyles2 } from '@grafana/ui';
+import React from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { LinkButton, Spinner, Text, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { trackTimepointViewerActionClicked } from 'features/tracking/timepointExplorerEvents';
 
@@ -8,32 +9,29 @@ import { getCheckType } from 'utils';
 import { useLogsDS } from 'hooks/useLogsDS';
 import { DocsLink } from 'components/DocsLink';
 import { useTimepointExplorerContext } from 'scenes/components/TimepointExplorer/TimepointExplorer.context';
-import { useStatefulTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.hooks';
+import {
+  useSelectedProbeNames,
+  useStatefulTimepoint,
+} from 'scenes/components/TimepointExplorer/TimepointExplorer.hooks';
 import { StatelessTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
+import { getCouldBePending, getPendingProbeNames } from 'scenes/components/TimepointExplorer/TimepointExplorer.utils';
 import { useFaroSessionLink } from 'scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks';
-
-type FaroActionStatus = 'no-session' | 'available';
-
-interface FaroAction {
-  status: FaroActionStatus;
-  href?: string;
-  tooltip: string;
-  onClick?: () => void;
-}
 
 const FRONTEND_OBSERVABILITY_DOCS_LINK =
   'https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability';
 
 export const FrontendO11yButton = ({ timepoint }: { timepoint: StatelessTimepoint }) => {
-  const styles = useStyles2(() => ({
-    italic: css({ fontStyle: 'italic' }),
-    muted: css({ fontStyle: 'italic', opacity: 0.7 }),
-  }));
-  const { check, checkType, viewerState, rumAvailability, markRumPresent } = useTimepointExplorerContext();
+  const styles = useStyles2(getStyles);
+  const { check, checkType, viewerState, rumAvailability, markRumPresent, currentAdjustedTime } =
+    useTimepointExplorerContext();
   const [, viewerProbeName, viewerExecutionIndex] = viewerState;
   const logsDS = useLogsDS();
   const isBrowserCheck = getCheckType(check.settings) === CheckType.Browser;
   const statefulTimepoint = useStatefulTimepoint(timepoint);
+  const selectedProbeNames = useSelectedProbeNames(statefulTimepoint);
+  const couldBePending = getCouldBePending(timepoint, currentAdjustedTime);
+  const pendingProbeNames = couldBePending ? getPendingProbeNames({ statefulTimepoint, selectedProbeNames }) : [];
+  const isSelectedProbePending = viewerProbeName !== undefined && pendingProbeNames.includes(viewerProbeName);
 
   const selectedExecution =
     viewerProbeName !== undefined && viewerExecutionIndex !== undefined
@@ -60,83 +58,89 @@ export const FrontendO11yButton = ({ timepoint }: { timepoint: StatelessTimepoin
     },
   });
 
-  const faroAction = useMemo<FaroAction | null>(() => {
-    if (!executionId) {
-      return null;
-    }
-
-    if (faroSession?.href) {
-      return {
-        status: 'available',
-        href: faroSession.href,
-        tooltip: 'View Frontend Observability session',
-        onClick: () => {
-          trackTimepointViewerActionClicked({
-            checkType,
-            action: 'view-frontend-observability-session',
-          });
-        },
-      };
-    }
-
-    return {
-      status: 'no-session',
-      tooltip: 'No Frontend Observability session was found for this execution',
-    };
-  }, [executionId, faroSession?.href, checkType]);
+  const isFaroInFlight = canQueryFaro && (isFaroLoading || isFaroFetching);
+  const showWaitingForSession =
+    rumAvailability === 'present' && (isSelectedProbePending || isFaroInFlight);
 
   // Frontend Observability only applies to browser checks.
-  if (!isBrowserCheck || !faroAction || isFaroError) {
+  if (!isBrowserCheck || isFaroError) {
+    return null;
+  }
+
+  if (showWaitingForSession) {
+    return (
+      <div className={styles.italic}>
+        <Text variant="body" color="secondary">
+          Waiting for session
+        </Text>
+      </div>
+    );
+  }
+
+  if (!executionId) {
     return null;
   }
 
   // Prefer a spinner over flashing empty/Add-RUM states, and over briefly
   // showing the previous execution's session while the new lookup is in flight.
-  if (canQueryFaro && (isFaroLoading || isFaroFetching)) {
-    return <Spinner />;
+  if (isFaroInFlight) {
+    return <Tooltip content="Looking for Frontend Observability session..."><Spinner /></Tooltip>;
   }
 
-  if (faroAction.status === 'no-session') {
-    // Only treat a completed successful empty lookup as "no session".
-    if (!isFaroSuccess) {
-      return null;
-    }
-
-    if (rumAvailability === 'present') {
-      return (
-        <Tooltip content="No Frontend Observability session was found for this execution.">
-          <div className={styles.muted}>No session for this run</div>
-        </Tooltip>
-      );
-    }
-
+  if (faroSession?.href) {
     return (
-      <Tooltip content="Add Frontend Observability to your application to start monitoring frontend performance and get insights into user experience.">
+      <LinkButton
+        key="frontend-observability"
+        icon="frontend-observability"
+        href={faroSession.href}
+        onClick={() => {
+          trackTimepointViewerActionClicked({
+            checkType,
+            action: 'view-frontend-observability-session',
+          });
+        }}
+        variant="secondary"
+        fill="outline"
+      >
+        View Frontend Session
+      </LinkButton>
+    );
+  }
+
+  // Only treat a completed successful empty lookup as "no session".
+  if (!isFaroSuccess) {
+    return null;
+  }
+
+  if (rumAvailability === 'present') {
+    return (
+      <Tooltip content="No Frontend Observability session was found for this execution.">
         <div className={styles.italic}>
-          <DocsLink
-            key="frontend-observability"
-            href={FRONTEND_OBSERVABILITY_DOCS_LINK}
-            source="timepoint_explorer_frontend_observability"
-          >
-            Add RUM to your app
-          </DocsLink>
+          <Text variant="body" color="secondary">
+            No session for this run
+          </Text>
         </div>
       </Tooltip>
     );
   }
 
   return (
-    <LinkButton
-      key="frontend-observability"
-      icon="frontend-observability"
-      href={faroAction.href}
-      disabled={faroAction.status !== 'available'}
-      tooltip={faroAction.tooltip}
-      onClick={faroAction.onClick}
-      variant="secondary"
-      fill="outline"
-    >
-      View Frontend Session
-    </LinkButton>
+    <Tooltip content="Add Frontend Observability to your application to start monitoring frontend performance and get insights into user experience.">
+      <div className={styles.italic}>
+        <DocsLink
+          key="frontend-observability"
+          href={FRONTEND_OBSERVABILITY_DOCS_LINK}
+          source="timepoint_explorer_frontend_observability"
+        >
+          Add RUM to your app
+        </DocsLink>
+      </div>
+    </Tooltip>
   );
 };
+
+const getStyles = (_theme: GrafanaTheme2) => ({
+  italic: css`
+    font-style: italic;
+  `,
+});

--- a/src/scenes/components/TimepointExplorer/TimepointExplorer.constants.ts
+++ b/src/scenes/components/TimepointExplorer/TimepointExplorer.constants.ts
@@ -15,6 +15,7 @@ export const REF_ID_EXECUTION_LIST_LOGS = `executionListLogs`;
 export const REF_ID_EXECUTION_VIEWER_LOGS = `executionViewerLogs`;
 export const REF_ID_MAX_PROBE_DURATION = `maxProbeDuration`;
 export const REF_ID_FARO_SESSION = `faroSession`;
+export const REF_ID_FARO_RUM_PROBE = `faroRumProbe`;
 
 export const FARO_APP_PLUGIN_ID = `grafana-kowalski-app`;
 

--- a/src/scenes/components/TimepointExplorer/TimepointExplorer.context.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointExplorer.context.tsx
@@ -61,6 +61,8 @@ import {
   getVisibleTimepointsTimeRange,
   getYAxisMax,
 } from 'scenes/components/TimepointExplorer/TimepointExplorer.utils';
+import { useCheckRumAvailability } from 'scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks';
+import { RumAvailability } from 'scenes/components/TimepointExplorer/TimepointViewerFaroSession.utils';
 
 interface TimepointExplorerContextType {
   alertEvents: CheckEvent[];
@@ -90,11 +92,13 @@ interface TimepointExplorerContextType {
   isLogsRetentionPeriodWithinTimerange: boolean;
   listLogsMap: Record<UnixTimestamp, StatefulTimepoint>;
   listWidth: number;
+  markRumPresent: () => void;
   miniMapCurrentPage: number;
   miniMapCurrentPageSections: MiniMapSections;
   miniMapCurrentSectionIndex: number;
   miniMapPages: MiniMapPages;
   renderingStrategy: 'start' | 'end';
+  rumAvailability: RumAvailability;
   timepoints: StatelessTimepoint[];
   timepointsDisplayCount: number;
   timepointWidth: number;
@@ -363,6 +367,11 @@ export const TimepointExplorerProvider = ({ children, check }: TimepointExplorer
     timeRange.to.valueOf()
   );
 
+  const { rumAvailability, markRumPresent } = useCheckRumAvailability({
+    checkType,
+    listLogsMap,
+  });
+
   const value: TimepointExplorerContextType = useMemo(() => {
     return {
       alertEvents,
@@ -392,11 +401,13 @@ export const TimepointExplorerProvider = ({ children, check }: TimepointExplorer
       isLogsRetentionPeriodWithinTimerange,
       listLogsMap,
       listWidth,
+      markRumPresent,
       miniMapCurrentPage,
       miniMapCurrentPageSections,
       miniMapCurrentSectionIndex,
       miniMapPages,
       renderingStrategy,
+      rumAvailability,
       timepoints,
       timepointsDisplayCount,
       timepointWidth,
@@ -435,11 +446,13 @@ export const TimepointExplorerProvider = ({ children, check }: TimepointExplorer
     isLogsRetentionPeriodWithinTimerange,
     listLogsMap,
     listWidth,
+    markRumPresent,
     miniMapCurrentPage,
     miniMapCurrentPageSections,
     miniMapCurrentSectionIndex,
     miniMapPages,
     renderingStrategy,
+    rumAvailability,
     timepoints,
     timepointsDisplayCount,
     timepointWidth,

--- a/src/scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks.test.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks.test.tsx
@@ -1,10 +1,16 @@
 import React, { PropsWithChildren } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
-import { useFaroSessionLink } from 'scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks';
+import { CheckType } from 'types';
+import { StatefulTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
+import {
+  useCheckRumAvailability,
+  useFaroSessionLink,
+} from 'scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks';
 
 const mockQueryLoki = jest.fn();
+const mockParseLokiLogs = jest.fn();
 
 jest.mock('hooks/useLogsDS', () => ({
   useLogsDS: () => ({ uid: 'loki-uid' }),
@@ -12,6 +18,10 @@ jest.mock('hooks/useLogsDS', () => ({
 
 jest.mock('features/queryDatasources/queryLoki', () => ({
   queryLoki: (args: unknown) => mockQueryLoki(args),
+}));
+
+jest.mock('features/parseLokiLogs/parseLokiLogs', () => ({
+  parseLokiLogs: (frame: unknown) => mockParseLokiLogs(frame),
 }));
 
 function createTestWrapper() {
@@ -30,7 +40,9 @@ const to = 1700000060000;
 describe('useFaroSessionLink', () => {
   beforeEach(() => {
     mockQueryLoki.mockReset();
+    mockParseLokiLogs.mockReset();
     mockQueryLoki.mockResolvedValue([]);
+    mockParseLokiLogs.mockReturnValue([]);
   });
 
   it('queries by exact execution id', async () => {
@@ -69,5 +81,261 @@ describe('useFaroSessionLink', () => {
 
     await new Promise((r) => setTimeout(r, 50));
     expect(mockQueryLoki).not.toHaveBeenCalled();
+  });
+
+  it('surfaces Loki failures as an error instead of a successful empty result', async () => {
+    mockQueryLoki.mockRejectedValue(new Error('loki timeout'));
+
+    const { result } = renderHook(
+      () =>
+        useFaroSessionLink({
+          executionId: 'exec-123',
+          from,
+          to,
+        }),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isSuccess).toBe(false);
+  });
+
+  it('returns null data on a successful empty lookup', async () => {
+    mockQueryLoki.mockResolvedValue([]);
+
+    const { result } = renderHook(
+      () =>
+        useFaroSessionLink({
+          executionId: 'exec-123',
+          from,
+          to,
+        }),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('invokes onSuccess with the session result when a Faro session is found', async () => {
+    const onSuccess = jest.fn();
+    mockQueryLoki.mockResolvedValue([{}]);
+    mockParseLokiLogs.mockReturnValue([
+      {
+        labels: { app_id: '2', session_id: 'abc123' },
+        timestamp: from,
+        body: '',
+        nanos: 0,
+        labelTypes: {},
+        id: '1',
+      },
+    ]);
+
+    renderHook(
+      () =>
+        useFaroSessionLink({
+          executionId: 'exec-123',
+          from,
+          to,
+          onSuccess,
+        }),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    expect(onSuccess).toHaveBeenCalledWith({
+      appId: '2',
+      sessionId: 'abc123',
+      href: '/a/grafana-kowalski-app/apps/2/sessions/abc123',
+    });
+  });
+
+  it('invokes onSuccess with null when the lookup succeeds empty', async () => {
+    const onSuccess = jest.fn();
+
+    renderHook(
+      () =>
+        useFaroSessionLink({
+          executionId: 'exec-123',
+          from,
+          to,
+          onSuccess,
+        }),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith(null));
+  });
+
+  it('does not invoke onSuccess when the lookup errors', async () => {
+    const onSuccess = jest.fn();
+    mockQueryLoki.mockRejectedValue(new Error('loki timeout'));
+
+    const { result } = renderHook(
+      () =>
+        useFaroSessionLink({
+          executionId: 'exec-123',
+          from,
+          to,
+          onSuccess,
+        }),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('keeps the previous session while a new execution id is fetching', async () => {
+    mockQueryLoki.mockResolvedValueOnce([{}]);
+    mockParseLokiLogs.mockReturnValueOnce([
+      {
+        labels: { app_id: '2', session_id: 'abc123' },
+        timestamp: from,
+        body: '',
+        nanos: 0,
+        labelTypes: {},
+        id: '1',
+      },
+    ]);
+
+    let executionId = 'exec-1';
+    const { result, rerender } = renderHook(
+      () =>
+        useFaroSessionLink({
+          executionId,
+          from,
+          to,
+        }),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.data?.sessionId).toBe('abc123'));
+
+    let resolveSecond: (value: unknown) => void = () => undefined;
+    mockQueryLoki.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSecond = resolve;
+      })
+    );
+
+    executionId = 'exec-2';
+    rerender();
+
+    await waitFor(() => expect(mockQueryLoki).toHaveBeenCalledTimes(2));
+    expect(result.current.isFetching).toBe(true);
+    expect(result.current.data?.sessionId).toBe('abc123');
+
+    resolveSecond([]);
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.data).toBeNull();
+  });
+});
+
+describe('useCheckRumAvailability', () => {
+  const listLogsMap: Record<number, StatefulTimepoint> = {
+    [from]: {
+      adjustedTime: from,
+      timepointDuration: 1000,
+      status: 'success',
+      index: 0,
+      config: { frequency: 60000, from, to },
+      maxProbeDuration: 1000,
+      probeResults: {
+        probeA: [{ labels: { execution_id: 'exec-1' } } as StatefulTimepoint['probeResults'][string][number]],
+      },
+    },
+  };
+
+  beforeEach(() => {
+    mockQueryLoki.mockReset();
+    mockParseLokiLogs.mockReset();
+    mockQueryLoki.mockResolvedValue([]);
+    mockParseLokiLogs.mockReturnValue([]);
+  });
+
+  it('does not probe for non-browser checks', async () => {
+    renderHook(
+      () =>
+        useCheckRumAvailability({
+          checkType: CheckType.Http,
+          listLogsMap,
+        }),
+      { wrapper: createTestWrapper() }
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockQueryLoki).not.toHaveBeenCalled();
+  });
+
+  it('probes with an OR of execution ids and marks present when logs exist', async () => {
+    mockQueryLoki.mockResolvedValue([{}]);
+    mockParseLokiLogs.mockReturnValue([{ labels: { app_id: '2', session_id: 'abc' } }]);
+
+    const { result } = renderHook(
+      () =>
+        useCheckRumAvailability({
+          checkType: CheckType.Browser,
+          listLogsMap,
+        }),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.rumAvailability).toBe('present'));
+    expect(mockQueryLoki.mock.calls[0][0].query).toContain('k6_testRunId=~"sm:(exec-1)"');
+  });
+
+  it('marks absent when the probe returns no logs', async () => {
+    mockQueryLoki.mockResolvedValue([]);
+    mockParseLokiLogs.mockReturnValue([]);
+
+    const { result } = renderHook(
+      () =>
+        useCheckRumAvailability({
+          checkType: CheckType.Browser,
+          listLogsMap,
+        }),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.rumAvailability).toBe('absent'));
+  });
+
+  it('leaves availability unknown when the probe errors', async () => {
+    mockQueryLoki.mockRejectedValue(new Error('timeout'));
+
+    const { result } = renderHook(
+      () =>
+        useCheckRumAvailability({
+          checkType: CheckType.Browser,
+          listLogsMap,
+        }),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => expect(mockQueryLoki).toHaveBeenCalled());
+    expect(result.current.rumAvailability).toBe('unknown');
+  });
+
+  it('promotes to present via markRumPresent even after an absent probe', async () => {
+    mockQueryLoki.mockResolvedValue([]);
+    mockParseLokiLogs.mockReturnValue([]);
+
+    const { result } = renderHook(
+      () =>
+        useCheckRumAvailability({
+          checkType: CheckType.Browser,
+          listLogsMap,
+        }),
+      { wrapper: createTestWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.rumAvailability).toBe('absent'));
+    act(() => {
+      result.current.markRumPresent();
+    });
+    await waitFor(() => expect(result.current.rumAvailability).toBe('present'));
   });
 });

--- a/src/scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks.ts
+++ b/src/scenes/components/TimepointExplorer/TimepointViewerFaroSession.hooks.ts
@@ -1,16 +1,24 @@
-import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { parseLokiLogs } from 'features/parseLokiLogs/parseLokiLogs';
 import { queryLoki } from 'features/queryDatasources/queryLoki';
 
+import { CheckType } from 'types';
 import { useLogsDS } from 'hooks/useLogsDS';
 import {
   FARO_APP_PLUGIN_ID,
+  REF_ID_FARO_RUM_PROBE,
   REF_ID_FARO_SESSION,
 } from 'scenes/components/TimepointExplorer/TimepointExplorer.constants';
+import { StatefulTimepoint, UnixTimestamp } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
 import {
   buildFaroSessionByExecutionIdLogQL,
   buildFaroSessionHref,
+  buildFaroSessionProbeLogQL,
+  collectExecutionIdsFromListLogsMap,
   getFaroSessionFromLogs,
+  reduceRumAvailability,
+  RumAvailability,
 } from 'scenes/components/TimepointExplorer/TimepointViewerFaroSession.utils';
 
 export interface FaroSessionResult {
@@ -24,6 +32,7 @@ interface UseFaroSessionLinkProps {
   from: number;
   to: number;
   enabled?: boolean;
+  onSuccess?: (data: FaroSessionResult | null) => void;
 }
 
 export function useFaroSessionLink({
@@ -31,10 +40,14 @@ export function useFaroSessionLink({
   from,
   to,
   enabled = true,
+  onSuccess,
 }: UseFaroSessionLinkProps) {
   const logsDS = useLogsDS();
   const canQuery = Boolean(logsDS && executionId && from && to && from < to && enabled);
   const expr = canQuery ? buildFaroSessionByExecutionIdLogQL(executionId) : '';
+  // Keep the latest callback without putting it in the query key / queryFn deps.
+  const onSuccessRef = useRef(onSuccess);
+  onSuccessRef.current = onSuccess;
 
   return useQuery<FaroSessionResult | null>({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps -- logsDS.uid is a stable identifier
@@ -44,35 +57,107 @@ export function useFaroSessionLink({
         return null;
       }
 
-      try {
-        const frames = await queryLoki<Record<string, string>, Record<string, string>>({
-          datasource: logsDS,
-          query: expr,
-          start: from,
-          end: to,
-          refId: REF_ID_FARO_SESSION,
-        });
+      const frames = await queryLoki<Record<string, string>, Record<string, string>>({
+        datasource: logsDS,
+        query: expr,
+        start: from,
+        end: to,
+        refId: REF_ID_FARO_SESSION,
+      });
 
-        const parsed = frames[0] ? parseLokiLogs(frames[0]) : [];
-        const session = getFaroSessionFromLogs(parsed);
+      const parsed = frames[0] ? parseLokiLogs(frames[0]) : [];
+      const session = getFaroSessionFromLogs(parsed);
 
-        if (!session) {
-          return null;
-        }
-
-        return {
-          appId: session.appId,
-          sessionId: session.sessionId,
-          href: buildFaroSessionHref({ pluginId: FARO_APP_PLUGIN_ID, ...session }),
-        };
-      } catch {
-        // Fail silently - Faro/FE O11y may not be available in this stack.
+      if (!session) {
+        onSuccessRef.current?.(null);
         return null;
       }
+
+      const result = {
+        appId: session.appId,
+        sessionId: session.sessionId,
+        href: buildFaroSessionHref({ pluginId: FARO_APP_PLUGIN_ID, ...session }),
+      };
+      onSuccessRef.current?.(result);
+      return result;
     },
     enabled: canQuery,
+    placeholderData: keepPreviousData,
     staleTime: 60_000,
     retry: false,
     throwOnError: false,
   });
+}
+
+interface UseCheckRumAvailabilityProps {
+  checkType: CheckType;
+  listLogsMap: Record<UnixTimestamp, StatefulTimepoint>;
+  enabled?: boolean;
+}
+
+export function useCheckRumAvailability({
+  checkType,
+  listLogsMap,
+  enabled = true,
+}: UseCheckRumAvailabilityProps) {
+  const logsDS = useLogsDS();
+  const [rumAvailability, setRumAvailability] = useState<RumAvailability>('unknown');
+  const isBrowserCheck = checkType === CheckType.Browser;
+
+  const { executionIds, from, to } = useMemo(
+    () => collectExecutionIdsFromListLogsMap(listLogsMap),
+    [listLogsMap]
+  );
+
+  const canProbe = Boolean(
+    enabled && isBrowserCheck && logsDS && executionIds.length > 0 && from && to && from < to
+  );
+  const expr = canProbe ? buildFaroSessionProbeLogQL(executionIds) : '';
+
+  const probeQuery = useQuery<'present' | 'absent'>({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- logsDS.uid is a stable identifier
+    queryKey: ['faro-rum-probe', logsDS?.uid, expr, from, to],
+    queryFn: async () => {
+      if (!logsDS) {
+        return 'absent';
+      }
+
+      const frames = await queryLoki<Record<string, string>, Record<string, string>>({
+        datasource: logsDS,
+        query: expr,
+        start: from,
+        end: to,
+        refId: REF_ID_FARO_RUM_PROBE,
+      });
+
+      const parsed = frames[0] ? parseLokiLogs(frames[0]) : [];
+      return parsed.length > 0 ? 'present' : 'absent';
+    },
+    enabled: canProbe,
+    staleTime: 60_000,
+    retry: false,
+    throwOnError: false,
+  });
+
+  useEffect(() => {
+    if (probeQuery.isError) {
+      setRumAvailability((current) => reduceRumAvailability(current, { type: 'probe-error' }));
+      return;
+    }
+
+    if (probeQuery.isSuccess && probeQuery.data) {
+      setRumAvailability((current) =>
+        reduceRumAvailability(current, { type: 'probe-result', result: probeQuery.data })
+      );
+    }
+  }, [probeQuery.isError, probeQuery.isSuccess, probeQuery.data]);
+
+  const markRumPresent = useCallback(() => {
+    setRumAvailability((current) => reduceRumAvailability(current, { type: 'passive-success' }));
+  }, []);
+
+  return {
+    rumAvailability,
+    markRumPresent,
+  };
 }

--- a/src/scenes/components/TimepointExplorer/TimepointViewerFaroSession.utils.test.ts
+++ b/src/scenes/components/TimepointExplorer/TimepointViewerFaroSession.utils.test.ts
@@ -1,8 +1,12 @@
 import { ParsedLokiRecord } from 'features/parseLokiLogs/parseLokiLogs.types';
+import { StatefulTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
 import {
   buildFaroSessionByExecutionIdLogQL,
   buildFaroSessionHref,
+  buildFaroSessionProbeLogQL,
+  collectExecutionIdsFromListLogsMap,
   getFaroSessionFromLogs,
+  reduceRumAvailability,
 } from 'scenes/components/TimepointExplorer/TimepointViewerFaroSession.utils';
 
 describe('buildFaroSessionByExecutionIdLogQL', () => {
@@ -109,5 +113,86 @@ describe('buildFaroSessionHref', () => {
         sessionId: 'a/b',
       })
     ).toBe('/a/grafana-kowalski-app/apps/with%20space/sessions/a%2Fb');
+  });
+});
+
+describe('buildFaroSessionProbeLogQL', () => {
+  it('returns an empty string when there are no execution ids', () => {
+    expect(buildFaroSessionProbeLogQL([])).toBe('');
+  });
+
+  it('ORs unique execution ids into a single regex match', () => {
+    expect(buildFaroSessionProbeLogQL(['exec-1', 'exec-2', 'exec-1'])).toBe(
+      '{kind=~"event|measurement"} | logfmt | k6_isK6Browser="true" | k6_testRunId=~"sm:(exec-1|exec-2)"'
+    );
+  });
+
+  it('escapes regex metacharacters in execution ids', () => {
+    expect(buildFaroSessionProbeLogQL(['exec.1+2'])).toContain('sm:(exec\\.1\\+2)');
+  });
+});
+
+describe('collectExecutionIdsFromListLogsMap', () => {
+  const makeTimepoint = (
+    adjustedTime: number,
+    executionIds: string[]
+  ): StatefulTimepoint => ({
+    adjustedTime,
+    timepointDuration: 1000,
+    status: 'success',
+    index: 0,
+    config: { frequency: 60000, from: adjustedTime, to: adjustedTime + 60000 },
+    maxProbeDuration: 1000,
+    probeResults: {
+      probeA: executionIds.map((execution_id) => ({
+        labels: { execution_id },
+      })) as StatefulTimepoint['probeResults'][string],
+    },
+  });
+
+  it('collects unique execution ids newest-first and returns a time window', () => {
+    const listLogsMap = {
+      3000: makeTimepoint(3000, ['exec-new']),
+      1000: makeTimepoint(1000, ['exec-old', 'exec-new']),
+    };
+
+    expect(collectExecutionIdsFromListLogsMap(listLogsMap)).toEqual({
+      executionIds: ['exec-new', 'exec-old'],
+      from: 1000,
+      to: 3000 + 1000 + 60000,
+    });
+  });
+
+  it('respects the execution id cap', () => {
+    const listLogsMap = {
+      1000: makeTimepoint(
+        1000,
+        Array.from({ length: 5 }, (_, i) => `exec-${i}`)
+      ),
+    };
+
+    expect(collectExecutionIdsFromListLogsMap(listLogsMap, 2).executionIds).toEqual(['exec-0', 'exec-1']);
+  });
+});
+
+describe('reduceRumAvailability', () => {
+  it('promotes to present on passive success', () => {
+    expect(reduceRumAvailability('unknown', { type: 'passive-success' })).toBe('present');
+    expect(reduceRumAvailability('absent', { type: 'passive-success' })).toBe('present');
+  });
+
+  it('applies probe present/absent when not already present', () => {
+    expect(reduceRumAvailability('unknown', { type: 'probe-result', result: 'present' })).toBe('present');
+    expect(reduceRumAvailability('unknown', { type: 'probe-result', result: 'absent' })).toBe('absent');
+  });
+
+  it('never demotes present', () => {
+    expect(reduceRumAvailability('present', { type: 'probe-result', result: 'absent' })).toBe('present');
+    expect(reduceRumAvailability('present', { type: 'probe-error' })).toBe('present');
+  });
+
+  it('leaves availability unchanged on probe error', () => {
+    expect(reduceRumAvailability('unknown', { type: 'probe-error' })).toBe('unknown');
+    expect(reduceRumAvailability('absent', { type: 'probe-error' })).toBe('absent');
   });
 });

--- a/src/scenes/components/TimepointExplorer/TimepointViewerFaroSession.utils.ts
+++ b/src/scenes/components/TimepointExplorer/TimepointViewerFaroSession.utils.ts
@@ -1,4 +1,14 @@
 import { ParsedLokiRecord } from 'features/parseLokiLogs/parseLokiLogs.types';
+import { StatefulTimepoint, UnixTimestamp } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
+
+export type RumAvailability = 'unknown' | 'present' | 'absent';
+
+export type RumAvailabilityEvent =
+  | { type: 'passive-success' }
+  | { type: 'probe-result'; result: 'present' | 'absent' }
+  | { type: 'probe-error' };
+
+export const FARO_RUM_PROBE_EXECUTION_ID_CAP = 50;
 
 /**
  * Builds a LogQL expression that finds the Faro web events for a specific check
@@ -12,6 +22,85 @@ import { ParsedLokiRecord } from 'features/parseLokiLogs/parseLokiLogs.types';
  */
 export function buildFaroSessionByExecutionIdLogQL(executionId: string): string {
   return `{kind=~"event|measurement"} | logfmt | k6_isK6Browser="true" | k6_testRunId="sm:${executionId}"`;
+}
+
+/**
+ * Existence probe across a capped set of execution ids for the current check.
+ * Uses a regex OR so one Loki query can tell us whether *any* of these runs
+ * produced Faro sessions (check-level RUM availability).
+ */
+export function buildFaroSessionProbeLogQL(executionIds: string[]): string {
+  const uniqueIds = [...new Set(executionIds.filter(Boolean))].slice(0, FARO_RUM_PROBE_EXECUTION_ID_CAP);
+  if (uniqueIds.length === 0) {
+    return '';
+  }
+
+  const escaped = uniqueIds.map(escapeLogQLRegex).join('|');
+  return `{kind=~"event|measurement"} | logfmt | k6_isK6Browser="true" | k6_testRunId=~"sm:(${escaped})"`;
+}
+
+function escapeLogQLRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function collectExecutionIdsFromListLogsMap(
+  listLogsMap: Record<UnixTimestamp, StatefulTimepoint>,
+  cap = FARO_RUM_PROBE_EXECUTION_ID_CAP
+): { executionIds: string[]; from: number; to: number } {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  let from = Number.POSITIVE_INFINITY;
+  let to = 0;
+
+  const timepoints = Object.values(listLogsMap).sort((a, b) => b.adjustedTime - a.adjustedTime);
+
+  for (const timepoint of timepoints) {
+    const executions = Object.values(timepoint.probeResults ?? {}).flat();
+    for (const execution of executions) {
+      const executionId = execution.labels?.execution_id;
+      if (!executionId || seen.has(executionId)) {
+        continue;
+      }
+
+      seen.add(executionId);
+      ids.push(executionId);
+      from = Math.min(from, timepoint.adjustedTime);
+      to = Math.max(to, timepoint.adjustedTime + timepoint.timepointDuration + timepoint.config.frequency);
+
+      if (ids.length >= cap) {
+        return { executionIds: ids, from, to };
+      }
+    }
+  }
+
+  if (ids.length === 0) {
+    return { executionIds: [], from: 0, to: 0 };
+  }
+
+  return { executionIds: ids, from, to };
+}
+
+/**
+ * Check-level RUM availability. `present` is sticky for the explorer session —
+ * neither a later empty probe nor a probe error can demote it.
+ */
+export function reduceRumAvailability(
+  current: RumAvailability,
+  event: RumAvailabilityEvent
+): RumAvailability {
+  if (current === 'present') {
+    return 'present';
+  }
+
+  if (event.type === 'passive-success') {
+    return 'present';
+  }
+
+  if (event.type === 'probe-result') {
+    return event.result;
+  }
+
+  return current;
 }
 
 interface FaroSessionIds {


### PR DESCRIPTION
Follow-up to #1667 / [grafana/synthetic-monitoring#509](https://github.com/grafana/synthetic-monitoring/issues/509).

## Problem

Some browser-check executions for an instrumented app return no matching Frontend Observability session even when other executions for the same check do. A successful empty lookup was treated like “not instrumented,” so the Timepoint Viewer showed **Add RUM to your app** — which is misleading when RUM is already present for the check.

## Solution

Track check-level RUM availability and use it to choose the empty-state copy:

- **Passive:** any successful per-execution Faro session lookup marks the check as RUM-present for the explorer session.
- **Probe:** once loaded timepoints expose `execution_id`s, one capped Loki existence query over those IDs sets present/absent (errors leave availability unknown; `present` is never demoted).

Empty successful lookups then show **No session for this run** when RUM is present, and keep the **Add RUM to your app** docs CTA when it is not. Loading/error handling from the prior work is preserved (spinner while fetching, silent omit on error).

## Test plan

- [ ] Browser check with Faro sessions: open Timepoint Viewer → **View Frontend Session** still works
- [ ] Same check, execution with no session after RUM is known present → muted **No session for this run** (no docs CTA)
- [ ] Browser check with no Faro data at all → **Add RUM to your app** after successful empty lookup
- [ ] Arrow between executions → spinner / no flash of wrong empty state
- [ ] Loki failure on session lookup → button omitted (not Add RUM)