### PR TITLE
chore: auto-approve Argo canary and prod deploys

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,13 @@ jobs:
       trigger-argo: ${{ github.event.inputs.branch == 'main' }}
       argo-workflow-slack-channel: '#sm-ops-deploys'
 
-      auto-merge-environments: dev,ops,prod
+      auto-merge-environments: dev,ops,prod-canary,prod
+
+      # Auto-approve every stage in Argo so the deployment progresses from
+      # canary through to prod without a manual "Resume" click.
+      # "0" = approve immediately; swap for a duration (e.g. "2h") to keep a soak.
+      auto-approve-durations: |-
+        {"dev": 0, "ops": 0, "prod-canary": 0, "prod": 0}
 
       # https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs
       node-version: 22


### PR DESCRIPTION
## Problem

Deploying the app to prod stalls waiting for a manual approval in Argo. Our manual deployment workflow inherits the shared `plugin-ci-workflows` default (`{"dev":0,"ops":0,"prod-canary":null,"prod":null}`), where `null` means Argo pauses at the `prod-canary` and `prod` stages until someone clicks the "Resume" button in the Argo UI.

## Solution

Set `auto-approve-durations` on the manual deployment workflow so Argo auto-approves every stage instead of blocking on a manual click, and add `prod-canary` to `auto-merge-environments` so its `deployment_tools` PR merges automatically too. Once a deploy is dispatched, Argo now progresses dev → ops → prod-canary → prod without human interaction.


## Notes for reviewers

- We don't use the canary stage as a soak/gate for this app, so all stages are set to `0` (approve immediately). 
