### PR TITLE
feat: attach global context props (page, check count) to all tracking events

### DIFF
--- a/src/features/tracking/globalTrackingProps.test.ts
+++ b/src/features/tracking/globalTrackingProps.test.ts
@@ -4,25 +4,9 @@ import { BASIC_DNS_CHECK, BASIC_HTTP_CHECK } from 'test/fixtures/checks';
 
 import { queryClient } from 'data/queryClient';
 
-function setViewport(width: number, height: number) {
-  Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: width });
-  Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: height });
-}
-
 describe('getGlobalTrackingProps', () => {
-  beforeEach(() => {
-    setViewport(1440, 900);
-  });
-
   afterEach(() => {
     queryClient.clear();
-  });
-
-  it('reports the viewport size', () => {
-    const props = getGlobalTrackingProps();
-
-    expect(props.screen_width).toBe(1440);
-    expect(props.screen_height).toBe(900);
   });
 
   describe('page', () => {
@@ -70,6 +54,7 @@ describe('getGlobalTrackingProps', () => {
   });
 
   it('still reports the other props when one resolver throws', () => {
+    queryClient.setQueryData(['checks', { includeAlerts: true }], [BASIC_HTTP_CHECK]);
     jest.mocked(locationService.getLocation).mockImplementationOnce(() => {
       throw new Error('location unavailable');
     });
@@ -77,7 +62,6 @@ describe('getGlobalTrackingProps', () => {
     const props = getGlobalTrackingProps();
 
     expect(props.page).toBeUndefined();
-    expect(props.screen_width).toBe(1440);
-    expect(props.screen_height).toBe(900);
+    expect(props.check_count).toBe(1);
   });
 });

--- a/src/features/tracking/globalTrackingProps.test.ts
+++ b/src/features/tracking/globalTrackingProps.test.ts
@@ -1,0 +1,83 @@
+import { locationService } from '@grafana/runtime';
+import { getGlobalTrackingProps } from 'features/tracking/globalTrackingProps';
+import { BASIC_DNS_CHECK, BASIC_HTTP_CHECK } from 'test/fixtures/checks';
+
+import { queryClient } from 'data/queryClient';
+
+function setViewport(width: number, height: number) {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: width });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: height });
+}
+
+describe('getGlobalTrackingProps', () => {
+  beforeEach(() => {
+    setViewport(1440, 900);
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it('reports the viewport size', () => {
+    const props = getGlobalTrackingProps();
+
+    expect(props.screen_width).toBe(1440);
+    expect(props.screen_height).toBe(900);
+  });
+
+  describe('page', () => {
+    it.each([
+      ['/a/grafana-synthetic-monitoring-app/home', 'home'],
+      ['/a/grafana-synthetic-monitoring-app/checks', 'checks'],
+      ['/a/grafana-synthetic-monitoring-app/checks/42', 'checks/:id'],
+      ['/a/grafana-synthetic-monitoring-app/checks/42/edit', 'checks/:id/edit'],
+      ['/a/grafana-synthetic-monitoring-app/checks/choose-type', 'checks/choose-type'],
+      ['/a/grafana-synthetic-monitoring-app/checks/new', 'checks/new'],
+      ['/a/grafana-synthetic-monitoring-app/checks/new/api-endpoint', 'checks/new/:checkTypeGroup'],
+      ['/a/grafana-synthetic-monitoring-app/config', 'config'],
+      ['/a/grafana-synthetic-monitoring-app/config/access-tokens', 'config/access-tokens'],
+      ['/a/grafana-synthetic-monitoring-app/probes', 'probes'],
+      ['/a/grafana-synthetic-monitoring-app/probes/7/edit', 'probes/:id/edit'],
+    ])('resolves %s to the route pattern "%s"', (pathname, expectedPattern) => {
+      locationService.push(pathname);
+
+      expect(getGlobalTrackingProps().page).toBe(expectedPattern);
+    });
+
+    it('reports the raw pathname for pages outside the plugin', () => {
+      locationService.push('/connections/datasources');
+
+      expect(getGlobalTrackingProps().page).toBe('/connections/datasources');
+    });
+
+    it('reports unknown plugin sub-pages as their app-relative pathname', () => {
+      locationService.push('/a/grafana-synthetic-monitoring-app/does-not-exist');
+
+      expect(getGlobalTrackingProps().page).toBe('/does-not-exist');
+    });
+  });
+
+  describe('check_count', () => {
+    it('is undefined when the check list has not been fetched', () => {
+      expect(getGlobalTrackingProps().check_count).toBeUndefined();
+    });
+
+    it('reports the number of checks in the query cache', () => {
+      queryClient.setQueryData(['checks', { includeAlerts: true }], [BASIC_HTTP_CHECK, BASIC_DNS_CHECK]);
+
+      expect(getGlobalTrackingProps().check_count).toBe(2);
+    });
+  });
+
+  it('still reports the other props when one resolver throws', () => {
+    jest.mocked(locationService.getLocation).mockImplementationOnce(() => {
+      throw new Error('location unavailable');
+    });
+
+    const props = getGlobalTrackingProps();
+
+    expect(props.page).toBeUndefined();
+    expect(props.screen_width).toBe(1440);
+    expect(props.screen_height).toBe(900);
+  });
+});

--- a/src/features/tracking/globalTrackingProps.ts
+++ b/src/features/tracking/globalTrackingProps.ts
@@ -17,9 +17,6 @@ const routeObjects = PAGE_ROUTE_PATTERNS.map((path) => ({ path }));
  * always current without needing navigation listeners. Each resolver is guarded
  * individually: enrichment must never break the interaction being tracked, and one
  * failing resolver shouldn't take the others down with it.
- *
- * Note the viewport is deliberately not included: Rudderstack captures it natively on
- * every event (`context.screen.innerWidth`/`innerHeight`).
  */
 export function getGlobalTrackingProps(): TrackingEventProps {
   return {

--- a/src/features/tracking/globalTrackingProps.ts
+++ b/src/features/tracking/globalTrackingProps.ts
@@ -14,13 +14,15 @@ const routeObjects = PAGE_ROUTE_PATTERNS.map((path) => ({ path }));
 /**
  * Context properties automatically attached to every tracking event (see
  * `createEventFactory`). Resolved lazily at the moment an event fires so values are
- * always current without needing resize/navigation listeners. Each resolver is guarded
+ * always current without needing navigation listeners. Each resolver is guarded
  * individually: enrichment must never break the interaction being tracked, and one
  * failing resolver shouldn't take the others down with it.
+ *
+ * Note the viewport is deliberately not included: Rudderstack captures it natively on
+ * every event (`context.screen.innerWidth`/`innerHeight`).
  */
 export function getGlobalTrackingProps(): TrackingEventProps {
   return {
-    ...guard(getViewportProps),
     ...guard(getPageProps),
     ...guard(getCheckCountProps),
   };
@@ -32,13 +34,6 @@ function guard(resolve: () => TrackingEventProps): TrackingEventProps {
   } catch {
     return {};
   }
-}
-
-function getViewportProps(): TrackingEventProps {
-  return {
-    screen_width: window.innerWidth,
-    screen_height: window.innerHeight,
-  };
 }
 
 /**

--- a/src/features/tracking/globalTrackingProps.ts
+++ b/src/features/tracking/globalTrackingProps.ts
@@ -34,11 +34,9 @@ function guard(resolve: () => TrackingEventProps): TrackingEventProps {
 }
 
 /**
- * Reports the current page as a route pattern (e.g. `checks/:id/edit`) rather than the
- * raw pathname so the property stays low-cardinality. `matchRoutes` ranks candidates,
- * so static patterns (`checks/choose-type`) win over dynamic ones (`checks/:id`).
- * Pages that don't resolve to a known pattern (e.g. external components rendered
- * outside the plugin's own pages) report their pathname as-is.
+ * Reports the current page as a low-cardinality route pattern (e.g. `checks/:id/edit`).
+ * `matchRoutes` ranks candidates, so static patterns win over dynamic ones. Unmatched
+ * pages (e.g. external components outside the plugin) report their pathname as-is.
  */
 function getPageProps(): TrackingEventProps {
   const { pathname } = locationService.getLocation();
@@ -55,10 +53,8 @@ function getPageProps(): TrackingEventProps {
 
 function getCheckCountProps(): TrackingEventProps {
   // The literal ['checks'] prefix must stay in sync with QUERY_KEYS.list in
-  // data/useChecks. It can't be imported from there because data/useChecks imports
-  // tracking event files, which would create an import cycle back into this module.
-  // getQueriesData is a passive cache read and never triggers a fetch, so the count is
-  // omitted until some page has loaded the check list.
+  // data/useChecks — it can't be imported from there without creating an import cycle
+  // (data/useChecks imports tracking event files). getQueriesData never triggers a fetch.
   const cachedChecksLists = queryClient.getQueriesData({ queryKey: ['checks'] });
   const checks = cachedChecksLists.map(([_, data]) => data).find(Array.isArray);
 

--- a/src/features/tracking/globalTrackingProps.ts
+++ b/src/features/tracking/globalTrackingProps.ts
@@ -1,0 +1,74 @@
+import { matchRoutes } from 'react-router';
+import { locationService } from '@grafana/runtime';
+import type { TrackingEventProps } from 'features/tracking/utils';
+
+import { PLUGIN_URL_PATH } from 'routing/constants';
+import { PAGE_ROUTE_PATTERNS } from 'routing/pagePatterns';
+import { queryClient } from 'data/queryClient';
+
+// the plugin base without its trailing slash, so the bare plugin root is recognised too
+const PLUGIN_BASE_PATH = PLUGIN_URL_PATH.replace(/\/$/, '');
+
+const routeObjects = PAGE_ROUTE_PATTERNS.map((path) => ({ path }));
+
+/**
+ * Context properties automatically attached to every tracking event (see
+ * `createEventFactory`). Resolved lazily at the moment an event fires so values are
+ * always current without needing resize/navigation listeners. Each resolver is guarded
+ * individually: enrichment must never break the interaction being tracked, and one
+ * failing resolver shouldn't take the others down with it.
+ */
+export function getGlobalTrackingProps(): TrackingEventProps {
+  return {
+    ...guard(getViewportProps),
+    ...guard(getPageProps),
+    ...guard(getCheckCountProps),
+  };
+}
+
+function guard(resolve: () => TrackingEventProps): TrackingEventProps {
+  try {
+    return resolve();
+  } catch {
+    return {};
+  }
+}
+
+function getViewportProps(): TrackingEventProps {
+  return {
+    screen_width: window.innerWidth,
+    screen_height: window.innerHeight,
+  };
+}
+
+/**
+ * Reports the current page as a route pattern (e.g. `checks/:id/edit`) rather than the
+ * raw pathname so the property stays low-cardinality. `matchRoutes` ranks candidates,
+ * so static patterns (`checks/choose-type`) win over dynamic ones (`checks/:id`).
+ * Pages that don't resolve to a known pattern (e.g. external components rendered
+ * outside the plugin's own pages) report their pathname as-is.
+ */
+function getPageProps(): TrackingEventProps {
+  const { pathname } = locationService.getLocation();
+
+  if (pathname !== PLUGIN_BASE_PATH && !pathname.startsWith(PLUGIN_URL_PATH)) {
+    return { page: pathname };
+  }
+
+  const appPathname = pathname.slice(PLUGIN_BASE_PATH.length) || '/';
+  const match = matchRoutes(routeObjects, appPathname)?.at(-1);
+
+  return { page: match?.route.path ?? appPathname };
+}
+
+function getCheckCountProps(): TrackingEventProps {
+  // The literal ['checks'] prefix must stay in sync with QUERY_KEYS.list in
+  // data/useChecks. It can't be imported from there because data/useChecks imports
+  // tracking event files, which would create an import cycle back into this module.
+  // getQueriesData is a passive cache read and never triggers a fetch, so the count is
+  // omitted until some page has loaded the check list.
+  const cachedChecksLists = queryClient.getQueriesData({ queryKey: ['checks'] });
+  const checks = cachedChecksLists.map(([_, data]) => data).find(Array.isArray);
+
+  return { check_count: checks?.length };
+}

--- a/src/features/tracking/utils.test.ts
+++ b/src/features/tracking/utils.test.ts
@@ -1,4 +1,9 @@
+import { getGlobalTrackingProps } from 'features/tracking/globalTrackingProps';
 import { createSMEventFactory, setTrackingBaseProps, TrackingEventProps } from 'features/tracking/utils';
+
+jest.mock('features/tracking/globalTrackingProps');
+
+const getGlobalTrackingPropsMock = jest.mocked(getGlobalTrackingProps);
 
 interface SampleEvent extends TrackingEventProps {
   /** The type of check, to exercise event-specific props in tests. */
@@ -20,6 +25,7 @@ describe('createEventFactory', () => {
 
   beforeEach(() => {
     setTrackingBaseProps({});
+    getGlobalTrackingPropsMock.mockReturnValue({});
     reportInteraction.mockClear();
   });
 
@@ -75,5 +81,51 @@ describe('createEventFactory', () => {
 
     const [, props] = reportInteraction.mock.calls[0];
     expect(props).toEqual({ checkType: 'browser' });
+  });
+
+  it('includes global context props on every event', () => {
+    getGlobalTrackingPropsMock.mockReturnValue({ screen_width: 1440, page: 'checks/:id' });
+    trackSampleEvent({ checkType: 'browser' });
+
+    expect(reportInteraction).toHaveBeenCalledWith('synthetic-monitoring_test_feature_sample_event', {
+      screen_width: 1440,
+      page: 'checks/:id',
+      checkType: 'browser',
+    });
+  });
+
+  it('resolves global context props at fire time, not at factory creation time', () => {
+    getGlobalTrackingPropsMock.mockReturnValue({ page: 'home' });
+    trackPropslessEvent();
+
+    getGlobalTrackingPropsMock.mockReturnValue({ page: 'checks' });
+    trackPropslessEvent();
+
+    expect(reportInteraction).toHaveBeenNthCalledWith(1, 'synthetic-monitoring_test_feature_propsless_event', {
+      page: 'home',
+    });
+    expect(reportInteraction).toHaveBeenNthCalledWith(2, 'synthetic-monitoring_test_feature_propsless_event', {
+      page: 'checks',
+    });
+  });
+
+  it('drops undefined global prop values instead of reporting them', () => {
+    getGlobalTrackingPropsMock.mockReturnValue({ check_count: undefined, page: 'home' });
+    trackPropslessEvent();
+
+    const [, props] = reportInteraction.mock.calls[0];
+    expect(props).not.toHaveProperty('check_count');
+    expect(props).toHaveProperty('page', 'home');
+  });
+
+  it('lets base props win over global props, and event props win over both', () => {
+    getGlobalTrackingPropsMock.mockReturnValue({ org_id: 1, checkType: 'from-global' });
+    setTrackingBaseProps({ org_id: 2, checkType: 'from-base' });
+    trackSampleEvent({ checkType: 'browser' });
+
+    expect(reportInteraction).toHaveBeenCalledWith('synthetic-monitoring_test_feature_sample_event', {
+      org_id: 2,
+      checkType: 'browser',
+    });
   });
 });

--- a/src/features/tracking/utils.test.ts
+++ b/src/features/tracking/utils.test.ts
@@ -84,11 +84,11 @@ describe('createEventFactory', () => {
   });
 
   it('includes global context props on every event', () => {
-    getGlobalTrackingPropsMock.mockReturnValue({ screen_width: 1440, page: 'checks/:id' });
+    getGlobalTrackingPropsMock.mockReturnValue({ check_count: 12, page: 'checks/:id' });
     trackSampleEvent({ checkType: 'browser' });
 
     expect(reportInteraction).toHaveBeenCalledWith('synthetic-monitoring_test_feature_sample_event', {
-      screen_width: 1440,
+      check_count: 12,
       page: 'checks/:id',
       checkType: 'browser',
     });

--- a/src/features/tracking/utils.ts
+++ b/src/features/tracking/utils.ts
@@ -22,7 +22,6 @@ export const createEventFactory = (product: string, featureName: string) => {
   return <P extends TrackingEventProps | undefined = undefined>(eventName: string) =>
     (props: P extends undefined ? void : P) => {
       const eventNameToReport = `${product}_${featureName}_${eventName}`;
-      // global context props are resolved at fire time so they are always current;
       // more specific props win on key collision: event props > base props > global props
       reportInteraction(eventNameToReport, {
         ...omitUndefined(getGlobalTrackingProps()),

--- a/src/features/tracking/utils.ts
+++ b/src/features/tracking/utils.ts
@@ -1,9 +1,13 @@
 // eslint-disable-next-line no-restricted-imports
 import { reportInteraction } from '@grafana/runtime';
+import { getGlobalTrackingProps } from 'features/tracking/globalTrackingProps';
 
 export type TrackingEventProps = {
   [key: string]: boolean | string | number | undefined;
 };
+
+const omitUndefined = (props: TrackingEventProps): TrackingEventProps =>
+  Object.fromEntries(Object.entries(props).filter(([_, value]) => value !== undefined));
 
 // Properties included on every event created through the factory, e.g. the Grafana Cloud
 // org identity. They resolve asynchronously (SM tenant API), so events fired before
@@ -11,14 +15,20 @@ export type TrackingEventProps = {
 let baseProps: TrackingEventProps = {};
 
 export const setTrackingBaseProps = (props: TrackingEventProps) => {
-  baseProps = Object.fromEntries(Object.entries(props).filter(([_, value]) => value !== undefined));
+  baseProps = omitUndefined(props);
 };
 
 export const createEventFactory = (product: string, featureName: string) => {
   return <P extends TrackingEventProps | undefined = undefined>(eventName: string) =>
     (props: P extends undefined ? void : P) => {
       const eventNameToReport = `${product}_${featureName}_${eventName}`;
-      reportInteraction(eventNameToReport, { ...baseProps, ...(props ?? {}) });
+      // global context props are resolved at fire time so they are always current;
+      // more specific props win on key collision: event props > base props > global props
+      reportInteraction(eventNameToReport, {
+        ...omitUndefined(getGlobalTrackingProps()),
+        ...baseProps,
+        ...(props ?? {}),
+      });
     };
 };
 

--- a/src/routing/pagePatterns.ts
+++ b/src/routing/pagePatterns.ts
@@ -1,0 +1,19 @@
+import { AppRoutes } from 'routing/types';
+
+/**
+ * Every routable page pattern in the app, in a `matchRoutes`-compatible shape. Used to
+ * resolve the current pathname to a low-cardinality `page` property on tracking events
+ * (see `features/tracking/globalTrackingProps`).
+ *
+ * `AppRoutes` doesn't include the nested leaf routes declared inline in
+ * `InitialisedRouter`, so those are listed explicitly here. When adding a page to the
+ * router, add its pattern here if no existing pattern matches it.
+ */
+export const PAGE_ROUTE_PATTERNS: string[] = [
+  ...Object.values(AppRoutes),
+  'checks/new/:checkTypeGroup',
+  'config/access-tokens',
+  'config/terraform',
+  'config/label-migration',
+  'config/secrets',
+];


### PR DESCRIPTION
Addresses: https://github.com/grafana/synthetic-monitoring-app/issues/1598

## Problem

Our tracking events capture what a user did but not the situation they were in when they did it. When we analyse events (or read feature feedback), we can't segment by basic environmental facts — which page the user was on, or whether they run 2 checks or 20,000. We learned this the hard way with Time Point Explorer feedback, where we couldn't correlate reactions with the user's setup. Missing properties require a code change, a release, and weeks of data accumulation before we can answer a question.

## Solution

Every event created through `createSMEventFactory` now automatically carries global context properties, resolved lazily at the moment the event fires (so they are always current, with no navigation listeners):

- `page` — the current page as a low-cardinality route pattern (e.g. `checks/:id/edit`), resolved via ranked `matchRoutes` against a new `PAGE_ROUTE_PATTERNS` list; pages outside the plugin (e.g. external components) report their raw pathname
- `check_count` — the tenant's total check count, read passively from the react-query cache (never triggers a fetch; omitted until a page has loaded the check list, mirroring how `org_id`/`stack_id` behave before the tenant resolves)

Each resolver is individually guarded so a failure in one can never break the interaction being tracked nor take the other properties down with it. Explicit properties always win on key collision: event props > base props (`org_id`/`stack_id`) > global props. The Faro echo backend forwards all interaction properties, so the enrichment reaches Faro automatically.

## Rollout context

This is PR 1 of 3 for #1598. PR 2 adds mounted "scope" enrichment (check metadata + dashboard time range + check form state) and PR 3 adds Time Point Explorer-specific properties.

Made with [Cursor](https://cursor.com)