### PR TITLE
fix: attach default folder UID to POST

### DIFF
--- a/src/data/useDefaultFolder.ts
+++ b/src/data/useDefaultFolder.ts
@@ -38,7 +38,13 @@ export type FolderStatus = 'loading' | 'available' | 'not-provisioned' | 'permis
  * rather than wastefully trying to list/create the folder.
  */
 export function useDefaultFolder(enabled = true) {
-  const { data: defaultFolder, isLoading, isError, error, refetch } = useQuery({
+  const {
+    data: defaultFolder,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
     queryKey: [...folderQueryKeys.all, 'default'] as const,
     queryFn: async (): Promise<GrafanaFolder> => {
       try {
@@ -64,7 +70,7 @@ export function useDefaultFolder(enabled = true) {
           getBackendSrv().fetch<GrafanaFolder>({
             method: 'POST',
             url: '/api/folders',
-            data: { title: DEFAULT_FOLDER_TITLE },
+            data: { title: DEFAULT_FOLDER_TITLE, uid: DEFAULT_FOLDER_UID },
             showErrorAlert: false,
           })
         ).then((res) => res.data);


### PR DESCRIPTION
**What this PR does / why we need it**:

The Synthetic Monitoring app creates its default Grafana folder using only the folder title, allowing Grafana to generate a random UID.

The SM API alert ruler expects the same folder to use the canonical `grafana-synthetic-monitoring-app` UID. If alert synchronization runs later, it may create a second folder with the same title but the canonical UID.

Once both folders exist, the app selects the canonical folder tree. Checks assigned to the older random-UID folder can then disappear from the checks list even though their folder still exists and is accessible.

**Which issue(s) this PR fixes**:

Addresses grafana/support-escalations#23263