### PR TITLE
fix: keep cost attribution labels grouped after saving a check

### DIFF
--- a/src/components/Checkster/components/form/layouts/GenericLabelContent.test.tsx
+++ b/src/components/Checkster/components/form/layouts/GenericLabelContent.test.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { OpenFeatureTestProvider } from '@openfeature/react-sdk';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SM_OPEN_FEATURE_DOMAIN } from 'services/featureFlags';
 import { TENANT_COST_ATTRIBUTION_LABELS } from 'test/fixtures/tenants';
+import { getTestFlagValues } from 'test/openFeatureTestProvider';
 import { mockFeatureToggles } from 'test/utils';
 
-import { FeatureName } from 'types';
+import { FeatureName, Label } from 'types';
 
 import { formTestRenderer } from '../__test__/formTestRenderer';
 import { GenericLabelContent } from './GenericLabelContent';
@@ -27,6 +32,35 @@ function renderGenericLabelContent(
     { description: 'Test description', ...props } as any,
     { calLabels: [], ...formValues }
   );
+}
+
+const RESET_BUTTON_TEXT = 'Simulate check refetch';
+
+// Saving a check refetches it, which re-seeds `labels` with every label on the check and clears
+// `calLabels`. This harness reproduces that reset so the regrouping can be asserted.
+function renderWithRefetchReset(calNames: string[], labels: Label[]) {
+  function Harness() {
+    const formMethods = useForm({ defaultValues: { labels, calLabels: [] }, mode: 'onChange' });
+
+    return (
+      <FormProvider {...formMethods}>
+        <form>
+          <GenericLabelContent description="Test description" calNames={calNames} />
+          <button type="button" onClick={() => formMethods.reset({ labels, calLabels: [] })}>
+            {RESET_BUTTON_TEXT}
+          </button>
+        </form>
+      </FormProvider>
+    );
+  }
+
+  render(
+    <OpenFeatureTestProvider domain={SM_OPEN_FEATURE_DOMAIN} flagValueMap={getTestFlagValues()}>
+      <Harness />
+    </OpenFeatureTestProvider>
+  );
+
+  return userEvent.setup();
 }
 
 describe('GenericLabelContent', () => {
@@ -137,6 +171,27 @@ describe('GenericLabelContent', () => {
           expect(screen.getByDisplayValue(name)).toBeInTheDocument();
         });
       });
+    });
+
+    it('keeps CAL labels out of the custom labels section after the form is reset', async () => {
+      const user = renderWithRefetchReset(calNames, [
+        { name: 'Team', value: 'team-a' },
+        { name: 'Service', value: 'service-a' },
+        { name: 'custom', value: 'my-value' },
+      ]);
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: 'Cost attribution label 1 value' })).toHaveValue('team-a');
+      });
+
+      await user.click(screen.getByRole('button', { name: RESET_BUTTON_TEXT }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: 'Cost attribution label 1 value' })).toHaveValue('team-a');
+      });
+      expect(screen.getByRole('textbox', { name: 'Cost attribution label 2 value' })).toHaveValue('service-a');
+      expect(screen.getByRole('textbox', { name: 'Custom labels 1 name' })).toHaveValue('custom');
+      expect(screen.queryByRole('textbox', { name: 'Custom labels 2 name' })).not.toBeInTheDocument();
     });
 
     describe('label limit accounts for CALs', () => {

--- a/src/components/Checkster/components/form/layouts/GenericLabelContent.tsx
+++ b/src/components/Checkster/components/form/layouts/GenericLabelContent.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { GrafanaTheme2 } from '@grafana/data';
 import { FieldValidationMessage, LoadingPlaceholder, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -28,17 +28,18 @@ export function GenericLabelContent({ description, isLoading, calNames = [], lab
   } = useFormContext<CheckFormValues>();
   const prevCalNamesRef = useRef<string[]>([]);
 
+  const watchedCalLabels = useWatch<CheckFormValues>({ name: 'calLabels' });
+
   useEffect(() => {
     const prevCalNames = prevCalNamesRef.current;
+    const currentCalLabels = getValues('calLabels') ?? [];
 
-    if (calNames.length === 0 && prevCalNames.length === 0) {
-      return;
-    }
-
-    const hasChanged =
+    const calNamesChanged =
       calNames.length !== prevCalNames.length || calNames.some((name, i) => name !== prevCalNames[i]);
+    const calRowsOutOfSync =
+      currentCalLabels.length !== calNames.length || calNames.some((name, i) => currentCalLabels[i]?.name !== name);
 
-    if (!hasChanged) {
+    if (!calNamesChanged && !calRowsOutOfSync) {
       return;
     }
 
@@ -49,8 +50,9 @@ export function GenericLabelContent({ description, isLoading, calNames = [], lab
     const staleCalNameSet = new Set(staleCalNames);
 
     const calRows = calNames.map((calName) => {
-      const existing = currentLabels.find((label) => label.name === calName);
-      return { name: calName, value: existing?.value ?? '' };
+      const fromLabels = currentLabels.find((label) => label.name === calName);
+      const fromCalLabels = currentCalLabels.find((label) => label?.name === calName);
+      return { name: calName, value: fromLabels?.value ?? fromCalLabels?.value ?? '' };
     });
 
     const remainingLabels = currentLabels.filter(
@@ -61,7 +63,7 @@ export function GenericLabelContent({ description, isLoading, calNames = [], lab
     setValue('labels', remainingLabels);
 
     prevCalNamesRef.current = calNames;
-  }, [calNames, getValues, setValue]);
+  }, [calNames, watchedCalLabels, getValues, setValue]);
 
   if (isLoading) {
     return <LoadingPlaceholder text="Loading label limits" />;


### PR DESCRIPTION
Addresses: https://github.com/grafana/synthetic-monitoring-app/issues/1791

## Problem

When a check has both cost attribution labels and custom labels, saving the check moves the cost attribution labels into the Custom labels section. The cost attribution rows are left blank, as though the values had been cleared.

Nothing is actually lost. The check is saved correctly and the labels return to their proper sections when you navigate away and come back, but it looks like the save has just discarded your cost attribution values.

## Solution

Sorting the labels into the two sections was a one-shot, only re-running when the tenant's cost attribution names changed. It now also runs whenever the cost attribution rows are out of sync with the names they should contain, which is the state a form reset leaves behind. It keys off the cost attribution rows rather than scanning the custom labels for cost-attribution-looking names

### Before

https://github.com/user-attachments/assets/adb055bf-5bad-4049-9cba-ef694d2f4eea

### After

https://github.com/user-attachments/assets/03eb6b77-61c6-413b-9af7-62a2d2e3bf75