### PR TITLE
fix: group cost attribution labels before the check form is populated

### DIFF
--- a/src/components/Checkster/components/form/generic/GenericNameValueField.test.tsx
+++ b/src/components/Checkster/components/form/generic/GenericNameValueField.test.tsx
@@ -37,6 +37,13 @@ jest.mock('data/useDefaultFolder', () => ({
   })),
 }));
 
+jest.mock('data/useTenantCostAttributionLabels', () => ({
+  useTenantCostAttributionLabels: jest.fn(() => ({
+    data: undefined,
+    isLoading: false,
+  })),
+}));
+
 const defaultProps = {
   field: 'labels',
   label: 'Labels',

--- a/src/components/Checkster/contexts/ChecksterContext.tsx
+++ b/src/components/Checkster/contexts/ChecksterContext.tsx
@@ -23,11 +23,13 @@ import { getCheckType } from 'utils';
 import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 import { useDefaultFolder } from 'data/useDefaultFolder';
 import { useProbesWithMetadata } from 'data/useProbes';
+import { useTenantCostAttributionLabels } from 'data/useTenantCostAttributionLabels';
 import { useDOMId } from 'hooks/useDOMId';
 
 import { ASSISTED_FORM_MERGE_FIELDS, DEFAULT_CHECK_TYPE, K6_CHECK_TYPES } from '../constants';
 import { useFormNavigationState } from '../hooks/useFormNavigationState';
 import { useProbeCompatibilityKey } from '../hooks/useProbeCompattibilityKey';
+import { groupLabelsByCalNames } from '../transformations/toFormValues.utils';
 import { getDefaultFormValues, toFormValues } from '../utils/adaptors';
 import { isCheck } from '../utils/check';
 import { flattenObjectKeys } from '../utils/form';
@@ -76,11 +78,17 @@ interface StashedValues {
 
 function useFormValuesMeta(checkType: CheckType, check: Check | undefined, probesWithMetadata: ProbeWithMetadata[], defaultFolderUid?: string) {
   const probeCompatibilityKey = useProbeCompatibilityKey(probesWithMetadata);
+  const { data: calData } = useTenantCostAttributionLabels();
+  const calNames = useMemo(() => calData?.names ?? [], [calData]);
 
   return useMemo(() => {
     const schema = createCheckSchema(checkType, probesWithMetadata);
     const refinedSchema = addRefinements<CheckFormValues>(schema);
     const formValues = check ? toFormValues(check) : getDefaultFormValues(checkType);
+    const grouped = groupLabelsByCalNames(formValues.labels, calNames);
+
+    formValues.labels = grouped.labels;
+    formValues.calLabels = grouped.calLabels;
 
     if (defaultFolderUid && !formValues.folderUid) {
       formValues.folderUid = defaultFolderUid;
@@ -93,7 +101,7 @@ function useFormValuesMeta(checkType: CheckType, check: Check | undefined, probe
     // Use probeCompatibilityKey instead of probesWithMetadata array reference
     // This ensures schema only recreates when probe compatibility actually changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [checkType, check, probeCompatibilityKey, defaultFolderUid]);
+  }, [checkType, check, probeCompatibilityKey, defaultFolderUid, calNames]);
 }
 
 export function ChecksterProvider({

--- a/src/components/Checkster/transformations/toFormValues.utils.test.ts
+++ b/src/components/Checkster/transformations/toFormValues.utils.test.ts
@@ -1,0 +1,39 @@
+import { groupLabelsByCalNames } from './toFormValues.utils';
+
+describe('groupLabelsByCalNames', () => {
+  it('returns a row per cost attribution name, in the order the tenant defines them', () => {
+    const result = groupLabelsByCalNames([{ name: 'Service', value: 'service-a' }], ['Team', 'Service']);
+
+    expect(result.calLabels).toEqual([
+      { name: 'Team', value: '' },
+      { name: 'Service', value: 'service-a' },
+    ]);
+  });
+
+  it('leaves a cost attribution value blank when the check does not set it', () => {
+    const result = groupLabelsByCalNames([], ['Team']);
+
+    expect(result.calLabels).toEqual([{ name: 'Team', value: '' }]);
+  });
+
+  it('removes cost attribution labels from the custom labels', () => {
+    const result = groupLabelsByCalNames(
+      [
+        { name: 'Team', value: 'team-a' },
+        { name: 'env', value: 'production' },
+      ],
+      ['Team']
+    );
+
+    expect(result.labels).toEqual([{ name: 'env', value: 'production' }]);
+  });
+
+  it('keeps every label as a custom label when the tenant has no cost attribution names', () => {
+    const labels = [
+      { name: 'Team', value: 'team-a' },
+      { name: 'env', value: 'production' },
+    ];
+
+    expect(groupLabelsByCalNames(labels, [])).toEqual({ calLabels: [], labels });
+  });
+});

--- a/src/components/Checkster/transformations/toFormValues.utils.ts
+++ b/src/components/Checkster/transformations/toFormValues.utils.ts
@@ -1,4 +1,4 @@
-import { Check, CheckAlertPublished, CheckFormValues, TLSConfig } from 'types';
+import { Check, CheckAlertPublished, CheckFormValues, Label, TLSConfig } from 'types';
 import { fromBase64 } from 'utils';
 import {
   GLOBAL_PREDEFINED_ALERTS,
@@ -38,6 +38,15 @@ const getDecodedIfPEM = (cert = '') => {
   }
   return cert;
 };
+
+export function groupLabelsByCalNames(labels: Label[], calNames: string[]) {
+  const calNameSet = new Set(calNames);
+
+  return {
+    calLabels: calNames.map((name) => ({ name, value: labels.find((label) => label.name === name)?.value ?? '' })),
+    labels: labels.filter((label) => !calNameSet.has(label.name)),
+  };
+}
 
 export function getBaseFormValuesFromCheck(check: Check): Omit<CheckFormValues, 'checkType' | 'settings'> {
   return {


### PR DESCRIPTION
Addresses the known limitation called out in #1796, which fixed https://github.com/grafana/synthetic-monitoring-app/issues/1791.

## Problem

After #1796 the labels end up in the right sections, but saving a check still produces a brief flash where the visible custom label rows show the cost attribution names and values before snapping back.

## Solution

Group the labels while the form values are derived, so the form is populated with them already separated and never holds a flat list.

Doing it here rather than in a component effect is what removes the flash: `reset()` writes into the label inputs before React re-renders, so by the time any effect could correct it the frame has already been painted.

### Before

https://github.com/user-attachments/assets/03eb6b77-61c6-413b-9af7-62a2d2e3bf75

### After

https://github.com/user-attachments/assets/ce34427f-f5d3-400c-9e37-79bc242dfb28