### PR TITLE
fix: paginate results by URL table to limit rendering

### DIFF
--- a/src/scenes/Scripted/ResultByTargetTable.tsx
+++ b/src/scenes/Scripted/ResultByTargetTable.tsx
@@ -23,6 +23,8 @@ export interface DataRow {
   latency: number;
 }
 
+const RESULTS_BY_TARGET_PAGE_SIZE = 50;
+
 export const ResultsByTargetTable = ({ checkType }: { checkType: CheckType }) => {
   const metricsDS = useMetricsDS();
   const label = checkType === CheckType.Scripted ? 'name' : 'url';
@@ -214,7 +216,8 @@ const ResultsByTargetTableView = ({ data, checkType }: { data?: PanelData; check
           expandableComponent={({ data }) => <ResultsByTargetTableRow data={data} checkType={checkType} />}
           //@ts-ignore - noDataText expects a string, but we want to render a component and it works
           noDataText={<Placeholder state={data?.state} errors={data?.errors} hasLoaded={hasLoaded} />}
-          pagination={false}
+          pagination={tableData.length > RESULTS_BY_TARGET_PAGE_SIZE}
+          paginationPerPage={RESULTS_BY_TARGET_PAGE_SIZE}
           id="assertion-table"
           name="Assertions"
         />


### PR DESCRIPTION
## Problem

The Results by URL table on scripted check dashboards renders every row at once. Checks with many HTTP requests can produce hundreds or thousands of rows, which slows down the dashboard and makes the table difficult to use.

## Solution

Enable pagination on the Results by URL table, limiting display to 50 rows per page. Pagination controls only appear when there are more than 50 results, keeping smaller result sets uncluttered. Expandable row details continue to work within each page.

## Test plan

- [ ] Open a scripted check dashboard with more than 50 URL results and confirm only 50 rows render per page
- [ ] Confirm pagination controls navigate between pages correctly
- [ ] Confirm expandable rows still work on paginated pages
- [ ] Open a check with fewer than 50 results and confirm no pagination controls are shown