### PR TITLE
feat: add Connected services graph to the check dashboard

### DIFF
--- a/src/features/knowledgeGraph/ConnectedServices.constants.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.constants.ts
@@ -4,7 +4,20 @@ export const CONNECTED_SERVICES_SUBTITLE = 'Neighbourhood from the Knowledge Gra
 export const CONNECTED_SERVICES_TEST_ID = {
   section: 'connected-services-section',
   graph: 'connected-services-graph',
+  node: 'connected-services-node',
+  edge: 'connected-services-edge',
   loading: 'connected-services-loading',
   error: 'connected-services-error',
+  empty: 'connected-services-empty',
   zeroState: 'connected-services-zero-state',
+} as const;
+
+/**
+ * Insight-ring severity colors, pinned to the Knowledge Graph's own values
+ * (`assertsColors` in the KG plugin) so a check's ring reads identically on both surfaces.
+ */
+export const KG_SEVERITY_COLORS = {
+  critical: '#F2495C',
+  warning: '#FF9830',
+  info: '#5794F2',
 } as const;

--- a/src/features/knowledgeGraph/ConnectedServices.hooks.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.hooks.ts
@@ -1,0 +1,73 @@
+import { useQuery } from '@tanstack/react-query';
+import { CoreApp, DataQueryRequest, DataQueryResponse, dateTime, LoadingState } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { DataQuery } from '@grafana/schema';
+import { isObservable, lastValueFrom } from 'rxjs';
+
+import { Check } from 'types';
+import { useKGDS } from 'hooks/useKGDS';
+
+import { buildServiceNeighbourhoodQuery, parseGraphFrames, ServiceNeighbourhood } from './ConnectedServices.utils';
+import { getSyntheticCheckEntityName } from './knowledgeGraph';
+
+/** The KG datasource's entityGraph query in Cypher mode (see the KG plugin's kgdatasource types). */
+interface KGEntityGraphQuery extends DataQuery {
+  queryType: 'entityGraph';
+  queryMode: 'cypher';
+  cypherQuery: string;
+}
+
+// The KG resolves entities against a time window; one hour matches the convention used by the
+// service-link lookups in knowledgeGraphApi.ts.
+const NEIGHBOURHOOD_WINDOW_MS = 60 * 60 * 1000;
+
+async function fetchServiceNeighbourhood(datasourceUid: string, checkEntityName: string): Promise<ServiceNeighbourhood> {
+  const datasource = await getDataSourceSrv().get({ uid: datasourceUid });
+
+  const to = dateTime();
+  const from = dateTime(to.valueOf() - NEIGHBOURHOOD_WINDOW_MS);
+  const query: KGEntityGraphQuery = {
+    refId: 'A',
+    queryType: 'entityGraph',
+    queryMode: 'cypher',
+    cypherQuery: buildServiceNeighbourhoodQuery(checkEntityName),
+  };
+
+  const request: DataQueryRequest = {
+    requestId: 'sm-kg-service-neighbourhood',
+    targets: [query],
+    range: { from, to, raw: { from: 'now-1h', to: 'now' } },
+    interval: '30s',
+    intervalMs: 30_000,
+    maxDataPoints: 100,
+    scopedVars: {},
+    timezone: 'browser',
+    app: CoreApp.Unknown,
+    startTime: Date.now(),
+  };
+
+  const result = datasource.query(request);
+  const response: DataQueryResponse = isObservable(result) ? await lastValueFrom(result) : await result;
+
+  if (response.state === LoadingState.Error || response.errors?.length) {
+    throw new Error(response.errors?.[0]?.message ?? 'The Knowledge Graph query failed.');
+  }
+
+  return parseGraphFrames(response.data ?? []);
+}
+
+/**
+ * Runs the check's service-neighbourhood Cypher query against the Knowledge Graph datasource
+ * (directly via the datasource API — no scenes query runner) and returns the parsed graph.
+ * Disabled when the KG datasource isn't present on the stack.
+ */
+export function useServiceNeighbourhood(check: Check) {
+  const kgDS = useKGDS();
+  const checkEntityName = getSyntheticCheckEntityName(check);
+
+  return useQuery({
+    queryKey: ['kg-service-neighbourhood', kgDS?.uid, checkEntityName],
+    enabled: Boolean(kgDS),
+    queryFn: () => fetchServiceNeighbourhood(kgDS!.uid, checkEntityName),
+  });
+}

--- a/src/features/knowledgeGraph/ConnectedServices.hooks.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.hooks.ts
@@ -6,6 +6,7 @@ import { isObservable, lastValueFrom } from 'rxjs';
 
 import { Check } from 'types';
 import { useKGDS } from 'hooks/useKGDS';
+import { STANDARD_REFRESH_INTERVAL } from 'components/constants';
 
 import { buildServiceNeighbourhoodQuery, parseGraphFrames, ServiceNeighbourhood } from './ConnectedServices.utils';
 import { getSyntheticCheckEntityName } from './knowledgeGraph';
@@ -69,5 +70,6 @@ export function useServiceNeighbourhood(check: Check) {
     queryKey: ['kg-service-neighbourhood', kgDS?.uid, checkEntityName],
     enabled: Boolean(kgDS),
     queryFn: () => fetchServiceNeighbourhood(kgDS!.uid, checkEntityName),
+    refetchInterval: STANDARD_REFRESH_INTERVAL,
   });
 }

--- a/src/features/knowledgeGraph/ConnectedServices.test.tsx
+++ b/src/features/knowledgeGraph/ConnectedServices.test.tsx
@@ -1,27 +1,76 @@
 import React from 'react';
-import { useAppPluginInstalled } from '@grafana/runtime';
+import { DataSourceInstanceSettings, LoadingState } from '@grafana/data';
+import { config, useAppPluginInstalled } from '@grafana/runtime';
 import { screen } from '@testing-library/react';
+import { of, throwError } from 'rxjs';
 import { BASIC_HTTP_CHECK } from 'test/fixtures/checks';
+import { LOGS_DATASOURCE, METRICS_DATASOURCE, SM_DATASOURCE } from 'test/fixtures/datasources';
+import { buildNeighbourhoodFrames } from 'test/fixtures/knowledgeGraph';
 import { render } from 'test/render';
 
 import { Check } from 'types';
+import { SMDataSource } from 'datasource/DataSource';
 
 import { ConnectedServices } from './ConnectedServices';
 import { CONNECTED_SERVICES_TEST_ID } from './ConnectedServices.constants';
 
 const mockUseAppPluginInstalled = useAppPluginInstalled as jest.Mock;
 
+const KG_DATASOURCE = {
+  uid: 'grafanacloud-knowledgegraph',
+  type: 'grafana-knowledgegraph-datasource',
+  name: 'Knowledge Graph',
+} as DataSourceInstanceSettings;
+
 function setKgInstalled(value: boolean) {
   mockUseAppPluginInstalled.mockReturnValue({ loading: false, error: undefined, value });
 }
+
+/**
+ * Registers the KG datasource (so `useKGDS` resolves it) and stubs its `query` method with the
+ * given implementation. Restored by the global afterEach (restoreAllMocks + the delete below).
+ *
+ * The spy goes on `jest.requireMock`'s module object: spying on an `import * as` namespace
+ * doesn't work here because the SWC interop hands the test a copy of the module exports.
+ */
+function setKgDatasource(query: jest.Mock) {
+  config.datasources[KG_DATASOURCE.name] = KG_DATASOURCE;
+  jest.spyOn(jest.requireMock('@grafana/runtime'), 'getDataSourceSrv').mockReturnValue({
+    getList: () => [METRICS_DATASOURCE, LOGS_DATASOURCE, SM_DATASOURCE],
+    // Serve the stubbed KG datasource for KG lookups; everything else (e.g. the SM datasource
+    // the test providers resolve) keeps the default behaviour from the global runtime mock.
+    get: jest.fn((ref?: unknown) => {
+      const uid = typeof ref === 'object' && ref !== null ? (ref as { uid?: string }).uid : ref;
+      if (uid === KG_DATASOURCE.uid) {
+        return Promise.resolve({ query });
+      }
+      return Promise.resolve(new SMDataSource(SM_DATASOURCE));
+    }),
+  });
+}
+
+afterEach(() => {
+  delete config.datasources[KG_DATASOURCE.name];
+});
 
 function checkWithLabels(labels: Check['labels']): Check {
   return { ...BASIC_HTTP_CHECK, labels };
 }
 
+const LINKED_CHECK = checkWithLabels([
+  { name: 'service_name', value: 'frontend' },
+  { name: 'namespace', value: 'otel-demo' },
+]);
+
+async function renderAndExpand(check: Check) {
+  const result = render(<ConnectedServices check={check} />);
+  await result.user.click(await screen.findByRole('button', { name: 'Expand connected services' }));
+  return result;
+}
+
 it('renders nothing when the Knowledge Graph app is not installed', async () => {
   setKgInstalled(false);
-  render(<ConnectedServices check={checkWithLabels([{ name: 'service_name', value: 'frontend' }])} />);
+  render(<ConnectedServices check={LINKED_CHECK} />);
 
   expect(screen.queryByTestId(CONNECTED_SERVICES_TEST_ID.section)).not.toBeInTheDocument();
 });
@@ -45,10 +94,6 @@ it('is collapsed by default and reveals the zero state when expanded (unlinked c
   );
 });
 
-// Note: the linked path (rendering the node graph itself) depends on the Knowledge Graph scenes
-// datasource and a SceneContext, so it is validated against a live stack rather than here. These
-// tests cover the gating and zero-state logic that determines whether the graph is shown at all.
-
 it('can be collapsed again after expanding', async () => {
   setKgInstalled(true);
   const { user } = render(<ConnectedServices check={checkWithLabels([{ name: 'Team', value: 'platform' }])} />);
@@ -58,4 +103,99 @@ it('can be collapsed again after expanding', async () => {
 
   await user.click(screen.getByRole('button', { name: 'Collapse connected services' }));
   expect(screen.queryByTestId(CONNECTED_SERVICES_TEST_ID.zeroState)).not.toBeInTheDocument();
+});
+
+it('renders the neighbourhood graph from the Cypher query result (linked check)', async () => {
+  setKgInstalled(true);
+  const { nodes, edges } = buildNeighbourhoodFrames();
+  const query = jest.fn().mockReturnValue(of({ data: [nodes, edges], state: LoadingState.Done }));
+  setKgDatasource(query);
+
+  await renderAndExpand(LINKED_CHECK);
+
+  expect(await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.graph)).toBeInTheDocument();
+  expect(screen.getAllByTestId(CONNECTED_SERVICES_TEST_ID.node)).toHaveLength(4);
+
+  // Node labels from the frames.
+  expect(screen.getByText('frontend')).toBeInTheDocument();
+  expect(screen.getByText('cart')).toBeInTheDocument();
+  expect(screen.getByText('gateway')).toBeInTheDocument();
+
+  // The Cypher query was sent to the KG datasource, scoped to this check's entity name.
+  const request = query.mock.calls[0][0];
+  expect(request.targets[0]).toMatchObject({ queryType: 'entityGraph', queryMode: 'cypher' });
+  expect(request.targets[0].cypherQuery).toContain(`${BASIC_HTTP_CHECK.job}__${BASIC_HTTP_CHECK.target}`);
+});
+
+it('shows the insights popup on node hover, with the deep link into the KG app', async () => {
+  setKgInstalled(true);
+  const { nodes, edges } = buildNeighbourhoodFrames();
+  const query = jest.fn().mockReturnValue(of({ data: [nodes, edges], state: LoadingState.Done }));
+  setKgDatasource(query);
+
+  const { user } = await renderAndExpand(LINKED_CHECK);
+  await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.graph);
+
+  await user.hover(screen.getByRole('button', { name: 'frontend (Service)' }));
+
+  // The service's insights from the frames (insightNames field).
+  expect(await screen.findByText('ErrorRatioBreach')).toBeInTheDocument();
+  expect(screen.getByText('LatencyAverageBreach')).toBeInTheDocument();
+
+  // The popup carries the entity deep link (clicking a node no longer navigates directly).
+  // The section header has an "Open in Knowledge Graph" link too, so match on the drawer URL.
+  const links = screen.getAllByRole('link', { name: /Open in Knowledge Graph/ });
+  const popupLink = links.find((link) => link.getAttribute('href')?.includes('/entities?'));
+  expect(popupLink).toBeDefined();
+  expect(popupLink).toHaveAttribute('href', expect.stringContaining('ed%5Bname%5D=frontend'));
+  expect(popupLink).toHaveAttribute('href', expect.stringContaining('ed%5Bscope%5D%5Benv%5D=prod'));
+});
+
+it('highlights an edge on hover and names the connection', async () => {
+  setKgInstalled(true);
+  const { nodes, edges } = buildNeighbourhoodFrames();
+  const query = jest.fn().mockReturnValue(of({ data: [nodes, edges], state: LoadingState.Done }));
+  setKgDatasource(query);
+
+  const { user } = await renderAndExpand(LINKED_CHECK);
+  await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.graph);
+
+  const edgeGroups = screen.getAllByTestId(CONNECTED_SERVICES_TEST_ID.edge);
+  expect(edgeGroups).toHaveLength(3);
+
+  // Every edge names its endpoints for the hover tooltip.
+  const edgeTitles = edgeGroups.map((group) => group.querySelector('title')?.textContent);
+  expect(edgeTitles).toContain('frontend → cart');
+
+  await user.hover(edgeGroups[0]);
+
+  // The hovered edge's visible path is emphasized while the others fade back.
+  const visiblePathOf = (group: Element) => group.querySelectorAll('path')[1];
+  expect(visiblePathOf(edgeGroups[0])).toHaveAttribute('stroke-width', '2');
+  expect(visiblePathOf(edgeGroups[1])).toHaveAttribute('opacity', '0.3');
+
+  await user.unhover(edgeGroups[0]);
+  expect(visiblePathOf(edgeGroups[0])).toHaveAttribute('stroke-width', '1.5');
+  expect(visiblePathOf(edgeGroups[1])).toHaveAttribute('opacity', '1');
+});
+
+it('shows the not-discovered-yet message when the query returns no entities', async () => {
+  setKgInstalled(true);
+  const query = jest.fn().mockReturnValue(of({ data: [], state: LoadingState.Done }));
+  setKgDatasource(query);
+
+  await renderAndExpand(LINKED_CHECK);
+
+  expect(await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.empty)).toBeInTheDocument();
+});
+
+it('shows the error state with a retry action when the query fails', async () => {
+  setKgInstalled(true);
+  const query = jest.fn().mockReturnValue(throwError(() => new Error('knowledge graph unavailable')));
+  setKgDatasource(query);
+
+  await renderAndExpand(LINKED_CHECK);
+
+  expect(await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.error)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
 });

--- a/src/features/knowledgeGraph/ConnectedServices.test.tsx
+++ b/src/features/knowledgeGraph/ConnectedServices.test.tsx
@@ -62,9 +62,9 @@ const LINKED_CHECK = checkWithLabels([
   { name: 'namespace', value: 'otel-demo' },
 ]);
 
-async function renderAndExpand(check: Check) {
+async function renderSection(check: Check) {
   const result = render(<ConnectedServices check={check} />);
-  await result.user.click(await screen.findByRole('button', { name: 'Expand connected services' }));
+  await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.section);
   return result;
 }
 
@@ -75,15 +75,9 @@ it('renders nothing when the Knowledge Graph app is not installed', async () => 
   expect(screen.queryByTestId(CONNECTED_SERVICES_TEST_ID.section)).not.toBeInTheDocument();
 });
 
-it('is collapsed by default and reveals the zero state when expanded (unlinked check)', async () => {
+it('is expanded on load and shows the zero state for an unlinked check', async () => {
   setKgInstalled(true);
-  const { user } = render(<ConnectedServices check={checkWithLabels([{ name: 'Team', value: 'platform' }])} />);
-
-  // The section header is present but the body (and therefore the zero state) is hidden until expanded.
-  expect(await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.section)).toBeInTheDocument();
-  expect(screen.queryByTestId(CONNECTED_SERVICES_TEST_ID.zeroState)).not.toBeInTheDocument();
-
-  await user.click(screen.getByRole('button', { name: 'Expand connected services' }));
+  await renderSection(checkWithLabels([{ name: 'Team', value: 'platform' }]));
 
   expect(screen.getByTestId(CONNECTED_SERVICES_TEST_ID.zeroState)).toBeInTheDocument();
   expect(screen.getByText('Connect this check to a service')).toBeInTheDocument();
@@ -94,15 +88,15 @@ it('is collapsed by default and reveals the zero state when expanded (unlinked c
   );
 });
 
-it('can be collapsed again after expanding', async () => {
+it('can be collapsed and expanded again', async () => {
   setKgInstalled(true);
-  const { user } = render(<ConnectedServices check={checkWithLabels([{ name: 'Team', value: 'platform' }])} />);
-
-  await user.click(await screen.findByRole('button', { name: 'Expand connected services' }));
-  expect(screen.getByTestId(CONNECTED_SERVICES_TEST_ID.zeroState)).toBeInTheDocument();
+  const { user } = await renderSection(checkWithLabels([{ name: 'Team', value: 'platform' }]));
 
   await user.click(screen.getByRole('button', { name: 'Collapse connected services' }));
   expect(screen.queryByTestId(CONNECTED_SERVICES_TEST_ID.zeroState)).not.toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: 'Expand connected services' }));
+  expect(screen.getByTestId(CONNECTED_SERVICES_TEST_ID.zeroState)).toBeInTheDocument();
 });
 
 it('renders the neighbourhood graph from the Cypher query result (linked check)', async () => {
@@ -111,7 +105,7 @@ it('renders the neighbourhood graph from the Cypher query result (linked check)'
   const query = jest.fn().mockReturnValue(of({ data: [nodes, edges], state: LoadingState.Done }));
   setKgDatasource(query);
 
-  await renderAndExpand(LINKED_CHECK);
+  await renderSection(LINKED_CHECK);
 
   expect(await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.graph)).toBeInTheDocument();
   expect(screen.getAllByTestId(CONNECTED_SERVICES_TEST_ID.node)).toHaveLength(4);
@@ -133,7 +127,7 @@ it('shows the insights popup on node hover, with the deep link into the KG app',
   const query = jest.fn().mockReturnValue(of({ data: [nodes, edges], state: LoadingState.Done }));
   setKgDatasource(query);
 
-  const { user } = await renderAndExpand(LINKED_CHECK);
+  const { user } = await renderSection(LINKED_CHECK);
   await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.graph);
 
   await user.hover(screen.getByRole('button', { name: 'frontend (Service)' }));
@@ -157,7 +151,7 @@ it('highlights an edge on hover and names the connection', async () => {
   const query = jest.fn().mockReturnValue(of({ data: [nodes, edges], state: LoadingState.Done }));
   setKgDatasource(query);
 
-  const { user } = await renderAndExpand(LINKED_CHECK);
+  const { user } = await renderSection(LINKED_CHECK);
   await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.graph);
 
   const edgeGroups = screen.getAllByTestId(CONNECTED_SERVICES_TEST_ID.edge);
@@ -184,7 +178,7 @@ it('shows the not-discovered-yet message when the query returns no entities', as
   const query = jest.fn().mockReturnValue(of({ data: [], state: LoadingState.Done }));
   setKgDatasource(query);
 
-  await renderAndExpand(LINKED_CHECK);
+  await renderSection(LINKED_CHECK);
 
   expect(await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.empty)).toBeInTheDocument();
 });
@@ -194,7 +188,7 @@ it('shows the error state with a retry action when the query fails', async () =>
   const query = jest.fn().mockReturnValue(throwError(() => new Error('knowledge graph unavailable')));
   setKgDatasource(query);
 
-  await renderAndExpand(LINKED_CHECK);
+  await renderSection(LINKED_CHECK);
 
   expect(await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.error)).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();

--- a/src/features/knowledgeGraph/ConnectedServices.tsx
+++ b/src/features/knowledgeGraph/ConnectedServices.tsx
@@ -52,7 +52,9 @@ export function ConnectedServices({ check }: ConnectedServicesProps) {
 
 function ConnectedServicesSection({ check }: ConnectedServicesProps) {
   const styles = useStyles2(getStyles);
-  const [isOpen, setIsOpen] = useState(false);
+  // Expanded on load: the graph is the point of the section, and the KG query only runs for a
+  // check that is actually linked to a service.
+  const [isOpen, setIsOpen] = useState(true);
 
   const serviceName = findLabelValue(check.labels ?? [], KG_SERVICE_NAME_LABEL);
   const namespace = findLabelValue(check.labels ?? [], KG_NAMESPACE_LABEL);

--- a/src/features/knowledgeGraph/ConnectedServices.tsx
+++ b/src/features/knowledgeGraph/ConnectedServices.tsx
@@ -1,20 +1,12 @@
-import React, { useMemo, useState } from 'react';
-import { GrafanaTheme2, LoadingState } from '@grafana/data';
+import React, { useState } from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
 import { useAppPluginInstalled } from '@grafana/runtime';
-import { VizConfigBuilders } from '@grafana/scenes';
-import { useDataTransformer, useQueryRunner, VizPanel } from '@grafana/scenes-react';
-import {
-  LayoutAlgorithm,
-  ZoomMode,
-} from '@grafana/schema/dist/esm/raw/composable/nodegraph/panelcfg/x/NodeGraphPanelCfg_types.gen';
 import { Icon, IconButton, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { Check } from 'types';
-import { getCheckType } from 'utils';
 import { AppRoutes } from 'routing/types';
 import { generateRoutePath } from 'routing/utils';
-import { useKGDS } from 'hooks/useKGDS';
 import { CenteredSpinner } from 'components/CenteredSpinner/CenteredSpinner';
 import { FORM_SECTION_QUERY_PARAM } from 'components/Checkster/constants';
 import { FormSectionName } from 'components/Checkster/types';
@@ -25,31 +17,13 @@ import {
   CONNECTED_SERVICES_TEST_ID,
   CONNECTED_SERVICES_TITLE,
 } from './ConnectedServices.constants';
-import {
-  buildServiceNeighbourhoodQuery,
-  getCheckNodeIcon,
-  getServiceEntityUrl,
-  graphPresentationTransformation,
-} from './ConnectedServices.utils';
-import {
-  findLabelValue,
-  getSyntheticCheckEntityName,
-  KG_NAMESPACE_LABEL,
-  KG_PLUGIN_ID,
-  KG_SERVICE_NAME_LABEL,
-} from './knowledgeGraph';
+import { useServiceNeighbourhood } from './ConnectedServices.hooks';
+import { getServiceEntityUrl } from './ConnectedServices.utils';
+import { ConnectedServicesGraph } from './ConnectedServicesGraph';
+import { findLabelValue, KG_NAMESPACE_LABEL, KG_PLUGIN_ID, KG_SERVICE_NAME_LABEL } from './knowledgeGraph';
 
-const viz = VizConfigBuilders.nodegraph()
-  // The node graph has no "fit to screen" on load, so the layout is what keeps the neighbourhood
-  // visible without manual zooming. A layered layout packs the check + service + one-hop
-  // callers/dependencies more compactly than the default force layout, and cooperative zoom stops
-  // page scrolling from hijacking the graph.
-  .setOption('layoutAlgorithm', LayoutAlgorithm.Layered)
-  .setOption('zoomMode', ZoomMode.Cooperative)
-  .build();
-// Since the panel doesn't fit-to-screen on load, give it a generous fixed height so the graph is
-// visible without clipping; users pan/zoom for anything larger.
-const GRAPH_HEIGHT = 560;
+// Reserve room for the loading state so the section doesn't jump when the graph arrives.
+const MIN_BODY_HEIGHT = 280;
 
 interface ConnectedServicesProps {
   check: Check;
@@ -58,13 +32,13 @@ interface ConnectedServicesProps {
 /**
  * Renders the check's Knowledge Graph service neighbourhood as an inline dashboard section (the
  * check, the Service linked via MONITORED_BY, and that Service's one-hop CALLS neighbours in both directions).
- * The node graph carries health arcs and insight counts, so red-ringed neighbours surface as RCA
- * hints without leaving the dashboard.
+ * The nodes carry the KG's insight rings, so red-ringed neighbours surface as RCA hints without
+ * leaving the dashboard.
  *
  * Gating:
  * - KG app not installed → renders nothing (SM works without the Knowledge Graph).
  * - Installed but the check has no service link → an inviting zero state pointing at the edit form.
- * - Installed and linked → the node graph, with loading/error states from the query runner.
+ * - Installed and linked → the neighbourhood graph, with loading/error states from the query.
  */
 export function ConnectedServices({ check }: ConnectedServicesProps) {
   const { value: kgInstalled } = useAppPluginInstalled(KG_PLUGIN_ID);
@@ -109,11 +83,7 @@ function ConnectedServicesSection({ check }: ConnectedServicesProps) {
 
       {isOpen && (
         <div className={styles.body}>
-          {serviceName ? (
-            <ServiceNeighbourhoodGraph check={check} serviceName={serviceName} />
-          ) : (
-            <ConnectedServicesZeroState checkId={check.id} />
-          )}
+          {serviceName ? <ServiceNeighbourhoodGraph check={check} /> : <ConnectedServicesZeroState checkId={check.id} />}
         </div>
       )}
     </section>
@@ -122,59 +92,47 @@ function ConnectedServicesSection({ check }: ConnectedServicesProps) {
 
 interface ServiceNeighbourhoodGraphProps {
   check: Check;
-  serviceName: string;
 }
 
-function ServiceNeighbourhoodGraph({ check, serviceName }: ServiceNeighbourhoodGraphProps) {
+function ServiceNeighbourhoodGraph({ check }: ServiceNeighbourhoodGraphProps) {
   const styles = useStyles2(getStyles);
-  const kgDS = useKGDS();
+  const { data, isLoading, isError, refetch } = useServiceNeighbourhood(check);
 
-  const cypherQuery = buildServiceNeighbourhoodQuery(getSyntheticCheckEntityName(check));
-
-  const dataProvider = useQueryRunner({
-    datasource: kgDS ? { uid: kgDS.uid, type: kgDS.type } : undefined,
-    queries: [
-      {
-        refId: 'A',
-        queryType: 'entityGraph',
-        queryMode: 'cypher',
-        cypherQuery,
-      },
-    ],
-  });
-
-  // Give the originating check node its check-type icon and strip the zero-value stat labels.
-  const nodeIcon = getCheckNodeIcon(getCheckType(check.settings));
-  const transformations = useMemo(() => [graphPresentationTransformation(nodeIcon)], [nodeIcon]);
-  const graphData = useDataTransformer({ transformations, data: dataProvider });
-
-  const { data } = graphData.useState();
-  const state = data?.state;
-
-  if (state === LoadingState.Error) {
+  if (isError) {
     return (
       <div data-testid={CONNECTED_SERVICES_TEST_ID.error}>
         <ErrorAlert
           title="Couldn't load the service graph."
           content="The Knowledge Graph datasource didn't respond. Check its status and try again."
           buttonText="Retry"
-          onClick={() => dataProvider.runQueries()}
+          onClick={() => refetch()}
         />
       </div>
     );
   }
 
-  return (
-    <div className={styles.graph} data-testid={CONNECTED_SERVICES_TEST_ID.graph}>
-      {state === LoadingState.Loading ? (
-        <div className={styles.loading} data-testid={CONNECTED_SERVICES_TEST_ID.loading}>
-          <CenteredSpinner aria-label="Loading connected services" />
-        </div>
-      ) : (
-        <VizPanel title="" dataProvider={graphData} viz={viz} hoverHeader />
-      )}
-    </div>
-  );
+  if (isLoading) {
+    return (
+      <div className={styles.loading} data-testid={CONNECTED_SERVICES_TEST_ID.loading}>
+        <CenteredSpinner aria-label="Loading connected services" />
+      </div>
+    );
+  }
+
+  if (!data || data.nodes.length === 0) {
+    // The check is linked but the KG hasn't discovered the entities yet (rules sync every few
+    // minutes, and the linked service may not exist under that name/namespace).
+    return (
+      <div className={styles.empty} data-testid={CONNECTED_SERVICES_TEST_ID.empty}>
+        <Text variant="body" color="secondary">
+          No graph data for this check yet. The Knowledge Graph may still be discovering it — check back in a few
+          minutes.
+        </Text>
+      </div>
+    );
+  }
+
+  return <ConnectedServicesGraph neighbourhood={data} />;
 }
 
 interface ConnectedServicesZeroStateProps {
@@ -235,11 +193,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
   body: css({
     padding: theme.spacing(0, 2, 2, 2),
   }),
-  graph: css({
-    height: GRAPH_HEIGHT,
-  }),
   loading: css({
-    height: '100%',
+    height: MIN_BODY_HEIGHT,
+  }),
+  empty: css({
+    display: 'flex',
+    justifyContent: 'center',
+    padding: theme.spacing(4, 2),
   }),
   zeroState: css({
     display: 'flex',

--- a/src/features/knowledgeGraph/ConnectedServices.utils.test.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.utils.test.ts
@@ -1,13 +1,15 @@
-import { DataFrame, FieldType } from '@grafana/data';
-
-import { CheckType } from 'types';
+import { toDataFrame } from '@grafana/data';
+import { buildNeighbourhoodFrames } from 'test/fixtures/knowledgeGraph';
 
 import {
-  applyGraphPresentation,
   buildServiceNeighbourhoodQuery,
   escapeCypher,
-  getCheckNodeIcon,
+  getEntityDrawerUrl,
+  getRingSegments,
   getServiceEntityUrl,
+  layoutNeighbourhood,
+  NeighbourhoodNode,
+  parseGraphFrames,
 } from './ConnectedServices.utils';
 
 describe('escapeCypher', () => {
@@ -54,73 +56,214 @@ describe('getServiceEntityUrl', () => {
   });
 });
 
-describe('getCheckNodeIcon', () => {
-  it("reuses the app's check-type-group icons (API Endpoint, Multi Step, Scripted, Browser)", () => {
-    expect(getCheckNodeIcon(CheckType.Http)).toBe('heart-rate');
-    expect(getCheckNodeIcon(CheckType.Dns)).toBe('heart-rate');
-    expect(getCheckNodeIcon(CheckType.MultiHttp)).toBe('gf-interpolation-step-after');
-    expect(getCheckNodeIcon(CheckType.Scripted)).toBe('k6');
-    expect(getCheckNodeIcon(CheckType.Browser)).toBe('globe');
+describe('getRingSegments', () => {
+  it('renders a single muted baseline segment for a healthy node (no insights)', () => {
+    expect(getRingSegments({ errors: 0, warning: 0, amend: 0 })).toEqual([{ severity: 'healthy', fraction: 1 }]);
+  });
+
+  it('maps a single severity to a full ring of that severity', () => {
+    expect(getRingSegments({ errors: 1, warning: 0, amend: 0 })).toEqual([{ severity: 'critical', fraction: 1 }]);
+    expect(getRingSegments({ errors: 0, warning: 1, amend: 0 })).toEqual([{ severity: 'warning', fraction: 1 }]);
+    expect(getRingSegments({ errors: 0, warning: 0, amend: 1 })).toEqual([{ severity: 'info', fraction: 1 }]);
+  });
+
+  it('splits mixed severities proportionally (the datasource emits 50/50 arcs)', () => {
+    expect(getRingSegments({ errors: 0.5, warning: 0, amend: 0.5 })).toEqual([
+      { severity: 'critical', fraction: 0.5 },
+      { severity: 'info', fraction: 0.5 },
+    ]);
+  });
+
+  it('normalizes fractions that do not sum to 1', () => {
+    expect(getRingSegments({ errors: 1, warning: 1, amend: 0 })).toEqual([
+      { severity: 'critical', fraction: 0.5 },
+      { severity: 'warning', fraction: 0.5 },
+    ]);
   });
 });
 
-describe('applyGraphPresentation', () => {
-  function buildNodesFrame(rows: Array<{ subtitle: string; icon: string }>): DataFrame {
-    return {
+describe('parseGraphFrames', () => {
+  it('parses the nodes and edges frames into the typed neighbourhood model', () => {
+    const { nodes, edges, ids } = buildNeighbourhoodFrames();
+
+    const graph = parseGraphFrames([nodes, edges]);
+
+    expect(graph.nodes).toHaveLength(4);
+    expect(graph.edges).toHaveLength(3);
+
+    const check = graph.nodes.find((n) => n.id === ids.checkId);
+    expect(check).toMatchObject({
+      name: 'my check__https://grafana.com',
+      entityType: 'SyntheticCheck',
+      icon: 'heart-rate',
+      insightCount: 0,
+      insightNames: [],
+      ringSegments: [{ severity: 'healthy', fraction: 1 }],
+      scope: { env: 'unknown', site: '', namespace: '' },
+    });
+
+    const service = graph.nodes.find((n) => n.id === ids.serviceId);
+    expect(service).toMatchObject({
+      name: 'frontend',
+      entityType: 'Service',
+      insightCount: 2,
+      insightNames: ['ErrorRatioBreach', 'LatencyAverageBreach'],
+      ringSegments: [{ severity: 'critical', fraction: 1 }],
+      scope: { env: 'prod', site: '', namespace: 'otel-demo' },
+    });
+
+    expect(graph.edges[0]).toEqual({ id: 'edge-0', source: ids.serviceId, target: ids.checkId });
+  });
+
+  it('drops invalid icon names rather than passing them to the Icon component', () => {
+    const nodes = toDataFrame({
       name: 'nodes',
-      length: rows.length,
       fields: [
-        { name: 'subtitle', type: FieldType.string, config: {}, values: rows.map((r) => r.subtitle) },
-        { name: 'icon', type: FieldType.string, config: {}, values: rows.map((r) => r.icon) },
-        { name: 'noderadius', type: FieldType.number, config: {}, values: rows.map(() => 35) },
-        { name: 'mainstat', type: FieldType.number, config: {}, values: rows.map(() => 0) },
+        { name: 'id', values: ['a'] },
+        { name: 'title', values: ['a'] },
+        { name: 'subtitle', values: ['Service'] },
+        { name: 'icon', values: ['not-a-real-icon'] },
       ],
-    } as unknown as DataFrame;
+    });
+
+    const graph = parseGraphFrames([nodes]);
+
+    expect(graph.nodes[0].icon).toBeUndefined();
+  });
+
+  it('returns an empty graph when the frames are missing (empty datasource response)', () => {
+    expect(parseGraphFrames([])).toEqual({ nodes: [], edges: [] });
+  });
+
+  it('degrades missing health fields to a healthy ring instead of throwing', () => {
+    const nodes = toDataFrame({
+      name: 'nodes',
+      fields: [
+        { name: 'id', values: ['a'] },
+        { name: 'title', values: ['a'] },
+        { name: 'subtitle', values: ['Service'] },
+      ],
+    });
+
+    const graph = parseGraphFrames([nodes]);
+
+    expect(graph.nodes[0].ringSegments).toEqual([{ severity: 'healthy', fraction: 1 }]);
+    expect(graph.nodes[0].insightCount).toBe(0);
+  });
+});
+
+describe('layoutNeighbourhood', () => {
+  it('lays out check + upstream on top, the monitored service in the middle, and downstream below', () => {
+    const { nodes, edges, ids } = buildNeighbourhoodFrames();
+    const graph = parseGraphFrames([nodes, edges]);
+
+    const layout = layoutNeighbourhood(graph);
+
+    const positionOf = (id: string) => layout.nodes.find((n) => n.node.id === id)!;
+    const check = positionOf(ids.checkId);
+    const upstream = positionOf(ids.upstreamId);
+    const service = positionOf(ids.serviceId);
+    const downstream = positionOf(ids.downstreamId);
+
+    // Three rows, top to bottom.
+    expect(check.y).toBe(upstream.y);
+    expect(check.y).toBeLessThan(service.y);
+    expect(service.y).toBeLessThan(downstream.y);
+
+    // Every edge gets a path between its endpoints, and the canvas fits all nodes.
+    expect(layout.edges).toHaveLength(3);
+    expect(layout.width).toBeGreaterThan(0);
+    expect(layout.height).toBeGreaterThan(downstream.y);
+  });
+
+  it('curves edges between nodes in the same row so they arc over the row instead of cutting through it', () => {
+    const buildNode = (id: string, entityType = 'Service'): NeighbourhoodNode => ({
+      id,
+      name: id,
+      entityType,
+      icon: undefined,
+      insightCount: 0,
+      insightNames: [],
+      ringSegments: [{ severity: 'healthy', fraction: 1 }],
+      scope: { env: 'prod', site: '', namespace: '' },
+    });
+
+    const layout = layoutNeighbourhood({
+      nodes: [
+        buildNode('check', 'SyntheticCheck'),
+        buildNode('service'),
+        buildNode('downstream-a'),
+        buildNode('downstream-b'),
+      ],
+      edges: [
+        { id: 'e1', source: 'check', target: 'service' },
+        { id: 'e2', source: 'service', target: 'downstream-a' },
+        { id: 'e3', source: 'service', target: 'downstream-b' },
+        // Sibling CALLS edge within the bottom row.
+        { id: 'e4', source: 'downstream-a', target: 'downstream-b' },
+      ],
+    });
+
+    const pathOf = (id: string) => layout.edges.find((e) => e.id === id)!.path;
+
+    // Inter-row edges stay orthogonal elbows; the sibling edge becomes a cubic bezier arc.
+    expect(pathOf('e2')).not.toContain('C');
+    expect(pathOf('e4')).toContain('C');
+
+    // The arc bows above the row: its control points sit higher than the node centers.
+    const downstreamA = layout.nodes.find((n) => n.node.id === 'downstream-a')!;
+    const controlY = Number(pathOf('e4').split('C')[1].trim().split(' ')[1]);
+    expect(controlY).toBeLessThan(downstreamA.y);
+  });
+
+  it('handles a check-only response (service not discovered yet) without edges', () => {
+    const layout = layoutNeighbourhood({
+      nodes: [
+        {
+          id: 'SyntheticCheck:a',
+          name: 'a',
+          entityType: 'SyntheticCheck',
+          icon: undefined,
+          insightCount: 0,
+          insightNames: [],
+          ringSegments: [{ severity: 'healthy', fraction: 1 }],
+          scope: { env: 'unknown', site: '', namespace: '' },
+        },
+      ],
+      edges: [],
+    });
+
+    expect(layout.nodes).toHaveLength(1);
+    expect(layout.edges).toHaveLength(0);
+  });
+});
+
+describe('getEntityDrawerUrl', () => {
+  function buildNode(overrides: Partial<NeighbourhoodNode> = {}): NeighbourhoodNode {
+    return {
+      id: 'Service:frontend:prod::otel-demo',
+      name: 'frontend',
+      entityType: 'Service',
+      icon: undefined,
+      insightCount: 0,
+      insightNames: [],
+      ringSegments: [{ severity: 'healthy', fraction: 1 }],
+      scope: { env: 'prod', site: '', namespace: 'otel-demo' },
+      ...overrides,
+    };
   }
 
-  it('sets the icon for the SyntheticCheck node only, leaves radius alone, and drops mainstat', () => {
-    const [frame] = applyGraphPresentation(
-      [
-        buildNodesFrame([
-          { subtitle: 'SyntheticCheck', icon: 'question-circle' },
-          { subtitle: 'Service', icon: 'cog' },
-        ]),
-      ],
-      'globe'
+  it('builds the KG entity-drawer link with type, name and the non-empty scope values', () => {
+    const url = getEntityDrawerUrl(buildNode());
+
+    expect(url).toBe(
+      '/a/grafana-asserts-app/entities?ed%5Btype%5D=Service&ed%5Bname%5D=frontend&ed%5Bscope%5D%5Benv%5D=prod&ed%5Bscope%5D%5Bnamespace%5D=otel-demo'
     );
-
-    const iconField = frame.fields.find((f) => f.name === 'icon');
-    const radiusField = frame.fields.find((f) => f.name === 'noderadius');
-
-    expect(iconField?.values).toEqual(['globe', 'cog']);
-    // Node sizing is left untouched — emphasis is via the icon only.
-    expect(radiusField?.values).toEqual([35, 35]);
-    expect(frame.fields.find((f) => f.name === 'mainstat')).toBeUndefined();
   });
 
-  it('drops the mainstat label from the edges frame', () => {
-    const edges = {
-      name: 'edges',
-      length: 1,
-      fields: [
-        { name: 'id', type: FieldType.string, config: {}, values: ['e0'] },
-        { name: 'mainstat', type: FieldType.number, config: {}, values: [0] },
-      ],
-    } as unknown as DataFrame;
+  it('omits empty scope values', () => {
+    const url = getEntityDrawerUrl(buildNode({ scope: { env: '', site: '', namespace: '' } }));
 
-    const [result] = applyGraphPresentation([edges], 'globe');
-
-    expect(result.fields.map((f) => f.name)).toEqual(['id']);
-  });
-
-  it('leaves frames that are neither nodes nor edges untouched', () => {
-    const other = {
-      name: 'other',
-      length: 1,
-      fields: [{ name: 'id', type: FieldType.string, config: {}, values: ['x'] }],
-    } as unknown as DataFrame;
-    const [result] = applyGraphPresentation([other], 'globe');
-
-    expect(result).toBe(other);
+    expect(url).toBe('/a/grafana-asserts-app/entities?ed%5Btype%5D=Service&ed%5Bname%5D=frontend');
   });
 });

--- a/src/features/knowledgeGraph/ConnectedServices.utils.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.utils.ts
@@ -1,30 +1,10 @@
-import { DataFrame, IconName } from '@grafana/data';
-import { CustomTransformOperator } from '@grafana/scenes';
-import { map } from 'rxjs';
-
-import { CheckType } from 'types';
-import { getCheckTypeGroup } from 'utils';
-import { CHECK_TYPE_GROUP_OPTIONS } from 'hooks/useCheckTypeGroupOptions';
+import { DataFrame, Field, toIconName } from '@grafana/data';
+import { IconName } from '@grafana/ui';
 
 import { KG_PLUGIN_ID, KG_SERVICE_ENTITY_TYPE, KG_SYNTHETIC_CHECK_ENTITY_TYPE } from './knowledgeGraph';
 
 const NODES_FRAME = 'nodes';
 const EDGES_FRAME = 'edges';
-const SUBTITLE_FIELD = 'subtitle';
-const ICON_FIELD = 'icon';
-// The KG datasource sets mainstat to 0 on every node and edge, which the panel renders as a "0.00"
-// label. It carries no meaning here, so we drop it to declutter the graph.
-const MAIN_STAT_FIELD = 'mainstat';
-
-/**
- * Icon for the originating check node. Reuses the icon the app already shows for the check's type
- * group on the "choose a check type" cards (`CHECK_TYPE_GROUP_OPTIONS`), so the graph stays visually
- * consistent with check creation. Falls back to the API Endpoint icon for anything unmapped.
- */
-export function getCheckNodeIcon(checkType: CheckType): IconName {
-  const group = getCheckTypeGroup(checkType);
-  return CHECK_TYPE_GROUP_OPTIONS.find((option) => option.value === group)?.icon ?? 'heart-rate';
-}
 
 /**
  * Escape values interpolated into a Cypher string so a target/job containing quotes or
@@ -67,49 +47,318 @@ export function getServiceEntityUrl(serviceName: string, namespace?: string): st
 }
 
 /**
- * Tidies the node graph frames for display:
- * - the originating SyntheticCheck node gets a check-type-specific icon so it's easy to spot which
- *   entity the user came from;
- * - the meaningless zero-valued `mainstat` label is stripped from both nodes and edges.
- *
- * Any other frame passes through unchanged; values are copied rather than mutated to keep it pure.
+ * Ring severity, ordered by precedence. Maps the KG datasource's arc fields to the same
+ * categories the Knowledge Graph uses for its insight rings: critical (arc__errors),
+ * warning (arc__warning), info (arc__amend), healthy (no insights).
  */
-export function applyGraphPresentation(frames: DataFrame[], icon: IconName): DataFrame[] {
-  return frames.map((frame) => {
-    if (frame.name === EDGES_FRAME) {
-      return { ...frame, fields: frame.fields.filter((field) => field.name !== MAIN_STAT_FIELD) };
-    }
+export type RingSeverity = 'critical' | 'warning' | 'info' | 'healthy';
 
-    if (frame.name !== NODES_FRAME) {
-      return frame;
-    }
+export interface RingSegment {
+  severity: RingSeverity;
+  /** Portion of the ring this segment occupies (all of a node's segments sum to 1). */
+  fraction: number;
+}
 
-    const subtitleField = frame.fields.find((field) => field.name === SUBTITLE_FIELD);
-    if (!subtitleField) {
-      return frame;
-    }
+export interface NeighbourhoodNode {
+  id: string;
+  name: string;
+  entityType: string;
+  /** Grafana icon name emitted by the KG datasource; undefined when unknown/invalid. */
+  icon?: IconName;
+  insightCount: number;
+  insightNames: string[];
+  ringSegments: RingSegment[];
+  scope: {
+    env: string;
+    site: string;
+    namespace: string;
+  };
+}
 
-    const isCheckNode = (index: number) => subtitleField.values[index] === KG_SYNTHETIC_CHECK_ENTITY_TYPE;
+export interface NeighbourhoodEdge {
+  id: string;
+  source: string;
+  target: string;
+}
 
-    const fields = frame.fields
-      .filter((field) => field.name !== MAIN_STAT_FIELD)
-      .map((field) => {
-        if (field.name === ICON_FIELD) {
-          return { ...field, values: field.values.map((value, index) => (isCheckNode(index) ? icon : value)) };
-        }
-        return field;
-      });
-
-    return { ...frame, fields };
-  });
+export interface ServiceNeighbourhood {
+  nodes: NeighbourhoodNode[];
+  edges: NeighbourhoodEdge[];
 }
 
 /**
- * Scenes transform wrapper around {@link applyGraphPresentation} for use with `useDataTransformer`,
- * bound to the icon for the current check type.
+ * Converts the KG datasource's arc fractions into ring segments. The datasource maps insight
+ * severities to arcs (critical → arc__errors, warning → arc__warning, info → arc__amend) and
+ * splits mixed severities proportionally; a healthy entity gets arc__success=1 which — matching
+ * the KG's own graph — we render as a single muted baseline ring rather than green.
  */
-export const graphPresentationTransformation =
-  (icon: IconName): CustomTransformOperator =>
-  () =>
-  (source) =>
-    source.pipe(map((frames) => applyGraphPresentation(frames, icon)));
+export function getRingSegments(arcs: { errors: number; warning: number; amend: number }): RingSegment[] {
+  const segments: RingSegment[] = [
+    { severity: 'critical' as const, fraction: arcs.errors },
+    { severity: 'warning' as const, fraction: arcs.warning },
+    { severity: 'info' as const, fraction: arcs.amend },
+  ].filter((segment) => segment.fraction > 0);
+
+  if (segments.length === 0) {
+    return [{ severity: 'healthy', fraction: 1 }];
+  }
+
+  const total = segments.reduce((sum, segment) => sum + segment.fraction, 0);
+  return segments.map((segment) => ({ ...segment, fraction: segment.fraction / total }));
+}
+
+function findField(frame: DataFrame | undefined, name: string): Field | undefined {
+  return frame?.fields.find((field) => field.name === name);
+}
+
+function stringAt(field: Field | undefined, index: number): string {
+  const value = field?.values[index];
+  return value == null ? '' : String(value);
+}
+
+function numberAt(field: Field | undefined, index: number): number {
+  const value = Number(field?.values[index]);
+  return Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Parses the node-graph frames the KG datasource returns for a Cypher entityGraph query into a
+ * typed model (frame contract from `frames_cypher.go` in the KG plugin: a "nodes" frame with
+ * id, title, subtitle, arc fractions, icon, secondarystat, insightNames and scope fields, and an
+ * "edges" frame with id, source, target). Tolerant to missing fields — anything absent degrades
+ * to a healthy ring / empty value rather than throwing.
+ */
+export function parseGraphFrames(frames: DataFrame[]): ServiceNeighbourhood {
+  const nodesFrame = frames.find((frame) => frame.name === NODES_FRAME);
+  const edgesFrame = frames.find((frame) => frame.name === EDGES_FRAME);
+
+  const idField = findField(nodesFrame, 'id');
+  const titleField = findField(nodesFrame, 'title');
+  const subtitleField = findField(nodesFrame, 'subtitle');
+  const iconField = findField(nodesFrame, 'icon');
+  const insightCountField = findField(nodesFrame, 'secondarystat');
+  const insightNamesField = findField(nodesFrame, 'insightNames');
+  const errorsField = findField(nodesFrame, 'arc__errors');
+  const warningField = findField(nodesFrame, 'arc__warning');
+  const amendField = findField(nodesFrame, 'arc__amend');
+  const envField = findField(nodesFrame, 'env');
+  const siteField = findField(nodesFrame, 'site');
+  const namespaceField = findField(nodesFrame, 'namespace');
+
+  const nodes: NeighbourhoodNode[] = [];
+  for (let i = 0; i < (nodesFrame?.length ?? 0); i++) {
+    nodes.push({
+      id: stringAt(idField, i),
+      name: stringAt(titleField, i),
+      entityType: stringAt(subtitleField, i),
+      icon: toIconName(stringAt(iconField, i)),
+      insightCount: numberAt(insightCountField, i),
+      insightNames: stringAt(insightNamesField, i).split(',').filter(Boolean),
+      ringSegments: getRingSegments({
+        errors: numberAt(errorsField, i),
+        warning: numberAt(warningField, i),
+        amend: numberAt(amendField, i),
+      }),
+      scope: {
+        env: stringAt(envField, i),
+        site: stringAt(siteField, i),
+        namespace: stringAt(namespaceField, i),
+      },
+    });
+  }
+
+  const edgeIdField = findField(edgesFrame, 'id');
+  const sourceField = findField(edgesFrame, 'source');
+  const targetField = findField(edgesFrame, 'target');
+
+  const edges: NeighbourhoodEdge[] = [];
+  for (let i = 0; i < (edgesFrame?.length ?? 0); i++) {
+    edges.push({
+      id: stringAt(edgeIdField, i),
+      source: stringAt(sourceField, i),
+      target: stringAt(targetField, i),
+    });
+  }
+
+  return { nodes, edges };
+}
+
+/**
+ * Deep link into the Knowledge Graph app's entity drawer — the same URL shape the KG datasource
+ * attaches to its node data links, so clicking any node opens exactly that entity (scoped by
+ * env/site/namespace, which disambiguates same-name entities across environments).
+ */
+export function getEntityDrawerUrl(node: NeighbourhoodNode): string {
+  const params = new URLSearchParams();
+  params.set('ed[type]', node.entityType);
+  params.set('ed[name]', node.name);
+
+  if (node.scope.env) {
+    params.set('ed[scope][env]', node.scope.env);
+  }
+  if (node.scope.site) {
+    params.set('ed[scope][site]', node.scope.site);
+  }
+  if (node.scope.namespace) {
+    params.set('ed[scope][namespace]', node.scope.namespace);
+  }
+
+  return `/a/${KG_PLUGIN_ID}/entities?${params.toString()}`;
+}
+
+// Layout geometry, sized to match the KG's node anatomy (44px nodes, labels beneath).
+export const NODE_RADIUS = 22;
+const HORIZONTAL_GAP = 132;
+const VERTICAL_GAP = 116;
+const PADDING_X = 72;
+const PADDING_TOP = 32;
+/** Extra room under the last row for its labels. */
+const PADDING_BOTTOM = 56;
+/** Gap between a node's ring and where its edges start/end (the arrowhead sits in this gap). */
+const EDGE_NODE_GAP = 6;
+
+export interface PositionedNode {
+  node: NeighbourhoodNode;
+  x: number;
+  y: number;
+}
+
+export interface PositionedEdge {
+  id: string;
+  /** SVG path: an orthogonal elbow from the source node's rim to the target node's rim. */
+  path: string;
+  /** Endpoint names, for the edge's hover tooltip and accessible label. */
+  sourceName: string;
+  targetName: string;
+}
+
+export interface NeighbourhoodLayout {
+  width: number;
+  height: number;
+  nodes: PositionedNode[];
+  edges: PositionedEdge[];
+}
+
+/**
+ * Deterministic layered layout for the check's neighbourhood, mirroring the KG's
+ * "explore connected entities" arrangement: rows top-to-bottom are
+ * [check + upstream callers] → [monitored service] → [downstream dependencies].
+ * The graph is bounded by the Cypher query (one hop of CALLS around one service), so a fixed
+ * 3-row layout always fits — no force simulation or layout dependency needed. Nodes that don't
+ * match any known role (future query changes) fall back to the bottom row.
+ */
+export function layoutNeighbourhood(graph: ServiceNeighbourhood): NeighbourhoodLayout {
+  const { nodes, edges } = graph;
+
+  const checkIds = new Set(nodes.filter((n) => n.entityType === KG_SYNTHETIC_CHECK_ENTITY_TYPE).map((n) => n.id));
+
+  // The monitored service is the node connected to the check by an edge (in either direction).
+  const serviceIds = new Set<string>();
+  for (const edge of edges) {
+    if (checkIds.has(edge.source) && !checkIds.has(edge.target)) {
+      serviceIds.add(edge.target);
+    }
+    if (checkIds.has(edge.target) && !checkIds.has(edge.source)) {
+      serviceIds.add(edge.source);
+    }
+  }
+
+  const upstreamIds = new Set<string>();
+  const downstreamIds = new Set<string>();
+  for (const edge of edges) {
+    if (serviceIds.has(edge.target) && !checkIds.has(edge.source) && !serviceIds.has(edge.source)) {
+      upstreamIds.add(edge.source);
+    }
+    if (serviceIds.has(edge.source) && !checkIds.has(edge.target) && !serviceIds.has(edge.target)) {
+      downstreamIds.add(edge.target);
+    }
+  }
+
+  const topRow = nodes.filter((n) => checkIds.has(n.id) || upstreamIds.has(n.id));
+  const middleRow = nodes.filter((n) => serviceIds.has(n.id));
+  const bottomRow = nodes.filter(
+    (n) => !checkIds.has(n.id) && !upstreamIds.has(n.id) && !serviceIds.has(n.id)
+  );
+
+  const rows = [topRow, middleRow, bottomRow].filter((row) => row.length > 0);
+
+  const maxRowLength = Math.max(1, ...rows.map((row) => row.length));
+  const width = PADDING_X * 2 + (maxRowLength - 1) * HORIZONTAL_GAP;
+  const height = PADDING_TOP + NODE_RADIUS + (rows.length - 1) * VERTICAL_GAP + NODE_RADIUS + PADDING_BOTTOM;
+  const centerX = width / 2;
+
+  const positioned = new Map<string, PositionedNode>();
+  rows.forEach((row, rowIndex) => {
+    const y = PADDING_TOP + NODE_RADIUS + rowIndex * VERTICAL_GAP;
+    row.forEach((node, colIndex) => {
+      const x = centerX + (colIndex - (row.length - 1) / 2) * HORIZONTAL_GAP;
+      positioned.set(node.id, { node, x, y });
+    });
+  });
+
+  const positionedEdges: PositionedEdge[] = [];
+  for (const edge of edges) {
+    const source = positioned.get(edge.source);
+    const target = positioned.get(edge.target);
+    if (!source || !target || edge.source === edge.target) {
+      continue;
+    }
+    positionedEdges.push({
+      id: edge.id,
+      path: buildElbowPath(source, target),
+      sourceName: source.node.name,
+      targetName: target.node.name,
+    });
+  }
+
+  return { width, height, nodes: [...positioned.values()], edges: positionedEdges };
+}
+
+/**
+ * Orthogonal elbow path between two nodes (vertical → horizontal → vertical, like the KG's
+ * entity graph edges), starting and ending just outside each node's ring so the arrowhead
+ * doesn't overlap it. Same-row edges arc over the row instead — a straight line would cut
+ * through any nodes sitting between the endpoints.
+ */
+function buildElbowPath(source: PositionedNode, target: PositionedNode): string {
+  const offset = NODE_RADIUS + EDGE_NODE_GAP;
+
+  if (source.y === target.y) {
+    return buildSameRowArcPath(source, target, offset);
+  }
+
+  const direction = target.y > source.y ? 1 : -1;
+  const startY = source.y + direction * offset;
+  const endY = target.y - direction * offset;
+
+  if (source.x === target.x) {
+    return `M ${source.x} ${startY} L ${target.x} ${endY}`;
+  }
+
+  const midY = (source.y + target.y) / 2;
+  return `M ${source.x} ${startY} L ${source.x} ${midY} L ${target.x} ${midY} L ${target.x} ${endY}`;
+}
+
+/**
+ * Curved arc for an edge between two nodes in the same row (sibling CALLS edges, e.g.
+ * checkout → cart). It leaves the source's upper shoulder, bows over the row (deeper for wider
+ * spans so stacked arcs separate), and lands on the target's upper shoulder — clear of the
+ * straight-through path, the labels beneath the row, and the top-center points where the
+ * inter-row elbow arrows land.
+ */
+function buildSameRowArcPath(source: PositionedNode, target: PositionedNode, offset: number): string {
+  const direction = target.x > source.x ? 1 : -1;
+  const shoulder = offset * Math.SQRT1_2;
+  const startX = source.x + direction * shoulder;
+  const endX = target.x - direction * shoulder;
+  const shoulderY = source.y - shoulder;
+
+  const span = Math.abs(target.x - source.x);
+  // Clamp so wide arcs neither reach the row above nor exit the canvas on the top row.
+  const depth = Math.min(48, 28 + span * 0.05, source.y - 8);
+  const controlY = source.y - depth;
+  const control1X = source.x + direction * span * 0.25;
+  const control2X = target.x - direction * span * 0.25;
+
+  return `M ${startX} ${shoulderY} C ${control1X} ${controlY} ${control2X} ${controlY} ${endX} ${shoulderY}`;
+}

--- a/src/features/knowledgeGraph/ConnectedServicesGraph.tsx
+++ b/src/features/knowledgeGraph/ConnectedServicesGraph.tsx
@@ -1,0 +1,379 @@
+import React, { useMemo, useState } from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, Stack, Text, TextLink, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { CONNECTED_SERVICES_TEST_ID, KG_SEVERITY_COLORS } from './ConnectedServices.constants';
+import {
+  getEntityDrawerUrl,
+  layoutNeighbourhood,
+  NeighbourhoodNode,
+  NODE_RADIUS,
+  PositionedEdge,
+  PositionedNode,
+  RingSegment,
+  ServiceNeighbourhood,
+} from './ConnectedServices.utils';
+import { KG_SERVICE_ENTITY_TYPE, KG_SYNTHETIC_CHECK_ENTITY_TYPE } from './knowledgeGraph';
+import { logo as smLogo } from 'img';
+
+// Node anatomy mirrors the KG entity graph (44px node: insight ring on the rim, disc inset,
+// icon centered, label beneath).
+const RING_RADIUS = NODE_RADIUS - 2;
+const RING_WIDTH = 2;
+const DISC_RADIUS = NODE_RADIUS - 7;
+const ICON_SIZE = 18;
+const BADGE_RADIUS = 9;
+const LABEL_OFFSET = NODE_RADIUS + 16;
+const LABEL_MAX_CHARS = 18;
+const ARROW_ID = 'connected-services-arrow';
+const ARROW_HOVER_ID = 'connected-services-arrow-hover';
+/** Invisible stroke width around each edge so thin lines are easy to hover. */
+const EDGE_HIT_WIDTH = 12;
+
+interface ConnectedServicesGraphProps {
+  neighbourhood: ServiceNeighbourhood;
+}
+
+/**
+ * Renders the check's Knowledge Graph neighbourhood in the style of the KG's own entity graph:
+ * circular nodes with severity rings (muted when healthy), an icon disc, name labels beneath,
+ * and orthogonal elbow edges between the layered rows. Every node deep-links to its entity in
+ * the Knowledge Graph app. Plain SVG — the graph is bounded (one service, one hop), so it needs
+ * no pan/zoom or layout engine.
+ */
+export function ConnectedServicesGraph({ neighbourhood }: ConnectedServicesGraphProps) {
+  const styles = useStyles2(getStyles);
+  const theme = useTheme2();
+  const layout = useMemo(() => layoutNeighbourhood(neighbourhood), [neighbourhood]);
+  const [hoveredEdgeId, setHoveredEdgeId] = useState<string | null>(null);
+
+  // SVG paints in document order, so draw the hovered edge after its siblings to lift it
+  // out of the tangle (nodes still render on top of all edges).
+  const orderedEdges = useMemo(() => {
+    if (!hoveredEdgeId) {
+      return layout.edges;
+    }
+    return [...layout.edges].sort((a, b) => Number(a.id === hoveredEdgeId) - Number(b.id === hoveredEdgeId));
+  }, [layout.edges, hoveredEdgeId]);
+
+  return (
+    <div className={styles.wrapper} data-testid={CONNECTED_SERVICES_TEST_ID.graph}>
+      <svg
+        width={layout.width}
+        height={layout.height}
+        viewBox={`0 0 ${layout.width} ${layout.height}`}
+        role="img"
+        aria-label="Connected services graph"
+      >
+        <defs>
+          <ArrowMarker id={ARROW_ID} fill={theme.colors.border.strong} />
+          <ArrowMarker id={ARROW_HOVER_ID} fill={theme.colors.text.primary} />
+        </defs>
+
+        {orderedEdges.map((edge) => (
+          <EdgePath
+            key={edge.id}
+            edge={edge}
+            theme={theme}
+            isHovered={edge.id === hoveredEdgeId}
+            isDimmed={hoveredEdgeId !== null && edge.id !== hoveredEdgeId}
+            onHoverChange={(hovered) => setHoveredEdgeId(hovered ? edge.id : null)}
+          />
+        ))}
+
+        {layout.nodes.map((positioned) => (
+          <NodeGlyph key={positioned.node.id} positioned={positioned} theme={theme} />
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+function ArrowMarker({ id, fill }: { id: string; fill: string }) {
+  return (
+    <marker id={id} viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill={fill} />
+    </marker>
+  );
+}
+
+interface EdgePathProps {
+  edge: PositionedEdge;
+  theme: GrafanaTheme2;
+  isHovered: boolean;
+  isDimmed: boolean;
+  onHoverChange: (hovered: boolean) => void;
+}
+
+/**
+ * One edge: a wide invisible stroke as the hover hit area plus the visible path. Hovering
+ * brightens the edge and its arrowhead while the rest of the edges fade back, and the native
+ * SVG title names the connection ("checkout → cart") — the sibling arcs overlap in busy rows,
+ * so color alone can't tell them apart.
+ */
+function EdgePath({ edge, theme, isHovered, isDimmed, onHoverChange }: EdgePathProps) {
+  return (
+    <g
+      data-testid={CONNECTED_SERVICES_TEST_ID.edge}
+      onMouseEnter={() => onHoverChange(true)}
+      onMouseLeave={() => onHoverChange(false)}
+    >
+      <title>{`${edge.sourceName} → ${edge.targetName}`}</title>
+      <path d={edge.path} fill="none" stroke="transparent" strokeWidth={EDGE_HIT_WIDTH} pointerEvents="stroke" />
+      <path
+        d={edge.path}
+        fill="none"
+        stroke={isHovered ? theme.colors.text.primary : theme.colors.border.strong}
+        strokeWidth={isHovered ? 2 : 1.5}
+        opacity={isDimmed ? 0.3 : 1}
+        markerEnd={`url(#${isHovered ? ARROW_HOVER_ID : ARROW_ID})`}
+        style={{ transition: 'opacity 100ms ease, stroke 100ms ease' }}
+      />
+    </g>
+  );
+}
+
+interface NodeGlyphProps {
+  positioned: PositionedNode;
+  theme: GrafanaTheme2;
+}
+
+function NodeGlyph({ positioned, theme }: NodeGlyphProps) {
+  const { node, x, y } = positioned;
+  const label = truncate(node.name);
+
+  // Interactive tooltip instead of direct navigation: hovering (or focusing — Tooltip makes the
+  // node keyboard-focusable, and clicking focuses it) opens a card with the entity's insights and
+  // the link into the Knowledge Graph. `interactive` keeps it open while moving the cursor into it.
+  return (
+    <Tooltip interactive placement="right" content={<NodeInsightsCard node={node} />}>
+      <g
+        data-testid={CONNECTED_SERVICES_TEST_ID.node}
+        role="button"
+        aria-label={`${node.name} (${node.entityType})`}
+        style={{ cursor: 'pointer', outline: 'none' }}
+      >
+        <circle cx={x} cy={y} r={getDiscRadius(node)} fill={getDiscFill(node, theme)} />
+        <Ring x={x} y={y} segments={node.ringSegments} theme={theme} />
+        <NodeIcon node={node} x={x} y={y} />
+        {node.insightCount > 0 && <InsightBadge x={x} y={y} node={node} />}
+        <text
+          x={x}
+          y={y + LABEL_OFFSET}
+          textAnchor="middle"
+          fontSize={11}
+          fill={theme.colors.text.primary}
+          style={{ textShadow: `0 0 4px ${theme.colors.background.canvas}` }}
+        >
+          {label}
+        </text>
+      </g>
+    </Tooltip>
+  );
+}
+
+interface NodeInsightsCardProps {
+  node: NeighbourhoodNode;
+}
+
+/**
+ * Popup card shown on node hover/focus: entity identity, its active insights (the Cypher
+ * response carries insight names and the node's overall severity, not per-insight severities),
+ * and the deep link into the Knowledge Graph that node clicks used to navigate to directly.
+ */
+function NodeInsightsCard({ node }: NodeInsightsCardProps) {
+  const styles = useStyles2(getStyles);
+  const scopeParts = [node.scope.env && node.scope.env !== 'unknown' ? node.scope.env : '', node.scope.namespace]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <Stack direction="column" gap={0.5}>
+      <Text weight="medium">{node.name}</Text>
+      <Text variant="bodySmall" color="secondary">
+        {scopeParts ? `${node.entityType} · ${scopeParts}` : node.entityType}
+      </Text>
+      {node.insightNames.length > 0 ? (
+        <ul className={styles.insightList}>
+          {node.insightNames.map((insightName) => (
+            <li key={insightName}>
+              <span className={styles.insightDot} style={{ background: severityBadgeFill(node.ringSegments[0]) }} />
+              {insightName}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <Text variant="bodySmall" color="secondary">
+          No active insights
+        </Text>
+      )}
+      <TextLink href={getEntityDrawerUrl(node)} variant="bodySmall" icon="external-link-alt" inline>
+        Open in Knowledge Graph
+      </TextLink>
+    </Stack>
+  );
+}
+
+interface RingProps {
+  x: number;
+  y: number;
+  segments: RingSegment[];
+  theme: GrafanaTheme2;
+}
+
+/**
+ * The insight ring around the disc. A healthy node gets a single muted baseline ring (matching
+ * the KG's design); insight severities render as proportional arc segments starting at 12
+ * o'clock, using the same colors as the KG's rings.
+ */
+function Ring({ x, y, segments, theme }: RingProps) {
+  const circumference = 2 * Math.PI * RING_RADIUS;
+  let cumulative = 0;
+
+  return (
+    <>
+      {segments.map((segment, index) => {
+        const dashLength = segment.fraction * circumference;
+        const dashOffset = -cumulative * circumference;
+        cumulative += segment.fraction;
+
+        return (
+          <circle
+            key={index}
+            cx={x}
+            cy={y}
+            r={RING_RADIUS}
+            fill="none"
+            stroke={getSeverityColor(segment, theme)}
+            strokeWidth={RING_WIDTH}
+            strokeDasharray={segment.fraction >= 1 ? undefined : `${dashLength} ${circumference}`}
+            strokeDashoffset={segment.fraction >= 1 ? undefined : dashOffset}
+            transform={`rotate(-90 ${x} ${y})`}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+interface NodeIconProps {
+  node: NeighbourhoodNode;
+  x: number;
+  y: number;
+}
+
+function NodeIcon({ node, x, y }: NodeIconProps) {
+  // The check node carries the Synthetic Monitoring logo — the KG only offers a generic
+  // heart-rate icon for SyntheticCheck entities, and the logo makes the origin unmistakable.
+  if (node.entityType === KG_SYNTHETIC_CHECK_ENTITY_TYPE) {
+    return (
+      <image
+        href={smLogo}
+        x={x - ICON_SIZE / 2}
+        y={y - ICON_SIZE / 2}
+        width={ICON_SIZE}
+        height={ICON_SIZE}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  if (!node.icon) {
+    return null;
+  }
+
+  // The flex wrapper centers the icon inside the foreignObject box regardless of the icon's
+  // intrinsic size (Grafana's "md" icon is 16px inside this 18px box).
+  return (
+    <foreignObject x={x - ICON_SIZE / 2} y={y - ICON_SIZE / 2} width={ICON_SIZE} height={ICON_SIZE} aria-hidden="true">
+      <div
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}
+      >
+        <Icon name={node.icon} size="md" style={{ color: '#fff', display: 'block' }} />
+      </div>
+    </foreignObject>
+  );
+}
+
+interface InsightBadgeProps {
+  x: number;
+  y: number;
+  node: NeighbourhoodNode;
+}
+
+/** Insight count in a severity-colored badge at the node's top-right, like the KG's node badges. */
+function InsightBadge({ x, y, node }: InsightBadgeProps) {
+  const severity = node.ringSegments[0];
+  const badgeX = x + NODE_RADIUS - 4;
+  const badgeY = y - NODE_RADIUS + 4;
+
+  return (
+    <g>
+      <circle cx={badgeX} cy={badgeY} r={BADGE_RADIUS} fill={severityBadgeFill(severity)} />
+      <text x={badgeX} y={badgeY + 3} textAnchor="middle" fontSize={10} fontWeight={600} fill="#fff">
+        {node.insightCount}
+      </text>
+    </g>
+  );
+}
+
+function severityBadgeFill(segment: RingSegment | undefined): string {
+  if (segment && segment.severity !== 'healthy') {
+    return KG_SEVERITY_COLORS[segment.severity];
+  }
+  return KG_SEVERITY_COLORS.info;
+}
+
+function getSeverityColor(segment: RingSegment, theme: GrafanaTheme2): string {
+  if (segment.severity === 'healthy') {
+    return theme.colors.border.medium;
+  }
+  return KG_SEVERITY_COLORS[segment.severity];
+}
+
+function getDiscRadius(node: NeighbourhoodNode): number {
+  // The check node's disc reaches the ring so the logo sits on a clean surface.
+  return node.entityType === KG_SYNTHETIC_CHECK_ENTITY_TYPE ? RING_RADIUS - RING_WIDTH / 2 : DISC_RADIUS;
+}
+
+function getDiscFill(node: NeighbourhoodNode, theme: GrafanaTheme2): string {
+  if (node.entityType === KG_SYNTHETIC_CHECK_ENTITY_TYPE) {
+    return theme.colors.background.secondary;
+  }
+  if (node.entityType === KG_SERVICE_ENTITY_TYPE) {
+    return theme.visualization.getColorByName('semi-dark-green');
+  }
+  return theme.visualization.getColorByName('semi-dark-blue');
+}
+
+function truncate(name: string): string {
+  return name.length > LABEL_MAX_CHARS ? `${name.slice(0, LABEL_MAX_CHARS - 1)}…` : name;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    display: 'flex',
+    justifyContent: 'center',
+    overflowX: 'auto',
+    background: theme.colors.background.canvas,
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(2),
+  }),
+  insightList: css({
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    fontSize: theme.typography.bodySmall.fontSize,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+  }),
+  insightDot: css({
+    display: 'inline-block',
+    width: 8,
+    height: 8,
+    borderRadius: theme.shape.radius.circle,
+    marginRight: theme.spacing(0.75),
+  }),
+});

--- a/src/features/knowledgeGraph/ConnectedServicesGraph.tsx
+++ b/src/features/knowledgeGraph/ConnectedServicesGraph.tsx
@@ -164,7 +164,9 @@ function NodeGlyph({ positioned, theme }: NodeGlyphProps) {
           textAnchor="middle"
           fontSize={11}
           fill={theme.colors.text.primary}
-          style={{ textShadow: `0 0 4px ${theme.colors.background.canvas}` }}
+          // Halo in the section's own background colour, so labels stay readable where they
+          // cross an edge.
+          style={{ textShadow: `0 0 4px ${theme.colors.background.primary}` }}
         >
           {label}
         </text>
@@ -356,9 +358,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     justifyContent: 'center',
     overflowX: 'auto',
-    background: theme.colors.background.canvas,
-    borderRadius: theme.shape.radius.default,
-    padding: theme.spacing(2),
+    // No surface of its own: the graph sits directly on the section's background so the
+    // section reads as one panel. Horizontal padding comes from the section body.
+    padding: theme.spacing(1, 0),
   }),
   insightList: css({
     listStyle: 'none',

--- a/src/test/fixtures/knowledgeGraph.ts
+++ b/src/test/fixtures/knowledgeGraph.ts
@@ -1,0 +1,47 @@
+import { toDataFrame } from '@grafana/data';
+
+/**
+ * Node-graph frames matching the KG datasource's Cypher entityGraph contract (frames_cypher.go
+ * in the KG plugin): a SyntheticCheck entity, its monitored service (carrying a critical
+ * insight), one downstream dependency and one upstream caller.
+ */
+export function buildNeighbourhoodFrames() {
+  const checkId = 'SyntheticCheck:my check__https://grafana.com:unknown::';
+  const serviceId = 'Service:frontend:prod::otel-demo';
+  const downstreamId = 'Service:cart:prod::otel-demo';
+  const upstreamId = 'Service:gateway:prod::otel-demo';
+
+  const nodes = toDataFrame({
+    name: 'nodes',
+    fields: [
+      { name: 'id', values: [checkId, serviceId, downstreamId, upstreamId] },
+      { name: 'title', values: ['my check__https://grafana.com', 'frontend', 'cart', 'gateway'] },
+      { name: 'subtitle', values: ['SyntheticCheck', 'Service', 'Service', 'Service'] },
+      { name: 'mainstat', values: [0, 0, 0, 0] },
+      { name: 'secondarystat', values: [0, 2, 0, 0] },
+      { name: 'arc__success', values: [1, 0, 1, 1] },
+      { name: 'arc__errors', values: [0, 1, 0, 0] },
+      { name: 'arc__amend', values: [0, 0, 0, 0] },
+      { name: 'arc__warning', values: [0, 0, 0, 0] },
+      { name: 'icon', values: ['heart-rate', 'apps', 'apps', 'apps'] },
+      { name: 'noderadius', values: [35, 35, 35, 35] },
+      { name: 'env', values: ['unknown', 'prod', 'prod', 'prod'] },
+      { name: 'site', values: ['', '', '', ''] },
+      { name: 'namespace', values: ['', 'otel-demo', 'otel-demo', 'otel-demo'] },
+      { name: 'insightNames', values: ['', 'ErrorRatioBreach,LatencyAverageBreach', '', ''] },
+    ],
+  });
+
+  const edges = toDataFrame({
+    name: 'edges',
+    fields: [
+      { name: 'id', values: ['edge-0', 'edge-1', 'edge-2'] },
+      // MONITORED_BY: Service → SyntheticCheck; CALLS: frontend → cart, gateway → frontend.
+      { name: 'source', values: [serviceId, serviceId, upstreamId] },
+      { name: 'target', values: [checkId, downstreamId, serviceId] },
+      { name: 'mainstat', values: [0, 0, 0] },
+    ],
+  });
+
+  return { nodes, edges, ids: { checkId, serviceId, downstreamId, upstreamId } };
+}


### PR DESCRIPTION
## Problem

When a synthetic check fails, users can't tell from the check dashboard where the monitored service sits in their system — which services call it and which services it depends on. That context lives in the Knowledge Graph's entity graph, so triaging "is it my service or something downstream?" means leaving Synthetic Monitoring and manually exploring the graph in another app.

## Solution

The check dashboard gets a new collapsible **Connected services** section that renders the check's one-hop neighbourhood from the Knowledge Graph: the check itself, the service it monitors, and that service's upstream callers and downstream dependencies, fetched via the KG datasource's Cypher query API.

Rather than the generic node graph panel, the graph is a SVG renderer  that mirrors the Knowledge Graph's own entity-graph design:

- Layered top-to-bottom layout: check + upstream callers → monitored service → downstream dependencies.
- KG node anatomy: insight severity rings (using the KG's colors), insight count badges, entity icons, and the Synthetic Monitoring logo on check nodes.
- Orthogonal elbow edges between rows; calls between services in the same row render as arcs over the row so they don't cut through neighbouring nodes.
- Hovering a node opens a popup with the entity's active insights and an "Open in Knowledge Graph" deep link (nodes no longer navigate away on click).
- Hovering an edge highlights it, fades the others, and names the connection (e.g. `checkout → cart`) — useful when sibling arcs overlap in busy rows.

The section handles all datasource states: loading, query errors with a retry action, an empty result while the KG is still discovering the check, and a zero state when the Knowledge Graph plugin isn't installed.

## Testing

Integration tests cover the graph rendering from Cypher result frames, the node insights popup and its deep link, edge hover highlighting, and the empty/error/zero states. Unit tests cover frame parsing, ring segment math, the layered layout (including same-row arcs), and the entity URL builders. Verified visually against a live stack with the OTel demo services.

<img width="2187" height="535" alt="image" src="https://github.com/user-attachments/assets/b9354eb4-f76d-4c9f-ae82-857ea7dc2df9" />

https://github.com/user-attachments/assets/87b9da3f-7113-46ee-af52-28a43b779d63

