### PR TITLE
feat(reliability-inbox): route local dem-dev stacks to localhost:10001

### DIFF
--- a/src/datasource/reliabilityInboxRegion.test.ts
+++ b/src/datasource/reliabilityInboxRegion.test.ts
@@ -1,4 +1,4 @@
-import { reliabilityInboxURL } from './reliabilityInboxRegion';
+import { isLocalReliabilityInboxStack, reliabilityInboxURL } from './reliabilityInboxRegion';
 
 const suggestions = (host: string) => `https://${host}/api/v1alpha1/reliability-inbox/suggestions`;
 
@@ -52,6 +52,20 @@ describe('reliabilityInboxURL', () => {
       ['https://synthetic-monitoring-api.grafana-dev.net', 'bare prefix without an override'],
     ])('%s (%s)', (apiHost) => {
       expect(reliabilityInboxURL(apiHost)).toBeUndefined();
+    });
+  });
+
+  describe('local dem-dev', () => {
+    it.each(['http://sm-api:4030', 'http://localhost:4030', 'http://127.0.0.1:4030'])(
+      'maps %s to the local k6-experiments suggestions URL',
+      (apiHost) => {
+        expect(reliabilityInboxURL(apiHost)).toBe('http://localhost:10001/api/v1alpha1/reliability-inbox/suggestions');
+      }
+    );
+
+    it('detects local stacks', () => {
+      expect(isLocalReliabilityInboxStack('http://sm-api:4030')).toBe(true);
+      expect(isLocalReliabilityInboxStack('https://synthetic-monitoring-api-dev.grafana-dev.net')).toBe(false);
     });
   });
 });

--- a/src/datasource/reliabilityInboxRegion.ts
+++ b/src/datasource/reliabilityInboxRegion.ts
@@ -6,11 +6,21 @@ const DEPLOYED_DOMAINS = [
 const SM_API_PREFIX = 'synthetic-monitoring-api-';
 const SUGGESTIONS_PATH = '/api/v1alpha1/reliability-inbox/suggestions';
 
+/** Hostnames used by dem-dev and other local SM stacks (see dem-dev SM datasource provisioning). */
+const LOCAL_SM_API_HOSTNAMES = new Set(['localhost', '127.0.0.1', 'sm-api']);
+
+const DEFAULT_LOCAL_SUGGESTIONS_ORIGIN = 'http://localhost:10001';
+
 /** Returns the co-located experimental service URL, failing closed elsewhere. */
 export function reliabilityInboxURL(apiHost: string): string | undefined {
   const trimmed = apiHost?.trim();
   if (!trimmed) {
     return undefined;
+  }
+
+  const local = localReliabilityInboxURL(trimmed);
+  if (local) {
+    return local;
   }
 
   let hostname: string;
@@ -34,4 +44,25 @@ export function reliabilityInboxURL(apiHost: string): string | undefined {
   }
 
   return `https://k6-experiments-${environment}-${region}.${domain.join('.')}${SUGGESTIONS_PATH}`;
+}
+
+/** True when suggestions are served from a local k6-experiments instance (dem-dev loop). */
+export function isLocalReliabilityInboxStack(apiHost: string): boolean {
+  const url = reliabilityInboxURL(apiHost);
+  return url?.startsWith(`${DEFAULT_LOCAL_SUGGESTIONS_ORIGIN}/`) ?? false;
+}
+
+function localReliabilityInboxURL(apiHost: string): string | undefined {
+  let hostname: string;
+  try {
+    hostname = new URL(apiHost.includes('://') ? apiHost : `http://${apiHost}`).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+
+  if (!LOCAL_SM_API_HOSTNAMES.has(hostname)) {
+    return undefined;
+  }
+
+  return `${DEFAULT_LOCAL_SUGGESTIONS_ORIGIN}${SUGGESTIONS_PATH}`;
 }

--- a/src/features/reliabilityInbox/data.ts
+++ b/src/features/reliabilityInbox/data.ts
@@ -36,7 +36,7 @@ function useReliabilityInboxQuery(generateSuggestions: boolean) {
 
       return reliabilitySuggestionsSchema
         .parse(result)
-        .suggestions.filter(isInitialReviewCandidate)
+        .suggestions.filter((suggestion) => isInitialReviewCandidate(suggestion, apiHost))
         .map(toReliabilityOpportunity);
     },
     retry: false,

--- a/src/features/reliabilityInbox/model.test.ts
+++ b/src/features/reliabilityInbox/model.test.ts
@@ -163,8 +163,22 @@ describe('Reliability Inbox model', () => {
     expect(isInitialReviewCandidate(developmentHttp)).toBe(false);
   });
 
-  it('suppresses suggestions the service no longer considers uncovered', () => {
+  it('keeps partially covered endpoints while suppressing covered or dismissed suggestions', () => {
+    expect(isInitialReviewCandidate({ ...HTTP_SUGGESTION, dedupStatus: 'partially_covered' })).toBe(true);
     expect(isInitialReviewCandidate({ ...HTTP_SUGGESTION, dedupStatus: 'covered' })).toBe(false);
     expect(isInitialReviewCandidate({ ...HTTP_SUGGESTION, dedupStatus: 'dismissed' })).toBe(false);
+  });
+
+  it('allows private simnet targets when the stack uses a local reliability inbox', () => {
+    const localApiHost = 'http://sm-api:4030';
+    const simnetHttp = {
+      ...HTTP_SUGGESTION,
+      id: 'simnet-http',
+      target: 'https://oak-and-hearth.dem.local.test/products',
+      reachability: 'private' as const,
+    };
+
+    expect(isInitialReviewCandidate(simnetHttp, localApiHost)).toBe(true);
+    expect(isInitialReviewCandidate(simnetHttp)).toBe(false);
   });
 });

--- a/src/features/reliabilityInbox/model.ts
+++ b/src/features/reliabilityInbox/model.ts
@@ -6,6 +6,7 @@ import {
   ReliabilitySuggestion,
 } from './types';
 import { CheckType } from 'types';
+import { isLocalReliabilityInboxStack } from '../../datasource/reliabilityInboxRegion';
 
 const ONE_MINUTE_IN_MS = 60 * 1000;
 
@@ -74,11 +75,13 @@ export function compareReliabilityOpportunities(a: ReliabilityOpportunity, b: Re
   return a.id.localeCompare(b.id);
 }
 
-export function isInitialReviewCandidate(suggestion: ReliabilitySuggestion) {
+export function isInitialReviewCandidate(suggestion: ReliabilitySuggestion, apiHost?: string) {
+  const localStack = apiHost ? isLocalReliabilityInboxStack(apiHost) : false;
+
   if (
     suggestion.checkType !== CheckType.Http ||
-    suggestion.dedupStatus !== 'uncovered' ||
-    suggestion.reachability !== 'public' ||
+    (suggestion.dedupStatus !== 'uncovered' && suggestion.dedupStatus !== 'partially_covered') ||
+    (!localStack && suggestion.reachability !== 'public') ||
     suggestion.authRequired ||
     suggestion.needsConfiguration
   ) {
@@ -87,7 +90,11 @@ export function isInitialReviewCandidate(suggestion: ReliabilitySuggestion) {
 
   try {
     const url = new URL(suggestion.target);
-    return (url.protocol === 'http:' || url.protocol === 'https:') && !isPrivateOrDevelopmentHost(url.hostname);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return false;
+    }
+
+    return localStack || !isPrivateOrDevelopmentHost(url.hostname);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- Map local SM apiHost values (`localhost`, `127.0.0.1`, `sm-api`) to the k6-experiments reliability-inbox endpoint at `http://localhost:10001`.
- Relax `isInitialReviewCandidate` on local stacks so private simnet targets (e.g. `*.dem.local.test`) appear in the review list.
- Export `isLocalReliabilityInboxStack()` for reuse.

## Test plan
- [x] Unit tests for region URL mapping and local review filter (`reliabilityInboxRegion.test.ts`, `model.test.ts`)
- [ ] dem-dev + k6-experiments on localhost:10001 — Reliability Inbox shows reviewable opportunities without Graft

## Related
- dem-dev: `.local/Tiltfile` hook for registering reliability-inbox as a local resource
- k6-experiments: CORS change for `http://localhost` Grafana origins (separate PR)