### PR TITLE
chore(faro): duplicate rudderstack events to faro and enhance faro instrumentation

### DIFF
--- a/docs/analytics/analytics-events.md
+++ b/docs/analytics/analytics-events.md
@@ -344,6 +344,24 @@ Tracks when an alert is deleted successfully
 | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
 | name | `"ProbeFailedExecutionsTooHigh" \| "TLSTargetCertificateCloseToExpiring" \| "HTTPRequestDurationTooHighAvg" \| "PingRequestDurationTooHighAvg" \| "DNSRequestDurationTooHighAvg"` | The name of the alert |
 
+### probes
+
+#### synthetic-monitoring_probes_probe_created
+
+Tracks when a private probe is created.
+
+#### synthetic-monitoring_probes_probe_updated
+
+Tracks when a private probe is updated.
+
+#### synthetic-monitoring_probes_probe_deleted
+
+Tracks when a private probe is deleted.
+
+#### synthetic-monitoring_probes_probe_token_reset
+
+Tracks when a private probe's token is reset.
+
 ### screenshots
 
 #### synthetic-monitoring_screenshots_expanded
@@ -433,6 +451,12 @@ Tracks when a secret is successfully deleted.
 | name   | type                                                                 | description                                                       |
 | ------ | -------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | source | `"check_editor_sidepanel_feature_tabs" \| "config_page_secrets_tab"` | The source context where the secrets management UI is being used. |
+
+### terraform
+
+#### synthetic-monitoring_terraform_config_viewed
+
+Tracks when the terraform config tab is viewed.
 
 ### testing_synthetics_landing
 

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@grafana/alerting": "13.0.2",
     "@grafana/assistant": "0.1.25",
     "@grafana/data": "13.0.2",
+    "@grafana/faro-core": "2.7.1",
     "@grafana/faro-web-sdk": "2.7.1",
     "@grafana/i18n": "13.0.2",
     "@grafana/runtime": "13.0.2",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,6 +9,7 @@ import { TrackingIdentity } from 'features/tracking/TrackingIdentity';
 
 import { ProvisioningJsonData } from 'types';
 import { getFaroConfig } from 'faro';
+import { registerFaroInteractionEchoBackend } from 'faroEchoBackend';
 import { InitialisedRouter } from 'routing/InitialisedRouter';
 import { MetaContextProvider } from 'contexts/MetaContext';
 import { PermissionsContextProvider } from 'contexts/PermissionsContext';
@@ -26,7 +27,7 @@ const { env, url, name } = getFaroConfig();
 // faro was filling up the console with error logs, and it annoyed me, so I disabled it for localhost
 if (window.location.hostname !== 'localhost') {
   getAppPluginVersion('grafana-synthetic-monitoring-app').then((version) => {
-    initializeFaro({
+    const faro = initializeFaro({
       url,
       app: {
         name,
@@ -39,6 +40,8 @@ if (window.location.hostname !== 'localhost') {
       },
       instrumentations: getWebInstrumentations(),
     });
+
+    registerFaroInteractionEchoBackend(faro);
   });
 }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -39,6 +39,17 @@ if (window.location.hostname !== 'localhost') {
         id: config.bootData.user.orgName,
       },
       instrumentations: getWebInstrumentations(),
+      // only send signals emitted while the user is on this plugin's pages
+      beforeSend: (event) => {
+        if ((event.meta.page?.url ?? '').includes('grafana-synthetic-monitoring-app')) {
+          return event;
+        }
+
+        return null;
+      },
+      experimental: {
+        trackNavigation: true,
+      },
     });
 
     registerFaroInteractionEchoBackend(faro);

--- a/src/data/useProbes.ts
+++ b/src/data/useProbes.ts
@@ -1,6 +1,12 @@
 import { useMemo } from 'react';
 import { type QueryKey, useMutation, UseMutationResult, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { isFetchError } from '@grafana/runtime';
+import {
+  trackProbeCreated,
+  trackProbeDeleted,
+  trackProbeTokenReset,
+  trackProbeUpdated,
+} from 'features/tracking/probeEvents';
 
 import { type MutationProps } from 'data/types';
 import { ExtendedProbe, type Probe, ProbeWithMetadata } from 'types';
@@ -136,6 +142,7 @@ export function useCreateProbe({ eventInfo, onError, onSuccess }: MutationProps<
       onError?.(error);
     },
     onSuccess: (data) => {
+      trackProbeCreated();
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.list });
       onSuccess?.(data);
     },
@@ -168,6 +175,7 @@ export function useUpdateProbe({ eventInfo, onError, onSuccess }: MutationProps<
       onError?.(error);
     },
     onSuccess: (data) => {
+      trackProbeUpdated();
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.list });
       onSuccess?.(data);
     },
@@ -200,6 +208,7 @@ export function useDeleteProbe({ eventInfo, onError, onSuccess }: MutationProps<
       onError?.(error);
     },
     onSuccess: (data) => {
+      trackProbeDeleted();
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.list });
       onSuccess?.(data);
     },
@@ -223,6 +232,7 @@ export function useResetProbeToken({ eventInfo, onError, onSuccess }: MutationPr
       onError?.(error);
     },
     onSuccess: (data) => {
+      trackProbeTokenReset();
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.list });
       onSuccess?.(data);
     },

--- a/src/faroEchoBackend.ts
+++ b/src/faroEchoBackend.ts
@@ -1,0 +1,38 @@
+import { Faro } from '@grafana/faro-web-sdk';
+import { EchoBackend, EchoEventType, InteractionEchoEvent, registerEchoBackend } from '@grafana/runtime';
+
+// events created via createSMEventFactory all share this prefix
+const INTERACTION_PREFIX = 'synthetic-monitoring_';
+
+// faro event attributes must be strings
+function toEventAttributes(properties: Record<string, unknown> = {}): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(properties)
+      .filter(([, value]) => value !== undefined && value !== null)
+      .map(([key, value]) => [key, typeof value === 'object' ? JSON.stringify(value) : String(value)])
+  );
+}
+
+let registered = false;
+
+// mirrors this plugin's reportInteraction (rudderstack) events into faro as events
+export function registerFaroInteractionEchoBackend(faro: Faro) {
+  if (registered) {
+    return;
+  }
+  registered = true;
+
+  const backend: EchoBackend<InteractionEchoEvent, {}> = {
+    options: {},
+    supportedEvents: [EchoEventType.Interaction],
+    addEvent: (event) => {
+      if (event.payload.interactionName.startsWith(INTERACTION_PREFIX)) {
+        faro.api.pushEvent(event.payload.interactionName, toEventAttributes(event.payload.properties));
+      }
+    },
+    // faro batches internally, nothing to flush
+    flush: () => {},
+  };
+
+  registerEchoBackend(backend);
+}

--- a/src/faroEchoBackend.ts
+++ b/src/faroEchoBackend.ts
@@ -1,17 +1,9 @@
+import { stringifyObjectValues } from '@grafana/faro-core';
 import { Faro } from '@grafana/faro-web-sdk';
 import { EchoBackend, EchoEventType, InteractionEchoEvent, registerEchoBackend } from '@grafana/runtime';
 
 // events created via createSMEventFactory all share this prefix
 const INTERACTION_PREFIX = 'synthetic-monitoring_';
-
-// faro event attributes must be strings
-function toEventAttributes(properties: Record<string, unknown> = {}): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(properties)
-      .filter(([, value]) => value !== undefined && value !== null)
-      .map(([key, value]) => [key, typeof value === 'object' ? JSON.stringify(value) : String(value)])
-  );
-}
 
 let registered = false;
 
@@ -27,7 +19,8 @@ export function registerFaroInteractionEchoBackend(faro: Faro) {
     supportedEvents: [EchoEventType.Interaction],
     addEvent: (event) => {
       if (event.payload.interactionName.startsWith(INTERACTION_PREFIX)) {
-        faro.api.pushEvent(event.payload.interactionName, toEventAttributes(event.payload.properties));
+        // faro event attributes must be strings
+        faro.api.pushEvent(event.payload.interactionName, stringifyObjectValues(event.payload.properties));
       }
     },
     // faro batches internally, nothing to flush

--- a/src/features/tracking/probeEvents.ts
+++ b/src/features/tracking/probeEvents.ts
@@ -1,0 +1,15 @@
+import { createSMEventFactory } from 'features/tracking/utils';
+
+const probeEvents = createSMEventFactory('probes');
+
+/** Tracks when a private probe is created. */
+export const trackProbeCreated = probeEvents('probe_created');
+
+/** Tracks when a private probe is updated. */
+export const trackProbeUpdated = probeEvents('probe_updated');
+
+/** Tracks when a private probe is deleted. */
+export const trackProbeDeleted = probeEvents('probe_deleted');
+
+/** Tracks when a private probe's token is reset. */
+export const trackProbeTokenReset = probeEvents('probe_token_reset');

--- a/src/features/tracking/terraformEvents.ts
+++ b/src/features/tracking/terraformEvents.ts
@@ -1,0 +1,6 @@
+import { createSMEventFactory } from 'features/tracking/utils';
+
+const terraformEvents = createSMEventFactory('terraform');
+
+/** Tracks when the terraform config tab is viewed. */
+export const trackTerraformConfigViewed = terraformEvents('config_viewed');

--- a/src/page/ConfigPageLayout/tabs/TerraformTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/TerraformTab.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Tab, TabContent, TabsBar, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { trackTerraformConfigViewed } from 'features/tracking/terraformEvents';
 
 import { FaroEvent, reportEvent } from 'faro';
 import { AppRoutes } from 'routing/types';
@@ -37,6 +38,7 @@ export function TerraformTab() {
 
   useEffect(() => {
     reportEvent(FaroEvent.ShowTerraformConfig);
+    trackTerraformConfigViewed();
   }, []);
 
   if (isLoading) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,7 +1438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/faro-core@npm:^2.7.1":
+"@grafana/faro-core@npm:2.7.1, @grafana/faro-core@npm:^2.7.1":
   version: 2.7.1
   resolution: "@grafana/faro-core@npm:2.7.1"
   dependencies:
@@ -13775,6 +13775,7 @@ __metadata:
     "@grafana/assistant": "npm:0.1.25"
     "@grafana/data": "npm:13.0.2"
     "@grafana/eslint-config": "npm:9.0.0"
+    "@grafana/faro-core": "npm:2.7.1"
     "@grafana/faro-web-sdk": "npm:2.7.1"
     "@grafana/i18n": "npm:13.0.2"
     "@grafana/runtime": "npm:13.0.2"


### PR DESCRIPTION
hi folks — we (Frontend Observability) are doing a pass over grafana plugins to improve faro dogfooding visibility. three small commits, each independently droppable:

1. **mirror reportInteraction events into faro** — a tiny echo backend (registered via the public `registerEchoBackend` API from `@grafana/runtime`) that forwards this plugin's `synthetic-monitoring_*` interaction events to your existing faro instance as events. rudderstack is unaffected; the same events just become visible next to your errors, web vitals, and traces in Frontend Observability. same pattern as grafana/logs-drilldown#2023.

2. **faro config hygiene** — adds a `beforeSend` filter so only signals from this plugin's pages are sent (`isolate: true` was already set 👍), and enables `experimental.trackNavigation` for navigation events (quality-of-life when exploring sessions in frontend o11y).

3. **five new events** — probe lifecycle (`probe_created` / `probe_updated` / `probe_deleted` / `probe_token_reset`, fired in the `useProbes` mutation onSuccess callbacks next to the existing faro `reportEvent`s) and `terraform_config_viewed`. these follow your `createSMEventFactory` convention. this commit is deliberately last so it's easy to drop if you'd rather pick your own events.

verified: lint, typecheck, and the probe/config-page test suites all pass. happy to adjust anything — feel free to push to the branch.

### user journey dogfooding

mirroring these interactions into faro also unlocks critical user journeys in frontend observability — journeys are built from faro events, so the duplicated interaction events can be used directly as journey steps to measure completion and drop-off of real product flows. (this app's faro apps are registered against the us-east-0 ops collector rather than the stack backing the frontend o11y team's app list, so I couldn't resolve a critical-journeys link — it lives under the app's "critical journeys" tab wherever your faro apps are managed.)
