### PR TITLE
feat: add Grafana Cloud org_id and stack_id to all tracking events

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,6 +5,7 @@ import { AppRootProps } from '@grafana/data';
 import { getWebInstrumentations, initializeFaro } from '@grafana/faro-web-sdk';
 import { config, getAppPluginVersion } from '@grafana/runtime';
 import { css, Global } from '@emotion/react';
+import { TrackingIdentity } from 'features/tracking/TrackingIdentity';
 
 import { ProvisioningJsonData } from 'types';
 import { getFaroConfig } from 'faro';
@@ -63,6 +64,7 @@ const App = (props: AppRootProps<ProvisioningJsonData>) => {
             <SMDatasourceProvider>
               <PermissionsContextProvider>
                 <AssistantContext />
+                <TrackingIdentity />
                 <DevTools>
                   <InitialisedRouter />
                 </DevTools>

--- a/src/features/tracking/TrackingIdentity.tsx
+++ b/src/features/tracking/TrackingIdentity.tsx
@@ -22,6 +22,11 @@ export const TrackingIdentity = () => {
         stack_id: Number.isFinite(tenant.stackId) ? tenant.stackId : undefined,
       });
     }
+
+    return () => {
+      // clear on unmount so the identity is only ever reported while it is known to be current
+      setTrackingBaseProps({});
+    };
   }, [tenant]);
 
   return null;

--- a/src/features/tracking/TrackingIdentity.tsx
+++ b/src/features/tracking/TrackingIdentity.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { setTrackingBaseProps } from 'features/tracking/utils';
+
+import { useTenant } from 'data/useTenant';
+
+/**
+ * Registers the Grafana Cloud org identity from the SM tenant as base properties on all
+ * tracking events. The property is named `org_id` (rather than camelCase) because downstream
+ * BigQuery consumers key off that exact column name. Renders nothing.
+ *
+ * Note this is the grafana.com org id, NOT the instance-internal org id from
+ * `config.bootData.user.orgId` (which is always 1 on cloud stacks).
+ */
+export const TrackingIdentity = () => {
+  const { data: tenant } = useTenant();
+
+  useEffect(() => {
+    if (typeof tenant?.orgId === 'number' && Number.isFinite(tenant.orgId)) {
+      setTrackingBaseProps({ org_id: tenant.orgId });
+    }
+  }, [tenant]);
+
+  return null;
+};

--- a/src/features/tracking/TrackingIdentity.tsx
+++ b/src/features/tracking/TrackingIdentity.tsx
@@ -4,19 +4,23 @@ import { setTrackingBaseProps } from 'features/tracking/utils';
 import { useTenant } from 'data/useTenant';
 
 /**
- * Registers the Grafana Cloud org identity from the SM tenant as base properties on all
- * tracking events. The property is named `org_id` (rather than camelCase) because downstream
- * BigQuery consumers key off that exact column name. Renders nothing.
+ * Registers the Grafana Cloud identity from the SM tenant as base properties on all
+ * tracking events. The properties are named `org_id`/`stack_id` (rather than camelCase)
+ * because downstream BigQuery consumers key off those exact column names. Renders nothing.
  *
- * Note this is the grafana.com org id, NOT the instance-internal org id from
+ * Note these are the grafana.com org and stack ids, NOT the instance-internal org id from
  * `config.bootData.user.orgId` (which is always 1 on cloud stacks).
  */
 export const TrackingIdentity = () => {
   const { data: tenant } = useTenant();
 
   useEffect(() => {
-    if (typeof tenant?.orgId === 'number' && Number.isFinite(tenant.orgId)) {
-      setTrackingBaseProps({ org_id: tenant.orgId });
+    if (tenant) {
+      // setTrackingBaseProps drops undefined values, so an invalid field is omitted rather than reported
+      setTrackingBaseProps({
+        org_id: Number.isFinite(tenant.orgId) ? tenant.orgId : undefined,
+        stack_id: Number.isFinite(tenant.stackId) ? tenant.stackId : undefined,
+      });
     }
   }, [tenant]);
 

--- a/src/features/tracking/utils.test.ts
+++ b/src/features/tracking/utils.test.ts
@@ -1,0 +1,76 @@
+import { createSMEventFactory, setTrackingBaseProps, TrackingEventProps } from 'features/tracking/utils';
+
+interface SampleEvent extends TrackingEventProps {
+  /** The type of check, to exercise event-specific props in tests. */
+  checkType: string;
+}
+
+const trackSampleEvent = createSMEventFactory('test_feature')<SampleEvent>('sample_event');
+const trackPropslessEvent = createSMEventFactory('test_feature')('propsless_event');
+
+describe('createEventFactory', () => {
+  const reportInteraction = jest.fn();
+
+  beforeAll(() => {
+    // the factory resolves reportInteraction from the mocked module object at call time,
+    // so replacing the property intercepts it (jest.spyOn on a namespace import does not,
+    // because the ESM interop hands the test a copy of the module object)
+    jest.requireMock('@grafana/runtime').reportInteraction = reportInteraction;
+  });
+
+  beforeEach(() => {
+    setTrackingBaseProps({});
+    reportInteraction.mockClear();
+  });
+
+  it('reports the composed event name with the given props', () => {
+    trackSampleEvent({ checkType: 'browser' });
+
+    expect(reportInteraction).toHaveBeenCalledTimes(1);
+    expect(reportInteraction).toHaveBeenCalledWith('synthetic-monitoring_test_feature_sample_event', {
+      checkType: 'browser',
+    });
+  });
+
+  it('includes base properties on events once set', () => {
+    setTrackingBaseProps({ org_id: 442 });
+    trackSampleEvent({ checkType: 'browser' });
+
+    expect(reportInteraction).toHaveBeenCalledWith('synthetic-monitoring_test_feature_sample_event', {
+      org_id: 442,
+      checkType: 'browser',
+    });
+  });
+
+  it('includes base properties on events without their own props', () => {
+    setTrackingBaseProps({ org_id: 442 });
+    trackPropslessEvent();
+
+    expect(reportInteraction).toHaveBeenCalledWith('synthetic-monitoring_test_feature_propsless_event', {
+      org_id: 442,
+    });
+  });
+
+  it('omits base properties entirely when cloud identity is not available', () => {
+    trackSampleEvent({ checkType: 'browser' });
+
+    const [, props] = reportInteraction.mock.calls[0];
+    expect(props).not.toHaveProperty('org_id');
+  });
+
+  it('drops undefined base property values instead of reporting them', () => {
+    setTrackingBaseProps({ org_id: undefined });
+    trackSampleEvent({ checkType: 'browser' });
+
+    const [, props] = reportInteraction.mock.calls[0];
+    expect(props).not.toHaveProperty('org_id');
+  });
+
+  it('lets event props win over base props on key collision', () => {
+    setTrackingBaseProps({ checkType: 'http' });
+    trackSampleEvent({ checkType: 'browser' });
+
+    const [, props] = reportInteraction.mock.calls[0];
+    expect(props).toEqual({ checkType: 'browser' });
+  });
+});

--- a/src/features/tracking/utils.test.ts
+++ b/src/features/tracking/utils.test.ts
@@ -33,21 +33,23 @@ describe('createEventFactory', () => {
   });
 
   it('includes base properties on events once set', () => {
-    setTrackingBaseProps({ org_id: 442 });
+    setTrackingBaseProps({ org_id: 442, stack_id: 2484 });
     trackSampleEvent({ checkType: 'browser' });
 
     expect(reportInteraction).toHaveBeenCalledWith('synthetic-monitoring_test_feature_sample_event', {
       org_id: 442,
+      stack_id: 2484,
       checkType: 'browser',
     });
   });
 
   it('includes base properties on events without their own props', () => {
-    setTrackingBaseProps({ org_id: 442 });
+    setTrackingBaseProps({ org_id: 442, stack_id: 2484 });
     trackPropslessEvent();
 
     expect(reportInteraction).toHaveBeenCalledWith('synthetic-monitoring_test_feature_propsless_event', {
       org_id: 442,
+      stack_id: 2484,
     });
   });
 
@@ -59,11 +61,12 @@ describe('createEventFactory', () => {
   });
 
   it('drops undefined base property values instead of reporting them', () => {
-    setTrackingBaseProps({ org_id: undefined });
+    setTrackingBaseProps({ org_id: undefined, stack_id: 2484 });
     trackSampleEvent({ checkType: 'browser' });
 
     const [, props] = reportInteraction.mock.calls[0];
     expect(props).not.toHaveProperty('org_id');
+    expect(props).toHaveProperty('stack_id', 2484);
   });
 
   it('lets event props win over base props on key collision', () => {

--- a/src/features/tracking/utils.ts
+++ b/src/features/tracking/utils.ts
@@ -5,11 +5,20 @@ export type TrackingEventProps = {
   [key: string]: boolean | string | number | undefined;
 };
 
+// Properties included on every event created through the factory, e.g. the Grafana Cloud
+// org identity. They resolve asynchronously (SM tenant API), so events fired before
+// resolution omit them entirely rather than reporting undefined values.
+let baseProps: TrackingEventProps = {};
+
+export const setTrackingBaseProps = (props: TrackingEventProps) => {
+  baseProps = Object.fromEntries(Object.entries(props).filter(([_, value]) => value !== undefined));
+};
+
 export const createEventFactory = (product: string, featureName: string) => {
   return <P extends TrackingEventProps | undefined = undefined>(eventName: string) =>
     (props: P extends undefined ? void : P) => {
       const eventNameToReport = `${product}_${featureName}_${eventName}`;
-      reportInteraction(eventNameToReport, props ?? undefined);
+      reportInteraction(eventNameToReport, { ...baseProps, ...(props ?? {}) });
     };
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Campaign and analytics tooling can't attribute our RudderStack events to a
Grafana Cloud org: `context_traits_org_id` carries the instance-internal org id,
which is set at the platform level and can't be
fixed in this plugin. Marketing needs the grafana.com org identity as event
properties to build cohorts (e.g. the SM → Frontend Observability campaign).

This adds two properties to **every** event created through the tracking
factory (`createSMEventFactory`), without touching any event definition:

- `org_id` — the grafana.com org id
- `stack_id` — the grafana.com stack id

Both are sourced from the SM tenant API (`TenantResponse.orgId` / `stackId`) —
not from `config.bootData.user.orgId`, which is the instance-internal value.
A new null-rendering `TrackingIdentity` component (mounted inside
`SMDatasourceProvider`) fetches the tenant via the existing `useTenant()` hook
and registers the ids as factory-level base properties once resolved.

Behavioral notes:

- **Async-safe:** events fired before the tenant resolves — or when there is no
  cloud tenant (local dev, uninitialized plugin, tenant fetch failure) — omit
  the properties entirely rather than reporting undefined values.
- **No contract changes:** existing event names and properties are unchanged;
  downstream BigQuery tables and campaign triggers keying off them are
  unaffected. The new properties are snake_cased in source (`org_id`, not
  `orgId`) so the BigQuery column names are exact and don't depend on
  RudderStack's key transformation.
- The grafana.com org **slug** is not available client-side, so it is
  deliberately not included rather than substituting an instance-internal or
  stack-level value. (The stack slug is derivable from `config.appUrl` if ever
  needed as a separate property.)

**Which issue(s) this PR fixes**:

n/a — supports Grafana Cloud org attribution for marketing campaign tooling

**Special notes for your reviewer**:

- New `utils.test.ts` covers the factory: event-name composition, base
  properties present on sample/props-less events, cleanly absent when cloud
  identity isn't available, undefined values dropped, and event props winning
  over base props on key collision.
- `useTenant()` is react-query cached, so this adds at most one extra
  `/sm/tenant` request per session (it's already fetched by
  `useLegacyAlertsRestriction` in many flows).
- No UI changes, so no screenshots.