### PR TITLE
fix: use theme radius tokens for check list cards and pills

### DIFF
--- a/src/components/ProbeCard/ProbeMetaPillsRow.tsx
+++ b/src/components/ProbeCard/ProbeMetaPillsRow.tsx
@@ -39,7 +39,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   pill: css({
     backgroundColor: theme.colors.background.primary,
-    borderRadius: '2px',
+    borderRadius: theme.shape.radius.sm,
     padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
     fontVariantNumeric: 'tabular-nums',
   }),

--- a/src/externalComponents/testingLanding/components/AgenticFeaturedCard.tsx
+++ b/src/externalComponents/testingLanding/components/AgenticFeaturedCard.tsx
@@ -93,7 +93,7 @@ function getStyles(theme: GrafanaTheme2) {
       bottom: 0,
       width: 3,
       background: 'linear-gradient(180deg, #F55F3E 0%, #FF8833 100%)',
-      borderRadius: '2px 0 0 2px',
+      borderRadius: `${theme.shape.radius.sm} 0 0 ${theme.shape.radius.sm}`,
     }),
     body: css({
       label: 'testing-synthetics-agentic-body',

--- a/src/page/CheckList/components/CheckListItemCard.tsx
+++ b/src/page/CheckList/components/CheckListItemCard.tsx
@@ -128,7 +128,7 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     container: css({
       backgroundColor: theme.colors.background.secondary,
-      borderRadius: '2px',
+      borderRadius: theme.shape.radius.lg,
       border: `1px solid transparent`,
       containerName,
       containerType: 'inline-size',

--- a/src/page/CheckList/components/CheckListItemCard.tsx
+++ b/src/page/CheckList/components/CheckListItemCard.tsx
@@ -130,6 +130,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       backgroundColor: theme.colors.background.secondary,
       borderRadius: theme.shape.radius.lg,
       border: `1px solid transparent`,
+      // Constant width so firing cards (which color it in) stay aligned with the rest
+      borderLeftWidth: '4px',
       containerName,
       containerType: 'inline-size',
     }),
@@ -167,7 +169,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     firingAlertCard: css({
       borderColor: theme.colors.error.border,
-      boxShadow: `inset 4px 0 0 ${theme.colors.error.text}`,
+      borderLeftColor: theme.colors.error.text,
     }),
     wrapper: css({
       overflow: 'hidden',

--- a/src/page/CheckList/components/CheckListItemDetails.tsx
+++ b/src/page/CheckList/components/CheckListItemDetails.tsx
@@ -169,7 +169,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   wrapDetailItem: css({
     backgroundColor: theme.colors.background.primary,
-    borderRadius: '2px',
+    borderRadius: theme.shape.radius.sm,
     padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
   }),
   separator: css({

--- a/src/page/CheckList/components/CheckListItemRow.tsx
+++ b/src/page/CheckList/components/CheckListItemRow.tsx
@@ -81,7 +81,7 @@ export const CheckListItemRow = ({
 const getStyles = (theme: GrafanaTheme2) => ({
   container: css({
     backgroundColor: theme.colors.background.secondary,
-    borderRadius: '2px',
+    borderRadius: theme.shape.radius.lg,
     border: `1px solid transparent`,
   }),
   disabledCard: css({

--- a/src/page/CheckList/components/CheckListItemRow.tsx
+++ b/src/page/CheckList/components/CheckListItemRow.tsx
@@ -83,13 +83,15 @@ const getStyles = (theme: GrafanaTheme2) => ({
     backgroundColor: theme.colors.background.secondary,
     borderRadius: theme.shape.radius.lg,
     border: `1px solid transparent`,
+    // Constant width so firing rows (which color it in) stay aligned with the rest
+    borderLeftWidth: '4px',
   }),
   disabledCard: css({
     backgroundColor: theme.colors.secondary.transparent,
   }),
   firingAlertRow: css({
     borderColor: theme.colors.error.border,
-    boxShadow: `inset 4px 0 0 ${theme.colors.error.text}`,
+    borderLeftColor: theme.colors.error.text,
   }),
   listCardWrapper: css({
     display: 'grid',

--- a/src/page/CheckList/components/Pill.tsx
+++ b/src/page/CheckList/components/Pill.tsx
@@ -24,7 +24,7 @@ export const Pill = ({ className, icon, color, onClick, children }: PropsWithChi
 const getStyles = (color: string) => (theme: GrafanaTheme2) => ({
   container: css`
     background-color: ${theme.colors.background.primary};
-    border-radius: 2px;
+    border-radius: ${theme.shape.radius.sm};
     padding: ${theme.spacing(0.5)} ${theme.spacing(1)};
     font-weight: ${theme.typography.fontWeightBold};
     font-size: 0.75rem;


### PR DESCRIPTION
Addresses: https://github.com/grafana/synthetic-monitoring-app/issues/1776

## Problem

The visual refresh initiative (behind the `grafana.visualDesignRefresh` feature flag) introduces a rounder UI, which makes hardcoded border-radius values stand out. Testing the plugin with the flag enabled showed that the check list cards and their metadata pills (check type, status, frequency, active series, location, executions) render with square or near-square corners (hardcoded `2px`/`3px` values), visibly mismatching the surrounding core components like buttons, search fields and badges. The same hardcoded values affect the probe cards on the Probes page and the featured card accent bar on the Testing & Synthetics landing page.

## Solution

Replace the hardcoded border-radius values with the theme tokens introduced for the refresh, following the guidance in the issue: card and row containers use `theme.shape.radius.lg`, and the small pills/badges use `theme.shape.radius.sm`. These tokens only require Grafana `>=12.3.0`, which our existing `grafanaDependency` (`>=13.0.0-0`) already satisfies, so no `plugin.json` or dependency changes are needed, and per the issue these changes do not need to be gated behind the feature flag.

## Additional context

The rest of the audit from the issue was verified with the flag enabled and needed no changes: backgrounds (including sticky headers/footers) and primary color usage render correctly, and the remaining hardcoded hex colors in the codebase are intentional (SVG illustration art, dashboard threshold colors and brand gradients). This is a styling-only change with no behavioral impact, so no integration tests were added; before/after screenshots below.

### Screenshots (before / after) 

1. Check list (cards)

Before
<img width="1181" height="488" alt="image" src="https://github.com/user-attachments/assets/7848b56f-af14-4d91-80b6-9fcb2257e86a" />

After
<img width="1088" height="843" alt="image" src="https://github.com/user-attachments/assets/68385153-a120-4254-826e-16b73665f6b0" />

2. Check list (list view)

Before
<img width="1475" height="530" alt="image" src="https://github.com/user-attachments/assets/7ef21ea5-99a8-462c-b004-d88cec7040c2" />

After
<img width="1414" height="285" alt="image" src="https://github.com/user-attachments/assets/32fbec7a-6b4e-4a0c-ada8-f82dcee1fbc6" />

3. Probes page

Before 
<img width="670" height="555" alt="image" src="https://github.com/user-attachments/assets/a5b9732a-b776-4e4c-8d7a-c08170a61477" />

After
<img width="737" height="655" alt="image" src="https://github.com/user-attachments/assets/a41c52a9-8c76-4aa7-813a-a2e110ffd9f9" />
