### PR TITLE
fix: replace expand/collapse all with a single toggle in folder view

### DIFF
--- a/src/page/CheckList/CheckList.folderView.test.tsx
+++ b/src/page/CheckList/CheckList.folderView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { CHECKS_TEST_ID } from 'test/dataTestIds';
 import { BASIC_HTTP_CHECK } from 'test/fixtures/checks';
 import {
@@ -248,6 +248,37 @@ describe('CheckList - Folder View Integration', () => {
 
       await user.click(emptyCheckbox);
       expect(screen.getByRole('button', { name: 'Delete folder' })).toBeInTheDocument();
+    });
+
+    test('a single button toggles between collapsing and expanding all folders', async () => {
+      const { user } = await renderCheckList([CHECK_IN_PRODUCTION]);
+
+      expect(await screen.findByText('Production HTTP check')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Collapse all folders' }));
+      expect(screen.queryByText('Production HTTP check')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Expand all folders' }));
+      expect(await screen.findByText('Production HTTP check')).toBeInTheDocument();
+    });
+
+    test('the toggle tracks only folders currently in the tree, ignoring stale collapsed ones', async () => {
+      const { user } = await renderCheckList([CHECK_IN_PRODUCTION, CHECK_WITH_ORPHANED_FOLDER]);
+
+      // Collapse the orphaned folder; its node only exists while its check
+      // is in the list.
+      expect(await screen.findByText('Orphaned folder check')).toBeInTheDocument();
+      await user.click(screen.getByLabelText('Collapse folder deleted-folder-uid'));
+
+      // Filter its check out: the folder leaves the tree (the count drops)
+      // but its UID stays in the collapsed set. Every folder still shown is
+      // expanded, so the toggle must offer to collapse, not report a
+      // collapsed state.
+      const searchInput = screen.getByPlaceholderText('Search by job name, endpoint, or label');
+      await user.type(searchInput, CHECK_IN_PRODUCTION.job);
+      await waitFor(() => expect(screen.getByText(/Folders \(5\)/)).toBeInTheDocument());
+
+      expect(screen.getByRole('button', { name: 'Collapse all folders' })).toBeInTheDocument();
     });
 
     test('deselecting an empty folder hides the delete action', async () => {

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -125,7 +125,9 @@ export function CheckListFolderView({
 
   // Same pattern as Alerting → Notification policies: one button that flips
   // between expand-all and collapse-all based on whether everything is open.
-  const allExpanded = collapsedFolders.size === 0;
+  // Only folders currently in the tree count: collapsedFolders can hold
+  // stale UIDs of folders that have since left it (filters, deletions).
+  const allExpanded = allUids.every((uid) => !collapsedFolders.has(uid));
 
   const toggleAllExpanded = () => {
     if (allExpanded) {

--- a/src/page/CheckList/components/CheckListFolderView.tsx
+++ b/src/page/CheckList/components/CheckListFolderView.tsx
@@ -123,11 +123,17 @@ export function CheckListFolderView({
     });
   };
 
-  const expandAll = () => setCollapsedFolders(new Set());
-  const collapseAll = () => setCollapsedFolders(new Set(allUids));
-
+  // Same pattern as Alerting → Notification policies: one button that flips
+  // between expand-all and collapse-all based on whether everything is open.
   const allExpanded = collapsedFolders.size === 0;
-  const allCollapsed = allUids.length > 0 && allUids.every((uid) => collapsedFolders.has(uid));
+
+  const toggleAllExpanded = () => {
+    if (allExpanded) {
+      setCollapsedFolders(new Set(allUids));
+    } else {
+      setCollapsedFolders(new Set());
+    }
+  };
 
   const checkItemProps = {
     checkAlertStates,
@@ -157,28 +163,14 @@ export function CheckListFolderView({
               Folders ({allUids.length})
               <Feedback feature="folder-view" about={{ text: 'New feature!' }} />
             </h3>
-            <Stack gap={1}>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={expandAll}
-                disabled={allExpanded}
-                icon="angle-down"
-                tooltip="Expand all folders"
-              >
-                Expand all
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={collapseAll}
-                disabled={allCollapsed}
-                icon="angle-right"
-                tooltip="Collapse all folders"
-              >
-                Collapse all
-              </Button>
-            </Stack>
+            <Button
+              variant="secondary"
+              icon={allExpanded ? 'table-collapse-all' : 'table-expand-all'}
+              onClick={toggleAllExpanded}
+              aria-label={allExpanded ? 'Collapse all folders' : 'Expand all folders'}
+            >
+              {allExpanded ? 'Collapse all' : 'Expand all'}
+            </Button>
           </div>
 
           {foldersWithChecks.map((node) => (


### PR DESCRIPTION
## Problem

In the check list folder view, Expand all and Collapse all were separate buttons. That took extra space and did not match how Grafana Alerting handles the same action on Notification policies, where a single control toggles between the two states.

## Solution

Folder view now uses one secondary button that switches between Expand all and Collapse all based on whether every folder is already expanded. The button label, icon, and aria-label update together so the control stays clear and accessible, aligned with the Alerting notification policies pattern.

https://github.com/user-attachments/assets/5433b084-4680-41e8-9b5c-9334c97ce77a

## Test plan

- [ ] Open Synthetic Monitoring → Checks and switch to folder view
- [ ] Confirm a single Expand all / Collapse all button appears next to the Folders heading
- [ ] With folders collapsed (or partially collapsed), click Expand all and verify all folders open
- [ ] With all folders expanded, confirm the button shows Collapse all and collapses every folder
- [ ] Confirm individual folder expand/collapse still works independently


Made with [Cursor](https://cursor.com)