### PR TITLE
fix: show checks in folders outside the default folder

### DIFF
--- a/src/data/folderPermissions.ts
+++ b/src/data/folderPermissions.ts
@@ -1,4 +1,4 @@
-import { Check } from 'types';
+import { Check, GrafanaFolder } from 'types';
 
 import { SMPermissions } from './permissions';
 
@@ -23,7 +23,7 @@ export interface FolderPermissionFlags {
  */
 export type FolderAccessState =
   | { type: 'loading' }
-  | { type: 'accessible'; permissions: FolderPermissionFlags }
+  | { type: 'accessible'; permissions: FolderPermissionFlags; folder?: GrafanaFolder }
   | { type: 'forbidden' }
   | { type: 'orphaned' };
 
@@ -39,9 +39,7 @@ export type FolderAccessState =
  *   forbidden:         folder exists but user cannot access it. Check is hidden.
  *   orphaned:          folder was deleted. SM RBAC applies directly.
  */
-export type CheckFolderStatus =
-  | { type: 'no-folder-context' }
-  | FolderAccessState;
+export type CheckFolderStatus = { type: 'no-folder-context' } | FolderAccessState;
 
 /**
  * The effective permissions for a check, combining SM RBAC and folder permissions.
@@ -64,7 +62,7 @@ export function resolveCheckFolderStatus(
   check: Pick<Check, 'folderUid'>,
   folderDetailsByUid: Map<string, FolderAccessState>,
   isFoldersEnabled: boolean,
-  defaultFolderUid?: string,
+  defaultFolderUid?: string
 ): CheckFolderStatus {
   if (!isFoldersEnabled) {
     return { type: 'no-folder-context' };
@@ -116,10 +114,7 @@ export function isCheckVisible(folderStatus: CheckFolderStatus): boolean {
  *   - loading → visible, read only (actions disabled until resolved)
  *   - forbidden → all false (check shouldn't be visible, but safe fallback)
  */
-export function computeCheckPermissions(
-  smPerms: SMPermissions,
-  folderStatus: CheckFolderStatus,
-): CheckPermissions {
+export function computeCheckPermissions(smPerms: SMPermissions, folderStatus: CheckFolderStatus): CheckPermissions {
   switch (folderStatus.type) {
     case 'no-folder-context':
     case 'orphaned':

--- a/src/data/useFolderPermissions.ts
+++ b/src/data/useFolderPermissions.ts
@@ -16,6 +16,7 @@ function toAccessState(folder: GrafanaFolder): FolderAccessState {
       canAdmin: folder.canAdmin ?? false,
       canDelete: folder.canDelete ?? false,
     },
+    folder,
   };
 }
 

--- a/src/hooks/useCheckFolderAccess.ts
+++ b/src/hooks/useCheckFolderAccess.ts
@@ -34,6 +34,7 @@ export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks:
     isFoldersAvailable,
     folderStatus,
     isLoading: isFoldersLoading,
+    isError: isFoldersError,
   } = useAllFolders();
 
   const accessibleFolderUids = useMemo(() => new Set(allFolders.map((f) => f.uid)), [allFolders]);
@@ -82,12 +83,14 @@ export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks:
   }, [checks, isFoldersAvailable, accessibleFolderUids, folderDetailsByUid, defaultFolderUid]);
 
   // Readable folders referenced by checks but living outside the default
-  // folder's subtree. The folder view renders these as top-level nodes so
-  // their checks don't silently disappear from the list. Empty until the
-  // subtree list settles, otherwise every folder would briefly classify as
-  // external while `accessibleFolderUids` is still empty.
+  // folder's subtree, so the folder view can show them instead of hiding
+  // their checks.
+  //
+  // We can only trust this once the subtree has loaded successfully: while
+  // loading (or if the child-folder fetch failed) we don't know the full
+  // subtree, so we'd wrongly flag in-subtree folders as external.
   const externalFolders = useMemo(() => {
-    if (isFoldersLoading) {
+    if (isFoldersLoading || isFoldersError) {
       return [];
     }
     const result: GrafanaFolder[] = [];
@@ -97,7 +100,7 @@ export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks:
       }
     });
     return result;
-  }, [folderDetailsByUid, accessibleFolderUids, isFoldersLoading]);
+  }, [folderDetailsByUid, accessibleFolderUids, isFoldersLoading, isFoldersError]);
 
   const getFolderStatus = useCallback(
     (check: Pick<Check, 'folderUid'>): CheckFolderStatus => {

--- a/src/hooks/useCheckFolderAccess.ts
+++ b/src/hooks/useCheckFolderAccess.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { Check } from 'types';
+import { Check, GrafanaFolder } from 'types';
 import {
   CheckFolderStatus,
   CheckPermissions,
@@ -28,12 +28,15 @@ import { useAllFolders } from 'data/useFolders';
  * Returns visibleChecks (filtered) and getPermissions (lookup function).
  */
 export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks: T[]) {
-  const { folders: allFolders, defaultFolderUid, isFoldersAvailable, folderStatus } = useAllFolders();
+  const {
+    folders: allFolders,
+    defaultFolderUid,
+    isFoldersAvailable,
+    folderStatus,
+    isLoading: isFoldersLoading,
+  } = useAllFolders();
 
-  const accessibleFolderUids = useMemo(
-    () => new Set(allFolders.map((f) => f.uid)),
-    [allFolders]
-  );
+  const accessibleFolderUids = useMemo(() => new Set(allFolders.map((f) => f.uid)), [allFolders]);
 
   const folderUids = useMemo(() => {
     if (!isFoldersAvailable) {
@@ -68,9 +71,33 @@ export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks:
       if (accessibleFolderUids.has(effectiveUid)) {
         return true;
       }
-      return folderDetailsByUid.get(effectiveUid)?.type === 'orphaned';
+      // Folders outside the default subtree: `accessible` means the folder
+      // exists and the user can read it (e.g. a check assigned to an external
+      // folder via the API, or a folder stranded by a default-folder UID
+      // mismatch), so its checks must stay visible. `orphaned` (404) checks
+      // are shown too. Only `forbidden` (403) hides a check.
+      const folderState = folderDetailsByUid.get(effectiveUid);
+      return folderState?.type === 'orphaned' || folderState?.type === 'accessible';
     });
   }, [checks, isFoldersAvailable, accessibleFolderUids, folderDetailsByUid, defaultFolderUid]);
+
+  // Readable folders referenced by checks but living outside the default
+  // folder's subtree. The folder view renders these as top-level nodes so
+  // their checks don't silently disappear from the list. Empty until the
+  // subtree list settles, otherwise every folder would briefly classify as
+  // external while `accessibleFolderUids` is still empty.
+  const externalFolders = useMemo(() => {
+    if (isFoldersLoading) {
+      return [];
+    }
+    const result: GrafanaFolder[] = [];
+    folderDetailsByUid.forEach((state, uid) => {
+      if (state.type === 'accessible' && state.folder && !accessibleFolderUids.has(uid)) {
+        result.push(state.folder);
+      }
+    });
+    return result;
+  }, [folderDetailsByUid, accessibleFolderUids, isFoldersLoading]);
 
   const getFolderStatus = useCallback(
     (check: Pick<Check, 'folderUid'>): CheckFolderStatus => {
@@ -88,6 +115,7 @@ export function useCheckFolderAccess<T extends Pick<Check, 'folderUid'>>(checks:
 
   return {
     visibleChecks,
+    externalFolders,
     getPermissions,
     getFolderStatus,
     isFoldersAvailable,

--- a/src/hooks/useChecksByFolder.ts
+++ b/src/hooks/useChecksByFolder.ts
@@ -10,6 +10,8 @@ export interface FolderNode {
   isAccessible: boolean;
   isOrphaned: boolean;
   isDefault?: boolean;
+  /** Folder exists and is readable but lives outside the default folder's subtree. */
+  isExternal?: boolean;
 }
 
 export interface ChecksByFolder {
@@ -59,14 +61,21 @@ export function collectAllChecks(node: FolderNode): Check[] {
  * The default folder is treated as an invisible root: its child folders are
  * promoted to top level, and checks assigned to it (or without a folderUid)
  * go into rootChecks.
+ *
+ * `externalFolders` are readable folders outside the default folder's subtree
+ * that have checks assigned to them (e.g. via the API, or stranded by a
+ * default-folder UID mismatch). They only get a node when a check references
+ * them, rendered at top level and flagged with `isExternal`.
  */
 export function buildChecksByFolder(
   checks: Check[],
   folders: GrafanaFolder[],
   defaultFolderUid?: string,
-  reverseFolderSort?: boolean
+  reverseFolderSort?: boolean,
+  externalFolders: GrafanaFolder[] = []
 ): ChecksByFolder {
-  const foldersById = new Map(folders.map((f) => [f.uid, f]));
+  const foldersById = new Map([...folders, ...externalFolders].map((f) => [f.uid, f]));
+  const externalUids = new Set(externalFolders.map((f) => f.uid));
   const nodeMap = new Map<string, FolderNode>();
 
   const getOrCreateNode = (uid: string): FolderNode => {
@@ -80,6 +89,7 @@ export function buildChecksByFolder(
         children: [],
         isAccessible: !!folder,
         isOrphaned: !folder,
+        isExternal: externalUids.has(uid),
       });
     }
     return nodeMap.get(uid)!;
@@ -104,6 +114,11 @@ export function buildChecksByFolder(
   });
 
   nodeMap.forEach((node) => {
+    // External folders stay at top level: their ancestors are not part of the
+    // SM folder data, so walking up would create bogus "not found" nodes.
+    if (node.isExternal) {
+      return;
+    }
     let current = node.folder;
     while (current?.parentUid && !isDefaultFolder(current.parentUid)) {
       getOrCreateNode(current.parentUid);

--- a/src/page/CheckList/CheckList.folderBulkActions.test.tsx
+++ b/src/page/CheckList/CheckList.folderBulkActions.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
 import {
   CHECK_IN_DELETABLE_FOLDER,
+  CHECK_IN_EXTERNAL_FOLDER,
   CHECK_IN_PRODUCTION,
   CHECK_IN_STAGING,
   CHECK_WITH_ORPHANED_FOLDER,
@@ -159,6 +160,18 @@ describe('CheckList - Folder Deletion on Bulk Delete', () => {
 
   it('does not offer folder deletion for orphaned folders', async () => {
     const { user } = await renderCheckList([CHECK_WITH_ORPHANED_FOLDER]);
+
+    const folderCheckbox = await screen.findByLabelText(/Select all checks in/);
+    await user.click(folderCheckbox);
+
+    await clickFolderDeleteButton(user, '1 selected');
+
+    expect(await screen.findByText('Delete 1 check')).toBeInTheDocument();
+    expect(screen.queryByText(/Delete folder/)).not.toBeInTheDocument();
+  });
+
+  it('does not offer folder deletion for folders outside the default folder', async () => {
+    const { user } = await renderCheckList([CHECK_IN_EXTERNAL_FOLDER]);
 
     const folderCheckbox = await screen.findByLabelText(/Select all checks in/);
     await user.click(folderCheckbox);

--- a/src/page/CheckList/CheckList.folderPermissions.test.tsx
+++ b/src/page/CheckList/CheckList.folderPermissions.test.tsx
@@ -365,6 +365,41 @@ describe('CheckList - Folder Permissions', () => {
     });
   });
 
+  describe('child-folder fetch failure', () => {
+    beforeEach(() => mockFeatureToggles({ [FeatureName.Folders]: true }));
+
+    it('does not mislabel in-subtree folders as external when the subtree fetch errors', async () => {
+      server.use(
+        apiRoute(`listChecks`, {
+          result: () => ({ json: [CHECK_IN_PRODUCTION] }),
+        }),
+        apiRoute(`listProbes`, {
+          result: () => ({ json: [PRIVATE_PROBE, PUBLIC_PROBE] }),
+        }),
+        // Default folder resolves fine (detail endpoint), but fetching its
+        // children fails. The subtree is then partial, so we must not assert
+        // that a legitimate child folder lives outside it.
+        apiRoute(`listFolders`, {
+          result: (req: Request) => {
+            const url = new URL(req.url);
+            if (url.searchParams.get('parentUid')) {
+              return { status: 500, json: { message: 'Internal server error' } };
+            }
+            return { json: [] };
+          },
+        })
+      );
+
+      render(<CheckList />, {
+        route: AppRoutes.Checks,
+        path: generateRoutePath(AppRoutes.Checks),
+      });
+
+      expect(await screen.findByText('Production HTTP check')).toBeInTheDocument();
+      expect(screen.queryByText('Outside default folder')).not.toBeInTheDocument();
+    });
+  });
+
   describe('with folders feature disabled', () => {
     it('shows all checks regardless of folderUid', async () => {
       await renderCheckList();

--- a/src/page/CheckList/CheckList.folderPermissions.test.tsx
+++ b/src/page/CheckList/CheckList.folderPermissions.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { BASIC_PING_CHECK } from 'test/fixtures/checks';
 import {
+  CHECK_IN_EXTERNAL_FOLDER,
   CHECK_IN_FORBIDDEN_FOLDER,
   CHECK_IN_PRODUCTION,
   CHECK_IN_READONLY_FOLDER,
@@ -105,6 +106,12 @@ describe('CheckList - Folder Permissions', () => {
         await renderCheckList();
         await screen.findByText('Production HTTP check');
         expect(await screen.findByText('Orphaned folder check')).toBeInTheDocument();
+      });
+
+      it('shows checks in readable folders outside the default folder subtree', async () => {
+        await renderCheckList([...ALL_CHECKS, CHECK_IN_EXTERNAL_FOLDER]);
+        await screen.findByText('Production HTTP check');
+        expect(await screen.findByText('External folder check')).toBeInTheDocument();
       });
     });
 

--- a/src/page/CheckList/CheckList.folderView.test.tsx
+++ b/src/page/CheckList/CheckList.folderView.test.tsx
@@ -3,12 +3,21 @@ import { screen } from '@testing-library/react';
 import { CHECKS_TEST_ID } from 'test/dataTestIds';
 import { BASIC_HTTP_CHECK } from 'test/fixtures/checks';
 import {
+  CHECK_IN_EXTERNAL_FOLDER,
   CHECK_IN_PRODUCTION,
   CHECK_IN_STAGING,
   CHECK_WITH_ORPHANED_FOLDER,
   CHECK_WITHOUT_FOLDER,
 } from 'test/fixtures/folderChecks';
-import { DEFAULT_FOLDER, FOLDER_DELETABLE, FOLDER_PRODUCTION, FOLDER_READONLY, FOLDER_STAGING, MOCK_FOLDERS } from 'test/fixtures/folders';
+import {
+  DEFAULT_FOLDER,
+  FOLDER_DELETABLE,
+  FOLDER_EXTERNAL,
+  FOLDER_PRODUCTION,
+  FOLDER_READONLY,
+  FOLDER_STAGING,
+  MOCK_FOLDERS,
+} from 'test/fixtures/folders';
 import { PRIVATE_PROBE, PUBLIC_PROBE } from 'test/fixtures/probes';
 import { apiRoute } from 'test/handlers';
 import { render } from 'test/render';
@@ -91,10 +100,7 @@ describe('buildChecksByFolder', () => {
   });
 
   test('returns empty rootChecks when no defaultFolderUid and all checks have folders', () => {
-    const { rootChecks } = buildChecksByFolder(
-      [CHECK_IN_PRODUCTION, CHECK_IN_STAGING],
-      MOCK_FOLDERS
-    );
+    const { rootChecks } = buildChecksByFolder([CHECK_IN_PRODUCTION, CHECK_IN_STAGING], MOCK_FOLDERS);
 
     expect(rootChecks).toHaveLength(0);
   });
@@ -159,6 +165,41 @@ describe('buildChecksByFolder', () => {
       expect(node.isOrphaned).toBe(true);
     });
   });
+
+  test('external folders referenced by checks appear at top level flagged as external', () => {
+    const { folderTree } = buildChecksByFolder([CHECK_IN_EXTERNAL_FOLDER], MOCK_FOLDERS, DEFAULT_FOLDER.uid, false, [
+      FOLDER_EXTERNAL,
+    ]);
+
+    const externalNode = folderTree.find((n) => n.folderUid === FOLDER_EXTERNAL.uid);
+    expect(externalNode).toBeDefined();
+    expect(externalNode!.isExternal).toBe(true);
+    expect(externalNode!.isOrphaned).toBe(false);
+    expect(externalNode!.isAccessible).toBe(true);
+    expect(externalNode!.folder?.title).toBe(FOLDER_EXTERNAL.title);
+    expect(externalNode!.checks).toHaveLength(1);
+  });
+
+  test('external folders without checks do not get nodes', () => {
+    const { folderTree } = buildChecksByFolder([CHECK_IN_PRODUCTION], MOCK_FOLDERS, DEFAULT_FOLDER.uid, false, [
+      FOLDER_EXTERNAL,
+    ]);
+
+    expect(collectAllFolderUids(folderTree)).not.toContain(FOLDER_EXTERNAL.uid);
+  });
+
+  test('external folder ancestors outside SM folder data do not create bogus nodes', () => {
+    const nestedExternal = { ...FOLDER_EXTERNAL, uid: 'external-child', parentUid: 'unknown-parent' };
+    const checkInNested: Check = { ...CHECK_IN_EXTERNAL_FOLDER, folderUid: nestedExternal.uid };
+
+    const { folderTree } = buildChecksByFolder([checkInNested], MOCK_FOLDERS, DEFAULT_FOLDER.uid, false, [
+      nestedExternal,
+    ]);
+
+    const allUids = collectAllFolderUids(folderTree);
+    expect(allUids).toContain(nestedExternal.uid);
+    expect(allUids).not.toContain('unknown-parent');
+  });
 });
 
 describe('CheckList - Folder View Integration', () => {
@@ -174,6 +215,18 @@ describe('CheckList - Folder View Integration', () => {
       await renderCheckList(FOLDER_CHECKS, 'view=folder');
 
       expect(await screen.findByText(/Folders/)).toBeInTheDocument();
+    });
+
+    test('renders checks in a readable folder outside the default subtree with a badge', async () => {
+      await renderCheckList([CHECK_IN_PRODUCTION, CHECK_IN_EXTERNAL_FOLDER], 'view=folder');
+
+      // The external fixture duplicates the default folder's title (the
+      // stranded-folder incident scenario); the default node is suffixed.
+      expect(await screen.findByText(FOLDER_EXTERNAL.title)).toBeInTheDocument();
+      expect(screen.getByText(`${FOLDER_EXTERNAL.title} (default)`)).toBeInTheDocument();
+      expect(await screen.findByText('Outside default folder')).toBeInTheDocument();
+      expect(screen.getByText('External folder check')).toBeInTheDocument();
+      expect(screen.queryByText('Folder not found')).not.toBeInTheDocument();
     });
 
     test('shows empty folders with 0 checks', async () => {

--- a/src/page/CheckList/CheckList.tsx
+++ b/src/page/CheckList/CheckList.tsx
@@ -39,7 +39,11 @@ import { matchesAllFilters } from 'page/CheckList/CheckList.utils';
 import { CheckListFolderView } from 'page/CheckList/components/CheckListFolderView';
 import { CheckListHeader } from 'page/CheckList/components/CheckListHeader';
 import { CheckListItem } from 'page/CheckList/components/CheckListItem';
-import { FolderErrorBanner, FolderNotProvisionedBanner, FolderPermissionBanner } from 'page/CheckList/components/FolderBanners';
+import {
+  FolderErrorBanner,
+  FolderNotProvisionedBanner,
+  FolderPermissionBanner,
+} from 'page/CheckList/components/FolderBanners';
 
 export const CheckList = () => {
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
@@ -98,7 +102,7 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
   const filters = useCheckFilters();
   const { isEnabled: isCALsEnabled } = useFeatureFlag(FeatureName.CALs);
   const { data: calData } = useTenantCostAttributionLabels();
-  const calNames = useMemo(() => (isCALsEnabled ? calData?.names ?? [] : []), [isCALsEnabled, calData?.names]);
+  const calNames = useMemo(() => (isCALsEnabled ? (calData?.names ?? []) : []), [isCALsEnabled, calData?.names]);
 
   // When folders are unavailable, fall back to card view synchronously so the
   // folder view never renders, while preserving the user's stored preference
@@ -162,7 +166,7 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
   const filteredChecks = filterChecks(checks, checkFiltersWithStatus, defaultFolderUid);
   const sortedChecks = sortChecks(filteredChecks, sortType, reachabilitySuccessRates, checkAlertStates, applyAlertSort);
   const folderAccess = useCheckFolderAccess(sortedChecks);
-  const { visibleChecks } = folderAccess;
+  const { visibleChecks, externalFolders } = folderAccess;
 
   const currentPageChecks = visibleChecks.slice((currentPage - 1) * CHECKS_PER_PAGE, currentPage * CHECKS_PER_PAGE);
   const totalPages = Math.ceil(visibleChecks.length / CHECKS_PER_PAGE);
@@ -303,10 +307,10 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
         onRetryAlertStates={refetchAlertStates}
         calNames={calNames}
       />
-      {foldersUnavailable && (
+      {foldersUnavailable &&
         // The error banner is actionable (Retry) and not dismissible, so it
         // always shows. The info banners are dismissible for the session.
-        folderStatus === 'error' ? (
+        (folderStatus === 'error' ? (
           <FolderErrorBanner onRetry={refetchFolders} />
         ) : (
           !folderBannerDismissed &&
@@ -315,12 +319,12 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
           ) : (
             <FolderPermissionBanner onDismiss={() => setFolderBannerDismissed(true)} />
           ))
-        )
-      )}
+        ))}
       {effectiveViewType === CheckListViewType.Folder ? (
         <CheckListFolderView
           checks={visibleChecks}
           folders={allFolders}
+          externalFolders={externalFolders}
           foldersMap={foldersMap}
           foldersLoading={isFoldersLoading}
           foldersError={isFoldersError}
@@ -343,17 +347,17 @@ const CheckListContent = ({ onChangeViewType, viewType }: CheckListContentProps)
             <div className={styles.list}>
               {currentPageChecks.map((check) => (
                 <div key={check.id} style={{ viewTransitionName: `check-${check.id}` }}>
-                <CheckListItem
-                  check={check}
-                  calNames={calNames}
-                  onLabelSelect={handleLabelSelect}
-                  onStatusSelect={handleStatusSelect}
-                  onTypeSelect={handleTypeSelect}
-                  onToggleCheckbox={handleCheckSelect}
-                  runtimeAlertState={getCheckRuntimeAlertState(checkAlertStates, check)}
-                  selected={selectedCheckIds.has(check.id!)}
-                  viewType={effectiveViewType}
-                />
+                  <CheckListItem
+                    check={check}
+                    calNames={calNames}
+                    onLabelSelect={handleLabelSelect}
+                    onStatusSelect={handleStatusSelect}
+                    onTypeSelect={handleTypeSelect}
+                    onToggleCheckbox={handleCheckSelect}
+                    runtimeAlertState={getCheckRuntimeAlertState(checkAlertStates, check)}
+                    selected={selectedCheckIds.has(check.id!)}
+                    viewType={effectiveViewType}
+                  />
                 </div>
               ))}
             </div>

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -1,6 +1,18 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Checkbox, ConfirmModal, Icon, IconButton, Pagination, Spinner, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import {
+  Badge,
+  Button,
+  Checkbox,
+  ConfirmModal,
+  Icon,
+  IconButton,
+  Pagination,
+  Spinner,
+  Stack,
+  Tooltip,
+  useStyles2,
+} from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { CheckListViewType } from 'page/CheckList/CheckList.types';
@@ -8,7 +20,14 @@ import { Check, CheckSort, CheckType, GrafanaFolder, Label } from 'types';
 import { useCheckFolderStatus } from 'contexts/CheckFolderAccessContext';
 import { CheckRuntimeAlertStates, getCheckRuntimeAlertState } from 'data/useCheckAlertStates';
 import { useDeleteFolder } from 'data/useFolders';
-import { buildChecksByFolder, collectAllCheckIds, collectAllChecks, collectAllFolderUids, FolderNode, getTotalCheckCount } from 'hooks/useChecksByFolder';
+import {
+  buildChecksByFolder,
+  collectAllCheckIds,
+  collectAllChecks,
+  collectAllFolderUids,
+  FolderNode,
+  getTotalCheckCount,
+} from 'hooks/useChecksByFolder';
 import { Feedback } from 'components/Feedback';
 import { CHECKS_PER_PAGE_CARD } from 'page/CheckList/CheckList.constants';
 import { CheckListItem } from 'page/CheckList/components/CheckListItem';
@@ -17,6 +36,7 @@ import { FolderBulkActions } from 'page/CheckList/components/FolderBulkActions';
 interface CheckListFolderViewProps {
   checks: Check[];
   folders: GrafanaFolder[];
+  externalFolders?: GrafanaFolder[];
   foldersMap: Map<string, GrafanaFolder>;
   foldersLoading?: boolean;
   foldersError?: boolean;
@@ -37,6 +57,7 @@ interface CheckListFolderViewProps {
 export function CheckListFolderView({
   checks,
   folders,
+  externalFolders,
   foldersMap,
   foldersLoading,
   foldersError,
@@ -56,8 +77,8 @@ export function CheckListFolderView({
   const styles = useStyles2(getStyles);
   const reverseFolderSort = sortType === CheckSort.ZToA;
   const { folderTree, rootChecks } = useMemo(
-    () => buildChecksByFolder(checks, folders, defaultFolderUid, reverseFolderSort),
-    [checks, folders, defaultFolderUid, reverseFolderSort]
+    () => buildChecksByFolder(checks, folders, defaultFolderUid, reverseFolderSort, externalFolders),
+    [checks, folders, defaultFolderUid, reverseFolderSort, externalFolders]
   );
 
   const defaultFolderNode: FolderNode | null = useMemo(() => {
@@ -198,9 +219,7 @@ export function CheckListFolderView({
         </div>
       )}
 
-      {!hasAnyContent && (
-        <div className={styles.emptyState}>No checks to display</div>
-      )}
+      {!hasAnyContent && <div className={styles.emptyState}>No checks to display</div>}
     </div>
   );
 }
@@ -228,7 +247,14 @@ interface FolderTreeBranchProps {
   onRetryFolders?: () => void;
 }
 
-function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkItemProps, onRetryFolders }: FolderTreeBranchProps) {
+function FolderTreeBranch({
+  node,
+  depth,
+  collapsedFolders,
+  toggleFolder,
+  checkItemProps,
+  onRetryFolders,
+}: FolderTreeBranchProps) {
   const styles = useStyles2(getStyles);
   const isExpanded = !collapsedFolders.has(node.folderUid);
   const totalChecks = getTotalCheckCount(node);
@@ -249,9 +275,10 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
   const isAllInFolderSelected = totalChecks > 0 && selectedCount === totalChecks;
   const isSomeInFolderSelected = selectedCount > 0 && !isAllInFolderSelected;
 
-  const deleteFolderTarget = isAllInFolderSelected && folderCanDelete && !node.isDefault && !node.isOrphaned
-    ? { uid: node.folderUid, title: node.folder?.title ?? node.folderUid }
-    : undefined;
+  const deleteFolderTarget =
+    isAllInFolderSelected && folderCanDelete && !node.isDefault && !node.isOrphaned
+      ? { uid: node.folderUid, title: node.folder?.title ?? node.folderUid }
+      : undefined;
 
   const isEmpty = totalChecks === 0;
   const canDeleteEmptyFolder = isEmpty && folderCanDelete && !node.isDefault && !node.isOrphaned;
@@ -291,7 +318,11 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
     <div className={isRoot ? styles.folderGroup : styles.nestedFolder}>
       <div className={isRoot ? styles.folderHeaderRoot : styles.folderHeaderNested}>
         <Checkbox
-          aria-label={isEmpty ? `Select folder ${node.folder?.title ?? 'folder'}` : `Select all checks in ${node.folder?.title ?? 'folder'}`}
+          aria-label={
+            isEmpty
+              ? `Select folder ${node.folder?.title ?? 'folder'}`
+              : `Select all checks in ${node.folder?.title ?? 'folder'}`
+          }
           checked={isEmpty ? emptyFolderSelected : isAllInFolderSelected}
           indeterminate={!isEmpty && isSomeInFolderSelected}
           onChange={handleFolderSelectAll}
@@ -320,15 +351,26 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
               ) : node.isOrphaned ? (
                 <span className={styles.orphanedLabel}>Folder not found</span>
               ) : (
-                node.folder?.title ?? node.folderUid
+                (node.folder?.title ?? node.folderUid)
               )}
             </span>
+            {node.isExternal && (
+              <Badge
+                text="Outside default folder"
+                color="orange"
+                icon="exclamation-triangle"
+                tooltip={`This is a separate folder (UID: ${node.folderUid}) outside the default Synthetic Monitoring folder. Move its checks to another folder to organize them with the rest.`}
+              />
+            )}
             {node.isOrphaned && !checkItemProps.foldersLoading && checkItemProps.foldersError && onRetryFolders && (
               <Button
                 variant="secondary"
                 size="sm"
                 icon="sync"
-                onClick={(e) => { e.stopPropagation(); onRetryFolders(); }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRetryFolders();
+                }}
                 tooltip="Retry loading folders"
               >
                 Retry
@@ -357,7 +399,10 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
               tooltip="Delete folder"
               size="sm"
               variant="destructive"
-              onClick={(e) => { e.stopPropagation(); setShowDeleteEmptyFolderModal(true); }}
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowDeleteEmptyFolderModal(true);
+              }}
             />
             <span className={styles.selectedCount}>1 selected</span>
             {showDeleteEmptyFolderModal && (
@@ -388,7 +433,11 @@ function FolderTreeBranch({ node, depth, collapsedFolders, toggleFolder, checkIt
             />
           ))}
           {node.checks.length > 0 && (
-            <PaginatedCheckList checks={node.checks} checkItemProps={checkItemProps} hideTopPagination={node.isDefault} />
+            <PaginatedCheckList
+              checks={node.checks}
+              checkItemProps={checkItemProps}
+              hideTopPagination={node.isDefault}
+            />
           )}
         </div>
       )}
@@ -414,10 +463,7 @@ function PaginatedCheckList({ checks, checkItemProps, hideTopPagination }: Pagin
     }
   }, [currentPage, clampedPage]);
 
-  const pageChecks = checks.slice(
-    (clampedPage - 1) * CHECKS_PER_PAGE_CARD,
-    clampedPage * CHECKS_PER_PAGE_CARD
-  );
+  const pageChecks = checks.slice((clampedPage - 1) * CHECKS_PER_PAGE_CARD, clampedPage * CHECKS_PER_PAGE_CARD);
 
   const paginationControls = totalPages > 1 && (
     <div className={styles.pagination}>

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -275,13 +275,17 @@ function FolderTreeBranch({
   const isAllInFolderSelected = totalChecks > 0 && selectedCount === totalChecks;
   const isSomeInFolderSelected = selectedCount > 0 && !isAllInFolderSelected;
 
+  // External folders live outside the SM folder tree and may hold unrelated
+  // content (dashboards, subfolders, alert rules), so we never offer to delete
+  // them -- the badge guides the user to move their checks out instead.
   const deleteFolderTarget =
-    isAllInFolderSelected && folderCanDelete && !node.isDefault && !node.isOrphaned
+    isAllInFolderSelected && folderCanDelete && !node.isDefault && !node.isOrphaned && !node.isExternal
       ? { uid: node.folderUid, title: node.folder?.title ?? node.folderUid }
       : undefined;
 
   const isEmpty = totalChecks === 0;
-  const canDeleteEmptyFolder = isEmpty && folderCanDelete && !node.isDefault && !node.isOrphaned;
+  const canDeleteEmptyFolder =
+    isEmpty && folderCanDelete && !node.isDefault && !node.isOrphaned && !node.isExternal;
   const [emptyFolderSelected, setEmptyFolderSelected] = useState(false);
   const [showDeleteEmptyFolderModal, setShowDeleteEmptyFolderModal] = useState(false);
   const { mutateAsync: deleteFolderAsync } = useDeleteFolder();

--- a/src/test/fixtures/folderChecks.ts
+++ b/src/test/fixtures/folderChecks.ts
@@ -1,7 +1,14 @@
 import { Check } from 'types';
 
 import { BASIC_DNS_CHECK, BASIC_HTTP_CHECK, BASIC_PING_CHECK } from './checks';
-import { FOLDER_DELETABLE, FOLDER_FORBIDDEN_UID, FOLDER_PRODUCTION, FOLDER_READONLY, FOLDER_STAGING } from './folders';
+import {
+  FOLDER_DELETABLE,
+  FOLDER_EXTERNAL,
+  FOLDER_FORBIDDEN_UID,
+  FOLDER_PRODUCTION,
+  FOLDER_READONLY,
+  FOLDER_STAGING,
+} from './folders';
 
 export const CHECK_IN_PRODUCTION: Check = {
   ...BASIC_HTTP_CHECK,
@@ -43,6 +50,13 @@ export const CHECK_WITH_ORPHANED_FOLDER: Check = {
   id: 205,
   job: 'Orphaned folder check',
   folderUid: 'deleted-folder-uid',
+};
+
+export const CHECK_IN_EXTERNAL_FOLDER: Check = {
+  ...BASIC_HTTP_CHECK,
+  id: 207,
+  job: 'External folder check',
+  folderUid: FOLDER_EXTERNAL.uid,
 };
 
 export const CHECK_IN_DELETABLE_FOLDER: Check = {

--- a/src/test/fixtures/folders.ts
+++ b/src/test/fixtures/folders.ts
@@ -57,4 +57,28 @@ export const FOLDER_DELETABLE: GrafanaFolder = {
 
 export const FOLDER_FORBIDDEN_UID = 'folder-forbidden';
 
-export const MOCK_FOLDERS: GrafanaFolder[] = [DEFAULT_FOLDER, FOLDER_PRODUCTION, FOLDER_STAGING, FOLDER_READONLY, FOLDER_DELETABLE];
+/**
+ * A readable folder living outside the default SM folder's subtree (no
+ * parentUid, random-looking UID). Mirrors the "stranded" state created when a
+ * duplicate default folder exists with a non-canonical UID, or when a check is
+ * assigned to an arbitrary folder via the API. Deliberately NOT part of
+ * MOCK_FOLDERS: the subtree list endpoint never returns it, only the detail
+ * endpoint does.
+ */
+export const FOLDER_EXTERNAL: GrafanaFolder = {
+  uid: 'afq0rsc7nhgcgc',
+  title: 'Grafana Synthetic Monitoring',
+  url: '/dashboards/f/afq0rsc7nhgcgc/grafana-synthetic-monitoring',
+  canEdit: true,
+  canDelete: true,
+  canAdmin: false,
+  canSave: true,
+};
+
+export const MOCK_FOLDERS: GrafanaFolder[] = [
+  DEFAULT_FOLDER,
+  FOLDER_PRODUCTION,
+  FOLDER_STAGING,
+  FOLDER_READONLY,
+  FOLDER_DELETABLE,
+];

--- a/src/test/handlers/folders.ts
+++ b/src/test/handlers/folders.ts
@@ -1,4 +1,4 @@
-import { FOLDER_FORBIDDEN_UID, MOCK_FOLDERS } from 'test/fixtures/folders';
+import { FOLDER_EXTERNAL, FOLDER_FORBIDDEN_UID, MOCK_FOLDERS } from 'test/fixtures/folders';
 
 import { ApiEntry } from './types';
 import { GrafanaFolder } from 'types';
@@ -28,6 +28,8 @@ export const listFolders: ApiEntry<Array<Pick<GrafanaFolder, 'uid' | 'title' | '
 /**
  * GET /api/folders/:uid — detail endpoint.
  * Returns the full folder object including permission fields.
+ * Also resolves FOLDER_EXTERNAL, which the list endpoint never returns
+ * (it lives outside the default folder's subtree).
  * Returns 403 for FOLDER_FORBIDDEN_UID, 404 for unknown UIDs.
  */
 export const getFolder: ApiEntry<GrafanaFolder> = {
@@ -41,7 +43,7 @@ export const getFolder: ApiEntry<GrafanaFolder> = {
       return { status: 403, json: { message: 'Access denied' } };
     }
 
-    const folder = MOCK_FOLDERS.find((f) => f.uid === uid);
+    const folder = [...MOCK_FOLDERS, FOLDER_EXTERNAL].find((f) => f.uid === uid);
 
     if (!folder) {
       return { status: 404, json: { message: 'Folder not found' } };


### PR DESCRIPTION
Addresses: https://github.com/grafana/support-escalations/issues/23263

## Problem

Checks assigned to a folder that lives outside the default Synthetic Monitoring folder's subtree disappeared from the checks list, even though the folder still existed and the user could access it. The checks stayed reachable by direct link, so from the user's perspective their checks had silently vanished from the list with no explanation.

This surfaced in production when a tenant ended up with a second folder named "Grafana Synthetic Monitoring" under a non-canonical UID: the app loaded the canonical folder's tree and every check still pointing at the older folder was stranded and hidden. The same gap affected any check assigned to an arbitrary folder outside the default subtree (for example via the API or Terraform).

## Solution

The checks list now hides a check only when its folder is genuinely forbidden (a 403 from the folder permissions endpoint). Folders that exist and are readable but sit outside the default folder's subtree are treated as visible.

In the folder view these "external" folders are surfaced as top-level nodes with their real title and an "Outside default folder" badge that explains the folder is separate from the default Synthetic Monitoring folder (including its UID to disambiguate same-named folders) and prompts the user to move its checks. Folder-level permissions still apply to these checks, so nothing is granted beyond what the user already has.

<img width="1150" height="514" alt="image" src="https://github.com/user-attachments/assets/a983e480-5ac0-4d4f-b523-84b956cf77bc" />

