### PR TITLE
fix: remove stale secrets datasource proxy routes

### DIFF
--- a/src/datasource/plugin.json
+++ b/src/datasource/plugin.json
@@ -76,54 +76,6 @@
           "content": "Bearer {{.SecureJsonData.accessToken}}"
         }
       ]
-    },
-    {
-      "path": "api/v1alpha1/secrets",
-      "method": "GET",
-      "url": "{{.JsonData.apiHost}}/api/v1alpha1/secrets",
-      "reqAction": "secret.securevalues:read",
-      "headers": [
-        {
-          "name": "Authorization",
-          "content": "Bearer {{.SecureJsonData.accessToken}}"
-        }
-      ]
-    },
-    {
-      "path": "api/v1alpha1/secrets",
-      "method": "PUT",
-      "url": "{{.JsonData.apiHost}}/api/v1alpha1/secrets",
-      "reqAction": "secret.securevalues:write",
-      "headers": [
-        {
-          "name": "Authorization",
-          "content": "Bearer {{.SecureJsonData.accessToken}}"
-        }
-      ]
-    },
-    {
-      "path": "api/v1alpha1/secrets",
-      "method": "POST",
-      "url": "{{.JsonData.apiHost}}/api/v1alpha1/secrets",
-      "reqAction": "secret.securevalues:create",
-      "headers": [
-        {
-          "name": "Authorization",
-          "content": "Bearer {{.SecureJsonData.accessToken}}"
-        }
-      ]
-    },
-    {
-      "path": "api/v1alpha1/secrets",
-      "method": "DELETE",
-      "url": "{{.JsonData.apiHost}}/api/v1alpha1/secrets",
-      "reqAction": "secret.securevalues:delete",
-      "headers": [
-        {
-          "name": "Authorization",
-          "content": "Bearer {{.SecureJsonData.accessToken}}"
-        }
-      ]
     }
   ],
 


### PR DESCRIPTION
The datasource proxy declared GET/PUT/POST/DELETE routes for api/v1alpha1/secrets, pointing at the Synthetic Monitoring API. These date back to the "intermediate secrets management" work and are no longer used: the app now reads and writes secrets directly through Grafana's App Platform secrets API (secret.grafana.app) via SecretsManagerClient added in 4af0d71ef, never through the datasource proxy. No TypeScript code references these routes.

Drop the dead route declarations.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
