### PR TITLE
fix(reliability-inbox): present evidence with accurate semantics

### DIFF
--- a/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
@@ -48,6 +48,7 @@ const HTTP_SUGGESTION: ReliabilitySuggestion = {
   checkType: 'http',
   evidence: {
     reqPerS: 1.6081232492997197,
+    errorRatio: 0.0014,
     p99Ms: 4,
     statusDistribution: {
       '200': 1.6058823529411763,
@@ -171,6 +172,7 @@ describe('ReliabilityInboxPage', () => {
     expect(screen.getByText('Demo evidence')).toBeInTheDocument();
     expect(screen.getByText('14,700')).toBeInTheDocument();
     expect(screen.getByText('requests · the last 24 hours')).toBeInTheDocument();
+    expect(screen.getByText('5xx responses')).toBeInTheDocument();
     expect(screen.getByLabelText('Observed requests over time')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'View in Explore' })).not.toBeInTheDocument();
 
@@ -206,6 +208,30 @@ describe('ReliabilityInboxPage', () => {
       'No traffic trend is available for this evidence window.'
     );
     expect(screen.queryByLabelText('Observed requests over time')).not.toBeInTheDocument();
+  });
+
+  it('does not render missing aggregate evidence as zero', async () => {
+    mockSuggestions({
+      ...HTTP_SUGGESTION,
+      evidence: {
+        statusDistribution: {},
+        families: HTTP_SUGGESTION.evidence.families,
+        activitySemantics: HTTP_SUGGESTION.evidence.activitySemantics,
+      },
+      evidencePrototype: undefined,
+    });
+
+    render(<ReliabilityInboxPage />, {
+      path: generateRoutePath(AppRoutes.ReliabilityInbox),
+      route: getRoute(AppRoutes.ReliabilityInbox),
+    });
+
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'No aggregate traffic values were returned for this suggestion.'
+    );
+    expect(screen.queryByText('0 req/s')).not.toBeInTheDocument();
+    expect(screen.queryByText('0 ms')).not.toBeInTheDocument();
+    expect(screen.queryByText('0.0%')).not.toBeInTheDocument();
   });
 
   it('keeps the existing page-level loading state while evidence is loading', async () => {

--- a/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
@@ -121,7 +121,7 @@ function ReliabilityInboxReview() {
       requestsPerSecond: selected.suggestion.evidence.reqPerS,
       estimatedRequestsInWindow: selected.requestVolume,
       p99Milliseconds: selected.suggestion.evidence.p99Ms,
-      httpErrorRate: selected.errorRate,
+      fiveXxResponseRatio: selected.suggestion.evidence.errorRatio,
       statusDistribution: selected.suggestion.evidence.statusDistribution,
       measurementWindow: 'last hour',
       telemetryFamilies: selected.suggestion.evidence.families,
@@ -216,7 +216,7 @@ function ReliabilityInboxReview() {
                 text={`${capitalize(opportunity.confidence)} confidence`}
               />
             </div>
-            <span>Public HTTP traffic · {opportunity.requestRate}</span>
+            <span>Public HTTP traffic{opportunity.requestRate ? ` · ${opportunity.requestRate}` : ''}</span>
           </button>
         ))}
       </aside>
@@ -282,8 +282,8 @@ function ReliabilityInboxReview() {
                   value={formatExactNumber(selected.evidencePrototype.exactRequestTotal)}
                   label={`requests · ${selected.evidencePrototype.window.label}`}
                 />
-                <EvidenceMetric value={selected.errorRate} label="HTTP error responses" />
-                <EvidenceMetric value={selected.p99} label="p99 response time" />
+                {selected.errorRate && <EvidenceMetric value={selected.errorRate} label="5xx responses" />}
+                {selected.p99 && <EvidenceMetric value={selected.p99} label="p99 response time" />}
               </div>
               <ReliabilityEvidenceTrend evidence={selected.evidencePrototype} />
               <p className={styles.sectionSummary}>
@@ -293,14 +293,20 @@ function ReliabilityInboxReview() {
           ) : (
             <>
               <div className={styles.metrics}>
-                <EvidenceMetric value={selected.requestVolume} label="estimated requests in the last hour" />
-                <EvidenceMetric value={selected.requestRate} label="observed request rate" />
-                <EvidenceMetric value={selected.errorRate} label="HTTP error responses" />
-                <EvidenceMetric value={selected.p99} label="p99 response time" />
+                {selected.requestVolume && (
+                  <EvidenceMetric value={selected.requestVolume} label="estimated requests in the last hour" />
+                )}
+                {selected.requestRate && <EvidenceMetric value={selected.requestRate} label="observed request rate" />}
+                {selected.errorRate && <EvidenceMetric value={selected.errorRate} label="5xx responses" />}
+                {selected.p99 && <EvidenceMetric value={selected.p99} label="p99 response time" />}
               </div>
-              <p className={styles.sectionSummary}>
-                Recent aggregate traffic shows sustained demand with measurable availability and latency.
-              </p>
+              {selected.requestVolume || selected.requestRate || selected.errorRate || selected.p99 ? (
+                <p className={styles.sectionSummary}>These values come from recent request telemetry.</p>
+              ) : (
+                <p className={styles.sectionSummary} role="status">
+                  No aggregate traffic values were returned for this suggestion.
+                </p>
+              )}
             </>
           )}
           <details className={styles.disclosure}>

--- a/src/features/reliabilityInbox/model.test.ts
+++ b/src/features/reliabilityInbox/model.test.ts
@@ -1,4 +1,4 @@
-import { ReliabilitySuggestion } from './types';
+import { ReliabilitySuggestion, reliabilitySuggestionSchema } from './types';
 import { CheckType } from 'types';
 
 import {
@@ -16,6 +16,7 @@ const HTTP_SUGGESTION: ReliabilitySuggestion = {
   checkType: 'http',
   evidence: {
     reqPerS: 1.6081232492997197,
+    errorRatio: 0.0014,
     p99Ms: 4,
     statusDistribution: {
       '200': 1.6058823529411763,
@@ -147,6 +148,25 @@ describe('Reliability Inbox model', () => {
         validStatusCodes: [200],
         locationPolicy: 'Run from the suggested public probe in Frankfurt.',
         estimatedExecutionsPerMonth: 43_200,
+      })
+    );
+  });
+
+  it('preserves absent numeric evidence instead of presenting it as zero', () => {
+    const suggestion = reliabilitySuggestionSchema.parse({
+      ...HTTP_SUGGESTION,
+      evidence: {
+        families: HTTP_SUGGESTION.evidence.families,
+        activitySemantics: HTTP_SUGGESTION.evidence.activitySemantics,
+      },
+    });
+
+    expect(toReliabilityOpportunity(suggestion)).toEqual(
+      expect.objectContaining({
+        requestVolume: undefined,
+        requestRate: undefined,
+        errorRate: undefined,
+        p99: undefined,
       })
     );
   });

--- a/src/features/reliabilityInbox/model.ts
+++ b/src/features/reliabilityInbox/model.ts
@@ -128,7 +128,8 @@ export function toReliabilityOpportunity(suggestion: ReliabilitySuggestion): Rel
     probeIds: proposedCheck.probeIds,
   };
   const readiness = getReadiness(suggestion);
-  const requestRate = `${formatDecimal(suggestion.evidence.reqPerS)} req/s`;
+  const requestRate =
+    suggestion.evidence.reqPerS === undefined ? undefined : `${formatDecimal(suggestion.evidence.reqPerS)} req/s`;
   const reachability = getReachabilityLabel(suggestion);
   const frequency = config.frequencyMs ? formatFrequency(config.frequencyMs) : 'Default schedule';
   const locations = config.probeIds.length;
@@ -144,7 +145,7 @@ export function toReliabilityOpportunity(suggestion: ReliabilitySuggestion): Rel
     id: suggestion.id,
     suggestion,
     subject: getSubject(suggestion.target),
-    observedSummary: `${requestRate} · ${reachability} · last hour`,
+    observedSummary: [requestRate, reachability, requestRate ? 'last hour' : undefined].filter(Boolean).join(' · '),
     rationale: suggestion.rationale ?? 'Observed demand appears to have no equivalent synthetic coverage.',
     value: getValue(suggestion.relevance),
     confidence: getConfidence(suggestion.confidence),
@@ -156,10 +157,13 @@ export function toReliabilityOpportunity(suggestion: ReliabilitySuggestion): Rel
         : `${frequency} · ${locationCopy} · ${assertion}`,
     estimatedUsage: estimateMonthlyUsage(config),
     sortScore: suggestion.relevance ?? suggestion.score * 100,
-    requestVolume: formatCompactNumber(suggestion.evidence.reqPerS * 60 * 60),
+    requestVolume:
+      suggestion.evidence.reqPerS === undefined
+        ? undefined
+        : formatCompactNumber(suggestion.evidence.reqPerS * 60 * 60),
     requestRate,
-    errorRate: formatErrorRate(suggestion),
-    p99: `${formatDecimal(suggestion.evidence.p99Ms)} ms`,
+    errorRate: formatErrorRate(suggestion.evidence.errorRatio),
+    p99: suggestion.evidence.p99Ms === undefined ? undefined : `${formatDecimal(suggestion.evidence.p99Ms)} ms`,
     evidencePrototype: suggestion.evidencePrototype,
     proposedCheck,
   };
@@ -401,11 +405,10 @@ function formatDecimal(value: number) {
   return new Intl.NumberFormat('en-US', { maximumFractionDigits: 1 }).format(value);
 }
 
-function formatErrorRate(suggestion: ReliabilitySuggestion) {
-  const errors = Object.entries(suggestion.evidence.statusDistribution).reduce((total, [status, rate]) => {
-    return Number(status) >= 400 ? total + rate : total;
-  }, 0);
-  const ratio = suggestion.evidence.reqPerS > 0 ? errors / suggestion.evidence.reqPerS : 0;
+function formatErrorRate(ratio?: number) {
+  if (ratio === undefined) {
+    return undefined;
+  }
 
   return new Intl.NumberFormat('en-US', {
     style: 'percent',

--- a/src/features/reliabilityInbox/types.ts
+++ b/src/features/reliabilityInbox/types.ts
@@ -37,12 +37,11 @@ export const reliabilitySuggestionSchema = z
     checkType: z.string(),
     evidence: z
       .object({
-        // Defaulted rather than required. Every field on the service's Evidence
-        // struct is `omitempty`, so a zero value is ABSENT from the JSON rather
-        // than 0 — and zero-traffic candidates are common (a host found via labels
-        // that carries no requests). Requiring these discarded every suggestion.
-        reqPerS: z.number().default(0),
-        p99Ms: z.number().default(0),
+        // Numeric evidence is optional because the service omits zero values.
+        // Preserve absence so the UI does not present missing telemetry as zero.
+        reqPerS: z.number().optional(),
+        errorRatio: z.number().optional(),
+        p99Ms: z.number().optional(),
         statusDistribution: z.record(z.string(), z.number()).default({}),
         families: z.array(z.string()).default([]),
         activitySemantics: z.array(z.string()).default([]),
@@ -125,10 +124,10 @@ export interface ReliabilityOpportunity {
   actionSummary: string;
   estimatedUsage?: string;
   sortScore: number;
-  requestVolume: string;
-  requestRate: string;
-  errorRate: string;
-  p99: string;
+  requestVolume?: string;
+  requestRate?: string;
+  errorRate?: string;
+  p99?: string;
   evidencePrototype?: ReliabilityEvidencePrototype;
   proposedCheck: ProposedHttpCheckDraft;
 }


### PR DESCRIPTION
## Summary
- preserve omitted numeric evidence instead of defaulting it to zero
- use the backend 5xx ratio rather than deriving an all-4xx-and-5xx error rate
- render only evidence values that were actually measured
- label hourly request totals as estimates

## Validation
- yarn test src/features/reliabilityInbox/model.test.ts src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx --runInBand
- yarn eslint on the five changed Reliability Inbox files
- yarn typecheck

## Stack
- Backend dependency: grafana/k6-experiments#29
- Base UI prototype: #1773
- This PR: evidence semantic correctness
- Child: #1798