### PR TITLE
feat: reference the synthetic-monitoring-checks agent skill in check authoring surfaces

### DIFF
--- a/docs/analytics/analytics-events.md
+++ b/docs/analytics/analytics-events.md
@@ -10,7 +10,7 @@ This document contains all the analytics events that are defined in the project.
 
 #### synthetic-monitoring_agent_skill_section_viewed
 
-Tracks when the agent skill reference content is shown: on render in the docs panels, on first reveal (expand or tool selection) elsewhere.
+Tracks when the agent skill reference content is shown, at most once per source per page load: on render in the docs panels, on first reveal (expand or tool selection) elsewhere.
 
 ##### Properties
 

--- a/docs/analytics/analytics-events.md
+++ b/docs/analytics/analytics-events.md
@@ -6,6 +6,39 @@ This document contains all the analytics events that are defined in the project.
 
 ## Events
 
+### agent_skill
+
+#### synthetic-monitoring_agent_skill_section_viewed
+
+Tracks when the agent skill reference content is shown: on render in the docs panels, on first expand on collapsible surfaces (choose-check-type, terraform-tab).
+
+##### Properties
+
+| name   | type                                                                                      | description                                                     |
+| ------ | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| source | `"docs-panel-scripted" \| "docs-panel-browser" \| "choose-check-type" \| "terraform-tab"` | Where in the app the agent skill reference was interacted with. |
+
+#### synthetic-monitoring_agent_skill_link_clicked
+
+Tracks when the agent skill repository link is clicked.
+
+##### Properties
+
+| name   | type                                                                                      | description                                                     |
+| ------ | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| source | `"docs-panel-scripted" \| "docs-panel-browser" \| "choose-check-type" \| "terraform-tab"` | Where in the app the agent skill reference was interacted with. |
+
+#### synthetic-monitoring_agent_skill_install_command_copied
+
+Tracks when one of the agent skill install commands is copied to the clipboard.
+
+##### Properties
+
+| name    | type                                                                                      | description                                                     |
+| ------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| source  | `"docs-panel-scripted" \| "docs-panel-browser" \| "choose-check-type" \| "terraform-tab"` | Where in the app the agent skill reference was interacted with. |
+| command | `"npx" \| "claude-plugin"`                                                                | Which install command was copied.                               |
+
 ### check_creation
 
 #### synthetic-monitoring_check_creation_add_new_check_button_clicked

--- a/docs/analytics/analytics-events.md
+++ b/docs/analytics/analytics-events.md
@@ -10,7 +10,7 @@ This document contains all the analytics events that are defined in the project.
 
 #### synthetic-monitoring_agent_skill_section_viewed
 
-Tracks when the agent skill reference content is shown: on render in the docs panels, on first expand on collapsible surfaces (choose-check-type, terraform-tab).
+Tracks when the agent skill reference content is shown: on render in the docs panels, on first reveal (expand or tool selection) elsewhere.
 
 ##### Properties
 
@@ -38,6 +38,29 @@ Tracks when one of the agent skill install commands is copied to the clipboard.
 | ------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
 | source  | `"docs-panel-scripted" \| "docs-panel-browser" \| "choose-check-type" \| "terraform-tab"` | Where in the app the agent skill reference was interacted with. |
 | command | `"npx" \| "claude-plugin"`                                                                | Which install command was copied.                               |
+
+#### synthetic-monitoring_agent_skill_tool_selected
+
+Tracks when a coding agent tool card is selected in the agent skill picker.
+
+##### Properties
+
+| name   | type                                                                                      | description                                                     |
+| ------ | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| source | `"docs-panel-scripted" \| "docs-panel-browser" \| "choose-check-type" \| "terraform-tab"` | Where in the app the agent skill reference was interacted with. |
+| tool   | `"claude-code" \| "agent-skills"`                                                         | Which coding agent tool card the user selected.                 |
+
+#### synthetic-monitoring_agent_skill_prompt_copied
+
+Tracks when one of the example authoring prompts is copied to the clipboard.
+
+##### Properties
+
+| name   | type                                                                                      | description                                                                               |
+| ------ | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| source | `"docs-panel-scripted" \| "docs-panel-browser" \| "choose-check-type" \| "terraform-tab"` | Where in the app the agent skill reference was interacted with.                           |
+| tool   | `undefined \| "claude-code" \| "agent-skills"`                                            | Which coding agent tool card the user selected. Absent on surfaces without a tool picker. |
+| prompt | `"site" \| "api-spec" \| "terraform-import"`                                              | Which example prompt variant was copied.                                                  |
 
 ### check_creation
 

--- a/src/components/AgentSkillReference/AgentSkillPicker.test.tsx
+++ b/src/components/AgentSkillReference/AgentSkillPicker.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { render } from 'test/render';
+
+import { AgentSkillPicker } from './AgentSkillPicker';
+import {
+  AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
+  AGENT_SKILL_PROMPTS,
+  AGENT_SKILL_TOOLS,
+} from './AgentSkillReference.constants';
+
+jest.mock('features/tracking/agentSkillEvents', () => ({
+  trackAgentSkillSectionViewed: jest.fn(),
+  trackAgentSkillLinkClicked: jest.fn(),
+  trackAgentSkillInstallCommandCopied: jest.fn(),
+  trackAgentSkillToolSelected: jest.fn(),
+  trackAgentSkillPromptCopied: jest.fn(),
+}));
+
+import {
+  trackAgentSkillInstallCommandCopied,
+  trackAgentSkillPromptCopied,
+  trackAgentSkillSectionViewed,
+  trackAgentSkillToolSelected,
+} from 'features/tracking/agentSkillEvents';
+
+const SOURCE = 'choose-check-type' as const;
+const [CLAUDE_CODE, AGENT_SKILLS] = AGENT_SKILL_TOOLS;
+
+describe('AgentSkillPicker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+      configurable: true,
+    });
+  });
+
+  it('renders a card per tool and no install steps until one is selected', async () => {
+    render(<AgentSkillPicker source={SOURCE} />);
+
+    for (const { name } of AGENT_SKILL_TOOLS) {
+      expect(await screen.findByRole('button', { name: new RegExp(name) })).toBeInTheDocument();
+    }
+    expect(screen.queryByText(/Install the skill/)).not.toBeInTheDocument();
+    expect(trackAgentSkillSectionViewed).not.toHaveBeenCalled();
+  });
+
+  it('shows the install steps for the selected tool and tracks the selection', async () => {
+    const { user } = render(<AgentSkillPicker source={SOURCE} />);
+
+    await user.click(await screen.findByRole('button', { name: new RegExp(CLAUDE_CODE.name) }));
+
+    expect(await screen.findByText(CLAUDE_CODE.installCommand)).toBeInTheDocument();
+    expect(screen.queryByText(AGENT_SKILLS.installCommand)).not.toBeInTheDocument();
+    expect(trackAgentSkillToolSelected).toHaveBeenCalledWith({ source: SOURCE, tool: CLAUDE_CODE.id });
+    expect(trackAgentSkillSectionViewed).toHaveBeenCalledTimes(1);
+
+    // switching tools swaps the install command but does not re-count the view
+    await user.click(screen.getByRole('button', { name: new RegExp(AGENT_SKILLS.name) }));
+    expect(await screen.findByText(AGENT_SKILLS.installCommand)).toBeInTheDocument();
+    expect(trackAgentSkillSectionViewed).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks copying the install command and remembers it for feedback', async () => {
+    const { user } = render(<AgentSkillPicker source={SOURCE} />);
+
+    await user.click(await screen.findByRole('button', { name: new RegExp(CLAUDE_CODE.name) }));
+    const copyButtons = await screen.findAllByRole('button', { name: 'Copy to clipboard' });
+    await user.click(copyButtons[0]);
+
+    expect(trackAgentSkillInstallCommandCopied).toHaveBeenCalledWith({
+      source: SOURCE,
+      command: CLAUDE_CODE.trackingId,
+    });
+    expect(JSON.parse(localStorage.getItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY) ?? 'false')).toBe(true);
+  });
+
+  it('swaps the example prompt via the toggle and tracks which variant is copied', async () => {
+    const [SITE_PROMPT, API_SPEC_PROMPT] = AGENT_SKILL_PROMPTS;
+    const { user } = render(<AgentSkillPicker source={SOURCE} />);
+
+    await user.click(await screen.findByRole('button', { name: new RegExp(CLAUDE_CODE.name) }));
+    expect(await screen.findByText(SITE_PROMPT.prompt)).toBeInTheDocument();
+    expect(screen.queryByText(API_SPEC_PROMPT.prompt)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: API_SPEC_PROMPT.label }));
+    expect(await screen.findByText(API_SPEC_PROMPT.prompt)).toBeInTheDocument();
+    expect(screen.queryByText(SITE_PROMPT.prompt)).not.toBeInTheDocument();
+
+    const copyButtons = screen.getAllByRole('button', { name: 'Copy to clipboard' });
+    await user.click(copyButtons[1]);
+    expect(trackAgentSkillPromptCopied).toHaveBeenCalledWith({
+      source: SOURCE,
+      tool: CLAUDE_CODE.id,
+      prompt: API_SPEC_PROMPT.id,
+    });
+  });
+
+  it('resets the copied state when switching prompts or tools', async () => {
+    const [SITE_PROMPT, API_SPEC_PROMPT] = AGENT_SKILL_PROMPTS;
+    const { user } = render(<AgentSkillPicker source={SOURCE} />);
+
+    await user.click(await screen.findByRole('button', { name: new RegExp(CLAUDE_CODE.name) }));
+    const copyButtons = await screen.findAllByRole('button', { name: 'Copy to clipboard' });
+    await user.click(copyButtons[1]);
+    expect(screen.getByRole('button', { name: 'Copied to clipboard' })).toBeInTheDocument();
+
+    // switching the prompt variant must not carry the "Copied" state over
+    await user.click(screen.getByRole('radio', { name: API_SPEC_PROMPT.label }));
+    expect(screen.queryByRole('button', { name: 'Copied to clipboard' })).not.toBeInTheDocument();
+
+    // same when copying the install command and switching tools
+    await user.click(screen.getAllByRole('button', { name: 'Copy to clipboard' })[0]);
+    expect(screen.getByRole('button', { name: 'Copied to clipboard' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: new RegExp(AGENT_SKILLS.name) }));
+    expect(screen.queryByRole('button', { name: 'Copied to clipboard' })).not.toBeInTheDocument();
+    // the chosen prompt variant persists across tool switches
+    expect(screen.getByText(API_SPEC_PROMPT.prompt)).toBeInTheDocument();
+    expect(screen.queryByText(SITE_PROMPT.prompt)).not.toBeInTheDocument();
+  });
+
+  it('asks for feedback on a return visit after an install command was copied', async () => {
+    localStorage.setItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY, 'true');
+    render(<AgentSkillPicker source={SOURCE} />);
+
+    expect(await screen.findByText('Did the skill help?')).toBeInTheDocument();
+  });
+});

--- a/src/components/AgentSkillReference/AgentSkillPicker.test.tsx
+++ b/src/components/AgentSkillReference/AgentSkillPicker.test.tsx
@@ -4,10 +4,12 @@ import { render } from 'test/render';
 
 import { AgentSkillPicker } from './AgentSkillPicker';
 import {
+  AGENT_SKILL_FEEDBACK_GIVEN_STORAGE_KEY,
   AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
   AGENT_SKILL_PROMPTS,
   AGENT_SKILL_TOOLS,
 } from './AgentSkillReference.constants';
+import { resetAgentSkillViewedSources } from './AgentSkillReference.hooks';
 
 jest.mock('features/tracking/agentSkillEvents', () => ({
   trackAgentSkillSectionViewed: jest.fn(),
@@ -31,6 +33,7 @@ describe('AgentSkillPicker', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    resetAgentSkillViewedSources();
     Object.defineProperty(navigator, 'clipboard', {
       value: {
         writeText: jest.fn().mockResolvedValue(undefined),
@@ -130,5 +133,25 @@ describe('AgentSkillPicker', () => {
     render(<AgentSkillPicker source={SOURCE} />);
 
     expect(await screen.findByText('Did the skill help?')).toBeInTheDocument();
+  });
+
+  it('stops asking for feedback once the user has reacted', async () => {
+    localStorage.setItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY, 'true');
+    const { user } = render(<AgentSkillPicker source={SOURCE} />);
+
+    await screen.findByText('Did the skill help?');
+    await user.click(screen.getByRole('button', { name: 'I love this feature' }));
+
+    // the reaction is persisted so future visits skip the ask
+    expect(JSON.parse(localStorage.getItem(AGENT_SKILL_FEEDBACK_GIVEN_STORAGE_KEY) ?? 'false')).toBe(true);
+  });
+
+  it('does not ask for feedback on visits after the user has already reacted', async () => {
+    localStorage.setItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY, 'true');
+    localStorage.setItem(AGENT_SKILL_FEEDBACK_GIVEN_STORAGE_KEY, 'true');
+    render(<AgentSkillPicker source={SOURCE} />);
+
+    expect(await screen.findByRole('button', { name: new RegExp(CLAUDE_CODE.name) })).toBeInTheDocument();
+    expect(screen.queryByText('Did the skill help?')).not.toBeInTheDocument();
   });
 });

--- a/src/components/AgentSkillReference/AgentSkillPicker.test.tsx
+++ b/src/components/AgentSkillReference/AgentSkillPicker.test.tsx
@@ -77,6 +77,8 @@ describe('AgentSkillPicker', () => {
       command: CLAUDE_CODE.trackingId,
     });
     expect(JSON.parse(localStorage.getItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY) ?? 'false')).toBe(true);
+    // the feedback ask must wait for a return visit, not appear mid-session
+    expect(screen.queryByText('Did the skill help?')).not.toBeInTheDocument();
   });
 
   it('swaps the example prompt via the toggle and tracks which variant is copied', async () => {

--- a/src/components/AgentSkillReference/AgentSkillPicker.tsx
+++ b/src/components/AgentSkillReference/AgentSkillPicker.tsx
@@ -35,6 +35,10 @@ export const AgentSkillPicker = ({ source }: AgentSkillPickerProps) => {
     AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
     false
   );
+  // Ask for feedback only on return visits: snapshot the flag at mount so a
+  // copy in the current session doesn't trigger the ask before the skill has
+  // actually been tried.
+  const [askForFeedback] = useState(hasCopiedInstall);
   const hasTrackedView = useRef(false);
 
   const selectedTool = AGENT_SKILL_TOOLS.find(({ id }) => id === selectedId);
@@ -57,7 +61,7 @@ export const AgentSkillPicker = ({ source }: AgentSkillPickerProps) => {
         <Text variant="h5" element="h3">
           Or author checks with your coding agent
         </Text>
-        {hasCopiedInstall && (
+        {askForFeedback && (
           <Feedback feature={AGENT_SKILL_FEEDBACK_FEATURE} about={{ text: 'Did the skill help?' }} />
         )}
       </Stack>

--- a/src/components/AgentSkillReference/AgentSkillPicker.tsx
+++ b/src/components/AgentSkillReference/AgentSkillPicker.tsx
@@ -1,0 +1,154 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
+import { css, cx } from '@emotion/css';
+import {
+  trackAgentSkillInstallCommandCopied,
+  trackAgentSkillLinkClicked,
+  trackAgentSkillSectionViewed,
+  trackAgentSkillToolSelected,
+} from 'features/tracking/agentSkillEvents';
+import { useLocalStorage } from 'usehooks-ts';
+
+import { Clipboard } from 'components/Clipboard';
+import { Feedback } from 'components/Feedback';
+
+import { AgentSkillPrompts } from './AgentSkillPrompts';
+import {
+  AGENT_SKILL_FEEDBACK_FEATURE,
+  AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
+  AGENT_SKILL_REPO_URL,
+  AGENT_SKILL_TOOLS,
+  AgentSkillReferenceSource,
+} from './AgentSkillReference.constants';
+
+type AgentSkillTool = (typeof AGENT_SKILL_TOOLS)[number];
+
+interface AgentSkillPickerProps {
+  source: AgentSkillReferenceSource;
+}
+
+export const AgentSkillPicker = ({ source }: AgentSkillPickerProps) => {
+  const styles = useStyles2(getStyles);
+  const [selectedId, setSelectedId] = useState<AgentSkillTool['id'] | null>(null);
+  const [hasCopiedInstall, setHasCopiedInstall] = useLocalStorage<boolean>(
+    AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
+    false
+  );
+  const hasTrackedView = useRef(false);
+
+  const selectedTool = AGENT_SKILL_TOOLS.find(({ id }) => id === selectedId);
+
+  const handleSelect = useCallback(
+    (tool: AgentSkillTool) => {
+      setSelectedId(tool.id);
+      trackAgentSkillToolSelected({ source, tool: tool.id });
+      if (!hasTrackedView.current) {
+        hasTrackedView.current = true;
+        trackAgentSkillSectionViewed({ source });
+      }
+    },
+    [source]
+  );
+
+  return (
+    <Stack direction="column" gap={1}>
+      <Stack direction="row" alignItems="center" gap={1}>
+        <Text variant="h5" element="h3">
+          Or author checks with your coding agent
+        </Text>
+        {hasCopiedInstall && (
+          <Feedback feature={AGENT_SKILL_FEEDBACK_FEATURE} about={{ text: 'Did the skill help?' }} />
+        )}
+      </Stack>
+      <div className={styles.cardRow}>
+        {AGENT_SKILL_TOOLS.map((tool) => (
+          <button
+            key={tool.id}
+            type="button"
+            className={cx(styles.toolCard, { [styles.toolCardSelected]: selectedId === tool.id })}
+            onClick={() => handleSelect(tool)}
+            aria-pressed={selectedId === tool.id}
+            data-fs-element={`Agent skill tool card ${tool.id} (${source})`}
+          >
+            <Text variant="h6" element="h4">
+              {tool.name}
+            </Text>
+            <Text color="secondary" variant="bodySmall">
+              {tool.cardDescription}
+            </Text>
+          </button>
+        ))}
+      </div>
+      {selectedTool && (
+        <Stack direction="column" gap={2}>
+          <Text element="p" color="secondary">
+            The Synthetic Monitoring skill teaches your agent to pick the simplest sufficient check type, author
+            scripted and browser checks that assert correctly, and validate them locally with <code>k6 run</code>.
+            Paste the resulting script into the check editor, or let your agent deploy it via Terraform or the API.
+          </Text>
+          <Stack direction="column" gap={0.5}>
+            <Text variant="h6" element="h4">
+              1. Install the skill (one-time)
+            </Text>
+            <div data-fs-element={`Agent skill install command ${selectedTool.trackingId} (${source})`}>
+              <Clipboard
+                key={selectedTool.id}
+                content={selectedTool.installCommand}
+                isCode
+                inlineCopy
+                onCopy={() => {
+                  setHasCopiedInstall(true);
+                  trackAgentSkillInstallCommandCopied({ source, command: selectedTool.trackingId });
+                }}
+              />
+            </div>
+          </Stack>
+          <Stack direction="column" gap={0.5}>
+            <Text variant="h6" element="h4">
+              2. Describe what you want monitored
+            </Text>
+            <AgentSkillPrompts source={source} tool={selectedTool.id} />
+          </Stack>
+          <div>
+            <TextLink
+              href={AGENT_SKILL_REPO_URL}
+              external
+              onClick={() => trackAgentSkillLinkClicked({ source })}
+              data-fs-element={`Agent skill repo link (${source})`}
+            >
+              View the skill on GitHub
+            </TextLink>
+          </div>
+        </Stack>
+      )}
+    </Stack>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  cardRow: css({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+    gap: theme.spacing(2),
+  }),
+  toolCard: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    gap: theme.spacing(0.5),
+    padding: theme.spacing(2),
+    textAlign: 'left',
+    background: theme.colors.background.secondary,
+    border: `1px solid transparent`,
+    borderRadius: theme.shape.radius.default,
+    cursor: 'pointer',
+
+    '&:hover': {
+      background: theme.colors.emphasize(theme.colors.background.secondary, 0.03),
+    },
+  }),
+  toolCardSelected: css({
+    borderColor: theme.colors.primary.border,
+  }),
+});

--- a/src/components/AgentSkillReference/AgentSkillPicker.tsx
+++ b/src/components/AgentSkillReference/AgentSkillPicker.tsx
@@ -1,26 +1,26 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
-import { css, cx } from '@emotion/css';
+import { Card, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 import {
   trackAgentSkillInstallCommandCopied,
   trackAgentSkillLinkClicked,
-  trackAgentSkillSectionViewed,
   trackAgentSkillToolSelected,
 } from 'features/tracking/agentSkillEvents';
-import { useLocalStorage } from 'usehooks-ts';
 
 import { Clipboard } from 'components/Clipboard';
 import { Feedback } from 'components/Feedback';
 
 import { AgentSkillPrompts } from './AgentSkillPrompts';
 import {
+  AGENT_SKILL_DEFAULT_COPY,
   AGENT_SKILL_FEEDBACK_FEATURE,
-  AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
   AGENT_SKILL_REPO_URL,
   AGENT_SKILL_TOOLS,
   AgentSkillReferenceSource,
+  AgentSkillToolId,
 } from './AgentSkillReference.constants';
+import { useAgentSkillFeedback, useTrackAgentSkillSectionViewed } from './AgentSkillReference.hooks';
 
 type AgentSkillTool = (typeof AGENT_SKILL_TOOLS)[number];
 
@@ -30,16 +30,9 @@ interface AgentSkillPickerProps {
 
 export const AgentSkillPicker = ({ source }: AgentSkillPickerProps) => {
   const styles = useStyles2(getStyles);
-  const [selectedId, setSelectedId] = useState<AgentSkillTool['id'] | null>(null);
-  const [hasCopiedInstall, setHasCopiedInstall] = useLocalStorage<boolean>(
-    AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
-    false
-  );
-  // Ask for feedback only on return visits: snapshot the flag at mount so a
-  // copy in the current session doesn't trigger the ask before the skill has
-  // actually been tried.
-  const [askForFeedback] = useState(hasCopiedInstall);
-  const hasTrackedView = useRef(false);
+  const [selectedId, setSelectedId] = useState<AgentSkillToolId | null>(null);
+  const { askForFeedback, markInstallCopied, markFeedbackGiven } = useAgentSkillFeedback();
+  const trackView = useTrackAgentSkillSectionViewed(source);
 
   const selectedTool = AGENT_SKILL_TOOLS.find(({ id }) => id === selectedId);
 
@@ -47,49 +40,44 @@ export const AgentSkillPicker = ({ source }: AgentSkillPickerProps) => {
     (tool: AgentSkillTool) => {
       setSelectedId(tool.id);
       trackAgentSkillToolSelected({ source, tool: tool.id });
-      if (!hasTrackedView.current) {
-        hasTrackedView.current = true;
-        trackAgentSkillSectionViewed({ source });
-      }
+      trackView();
     },
-    [source]
+    [source, trackView]
   );
 
   return (
     <Stack direction="column" gap={1}>
       <Stack direction="row" alignItems="center" gap={1}>
-        <Text variant="h5" element="h3">
+        <Text variant="body" weight="medium" element="h3">
           Or author checks with your coding agent
         </Text>
         {askForFeedback && (
-          <Feedback feature={AGENT_SKILL_FEEDBACK_FEATURE} about={{ text: 'Did the skill help?' }} />
+          <Feedback
+            feature={AGENT_SKILL_FEEDBACK_FEATURE}
+            about={{ text: 'Did the skill help?' }}
+            onReaction={markFeedbackGiven}
+          />
         )}
       </Stack>
       <div className={styles.cardRow}>
         {AGENT_SKILL_TOOLS.map((tool) => (
-          <button
-            key={tool.id}
-            type="button"
-            className={cx(styles.toolCard, { [styles.toolCardSelected]: selectedId === tool.id })}
-            onClick={() => handleSelect(tool)}
-            aria-pressed={selectedId === tool.id}
-            data-fs-element={`Agent skill tool card ${tool.id} (${source})`}
-          >
-            <Text variant="h6" element="h4">
-              {tool.name}
-            </Text>
-            <Text color="secondary" variant="bodySmall">
-              {tool.cardDescription}
-            </Text>
-          </button>
+          <div key={tool.id} data-fs-element={`Agent skill tool card ${tool.id} (${source})`}>
+            <Card
+              noMargin
+              isSelected={selectedId === tool.id}
+              onClick={() => handleSelect(tool)}
+              className={styles.toolCard}
+            >
+              <Card.Heading>{tool.name}</Card.Heading>
+              <Card.Description>{tool.cardDescription}</Card.Description>
+            </Card>
+          </div>
         ))}
       </div>
       {selectedTool && (
         <Stack direction="column" gap={2}>
           <Text element="p" color="secondary">
-            The Synthetic Monitoring skill teaches your agent to pick the simplest sufficient check type, author
-            scripted and browser checks that assert correctly, and validate them locally with <code>k6 run</code>.
-            Paste the resulting script into the check editor, or let your agent deploy it via Terraform or the API.
+            {AGENT_SKILL_DEFAULT_COPY.description}
           </Text>
           <Stack direction="column" gap={0.5}>
             <Text variant="h6" element="h4">
@@ -102,7 +90,7 @@ export const AgentSkillPicker = ({ source }: AgentSkillPickerProps) => {
                 isCode
                 inlineCopy
                 onCopy={() => {
-                  setHasCopiedInstall(true);
+                  markInstallCopied();
                   trackAgentSkillInstallCommandCopied({ source, command: selectedTool.trackingId });
                 }}
               />
@@ -133,26 +121,10 @@ export const AgentSkillPicker = ({ source }: AgentSkillPickerProps) => {
 const getStyles = (theme: GrafanaTheme2) => ({
   cardRow: css({
     display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
     gap: theme.spacing(2),
   }),
   toolCard: css({
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-    gap: theme.spacing(0.5),
-    padding: theme.spacing(2),
-    textAlign: 'left',
-    background: theme.colors.background.secondary,
-    border: `1px solid transparent`,
-    borderRadius: theme.shape.radius.default,
-    cursor: 'pointer',
-
-    '&:hover': {
-      background: theme.colors.emphasize(theme.colors.background.secondary, 0.03),
-    },
-  }),
-  toolCardSelected: css({
-    borderColor: theme.colors.primary.border,
+    height: '100%',
   }),
 });

--- a/src/components/AgentSkillReference/AgentSkillPrompts.tsx
+++ b/src/components/AgentSkillReference/AgentSkillPrompts.tsx
@@ -4,22 +4,26 @@ import { trackAgentSkillPromptCopied } from 'features/tracking/agentSkillEvents'
 
 import { Clipboard } from 'components/Clipboard';
 
-import { AGENT_SKILL_PROMPTS, AgentSkillReferenceSource } from './AgentSkillReference.constants';
+import { AGENT_SKILL_PROMPTS, AgentSkillReferenceSource, AgentSkillToolId } from './AgentSkillReference.constants';
 
 type AgentSkillPromptId = (typeof AGENT_SKILL_PROMPTS)[number]['id'];
 
 interface AgentSkillPromptsProps {
   source: AgentSkillReferenceSource;
-  tool?: 'claude-code' | 'agent-skills';
+  tool?: AgentSkillToolId;
   /** Render the introductory line above the prompt block. */
   showIntro?: boolean;
 }
 
 export const AgentSkillPrompts = ({ source, tool, showIntro = false }: AgentSkillPromptsProps) => {
   const prompts = AGENT_SKILL_PROMPTS.filter(({ sources }) => sources.includes(source));
-  const [promptId, setPromptId] = useState<AgentSkillPromptId>(prompts[0].id);
+  const [promptId, setPromptId] = useState<AgentSkillPromptId | undefined>(prompts[0]?.id);
 
   const selectedPrompt = prompts.find(({ id }) => id === promptId) ?? prompts[0];
+
+  if (!selectedPrompt) {
+    return null;
+  }
 
   return (
     <Stack direction="column" gap={0.5}>

--- a/src/components/AgentSkillReference/AgentSkillPrompts.tsx
+++ b/src/components/AgentSkillReference/AgentSkillPrompts.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { RadioButtonGroup, Stack, Text } from '@grafana/ui';
+import { trackAgentSkillPromptCopied } from 'features/tracking/agentSkillEvents';
+
+import { Clipboard } from 'components/Clipboard';
+
+import { AGENT_SKILL_PROMPTS, AgentSkillReferenceSource } from './AgentSkillReference.constants';
+
+type AgentSkillPromptId = (typeof AGENT_SKILL_PROMPTS)[number]['id'];
+
+interface AgentSkillPromptsProps {
+  source: AgentSkillReferenceSource;
+  tool?: 'claude-code' | 'agent-skills';
+  /** Render the introductory line above the prompt block. */
+  showIntro?: boolean;
+}
+
+export const AgentSkillPrompts = ({ source, tool, showIntro = false }: AgentSkillPromptsProps) => {
+  const prompts = AGENT_SKILL_PROMPTS.filter(({ sources }) => sources.includes(source));
+  const [promptId, setPromptId] = useState<AgentSkillPromptId>(prompts[0].id);
+
+  const selectedPrompt = prompts.find(({ id }) => id === promptId) ?? prompts[0];
+
+  return (
+    <Stack direction="column" gap={0.5}>
+      {showIntro && (
+        <Text element="p" color="secondary" variant="bodySmall">
+          {prompts.length > 1
+            ? 'Then tell your agent what you need — start from one of these prompts:'
+            : 'Then tell your agent what you need — start from this prompt:'}
+        </Text>
+      )}
+      {prompts.length > 1 && (
+        <div>
+          <RadioButtonGroup
+            options={prompts.map(({ id, label }) => ({ value: id, label }))}
+            value={selectedPrompt.id}
+            onChange={setPromptId}
+            size="sm"
+          />
+        </div>
+      )}
+      <div data-fs-element={`Agent skill example prompt ${selectedPrompt.id} (${source})`}>
+        <Clipboard
+          key={selectedPrompt.id}
+          content={selectedPrompt.prompt}
+          isCode
+          inlineCopy
+          onCopy={() => trackAgentSkillPromptCopied({ source, tool, prompt: selectedPrompt.id })}
+        />
+      </div>
+    </Stack>
+  );
+};

--- a/src/components/AgentSkillReference/AgentSkillReference.constants.ts
+++ b/src/components/AgentSkillReference/AgentSkillReference.constants.ts
@@ -9,18 +9,70 @@ export type AgentSkillReferenceSource =
 export const AGENT_SKILL_REPO_URL =
   'https://github.com/grafana/skills/tree/main/skills/grafana-cloud/synthetic-monitoring-checks';
 
-export const AGENT_SKILL_INSTALL_COMMANDS = [
+export const AGENT_SKILL_TOOLS = [
   {
-    command: 'npx skills add grafana/skills',
-    trackingId: 'npx' as const,
-    label: 'Any Agent Skills compatible tool (Claude Code, Cursor, Codex, ...)',
+    id: 'claude-code' as const,
+    trackingId: 'claude-plugin' as const,
+    name: 'Claude Code',
+    cardDescription: 'Install the Synthetic Monitoring skill as a Claude Code plugin.',
+    installCommand: 'claude plugin install grafana-cloud@grafana-skills',
+    installLabel: 'Claude Code plugin',
   },
   {
-    command: 'claude plugin install grafana-cloud@grafana-skills',
-    trackingId: 'claude-plugin' as const,
-    label: 'Claude Code plugin',
+    id: 'agent-skills' as const,
+    trackingId: 'npx' as const,
+    name: 'Cursor, Codex & other agents',
+    cardDescription: 'Install via the Agent Skills CLI — works with any compatible coding agent.',
+    installCommand: 'npx skills add grafana/skills',
+    installLabel: 'Any Agent Skills compatible tool (Claude Code, Cursor, Codex, ...)',
   },
 ];
+
+export const AGENT_SKILL_INSTALL_COMMANDS = AGENT_SKILL_TOOLS.map(({ installCommand, trackingId, installLabel }) => ({
+  command: installCommand,
+  trackingId,
+  label: installLabel,
+}));
+
+export const AGENT_SKILL_PROMPTS: Array<{
+  id: 'site' | 'api-spec' | 'terraform-import';
+  label: string;
+  prompt: string;
+  sources: AgentSkillReferenceSource[];
+}> = [
+  {
+    id: 'site',
+    label: 'From your site',
+    prompt: `Create Grafana Cloud Synthetic Monitoring checks for <your site URL>. The journey that matters most is: <e.g. login → view account → transfer>. Explore the target yourself — pages and any /api/* routes — to find endpoints and stable selectors, and only ask me what you can't discover. Choose the simplest sufficient check type, keep anything touching production read-only or self-cleaning, and validate scripts locally with k6 run, passing several times in a row, before giving me something I can deploy.`,
+    sources: ['docs-panel-scripted', 'docs-panel-browser', 'choose-check-type'],
+  },
+  {
+    id: 'api-spec',
+    label: 'From an API spec',
+    prompt: `Create Grafana Cloud Synthetic Monitoring checks from my API spec: <path or URL to OpenAPI/Swagger/Postman file>. The production base URL is <https://api.example.com> — verify it, don't trust the spec's servers list. Don't monitor every endpoint: pick the 1–3 journeys whose failure means customers are impacted and write one check per journey, asserting the fields the response schemas promise. Only include mutating operations if the journey cleans up after itself, map any credentials to SM secrets rather than inlining them, and validate scripts locally with k6 run, passing several times in a row, before giving me something I can deploy.`,
+    sources: ['docs-panel-scripted', 'docs-panel-browser', 'choose-check-type'],
+  },
+  {
+    id: 'terraform-import',
+    label: 'Adopt existing checks',
+    prompt: `Using the Grafana Cloud Synthetic Monitoring Terraform export below, please create the proper Terraform files for me: a maintainable layout with provider auth via variables and no inlined tokens or secrets. Run the import commands and confirm terraform plan shows no changes, so my live checks aren't modified or recreated.
+
+<paste the exported config and import commands from this page>`,
+    sources: ['terraform-tab'],
+  },
+];
+
+export const AGENT_SKILL_DEFAULT_COPY = {
+  title: 'Author checks with your coding agent',
+  description:
+    'The Synthetic Monitoring skill teaches coding agents to pick the simplest sufficient check type, author scripted and browser checks that assert correctly, and validate them locally with k6 run. Paste the resulting script into the editor here, or let your agent deploy it via Terraform or the API.',
+};
+
+export const AGENT_SKILL_TERRAFORM_COPY = {
+  title: 'Use your coding agent to create Terraform files for your existing checks',
+  description:
+    'The Synthetic Monitoring skill teaches coding agents to turn the export on this page into a maintainable Terraform project — imported cleanly, with no changes to your live checks — and to author and validate future checks as code.',
+};
 
 // Set when the user copies an install command so return visits can ask for feedback.
 export const AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY = 'synthetic-monitoring-agentSkillInstallCopied';

--- a/src/components/AgentSkillReference/AgentSkillReference.constants.ts
+++ b/src/components/AgentSkillReference/AgentSkillReference.constants.ts
@@ -1,0 +1,28 @@
+// Kept in sync with the inline source unions in features/tracking/agentSkillEvents.ts
+// (the tracking lint rule disallows shared type aliases in event files).
+export type AgentSkillReferenceSource =
+  | 'docs-panel-scripted'
+  | 'docs-panel-browser'
+  | 'choose-check-type'
+  | 'terraform-tab';
+
+export const AGENT_SKILL_REPO_URL =
+  'https://github.com/grafana/skills/tree/main/skills/grafana-cloud/synthetic-monitoring-checks';
+
+export const AGENT_SKILL_INSTALL_COMMANDS = [
+  {
+    command: 'npx skills add grafana/skills',
+    trackingId: 'npx' as const,
+    label: 'Any Agent Skills compatible tool (Claude Code, Cursor, Codex, ...)',
+  },
+  {
+    command: 'claude plugin install grafana-cloud@grafana-skills',
+    trackingId: 'claude-plugin' as const,
+    label: 'Claude Code plugin',
+  },
+];
+
+// Set when the user copies an install command so return visits can ask for feedback.
+export const AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY = 'synthetic-monitoring-agentSkillInstallCopied';
+
+export const AGENT_SKILL_FEEDBACK_FEATURE = 'agent-skill';

--- a/src/components/AgentSkillReference/AgentSkillReference.constants.ts
+++ b/src/components/AgentSkillReference/AgentSkillReference.constants.ts
@@ -1,5 +1,6 @@
-// Kept in sync with the inline source unions in features/tracking/agentSkillEvents.ts
-// (the tracking lint rule disallows shared type aliases in event files).
+// Kept in sync with the inline source unions in features/tracking/agentSkillEvents.ts.
+// The unions are duplicated there on purpose: features/tracking is a leaf layer and
+// should not import from components/, so the event file cannot share this alias.
 export type AgentSkillReferenceSource =
   | 'docs-panel-scripted'
   | 'docs-panel-browser'
@@ -27,6 +28,8 @@ export const AGENT_SKILL_TOOLS = [
     installLabel: 'Any Agent Skills compatible tool (Claude Code, Cursor, Codex, ...)',
   },
 ];
+
+export type AgentSkillToolId = (typeof AGENT_SKILL_TOOLS)[number]['id'];
 
 export const AGENT_SKILL_INSTALL_COMMANDS = AGENT_SKILL_TOOLS.map(({ installCommand, trackingId, installLabel }) => ({
   command: installCommand,
@@ -65,7 +68,7 @@ export const AGENT_SKILL_PROMPTS: Array<{
 export const AGENT_SKILL_DEFAULT_COPY = {
   title: 'Author checks with your coding agent',
   description:
-    'The Synthetic Monitoring skill teaches coding agents to pick the simplest sufficient check type, author scripted and browser checks that assert correctly, and validate them locally with k6 run. Paste the resulting script into the editor here, or let your agent deploy it via Terraform or the API.',
+    'The Synthetic Monitoring skill teaches coding agents to pick the simplest sufficient check type, author scripted and browser checks that assert correctly, and validate them locally with k6 run. Paste the resulting script into the check editor, or let your agent deploy it via Terraform or the API.',
 };
 
 export const AGENT_SKILL_TERRAFORM_COPY = {
@@ -76,5 +79,8 @@ export const AGENT_SKILL_TERRAFORM_COPY = {
 
 // Set when the user copies an install command so return visits can ask for feedback.
 export const AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY = 'synthetic-monitoring-agentSkillInstallCopied';
+
+// Set once the user reacts to the "Did the skill help?" ask so we stop asking.
+export const AGENT_SKILL_FEEDBACK_GIVEN_STORAGE_KEY = 'synthetic-monitoring-agentSkillFeedbackGiven';
 
 export const AGENT_SKILL_FEEDBACK_FEATURE = 'agent-skill';

--- a/src/components/AgentSkillReference/AgentSkillReference.hooks.ts
+++ b/src/components/AgentSkillReference/AgentSkillReference.hooks.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react';
+import { trackAgentSkillSectionViewed } from 'features/tracking/agentSkillEvents';
+import { useLocalStorage } from 'usehooks-ts';
+
+import {
+  AGENT_SKILL_FEEDBACK_GIVEN_STORAGE_KEY,
+  AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
+  AgentSkillReferenceSource,
+} from './AgentSkillReference.constants';
+
+/**
+ * Gates the "Did the skill help?" ask. It shows only on return visits after an
+ * install command was copied (the flag is snapshotted at mount so a copy in the
+ * current session doesn't trigger the ask before the skill has actually been
+ * tried), and stops for good once the user has reacted to it.
+ */
+export function useAgentSkillFeedback() {
+  const [hasCopiedInstall, setHasCopiedInstall] = useLocalStorage<boolean>(
+    AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
+    false
+  );
+  const [feedbackGiven, setFeedbackGiven] = useLocalStorage<boolean>(AGENT_SKILL_FEEDBACK_GIVEN_STORAGE_KEY, false);
+  const [askForFeedback] = useState(hasCopiedInstall && !feedbackGiven);
+
+  const markInstallCopied = useCallback(() => setHasCopiedInstall(true), [setHasCopiedInstall]);
+  // Persist for future mounts only; the ask stays visible for the rest of this
+  // session so the user can still finish the comment form.
+  const markFeedbackGiven = useCallback(() => setFeedbackGiven(true), [setFeedbackGiven]);
+
+  return { askForFeedback, markInstallCopied, markFeedbackGiven };
+}
+
+// Sources already counted in this page load. Deduped at module level (not per
+// component instance) so remounts, e.g. switching Checkster feature tabs back
+// and forth, don't inflate the section_viewed metric.
+const viewedSources = new Set<AgentSkillReferenceSource>();
+
+/** Test-only: clears the per-page-load section_viewed dedupe between tests. */
+export function resetAgentSkillViewedSources() {
+  viewedSources.clear();
+}
+
+/**
+ * Returns a callback that fires the section_viewed event at most once per
+ * source per page load. Call it whenever the reference content becomes
+ * visible (render, expand, or first tool selection depending on the surface).
+ */
+export function useTrackAgentSkillSectionViewed(source: AgentSkillReferenceSource) {
+  return useCallback(() => {
+    if (!viewedSources.has(source)) {
+      viewedSources.add(source);
+      trackAgentSkillSectionViewed({ source });
+    }
+  }, [source]);
+}

--- a/src/components/AgentSkillReference/AgentSkillReference.test.tsx
+++ b/src/components/AgentSkillReference/AgentSkillReference.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { render } from 'test/render';
+
+import { AgentSkillReference } from './AgentSkillReference';
+import { AGENT_SKILL_INSTALL_COMMANDS, AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY } from './AgentSkillReference.constants';
+
+jest.mock('features/tracking/agentSkillEvents', () => ({
+  trackAgentSkillSectionViewed: jest.fn(),
+  trackAgentSkillLinkClicked: jest.fn(),
+  trackAgentSkillInstallCommandCopied: jest.fn(),
+}));
+
+import {
+  trackAgentSkillInstallCommandCopied,
+  trackAgentSkillLinkClicked,
+  trackAgentSkillSectionViewed,
+} from 'features/tracking/agentSkillEvents';
+
+const SOURCE = 'docs-panel-scripted' as const;
+
+describe('AgentSkillReference', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+      configurable: true,
+    });
+  });
+
+  it('renders both install commands and tracks the section view', async () => {
+    render(<AgentSkillReference source={SOURCE} />);
+
+    for (const { command } of AGENT_SKILL_INSTALL_COMMANDS) {
+      expect(await screen.findByText(command)).toBeInTheDocument();
+    }
+    expect(trackAgentSkillSectionViewed).toHaveBeenCalledWith({ source: SOURCE });
+  });
+
+  it('tracks copying an install command and remembers it for feedback', async () => {
+    const { user } = render(<AgentSkillReference source={SOURCE} />);
+
+    const copyButtons = await screen.findAllByRole('button', { name: 'Copy to clipboard' });
+    await user.click(copyButtons[0]);
+
+    expect(trackAgentSkillInstallCommandCopied).toHaveBeenCalledWith({
+      source: SOURCE,
+      command: AGENT_SKILL_INSTALL_COMMANDS[0].trackingId,
+    });
+    expect(JSON.parse(localStorage.getItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY) ?? 'false')).toBe(true);
+  });
+
+  it('tracks clicking the repository link', async () => {
+    const { user } = render(<AgentSkillReference source={SOURCE} />);
+
+    const link = await screen.findByRole('link', { name: /View the skill on GitHub/ });
+    await user.click(link);
+
+    expect(trackAgentSkillLinkClicked).toHaveBeenCalledWith({ source: SOURCE });
+  });
+
+  it('does not ask for feedback before an install command has been copied', async () => {
+    render(<AgentSkillReference source={SOURCE} />);
+
+    await screen.findByText('Author checks with your AI coding agent');
+    expect(screen.queryByText('Did the skill help?')).not.toBeInTheDocument();
+  });
+
+  it('asks for feedback on a return visit after an install command was copied', async () => {
+    localStorage.setItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY, 'true');
+    render(<AgentSkillReference source={SOURCE} />);
+
+    expect(await screen.findByText('Did the skill help?')).toBeInTheDocument();
+  });
+
+  describe('collapsible mode', () => {
+    it('starts collapsed and only tracks the view on first expand', async () => {
+      const { user } = render(<AgentSkillReference source={SOURCE} collapsible />);
+
+      const toggle = await screen.findByText('Author checks with your AI coding agent');
+      expect(screen.queryByText(AGENT_SKILL_INSTALL_COMMANDS[0].command)).not.toBeInTheDocument();
+      expect(trackAgentSkillSectionViewed).not.toHaveBeenCalled();
+
+      await user.click(toggle);
+      expect(await screen.findByText(AGENT_SKILL_INSTALL_COMMANDS[0].command)).toBeInTheDocument();
+      expect(trackAgentSkillSectionViewed).toHaveBeenCalledTimes(1);
+      expect(trackAgentSkillSectionViewed).toHaveBeenCalledWith({ source: SOURCE });
+
+      // collapsing and re-expanding does not double-count the view
+      await user.click(toggle);
+      await user.click(toggle);
+      expect(trackAgentSkillSectionViewed).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the feedback ask outside the collapse after an install command was copied', async () => {
+      localStorage.setItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY, 'true');
+      render(<AgentSkillReference source={SOURCE} collapsible />);
+
+      expect(await screen.findByText('Did the skill help?')).toBeInTheDocument();
+      expect(screen.queryByText(AGENT_SKILL_INSTALL_COMMANDS[0].command)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/AgentSkillReference/AgentSkillReference.test.tsx
+++ b/src/components/AgentSkillReference/AgentSkillReference.test.tsx
@@ -3,17 +3,26 @@ import { screen } from '@testing-library/react';
 import { render } from 'test/render';
 
 import { AgentSkillReference } from './AgentSkillReference';
-import { AGENT_SKILL_INSTALL_COMMANDS, AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY } from './AgentSkillReference.constants';
+import {
+  AGENT_SKILL_DEFAULT_COPY,
+  AGENT_SKILL_INSTALL_COMMANDS,
+  AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
+  AGENT_SKILL_PROMPTS,
+  AGENT_SKILL_TERRAFORM_COPY,
+} from './AgentSkillReference.constants';
 
 jest.mock('features/tracking/agentSkillEvents', () => ({
   trackAgentSkillSectionViewed: jest.fn(),
   trackAgentSkillLinkClicked: jest.fn(),
   trackAgentSkillInstallCommandCopied: jest.fn(),
+  trackAgentSkillToolSelected: jest.fn(),
+  trackAgentSkillPromptCopied: jest.fn(),
 }));
 
 import {
   trackAgentSkillInstallCommandCopied,
   trackAgentSkillLinkClicked,
+  trackAgentSkillPromptCopied,
   trackAgentSkillSectionViewed,
 } from 'features/tracking/agentSkillEvents';
 
@@ -53,6 +62,39 @@ describe('AgentSkillReference', () => {
     expect(JSON.parse(localStorage.getItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY) ?? 'false')).toBe(true);
   });
 
+  it('shows the example prompts and tracks copying one without a tool', async () => {
+    const [SITE_PROMPT, API_SPEC_PROMPT] = AGENT_SKILL_PROMPTS;
+    const { user } = render(<AgentSkillReference source={SOURCE} />);
+
+    expect(await screen.findByText(SITE_PROMPT.prompt)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: API_SPEC_PROMPT.label }));
+    expect(await screen.findByText(API_SPEC_PROMPT.prompt)).toBeInTheDocument();
+
+    const copyButtons = screen.getAllByRole('button', { name: 'Copy to clipboard' });
+    await user.click(copyButtons[copyButtons.length - 1]);
+    expect(trackAgentSkillPromptCopied).toHaveBeenCalledWith({
+      source: SOURCE,
+      tool: undefined,
+      prompt: API_SPEC_PROMPT.id,
+    });
+  });
+
+  it('shows only the terraform adoption prompt on the terraform tab, without a toggle', async () => {
+    const TERRAFORM_PROMPT = AGENT_SKILL_PROMPTS.find(({ id }) => id === 'terraform-import')!;
+    render(<AgentSkillReference source="terraform-tab" />);
+
+    expect(await screen.findByText(AGENT_SKILL_TERRAFORM_COPY.title)).toBeInTheDocument();
+    expect(screen.queryByText(AGENT_SKILL_DEFAULT_COPY.title)).not.toBeInTheDocument();
+    expect(screen.getByText(new RegExp(TERRAFORM_PROMPT.prompt.slice(0, 60)))).toBeInTheDocument();
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    for (const { id, prompt } of AGENT_SKILL_PROMPTS) {
+      if (id !== 'terraform-import') {
+        expect(screen.queryByText(prompt)).not.toBeInTheDocument();
+      }
+    }
+  });
+
   it('tracks clicking the repository link', async () => {
     const { user } = render(<AgentSkillReference source={SOURCE} />);
 
@@ -65,7 +107,7 @@ describe('AgentSkillReference', () => {
   it('does not ask for feedback before an install command has been copied', async () => {
     render(<AgentSkillReference source={SOURCE} />);
 
-    await screen.findByText('Author checks with your AI coding agent');
+    await screen.findByText(AGENT_SKILL_DEFAULT_COPY.title);
     expect(screen.queryByText('Did the skill help?')).not.toBeInTheDocument();
   });
 
@@ -80,7 +122,7 @@ describe('AgentSkillReference', () => {
     it('starts collapsed and only tracks the view on first expand', async () => {
       const { user } = render(<AgentSkillReference source={SOURCE} collapsible />);
 
-      const toggle = await screen.findByText('Author checks with your AI coding agent');
+      const toggle = await screen.findByText(AGENT_SKILL_DEFAULT_COPY.title);
       expect(screen.queryByText(AGENT_SKILL_INSTALL_COMMANDS[0].command)).not.toBeInTheDocument();
       expect(trackAgentSkillSectionViewed).not.toHaveBeenCalled();
 

--- a/src/components/AgentSkillReference/AgentSkillReference.test.tsx
+++ b/src/components/AgentSkillReference/AgentSkillReference.test.tsx
@@ -5,11 +5,13 @@ import { render } from 'test/render';
 import { AgentSkillReference } from './AgentSkillReference';
 import {
   AGENT_SKILL_DEFAULT_COPY,
+  AGENT_SKILL_FEEDBACK_GIVEN_STORAGE_KEY,
   AGENT_SKILL_INSTALL_COMMANDS,
   AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
   AGENT_SKILL_PROMPTS,
   AGENT_SKILL_TERRAFORM_COPY,
 } from './AgentSkillReference.constants';
+import { resetAgentSkillViewedSources } from './AgentSkillReference.hooks';
 
 jest.mock('features/tracking/agentSkillEvents', () => ({
   trackAgentSkillSectionViewed: jest.fn(),
@@ -32,6 +34,7 @@ describe('AgentSkillReference', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    resetAgentSkillViewedSources();
     Object.defineProperty(navigator, 'clipboard', {
       value: {
         writeText: jest.fn().mockResolvedValue(undefined),
@@ -118,6 +121,36 @@ describe('AgentSkillReference', () => {
     render(<AgentSkillReference source={SOURCE} />);
 
     expect(await screen.findByText('Did the skill help?')).toBeInTheDocument();
+  });
+
+  it('persists the reaction and stops asking on visits after the user has reacted', async () => {
+    localStorage.setItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY, 'true');
+    localStorage.setItem(AGENT_SKILL_FEEDBACK_GIVEN_STORAGE_KEY, 'true');
+    render(<AgentSkillReference source={SOURCE} />);
+
+    await screen.findByText(AGENT_SKILL_DEFAULT_COPY.title);
+    expect(screen.queryByText('Did the skill help?')).not.toBeInTheDocument();
+  });
+
+  it('records the reaction so future visits skip the ask', async () => {
+    localStorage.setItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY, 'true');
+    const { user } = render(<AgentSkillReference source={SOURCE} />);
+
+    await screen.findByText('Did the skill help?');
+    await user.click(screen.getByRole('button', { name: "I don't like this feature" }));
+
+    expect(JSON.parse(localStorage.getItem(AGENT_SKILL_FEEDBACK_GIVEN_STORAGE_KEY) ?? 'false')).toBe(true);
+  });
+
+  it('only fires section_viewed once per page load across remounts', async () => {
+    const { unmount } = render(<AgentSkillReference source={SOURCE} />);
+    await screen.findByText(AGENT_SKILL_DEFAULT_COPY.title);
+    expect(trackAgentSkillSectionViewed).toHaveBeenCalledTimes(1);
+
+    unmount();
+    render(<AgentSkillReference source={SOURCE} />);
+    await screen.findByText(AGENT_SKILL_DEFAULT_COPY.title);
+    expect(trackAgentSkillSectionViewed).toHaveBeenCalledTimes(1);
   });
 
   describe('collapsible mode', () => {

--- a/src/components/AgentSkillReference/AgentSkillReference.test.tsx
+++ b/src/components/AgentSkillReference/AgentSkillReference.test.tsx
@@ -60,6 +60,8 @@ describe('AgentSkillReference', () => {
       command: AGENT_SKILL_INSTALL_COMMANDS[0].trackingId,
     });
     expect(JSON.parse(localStorage.getItem(AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY) ?? 'false')).toBe(true);
+    // the feedback ask must wait for a return visit, not appear mid-session
+    expect(screen.queryByText('Did the skill help?')).not.toBeInTheDocument();
   });
 
   it('shows the example prompts and tracks copying one without a tool', async () => {

--- a/src/components/AgentSkillReference/AgentSkillReference.tsx
+++ b/src/components/AgentSkillReference/AgentSkillReference.tsx
@@ -10,15 +10,19 @@ import { useLocalStorage } from 'usehooks-ts';
 import { Clipboard } from 'components/Clipboard';
 import { Feedback } from 'components/Feedback';
 
+import { AgentSkillPrompts } from './AgentSkillPrompts';
 import {
+  AGENT_SKILL_DEFAULT_COPY,
   AGENT_SKILL_FEEDBACK_FEATURE,
   AGENT_SKILL_INSTALL_COMMANDS,
   AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
   AGENT_SKILL_REPO_URL,
+  AGENT_SKILL_TERRAFORM_COPY,
   AgentSkillReferenceSource,
 } from './AgentSkillReference.constants';
 
-const TITLE = 'Author checks with your AI coding agent';
+const getCopy = (source: AgentSkillReferenceSource) =>
+  source === 'terraform-tab' ? AGENT_SKILL_TERRAFORM_COPY : AGENT_SKILL_DEFAULT_COPY;
 
 interface AgentSkillReferenceProps {
   source: AgentSkillReferenceSource;
@@ -60,12 +64,13 @@ export const AgentSkillReference = ({ source, collapsible = false }: AgentSkillR
   );
 
   const content = <AgentSkillReferenceContent source={source} onCopy={handleCopy} />;
+  const { title } = getCopy(source);
 
   if (collapsible) {
     return (
       <Stack direction="column" gap={0.5}>
         <Collapse
-          label={TITLE}
+          label={title}
           isOpen={isOpen}
           onToggle={() => {
             const nextIsOpen = !isOpen;
@@ -86,7 +91,7 @@ export const AgentSkillReference = ({ source, collapsible = false }: AgentSkillR
     <Stack direction="column" gap={2}>
       <Stack direction="row" alignItems="center" gap={1}>
         <Text variant="h4" element="h3">
-          {TITLE}
+          {title}
         </Text>
         {feedback}
       </Stack>
@@ -102,11 +107,7 @@ interface AgentSkillReferenceContentProps {
 
 const AgentSkillReferenceContent = ({ source, onCopy }: AgentSkillReferenceContentProps) => (
   <Stack direction="column" gap={2}>
-    <Text element="p">
-      The Synthetic Monitoring skill teaches AI coding agents to pick the simplest sufficient check type, author
-      scripted and browser checks that assert correctly, and validate them locally with <code>k6 run</code>. Paste the
-      resulting script into the editor here, or let your agent deploy it via Terraform or the API.
-    </Text>
+    <Text element="p">{getCopy(source).description}</Text>
     {AGENT_SKILL_INSTALL_COMMANDS.map(({ command, trackingId, label }) => (
       <Stack direction="column" gap={0.5} key={trackingId}>
         <Text element="p" color="secondary" variant="bodySmall">
@@ -117,6 +118,7 @@ const AgentSkillReferenceContent = ({ source, onCopy }: AgentSkillReferenceConte
         </div>
       </Stack>
     ))}
+    <AgentSkillPrompts source={source} showIntro />
     <div>
       <TextLink
         href={AGENT_SKILL_REPO_URL}

--- a/src/components/AgentSkillReference/AgentSkillReference.tsx
+++ b/src/components/AgentSkillReference/AgentSkillReference.tsx
@@ -1,0 +1,131 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Collapse, Stack, Text, TextLink } from '@grafana/ui';
+import {
+  trackAgentSkillInstallCommandCopied,
+  trackAgentSkillLinkClicked,
+  trackAgentSkillSectionViewed,
+} from 'features/tracking/agentSkillEvents';
+import { useLocalStorage } from 'usehooks-ts';
+
+import { Clipboard } from 'components/Clipboard';
+import { Feedback } from 'components/Feedback';
+
+import {
+  AGENT_SKILL_FEEDBACK_FEATURE,
+  AGENT_SKILL_INSTALL_COMMANDS,
+  AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
+  AGENT_SKILL_REPO_URL,
+  AgentSkillReferenceSource,
+} from './AgentSkillReference.constants';
+
+const TITLE = 'Author checks with your AI coding agent';
+
+interface AgentSkillReferenceProps {
+  source: AgentSkillReferenceSource;
+  /** Render as a collapsed single line that expands in place. Use on dense pages. */
+  collapsible?: boolean;
+}
+
+export const AgentSkillReference = ({ source, collapsible = false }: AgentSkillReferenceProps) => {
+  const [hasCopiedInstall, setHasCopiedInstall] = useLocalStorage<boolean>(
+    AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
+    false
+  );
+  const [isOpen, setIsOpen] = useState(false);
+  const hasTrackedView = useRef(false);
+
+  const trackView = useCallback(() => {
+    if (!hasTrackedView.current) {
+      hasTrackedView.current = true;
+      trackAgentSkillSectionViewed({ source });
+    }
+  }, [source]);
+
+  useEffect(() => {
+    if (!collapsible) {
+      trackView();
+    }
+  }, [collapsible, trackView]);
+
+  const handleCopy = useCallback(
+    (command: 'npx' | 'claude-plugin') => {
+      setHasCopiedInstall(true);
+      trackAgentSkillInstallCommandCopied({ source, command });
+    },
+    [setHasCopiedInstall, source]
+  );
+
+  const feedback = hasCopiedInstall && (
+    <Feedback feature={AGENT_SKILL_FEEDBACK_FEATURE} about={{ text: 'Did the skill help?' }} />
+  );
+
+  const content = <AgentSkillReferenceContent source={source} onCopy={handleCopy} />;
+
+  if (collapsible) {
+    return (
+      <Stack direction="column" gap={0.5}>
+        <Collapse
+          label={TITLE}
+          isOpen={isOpen}
+          onToggle={() => {
+            const nextIsOpen = !isOpen;
+            setIsOpen(nextIsOpen);
+            if (nextIsOpen) {
+              trackView();
+            }
+          }}
+        >
+          {content}
+        </Collapse>
+        {feedback}
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack direction="column" gap={2}>
+      <Stack direction="row" alignItems="center" gap={1}>
+        <Text variant="h4" element="h3">
+          {TITLE}
+        </Text>
+        {feedback}
+      </Stack>
+      {content}
+    </Stack>
+  );
+};
+
+interface AgentSkillReferenceContentProps {
+  source: AgentSkillReferenceSource;
+  onCopy: (command: 'npx' | 'claude-plugin') => void;
+}
+
+const AgentSkillReferenceContent = ({ source, onCopy }: AgentSkillReferenceContentProps) => (
+  <Stack direction="column" gap={2}>
+    <Text element="p">
+      The Synthetic Monitoring skill teaches AI coding agents to pick the simplest sufficient check type, author
+      scripted and browser checks that assert correctly, and validate them locally with <code>k6 run</code>. Paste the
+      resulting script into the editor here, or let your agent deploy it via Terraform or the API.
+    </Text>
+    {AGENT_SKILL_INSTALL_COMMANDS.map(({ command, trackingId, label }) => (
+      <Stack direction="column" gap={0.5} key={trackingId}>
+        <Text element="p" color="secondary" variant="bodySmall">
+          {label}
+        </Text>
+        <div data-fs-element={`Agent skill install command ${trackingId} (${source})`}>
+          <Clipboard content={command} isCode inlineCopy onCopy={() => onCopy(trackingId)} />
+        </div>
+      </Stack>
+    ))}
+    <div>
+      <TextLink
+        href={AGENT_SKILL_REPO_URL}
+        external
+        onClick={() => trackAgentSkillLinkClicked({ source })}
+        data-fs-element={`Agent skill repo link (${source})`}
+      >
+        View the skill on GitHub
+      </TextLink>
+    </div>
+  </Stack>
+);

--- a/src/components/AgentSkillReference/AgentSkillReference.tsx
+++ b/src/components/AgentSkillReference/AgentSkillReference.tsx
@@ -35,6 +35,10 @@ export const AgentSkillReference = ({ source, collapsible = false }: AgentSkillR
     AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
     false
   );
+  // Ask for feedback only on return visits: snapshot the flag at mount so a
+  // copy in the current session doesn't trigger the ask before the skill has
+  // actually been tried.
+  const [askForFeedback] = useState(hasCopiedInstall);
   const [isOpen, setIsOpen] = useState(false);
   const hasTrackedView = useRef(false);
 
@@ -59,7 +63,7 @@ export const AgentSkillReference = ({ source, collapsible = false }: AgentSkillR
     [setHasCopiedInstall, source]
   );
 
-  const feedback = hasCopiedInstall && (
+  const feedback = askForFeedback && (
     <Feedback feature={AGENT_SKILL_FEEDBACK_FEATURE} about={{ text: 'Did the skill help?' }} />
   );
 

--- a/src/components/AgentSkillReference/AgentSkillReference.tsx
+++ b/src/components/AgentSkillReference/AgentSkillReference.tsx
@@ -1,11 +1,6 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Collapse, Stack, Text, TextLink } from '@grafana/ui';
-import {
-  trackAgentSkillInstallCommandCopied,
-  trackAgentSkillLinkClicked,
-  trackAgentSkillSectionViewed,
-} from 'features/tracking/agentSkillEvents';
-import { useLocalStorage } from 'usehooks-ts';
+import { trackAgentSkillInstallCommandCopied, trackAgentSkillLinkClicked } from 'features/tracking/agentSkillEvents';
 
 import { Clipboard } from 'components/Clipboard';
 import { Feedback } from 'components/Feedback';
@@ -15,11 +10,11 @@ import {
   AGENT_SKILL_DEFAULT_COPY,
   AGENT_SKILL_FEEDBACK_FEATURE,
   AGENT_SKILL_INSTALL_COMMANDS,
-  AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
   AGENT_SKILL_REPO_URL,
   AGENT_SKILL_TERRAFORM_COPY,
   AgentSkillReferenceSource,
 } from './AgentSkillReference.constants';
+import { useAgentSkillFeedback, useTrackAgentSkillSectionViewed } from './AgentSkillReference.hooks';
 
 const getCopy = (source: AgentSkillReferenceSource) =>
   source === 'terraform-tab' ? AGENT_SKILL_TERRAFORM_COPY : AGENT_SKILL_DEFAULT_COPY;
@@ -31,23 +26,9 @@ interface AgentSkillReferenceProps {
 }
 
 export const AgentSkillReference = ({ source, collapsible = false }: AgentSkillReferenceProps) => {
-  const [hasCopiedInstall, setHasCopiedInstall] = useLocalStorage<boolean>(
-    AGENT_SKILL_INSTALL_COPIED_STORAGE_KEY,
-    false
-  );
-  // Ask for feedback only on return visits: snapshot the flag at mount so a
-  // copy in the current session doesn't trigger the ask before the skill has
-  // actually been tried.
-  const [askForFeedback] = useState(hasCopiedInstall);
+  const { askForFeedback, markInstallCopied, markFeedbackGiven } = useAgentSkillFeedback();
   const [isOpen, setIsOpen] = useState(false);
-  const hasTrackedView = useRef(false);
-
-  const trackView = useCallback(() => {
-    if (!hasTrackedView.current) {
-      hasTrackedView.current = true;
-      trackAgentSkillSectionViewed({ source });
-    }
-  }, [source]);
+  const trackView = useTrackAgentSkillSectionViewed(source);
 
   useEffect(() => {
     if (!collapsible) {
@@ -57,14 +38,18 @@ export const AgentSkillReference = ({ source, collapsible = false }: AgentSkillR
 
   const handleCopy = useCallback(
     (command: 'npx' | 'claude-plugin') => {
-      setHasCopiedInstall(true);
+      markInstallCopied();
       trackAgentSkillInstallCommandCopied({ source, command });
     },
-    [setHasCopiedInstall, source]
+    [markInstallCopied, source]
   );
 
   const feedback = askForFeedback && (
-    <Feedback feature={AGENT_SKILL_FEEDBACK_FEATURE} about={{ text: 'Did the skill help?' }} />
+    <Feedback
+      feature={AGENT_SKILL_FEEDBACK_FEATURE}
+      about={{ text: 'Did the skill help?' }}
+      onReaction={markFeedbackGiven}
+    />
   );
 
   const content = <AgentSkillReferenceContent source={source} onCopy={handleCopy} />;

--- a/src/components/AssistantContext/AssistantContext.constants.ts
+++ b/src/components/AssistantContext/AssistantContext.constants.ts
@@ -114,6 +114,34 @@ function smK6Conventions(): ChatContextItem {
   });
 }
 
+/**
+ * Hidden context attached to pages where the user is choosing or authoring a
+ * check. Assistant cannot run the Agent Skill itself, but it should know the
+ * skill exists so it can route users who author with an AI coding agent
+ * (Claude Code, Cursor, Codex, ...) to it instead of leaving them to generate
+ * load-test-shaped scripts from scratch.
+ */
+function agentSkillRecommendation(): ChatContextItem {
+  return hiddenStructured('Synthetic Monitoring agent skill', {
+    pageType: 'sm-agent-skill',
+    audience: 'check-authoring',
+    summary:
+      'A Synthetic Monitoring Agent Skill exists for AI coding agents (Claude Code, Cursor, Codex, and other Agent Skills compatible tools). It teaches an agent to choose the simplest sufficient check type, author scripted and browser checks with correct fail-fast assertions, validate them locally with `k6 run`, and deploy via the UI, API, or Terraform.',
+    whenToRecommend: [
+      'The user mentions authoring checks with an AI coding agent, in their IDE, in their terminal, or locally.',
+      'The user wants to convert an OpenAPI spec or an existing k6 script into checks as a larger local workflow.',
+      'The user asks how to manage many checks as code, or wants Terraform for scripted/browser checks.',
+      'The user is unsure which check type to pick and prefers working outside the Grafana UI.',
+    ],
+    howToInstall: [
+      'Any Agent Skills compatible tool: `npx skills add grafana/skills`',
+      'Claude Code plugin: `claude plugin install grafana-cloud@grafana-skills`',
+    ],
+    repository: 'https://github.com/grafana/skills/tree/main/skills/grafana-cloud/synthetic-monitoring-checks',
+    note: 'Scripts authored with the skill are portable k6 — users can paste them directly into the script editor in this app instead of deploying via Terraform or the API. Do NOT attempt to execute the skill yourself; it is an instruction set for coding agents with local file and terminal access.',
+  });
+}
+
 const root = PLUGIN_URL_PATH.replace(/\/$/, '');
 
 // Pre-built regex fragments so the route shape is obvious at the call site.
@@ -192,6 +220,7 @@ export const ASSISTANT_PAGE_CONTEXTS: readonly AssistantPageContextEntry[] = [
         capabilities: ['explain-check-types', 'recommend-check-type'],
         help: 'User is picking which kind of synthetic check to create: API (HTTP, DNS, TCP, gRPC), Ping, Traceroute, k6 scripted, or k6 browser. Help with: which check type fits a given monitoring goal, the trade-offs between scripted and protocol-level checks, and when to choose browser checks.',
       }),
+      agentSkillRecommendation(),
     ],
     createQuestions: () => [
       question(
@@ -270,6 +299,7 @@ export const ASSISTANT_PAGE_CONTEXTS: readonly AssistantPageContextEntry[] = [
         help: `User is creating a k6 scripted check (JavaScript) for synthetic monitoring. This is NOT a load test — the script runs as a single-VU probe check on a recurring schedule. Help with: writing the script (default export, http requests, sleep used sparingly), using the k6-testing assertions library (expect() from ${DOC_URLS.k6Assertions}) to fail-fast on assertion violations, referencing credentials via the SM Secrets module, and adapting existing perf-testing-shaped k6 scripts (stages/VUs/thresholds, classic check() calls) into the SM single-VU model. Prefer expect() over the classic check() function.`,
       }),
       smK6Conventions(),
+      agentSkillRecommendation(),
     ],
     createQuestions: () => [
       question(
@@ -302,6 +332,7 @@ export const ASSISTANT_PAGE_CONTEXTS: readonly AssistantPageContextEntry[] = [
         help: `User is creating a k6 browser check (real headless browser) for synthetic monitoring. This is NOT a load test — the script runs as a single-VU probe check on a recurring schedule. Help with: writing browser scripts using the k6 browser API (page.goto, locator, waitForSelector), asserting on page content and DOM state with the k6-testing assertions library's auto-retrying matchers (await expect(page.locator(...)).toBeVisible(), .toHaveText(...), etc. — see ${DOC_URLS.k6Assertions}), navigating multi-page flows, referencing credentials via SM Secrets, and avoiding load-test constructs (no stages/VUs/thresholds). Prefer expect() over the classic check() function. Do NOT suggest page.screenshot() — screenshot capture is not currently functional in SM. For recommended patterns on element selection, handling dynamic elements, simulating user input delay, and cleaning up resources, see ${DOC_URLS.k6BrowserPractices}.`,
       }),
       smK6Conventions(),
+      agentSkillRecommendation(),
     ],
     createQuestions: () => [
       question(
@@ -353,6 +384,7 @@ export const ASSISTANT_PAGE_CONTEXTS: readonly AssistantPageContextEntry[] = [
         help: 'User is editing an existing synthetic monitoring check. Help with: adjusting target/URL, request method/headers/body, response validation, probe selection, frequency/timeout, k6 script edits for scripted/browser checks, and per-check alert configuration. If the check being edited is a k6 scripted or browser check, follow the SM k6 conventions in the hidden context — do not introduce load-test constructs.',
       }),
       smK6Conventions(),
+      agentSkillRecommendation(),
     ],
     createQuestions: () => [
       question(

--- a/src/components/Checkster/feature/docs/DocsPanelBrowser.tsx
+++ b/src/components/Checkster/feature/docs/DocsPanelBrowser.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Stack } from '@grafana/ui';
 
+import { AgentSkillReference } from 'components/AgentSkillReference/AgentSkillReference';
 import { AboutBrowserChecks } from 'components/Checkster/feature/docs/AboutBrowserChecks';
 import { Aboutk6Studio } from 'components/Checkster/feature/docs/Aboutk6Studio';
 import {
@@ -19,6 +20,7 @@ export const DocsPanelBrowserCheck = () => {
     <Box padding={2}>
       <Stack direction="column" gap={2}>
         <AboutBrowserChecks />
+        <AgentSkillReference source="docs-panel-browser" />
         <Aboutk6Studio source={source} />
         <DocumentationLinks
           links={[

--- a/src/components/Checkster/feature/docs/DocsPanelScripted.tsx
+++ b/src/components/Checkster/feature/docs/DocsPanelScripted.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Stack } from '@grafana/ui';
 
+import { AgentSkillReference } from 'components/AgentSkillReference/AgentSkillReference';
 import { Aboutk6Studio } from 'components/Checkster/feature/docs/Aboutk6Studio';
 import { AboutScriptedChecks } from 'components/Checkster/feature/docs/AboutScriptedChecks';
 import {
@@ -18,6 +19,7 @@ export const DocsPanelScriptedCheck = () => {
     <Box padding={2}>
       <Stack direction="column" gap={2}>
         <AboutScriptedChecks />
+        <AgentSkillReference source="docs-panel-scripted" />
         <Aboutk6Studio source={source} />
         <DocumentationLinks
           links={[

--- a/src/components/Clipboard/Clipboard.tsx
+++ b/src/components/Clipboard/Clipboard.tsx
@@ -14,9 +14,18 @@ interface ClipboardProps {
   highlight?: string | string[];
   isCode?: boolean;
   inlineCopy?: boolean;
+  onCopy?: () => void;
 }
 
-export function Clipboard({ content, className, truncate, highlight, isCode, inlineCopy = false }: ClipboardProps) {
+export function Clipboard({
+  content,
+  className,
+  truncate,
+  highlight,
+  isCode,
+  inlineCopy = false,
+  onCopy,
+}: ClipboardProps) {
   const styles = useStyles2(getStyles);
 
   return (
@@ -37,6 +46,7 @@ export function Clipboard({ content, className, truncate, highlight, isCode, inl
         buttonText="Copy to clipboard"
         buttonTextCopied="Copied to clipboard"
         content={content}
+        onClipboardCopy={onCopy}
         onClipboardError={(err) => {
           appEvents.emit(AppEvents.alertError, [`Failed to copy to clipboard: ${err}`]);
         }}

--- a/src/components/Feedback/Feedback.tsx
+++ b/src/components/Feedback/Feedback.tsx
@@ -18,9 +18,11 @@ interface FeedbackProps {
   about?: FeedbackAboutProps;
   feature: string;
   placement?: ComponentProps<typeof Toggletip>['placement'];
+  /** Called when the user clicks a reaction, in addition to the built-in tracking. */
+  onReaction?: (reaction: 'good' | 'bad') => void;
 }
 
-export const Feedback = ({ about, feature, placement }: FeedbackProps) => {
+export const Feedback = ({ about, feature, placement, onReaction }: FeedbackProps) => {
   const [active, setActive] = useState<'good' | 'bad' | null>(null);
 
   return (
@@ -32,6 +34,7 @@ export const Feedback = ({ about, feature, placement }: FeedbackProps) => {
         onClick={() => {
           setActive('good');
           trackFeatureFeedback({ feature, reaction: 'good' });
+          onReaction?.('good');
         }}
         onClose={() => setActive(null)}
         reaction="good"
@@ -44,6 +47,7 @@ export const Feedback = ({ about, feature, placement }: FeedbackProps) => {
         onClick={() => {
           setActive('bad');
           trackFeatureFeedback({ feature, reaction: 'bad' });
+          onReaction?.('bad');
         }}
         onClose={() => setActive(null)}
         reaction="bad"

--- a/src/features/tracking/agentSkillEvents.ts
+++ b/src/features/tracking/agentSkillEvents.ts
@@ -30,7 +30,7 @@ interface AgentSkillPromptEvent extends TrackingEventProps {
   prompt: 'site' | 'api-spec' | 'terraform-import';
 }
 
-/** Tracks when the agent skill reference content is shown: on render in the docs panels, on first reveal (expand or tool selection) elsewhere. */
+/** Tracks when the agent skill reference content is shown, at most once per source per page load: on render in the docs panels, on first reveal (expand or tool selection) elsewhere. */
 export const trackAgentSkillSectionViewed = agentSkillEvents<AgentSkillEvent>('section_viewed');
 
 /** Tracks when the agent skill repository link is clicked. */

--- a/src/features/tracking/agentSkillEvents.ts
+++ b/src/features/tracking/agentSkillEvents.ts
@@ -14,7 +14,23 @@ interface AgentSkillInstallCommandEvent extends TrackingEventProps {
   command: 'npx' | 'claude-plugin';
 }
 
-/** Tracks when the agent skill reference content is shown: on render in the docs panels, on first expand on collapsible surfaces (choose-check-type, terraform-tab). */
+interface AgentSkillToolEvent extends TrackingEventProps {
+  /** Where in the app the agent skill reference was interacted with. */
+  source: 'docs-panel-scripted' | 'docs-panel-browser' | 'choose-check-type' | 'terraform-tab';
+  /** Which coding agent tool card the user selected. */
+  tool: 'claude-code' | 'agent-skills';
+}
+
+interface AgentSkillPromptEvent extends TrackingEventProps {
+  /** Where in the app the agent skill reference was interacted with. */
+  source: 'docs-panel-scripted' | 'docs-panel-browser' | 'choose-check-type' | 'terraform-tab';
+  /** Which coding agent tool card the user selected. Absent on surfaces without a tool picker. */
+  tool?: 'claude-code' | 'agent-skills';
+  /** Which example prompt variant was copied. */
+  prompt: 'site' | 'api-spec' | 'terraform-import';
+}
+
+/** Tracks when the agent skill reference content is shown: on render in the docs panels, on first reveal (expand or tool selection) elsewhere. */
 export const trackAgentSkillSectionViewed = agentSkillEvents<AgentSkillEvent>('section_viewed');
 
 /** Tracks when the agent skill repository link is clicked. */
@@ -23,3 +39,9 @@ export const trackAgentSkillLinkClicked = agentSkillEvents<AgentSkillEvent>('lin
 /** Tracks when one of the agent skill install commands is copied to the clipboard. */
 export const trackAgentSkillInstallCommandCopied =
   agentSkillEvents<AgentSkillInstallCommandEvent>('install_command_copied');
+
+/** Tracks when a coding agent tool card is selected in the agent skill picker. */
+export const trackAgentSkillToolSelected = agentSkillEvents<AgentSkillToolEvent>('tool_selected');
+
+/** Tracks when one of the example authoring prompts is copied to the clipboard. */
+export const trackAgentSkillPromptCopied = agentSkillEvents<AgentSkillPromptEvent>('prompt_copied');

--- a/src/features/tracking/agentSkillEvents.ts
+++ b/src/features/tracking/agentSkillEvents.ts
@@ -1,0 +1,25 @@
+import { createSMEventFactory, TrackingEventProps } from 'features/tracking/utils';
+
+const agentSkillEvents = createSMEventFactory('agent_skill');
+
+interface AgentSkillEvent extends TrackingEventProps {
+  /** Where in the app the agent skill reference was interacted with. */
+  source: 'docs-panel-scripted' | 'docs-panel-browser' | 'choose-check-type' | 'terraform-tab';
+}
+
+interface AgentSkillInstallCommandEvent extends TrackingEventProps {
+  /** Where in the app the agent skill reference was interacted with. */
+  source: 'docs-panel-scripted' | 'docs-panel-browser' | 'choose-check-type' | 'terraform-tab';
+  /** Which install command was copied. */
+  command: 'npx' | 'claude-plugin';
+}
+
+/** Tracks when the agent skill reference content is shown: on render in the docs panels, on first expand on collapsible surfaces (choose-check-type, terraform-tab). */
+export const trackAgentSkillSectionViewed = agentSkillEvents<AgentSkillEvent>('section_viewed');
+
+/** Tracks when the agent skill repository link is clicked. */
+export const trackAgentSkillLinkClicked = agentSkillEvents<AgentSkillEvent>('link_clicked');
+
+/** Tracks when one of the agent skill install commands is copied to the clipboard. */
+export const trackAgentSkillInstallCommandCopied =
+  agentSkillEvents<AgentSkillInstallCommandEvent>('install_command_copied');

--- a/src/page/ChooseCheckGroup/ChooseCheckGroup.tsx
+++ b/src/page/ChooseCheckGroup/ChooseCheckGroup.tsx
@@ -6,7 +6,7 @@ import { css } from '@emotion/css';
 import { CHECKS_TEST_ID } from 'test/dataTestIds';
 
 import { useCheckTypeGroupOptions } from 'hooks/useCheckTypeGroupOptions';
-import { AgentSkillReference } from 'components/AgentSkillReference/AgentSkillReference';
+import { AgentSkillPicker } from 'components/AgentSkillReference/AgentSkillPicker';
 import { OverLimitAlert } from 'components/OverLimitAlert';
 
 import { CheckGroupCard } from './components/CheckGroupCard';
@@ -29,8 +29,8 @@ export const ChooseCheckGroup = () => {
               return <CheckGroupCard key={group.label} group={group} />;
             })}
           </div>
-          <Box maxWidth={100}>
-            <AgentSkillReference source="choose-check-type" collapsible />
+          <Box maxWidth={100} marginTop={2}>
+            <AgentSkillPicker source="choose-check-type" />
           </Box>
         </Stack>
       </div>

--- a/src/page/ChooseCheckGroup/ChooseCheckGroup.tsx
+++ b/src/page/ChooseCheckGroup/ChooseCheckGroup.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
-import { Stack, useStyles2 } from '@grafana/ui';
+import { Box, Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { CHECKS_TEST_ID } from 'test/dataTestIds';
 
 import { useCheckTypeGroupOptions } from 'hooks/useCheckTypeGroupOptions';
+import { AgentSkillReference } from 'components/AgentSkillReference/AgentSkillReference';
 import { OverLimitAlert } from 'components/OverLimitAlert';
 
 import { CheckGroupCard } from './components/CheckGroupCard';
@@ -28,6 +29,9 @@ export const ChooseCheckGroup = () => {
               return <CheckGroupCard key={group.label} group={group} />;
             })}
           </div>
+          <Box maxWidth={100}>
+            <AgentSkillReference source="choose-check-type" collapsible />
+          </Box>
         </Stack>
       </div>
     </PluginPage>

--- a/src/page/ChooseCheckGroup/ChooseCheckGroup.tsx
+++ b/src/page/ChooseCheckGroup/ChooseCheckGroup.tsx
@@ -29,7 +29,7 @@ export const ChooseCheckGroup = () => {
               return <CheckGroupCard key={group.label} group={group} />;
             })}
           </div>
-          <Box maxWidth={100} marginTop={2}>
+          <Box marginTop={2}>
             <AgentSkillPicker source="choose-check-type" />
           </Box>
         </Stack>

--- a/src/page/ConfigPageLayout/tabs/TerraformTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/TerraformTab.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { AGENT_SKILL_INSTALL_COMMANDS } from '../../../components/AgentSkillReference/AgentSkillReference.constants';
 import { CONFIG_TEST_ID, UI_TEST_ID } from '../../../test/dataTestIds';
 import { BASIC_PING_CHECK } from '../../../test/fixtures/checks';
 import { PRIVATE_PROBE, UNSELECTED_PRIVATE_PROBE } from '../../../test/fixtures/probes';
@@ -33,6 +34,14 @@ async function renderTerraformTab() {
   await result.findByTestId(CONFIG_TEST_ID.content);
 
   return result;
+}
+
+// The agent skill reference at the top of the tab renders its install commands
+// as preformatted blocks too; skip them to get to the terraform content.
+const AGENT_SKILL_COMMANDS: string[] = AGENT_SKILL_INSTALL_COMMANDS.map(({ command }) => command);
+
+function getTerraformPreformatted(getAllByTestId: (id: string) => HTMLElement[]) {
+  return getAllByTestId(UI_TEST_ID.preformatted).filter((el) => !AGENT_SKILL_COMMANDS.includes(el.textContent ?? ''));
 }
 
 describe('TerraformTab', () => {
@@ -92,7 +101,7 @@ describe('TerraformTab', () => {
 
   it('should show correct terraform HCL config by default', async () => {
     const { getAllByTestId } = await renderTerraformTab();
-    const preformatted = getAllByTestId(UI_TEST_ID.preformatted);
+    const preformatted = getTerraformPreformatted(getAllByTestId);
     const content = preformatted[0].textContent ?? '';
 
     // Should contain HCL syntax elements
@@ -109,7 +118,7 @@ describe('TerraformTab', () => {
     const jsonTab = getByText('JSON');
     await user.click(jsonTab);
 
-    const preformatted = getAllByTestId(UI_TEST_ID.preformatted);
+    const preformatted = getTerraformPreformatted(getAllByTestId);
     // Since content escapes '<' and '>', we need to replace them back
     const content = JSON.parse((preformatted[0].textContent ?? '').replace('&lt;', '<').replace('&gt;', '>'));
     expect(content).toEqual(TERRAFORM_BASIC_PING_CHECK);
@@ -139,7 +148,7 @@ describe('TerraformTab', () => {
       // Should show "Import checks" subtitle
       expect(getByText('Import checks', { selector: 'h4' })).toBeInTheDocument();
 
-      const preformatted = getAllByTestId(UI_TEST_ID.preformatted);
+      const preformatted = getTerraformPreformatted(getAllByTestId);
       expect(preformatted[1]).toHaveTextContent(
         'terraform import grafana_synthetic_monitoring_check.Job_name_for_ping_grafana_com 6'
       );
@@ -156,7 +165,7 @@ describe('TerraformTab', () => {
       // Should show "Import checks" subtitle
       expect(getByText('Import checks', { selector: 'h4' })).toBeInTheDocument();
 
-      const preformatted = getAllByTestId(UI_TEST_ID.preformatted);
+      const preformatted = getTerraformPreformatted(getAllByTestId);
       const content = preformatted[1].textContent ?? '';
       expect(content).toContain('import {');
       expect(content).toContain('to = grafana_synthetic_monitoring_check.Job_name_for_ping_grafana_com');
@@ -185,7 +194,7 @@ describe('TerraformTab', () => {
           })
         );
         const { getAllByTestId } = await renderTerraformTab();
-        const preformatted = getAllByTestId(UI_TEST_ID.preformatted);
+        const preformatted = getTerraformPreformatted(getAllByTestId);
         expect(preformatted[2]).toHaveTextContent(
           `terraform import grafana_synthetic_monitoring_probe.${PRIVATE_PROBE.name} 1:<PROBE_ACCESS_TOKEN>`
         );
@@ -208,7 +217,7 @@ describe('TerraformTab', () => {
         const importBlocksTab = getByText('Import blocks');
         await user.click(importBlocksTab);
 
-        const preformatted = getAllByTestId(UI_TEST_ID.preformatted);
+        const preformatted = getTerraformPreformatted(getAllByTestId);
         const content = preformatted[2].textContent ?? '';
         expect(content).toContain('import {');
         expect(content).toContain(`to = grafana_synthetic_monitoring_probe.${PRIVATE_PROBE.name}`);

--- a/src/page/ConfigPageLayout/tabs/TerraformTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/TerraformTab.tsx
@@ -9,6 +9,7 @@ import { AppRoutes } from 'routing/types';
 import { generateRoutePath } from 'routing/utils';
 import { getUserPermissions } from 'data/permissions';
 import { useTerraformConfig } from 'hooks/useTerraformConfig';
+import { AgentSkillReference } from 'components/AgentSkillReference/AgentSkillReference';
 import { ContactAdminAlert } from 'page/ContactAdminAlert';
 
 import { ConfigContent } from '../ConfigContent';
@@ -64,6 +65,10 @@ export function TerraformTab() {
         You can manage Synthetic monitoring checks using Terraform as well as export your current checks as
         configuration.
       </p>
+
+      <ConfigContent.Section>
+        <AgentSkillReference source="terraform-tab" collapsible />
+      </ConfigContent.Section>
 
       <ConfigContent.Section title="Prerequisites">
         <div>


### PR DESCRIPTION
## Problem

Authoring synthetic monitoring checks — especially k6 scripted and browser checks — has a steep learning curve. Users starting from the blank script editor have to learn SM's execution model, assertion semantics (a bare `check()` never fails `probe_success`), locator strategies, and deployment options on their own. Meanwhile, a battle-tested Agent Skill (`synthetic-monitoring-checks` in the public [grafana/skills](https://github.com/grafana/skills) repo) teaches coding agents like Claude Code, Cursor, and Codex to do exactly this — choose the simplest sufficient check type, author and locally validate correct scripts, and deploy via UI, API, or Terraform — but nothing in the app tells users it exists.

## Solution

References the skill at the moments users need it, framed for each surface:

- **Choose-check-type page**: a tool picker (Claude Code / Cursor, Codex & other agents). Selecting a tool reveals its one-time install command and copyable starter prompts — "From your site" or "From an API spec" — so a user can go from blank page to a working agent session in two copies.
- **Scripted & browser docs side-panels**: the full reference block (install commands, the same starter prompts, repo link) next to the script editor, where the "Need help writing scripts?" button already lands.
- **Terraform config tab**: a collapsed single-line section framed around adoption — "Use your coding agent to create Terraform files for your existing checks" — with a prompt that feeds the page's own export to the agent and requires a no-op `terraform plan`.
- **Grafana Assistant**: hidden page context on the choose/scripted/browser/edit routes so Assistant can recommend the skill to users who author with coding agents (Assistant cannot run the skill itself).

## Measurement

New `agent_skill` tracking events (auto-mirrored to Faro, tagged with `org_id`/`stack_id`): `section_viewed` (on render in docs panels; on first reveal elsewhere, so it measures intent rather than traffic), `tool_selected`, `install_command_copied`, `prompt_copied` (with prompt variant), and `link_clicked` — all carrying a per-surface `source` property. Copying an install command sets a local marker; on return visits the existing `Feedback` widget asks "Did the skill help?" to capture qualitative signal from users who actually tried it. Effectiveness funnel: `install_command_copied` → scripted/browser `check_created` on the same stack.

The feature ships ungated to measure effectiveness immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)