### PR TITLE
fix: show secrets side-panel tab for HTTP checks

### DIFF
--- a/src/components/Checkster/contexts/FeatureTabsContext.test.tsx
+++ b/src/components/Checkster/contexts/FeatureTabsContext.test.tsx
@@ -1,0 +1,75 @@
+import React, { PropsWithChildren } from 'react';
+import { renderHook } from '@testing-library/react';
+
+import { CheckType, FeatureName } from 'types';
+import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
+
+import { useChecksterContext } from './ChecksterContext';
+import { FeatureTabsContextProvider, useFeatureTabsContext } from './FeatureTabsContext';
+
+jest.mock('contexts/FeatureFlagContext', () => ({
+  isFeatureEnabled: jest.fn(),
+}));
+
+jest.mock('./ChecksterContext', () => ({
+  useChecksterContext: jest.fn(),
+}));
+
+const mockIsFeatureEnabled = isFeatureEnabled as jest.Mock;
+const mockUseChecksterContext = useChecksterContext as jest.Mock;
+
+function setup(checkType: CheckType) {
+  mockUseChecksterContext.mockReturnValue({ checkType });
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <FeatureTabsContextProvider>{children}</FeatureTabsContextProvider>
+  );
+
+  return renderHook(() => useFeatureTabsContext(), { wrapper });
+}
+
+function hasSecretsTab(result: ReturnType<typeof setup>['result']) {
+  return result.current.tabs.some(([label]) => label === 'Secrets');
+}
+
+describe('FeatureTabsContext secrets tab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when the SecretsManagement feature flag is enabled', () => {
+    beforeEach(() => {
+      mockIsFeatureEnabled.mockImplementation((name: FeatureName) => name === FeatureName.SecretsManagement);
+    });
+
+    it.each([CheckType.Http, CheckType.Browser, CheckType.Scripted])(
+      'shows the Secrets tab for %s checks',
+      (checkType) => {
+        const { result } = setup(checkType);
+        expect(hasSecretsTab(result)).toBe(true);
+      }
+    );
+
+    it.each([CheckType.Dns, CheckType.Grpc, CheckType.MultiHttp, CheckType.Ping, CheckType.Tcp, CheckType.Traceroute])(
+      'hides the Secrets tab for incompatible %s checks',
+      (checkType) => {
+        const { result } = setup(checkType);
+        expect(hasSecretsTab(result)).toBe(false);
+      }
+    );
+  });
+
+  describe('when the SecretsManagement feature flag is disabled', () => {
+    beforeEach(() => {
+      mockIsFeatureEnabled.mockReturnValue(false);
+    });
+
+    it.each([CheckType.Http, CheckType.Browser, CheckType.Scripted])(
+      'hides the Secrets tab for %s checks even though the check type is compatible',
+      (checkType) => {
+        const { result } = setup(checkType);
+        expect(hasSecretsTab(result)).toBe(false);
+      }
+    );
+  });
+});

--- a/src/components/Checkster/feature/secrets/SecretsPanel.tsx
+++ b/src/components/Checkster/feature/secrets/SecretsPanel.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/css';
 import { CheckType } from 'types';
 import { SecretsManagementUI } from 'page/ConfigPageLayout/tabs/SecretsManagementTab/SecretsManagementUI';
 
-export const SECRETS_CHECK_COMPATIBILITY: CheckType[] = [CheckType.Browser, CheckType.Scripted];
+export const SECRETS_CHECK_COMPATIBILITY: CheckType[] = [CheckType.Browser, CheckType.Scripted, CheckType.Http];
 
 export function SecretsPanel() {
   const theme = useTheme2();


### PR DESCRIPTION
Add CheckType.Http to SECRETS_CHECK_COMPATIBILITY so the Secrets feature tab appears in the check editor for HTTP checks, in addition to Browser and Scripted. HTTP credential fields (basic auth password, bearer token, TLS cert/key) already opt into secret references via allowSecrets, so no further wiring is needed.

Add tests for the previously-uncovered tab-filtering logic in FeatureTabsContext, asserting the Secrets tab is shown for compatible check types when the SecretsManagement flag is on and hidden otherwise.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
