### PR TITLE
fix: point faro config at the recreated collector apps

### DIFF
--- a/src/faro.ts
+++ b/src/faro.ts
@@ -95,20 +95,20 @@ export function getFaroConfig() {
   switch (env) {
     case FaroEnv.Dev:
       return {
-        url: 'https://faro-collector-ops-us-east-0.grafana-ops.net/collect/769f675a8e1e8b05f05b478b7002259b',
+        url: 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/914df333264c1827e53d6a613704b6e6',
         name: 'synthetic-monitoring-app-dev',
         env: FaroEnv.Dev,
       };
     case FaroEnv.Staging:
       return {
-        url: 'https://faro-collector-ops-us-east-0.grafana-ops.net/collect/73212b0adc2a3d002ee3befa3b48c4d9',
+        url: 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/40defe4600ad1deb0d47487f46841da3',
         name: 'synthetic-monitoring-app-staging',
         env: FaroEnv.Staging,
       };
     case FaroEnv.Prod:
     default:
       return {
-        url: 'https://faro-collector-ops-us-east-0.grafana-ops.net/collect/837791054a26c6aba5d32ece9030be32',
+        url: 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/eedd4e9616af3ea1847d89f0284979a9',
         name: 'synthetic-monitoring-app-prod',
         env: FaroEnv.Prod,
       };


### PR DESCRIPTION
### what

updates the three collector URLs in `getFaroConfig()` (`src/faro.ts`) to newly created faro apps. the apps referenced by the old URLs no longer exist — they are absent from the ops frontend observability stack, and the `us-east-0` collector endpoints they pointed at are dead — so all faro telemetry from this plugin (errors, web vitals, traces) has been going nowhere.

the apps have been recreated with the same names (`synthetic-monitoring-app-dev` / `-staging` / `-prod`); only the app keys and the collector region (`eu-south-0`, matching every other app on that stack) changed:

| env | app id | cors origins |
|---|---|---|
| dev | 168 | `*.grafana-dev.net`, `http://localhost:3000` |
| staging | 169 | `*.grafana-ops.net` |
| prod | 170 | `*.grafana.net` |

### notes for reviewers

1. the CORS origins follow the conventions of sibling apps on the stack — if your staging environment runs on a different domain, the app settings can be adjusted without another code change
2. any custom settings the old apps had (extra log labels, session replay, etc.) could not be recovered — if you remember any, they can be re-applied in the app settings
3. if the original apps were deleted deliberately (rather than lost in the collector region migration), happy to close this and remove the new apps instead — let me know