### PR TITLE
fix: map legacy us-central2 backend address to the us-central-7 probe API server

### DIFF
--- a/src/components/ProbeAPIServer/ProbeAPIServer.test.tsx
+++ b/src/components/ProbeAPIServer/ProbeAPIServer.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import { render } from 'test/render';
 
-import { GRAFANA_DEV_ENTRY } from 'hooks/useProbeApiServer';
+import { GRAFANA_DEV_ENTRY, LEGACY_US_CENTRAL2_ENTRY } from 'hooks/useProbeApiServer';
 import { ProbeAPIServer } from 'components/ProbeAPIServer';
 
 // Mock useBackendAddress for the third test only
@@ -41,9 +41,15 @@ describe('ProbeAPIServer', () => {
     mockUseBackendAddress.mockReturnValue('synthetic-monitoring-api-private.example.net');
 
     render(<ProbeAPIServer source="test" />);
-    expect(
-      await screen.findByText('synthetic-monitoring-grpc-private.example.net:443')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('synthetic-monitoring-grpc-private.example.net:443')).toBeInTheDocument();
+  });
+
+  it(`should show the us-central-7 probe API server URL for the legacy us-central2 backend address`, async () => {
+    mockUseBackendAddress.mockReturnValue(LEGACY_US_CENTRAL2_ENTRY.backendAddress);
+
+    render(<ProbeAPIServer source="test" />);
+    expect(await screen.findByText(LEGACY_US_CENTRAL2_ENTRY.apiServerURL)).toBeInTheDocument();
+    expect(screen.queryByRole('alert', { name: /No probe API server found/ })).not.toBeInTheDocument();
   });
 
   it(`should show an error if the probe API server URL is not found`, async () => {

--- a/src/hooks/useProbeApiServer.ts
+++ b/src/hooks/useProbeApiServer.ts
@@ -10,11 +10,25 @@ export const GRAFANA_DEV_ENTRY = {
   provider: '',
 };
 
+// The us-central2 cluster was migrated to prod-us-central-7 (grafana/synthetic-monitoring-api#1352)
+// but existing stacks may still be provisioned with the legacy apiHost, which remains routable for
+// backwards compatibility. Remove once stack provisioning no longer hands out the legacy address.
+export const LEGACY_US_CENTRAL2_ENTRY = {
+  backendAddress: 'synthetic-monitoring-api-us-central2.grafana.net',
+  apiServerURL: 'synthetic-monitoring-grpc-us-central-7.grafana.net:443',
+  region: 'United States',
+  provider: 'Azure',
+};
+
 export function useProbeApiServer() {
   const backendAddress = useBackendAddress();
-  const probeMapping = [...probeMappings, ...byocProbeMappings, ...devProbeMappings, GRAFANA_DEV_ENTRY].find(
-    (mapping) => mapping.backendAddress === backendAddress
-  );
+  const probeMapping = [
+    ...probeMappings,
+    ...byocProbeMappings,
+    ...devProbeMappings,
+    GRAFANA_DEV_ENTRY,
+    LEGACY_US_CENTRAL2_ENTRY,
+  ].find((mapping) => mapping.backendAddress === backendAddress);
 
   if (!probeMapping) {
     return undefined;


### PR DESCRIPTION
Addresses: https://github.com/grafana/support-escalations/issues/23611

## Problem

Stacks provisioned in the Azure US Central region before the `us-central2` → `prod-us-central-7` cluster migration (grafana/synthetic-monitoring-api#1352) can still have `https://synthetic-monitoring-api-us-central2.grafana.net` as their provisioned `apiHost`. The legacy hostname is intentionally kept routable so these stacks keep working — but when their users try to set up a private probe, the probe API server lookup finds no match for the legacy backend address and dead-ends with a "No probe API server found" error telling them to contact support.

Re-initialising the Synthetic Monitoring datasource does not help, because initialisation copies `apiHost` straight back from the provisioned plugin jsonData.

## Solution

Add a legacy alias entry mapping the `us-central2` backend address to `synthetic-monitoring-grpc-us-central-7.grafana.net:443` — both hostnames route to the same API, so users in this state now get the correct probe API server URL instead of an error.

The alias lives alongside `GRAFANA_DEV_ENTRY` in `useProbeApiServer` rather than in `probeAPIServerMappings.json`, because that file is auto-generated from the public docs table and CI-verified against it, and we don't want to advertise a deprecated hostname in public docs.

## Additional context

- This fixes the private probe setup UX only. Affected stacks still send all SM API traffic to the legacy hostname via their provisioned `apiHost`; migrating stack provisioning to the new address remains the upstream fix and is a prerequisite for ever decommissioning the legacy DNS. The alias (marked with a comment) should be removed once provisioning no longer hands out the legacy address.
- Trade-off: affected stacks will no longer emit the `NoProbeMappingFound` Faro event, which was our only telemetry on how many stacks still carry the legacy address.

## Verification

All existing `ProbeAPIServer` integration tests pass plus a new one covering the legacy address. Support has handed the `us-central-7` endpoint to the affected customer; their confirmation that it works was still pending as of the escalation's last update — worth holding merge until that lands.

Made with [Cursor](https://cursor.com)