### PR TITLE
refactor: replace Reliability Inbox ratings with evidence

### DIFF
--- a/src/features/reliabilityInbox/ReliabilityInboxBanner.test.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxBanner.test.tsx
@@ -25,7 +25,7 @@ const OPPORTUNITY = {
 describe('ReliabilityInboxBanner', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('links the highest-priority suggestion to the review page', async () => {
+  it('links the next recommendation to the review page', async () => {
     jest.mocked(useCachedReliabilityInboxSuggestions).mockReturnValue({
       data: [OPPORTUNITY],
     } as ReturnType<typeof useCachedReliabilityInboxSuggestions>);
@@ -34,7 +34,7 @@ describe('ReliabilityInboxBanner', () => {
     render(<ReliabilityInboxBanner />);
 
     expect(screen.getByText('Reliability Inbox · 1 opportunity')).toBeInTheDocument();
-    expect(screen.getByText('Highest priority: mcp.goagain.dev')).toBeInTheDocument();
+    expect(screen.getByText('Recommended next: mcp.goagain.dev')).toBeInTheDocument();
     const reviewLink = screen.getByRole('link', { name: 'Review suggestions' });
     expect(reviewLink).toHaveAttribute('href', generateRoutePath(AppRoutes.ReliabilityInbox));
     await waitFor(() =>
@@ -55,8 +55,8 @@ describe('ReliabilityInboxBanner', () => {
 
     render(<ReliabilityInboxBanner />);
 
-    expect(screen.getByText('Generate prioritized suggestions when you are ready to review them.')).toBeInTheDocument();
-    expect(screen.queryByText(/Highest priority:/)).not.toBeInTheDocument();
+    expect(screen.getByText('Generate actionable recommendations when you are ready to review them.')).toBeInTheDocument();
+    expect(screen.queryByText(/Recommended next:/)).not.toBeInTheDocument();
     expect(trackInboxExposure).not.toHaveBeenCalled();
   });
 });

--- a/src/features/reliabilityInbox/ReliabilityInboxBanner.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxBanner.tsx
@@ -49,8 +49,8 @@ export function ReliabilityInboxBanner() {
             </Text>
             <Text color="secondary" variant="bodySmall">
               {topOpportunity
-                ? `Highest priority: ${topOpportunity.subject}`
-                : 'Generate prioritized suggestions when you are ready to review them.'}
+                ? `Recommended next: ${topOpportunity.subject}`
+                : 'Generate actionable recommendations when you are ready to review them.'}
             </Text>
           </Stack>
         </Stack>

--- a/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
@@ -52,11 +52,22 @@ const HTTP_SUGGESTION: ReliabilitySuggestion = {
     'Create a Grafana Synthetic Monitoring http check for https://mcp.goagain.dev/. Suggested configuration: job "mcp.goagain.dev", frequency 1m0s, timeout 2s, expect HTTP status [200], fail if not SSL, probe IDs [7].',
 };
 
+const LOWER_PRIORITY_HTTP_SUGGESTION: ReliabilitySuggestion = {
+  ...HTTP_SUGGESTION,
+  id: 'lower-priority-http-suggestion',
+  target: 'https://secondary.goagain.dev/',
+  relevance: 20,
+  evidence: {
+    ...HTTP_SUGGESTION.evidence,
+    reqPerS: 0.5,
+  },
+};
+
 const openAssistant = jest.fn();
 
-function mockSuggestions(suggestion = HTTP_SUGGESTION) {
+function mockSuggestions(suggestions: ReliabilitySuggestion[] = [HTTP_SUGGESTION]) {
   const result = {
-    data: [toReliabilityOpportunity(suggestion)],
+    data: suggestions.map(toReliabilityOpportunity),
     isLoading: false,
     isError: false,
     refetch: jest.fn(),
@@ -65,8 +76,8 @@ function mockSuggestions(suggestion = HTTP_SUGGESTION) {
   jest.mocked(useReliabilityInboxSuggestions).mockReturnValue(result);
 }
 
-function renderPage() {
-  mockSuggestions();
+function renderPage(suggestions?: ReliabilitySuggestion[]) {
+  mockSuggestions(suggestions);
 
   return render(<ReliabilityInboxPage />, {
     path: generateRoutePath(AppRoutes.ReliabilityInbox),
@@ -86,64 +97,65 @@ describe('ReliabilityInboxPage', () => {
     });
   });
 
-  it('leads with an actionable recommendation and the evidence behind it', async () => {
+  it('separates the suggested check from the evidence behind it', async () => {
     const { user } = renderPage();
 
-    expect(await screen.findByRole('heading', { name: 'Add an HTTP check for mcp.goagain.dev' })).toBeInTheDocument();
-    expect(screen.getByText('Recommended next step')).toBeInTheDocument();
+    await screen.findByRole('heading', { name: 'Create an HTTP check' });
 
-    const endpoint = screen.getByLabelText('Recommended endpoint');
-    expect(within(endpoint).getByText('GET')).toBeInTheDocument();
-    expect(within(endpoint).getByText('mcp.goagain.dev')).toBeInTheDocument();
-    expect(within(endpoint).queryByText('https://mcp.goagain.dev/')).not.toBeInTheDocument();
-
-    const queueSubject = within(screen.getByLabelText('Review queue')).getByText('mcp.goagain.dev');
-    expect(queueSubject).toHaveAttribute('title', 'https://mcp.goagain.dev/');
-
-    const queue = screen.getByLabelText('Review queue');
-    expect(within(queue).getByText('Recommended next')).toBeInTheDocument();
-    expect(within(queue).getByText('No matching check found')).toBeInTheDocument();
-    expect(within(queue).getByText('Public HTTP · 1.6 req/s')).toBeInTheDocument();
-
-    expect(
-      screen.getByText(
-        'We observed 5.8k requests in the last hour, and no matching Synthetic Monitoring check was found.'
-      )
-    ).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'No matching check found' })).toBeInTheDocument();
-    expect(screen.queryByText('High value')).not.toBeInTheDocument();
-    expect(screen.queryByText('High confidence')).not.toBeInTheDocument();
-    expect(screen.queryByText('Ready to review')).not.toBeInTheDocument();
-    expect(screen.getByText('5.8k')).toBeInTheDocument();
-    expect(screen.getByText('estimated requests in the last hour')).toBeInTheDocument();
-    expect(screen.getByText('5xx responses')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Investigate in Explore' })).toHaveAttribute(
+    const suggestedCheck = screen.getByRole('region', { name: 'Create an HTTP check' });
+    const evidence = screen.getByRole('region', { name: 'Why this recommendation' });
+    expect(within(suggestedCheck).getByText('Suggested check')).toBeInTheDocument();
+    expect(within(evidence).getByRole('heading', { name: 'Observed traffic evidence' })).toBeInTheDocument();
+    expect(within(suggestedCheck).getByLabelText('Suggested check endpoint')).toHaveTextContent(
+      'MethodGETTargetmcp.goagain.dev'
+    );
+    expect(within(evidence).getByRole('link', { name: 'Explore telemetry' })).toHaveAttribute(
       'href',
       expect.stringContaining('/explore?')
     );
 
-    const coverageDisclosure = screen.getByText('How we checked').closest('details');
-    expect(coverageDisclosure).not.toHaveAttribute('open');
-    await user.click(screen.getByText('How we checked'));
-    expect(coverageDisclosure).toHaveAttribute('open');
-    expect(screen.getByText(/Similar or indirect monitoring may still exist/)).toBeVisible();
-
-    expect(screen.queryByText('host.docker.internal')).not.toBeInTheDocument();
-    expect(openAssistant).not.toHaveBeenCalled();
+    await user.click(within(evidence).getByText('How we checked'));
+    expect(
+      within(evidence).getByText(
+        'We compared the endpoint and path with accessible HTTP checks. Aliases, redirects, upstream checks, and checks for other paths may not match directly.'
+      )
+    ).toBeVisible();
     expect(trackRecommendationReviewed).toHaveBeenCalledWith({
       opportunityId: 'http-suggestion',
       checkType: 'http',
     });
   });
 
-  it('does not render missing aggregate evidence as zero', async () => {
-    mockSuggestions({
-      ...HTTP_SUGGESTION,
-      evidence: {
-        statusDistribution: {},
-        families: HTTP_SUGGESTION.evidence.families,
-      },
+  it('updates the detail pane when a different recommendation is selected', async () => {
+    const { user } = renderPage([HTTP_SUGGESTION, LOWER_PRIORITY_HTTP_SUGGESTION]);
+
+    await screen.findByRole('heading', { name: 'Create an HTTP check' });
+
+    const queue = screen.getByLabelText('Recommendations');
+    const queueItems = within(queue).getAllByRole('button');
+    await user.click(queueItems[1]);
+
+    expect(queueItems[0]).toHaveAttribute('aria-pressed', 'false');
+    expect(queueItems[1]).toHaveAttribute('aria-pressed', 'true');
+    expect(
+      within(screen.getByLabelText('Suggested check endpoint')).getByText('secondary.goagain.dev')
+    ).toBeInTheDocument();
+    expect(trackRecommendationReviewed).toHaveBeenCalledWith({
+      opportunityId: 'lower-priority-http-suggestion',
+      checkType: 'http',
     });
+  });
+
+  it('does not render missing aggregate evidence as zero', async () => {
+    mockSuggestions([
+      {
+        ...HTTP_SUGGESTION,
+        evidence: {
+          statusDistribution: {},
+          families: HTTP_SUGGESTION.evidence.families,
+        },
+      },
+    ]);
 
     render(<ReliabilityInboxPage />, {
       path: generateRoutePath(AppRoutes.ReliabilityInbox),
@@ -156,7 +168,7 @@ describe('ReliabilityInboxPage', () => {
     expect(screen.queryByText('0 req/s')).not.toBeInTheDocument();
     expect(screen.queryByText('0 ms')).not.toBeInTheDocument();
     expect(screen.queryByText('0.0%')).not.toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'Investigate in Explore' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Explore telemetry' })).not.toBeInTheDocument();
   });
 
   it('keeps the existing page-level loading state while evidence is loading', async () => {
@@ -173,33 +185,36 @@ describe('ReliabilityInboxPage', () => {
     });
 
     expect(await screen.findByText('Loading Reliability Inbox…')).toBeInTheDocument();
-    expect(screen.queryByText('Evidence at a glance')).not.toBeInTheDocument();
+    expect(screen.queryByText('Why this recommendation')).not.toBeInTheDocument();
   });
 
   it('shows a compact proposed check with configuration details on demand', async () => {
     const { user } = renderPage();
 
-    expect(await screen.findByRole('heading', { name: 'GET mcp.goagain.dev' })).toBeInTheDocument();
-    expect(screen.getByText('HTTP GET · Every 1 minute')).toBeInTheDocument();
-    expect(screen.getAllByText('Run from the configured public probe with ID 7.')[0]).toBeVisible();
+    const suggestedCheck = await screen.findByRole('region', { name: 'Create an HTTP check' });
+    expect(within(suggestedCheck).getByText('Public HTTP')).toBeInTheDocument();
+    expect(within(suggestedCheck).getByText('Every 1 minute')).toBeInTheDocument();
+    expect(within(suggestedCheck).getAllByText('Require HTTPS')[0]).toBeInTheDocument();
+    expect(within(suggestedCheck).getByText('Run from the configured public probe with ID 7.')).not.toBeVisible();
 
-    const configurationDisclosure = screen.getByText('View configuration details').closest('details');
+    const configurationDisclosure = within(suggestedCheck).getByText('View configuration details').closest('details');
     expect(configurationDisclosure).not.toHaveAttribute('open');
-    expect(screen.getByText('https://mcp.goagain.dev/')).not.toBeVisible();
-    await user.click(screen.getByText('View configuration details'));
+    expect(within(suggestedCheck).getByText('https://mcp.goagain.dev/')).not.toBeVisible();
+    await user.click(within(suggestedCheck).getByText('View configuration details'));
     expect(configurationDisclosure).toHaveAttribute('open');
-    expect(screen.getByText('https://mcp.goagain.dev/')).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Copy target URL' })).toBeVisible();
-    expect(screen.getByText('2 seconds')).toBeVisible();
-    expect(screen.getByText('Require HTTPS')).toBeVisible();
+    expect(within(suggestedCheck).getByText('https://mcp.goagain.dev/')).toBeVisible();
+    expect(within(suggestedCheck).getByRole('button', { name: 'Copy target URL' })).toBeVisible();
+    expect(within(suggestedCheck).getByText('2 seconds')).toBeVisible();
+    expect(within(configurationDisclosure!).getByText('Require HTTPS')).toBeVisible();
+    expect(within(configurationDisclosure!).getByText('Run from the configured public probe with ID 7.')).toBeVisible();
 
-    expect(screen.getByRole('button', { name: 'Review and customize check' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Review and customize check' })).toHaveAttribute(
+    expect(within(suggestedCheck).getByRole('button', { name: 'Review and customize' })).toBeInTheDocument();
+    expect(within(suggestedCheck).getByRole('button', { name: 'Review and customize' })).toHaveAttribute(
       'aria-describedby',
       'reliability-inbox-assistant-action-help'
     );
     expect(
-      screen.getByText(
+      within(suggestedCheck).getByText(
         'Assistant will guide setup and recommend a configuration from this proposal. Nothing is created or saved until you confirm.'
       )
     ).toBeInTheDocument();
@@ -209,7 +224,7 @@ describe('ReliabilityInboxPage', () => {
   it('hands structured evidence and draft to Assistant as bounded setup guidance', async () => {
     const { user } = renderPage();
 
-    await user.click(await screen.findByRole('button', { name: 'Review and customize check' }));
+    await user.click(await screen.findByRole('button', { name: 'Review and customize' }));
 
     expect(trackSetupWithAssistant).toHaveBeenCalledWith({
       opportunityId: 'http-suggestion',
@@ -240,5 +255,25 @@ describe('ReliabilityInboxPage', () => {
         ],
       })
     );
+  });
+
+  it('defers probe location selection to the review flow', async () => {
+    mockSuggestions([
+      {
+        ...HTTP_SUGGESTION,
+        prompt:
+          'Create a Grafana Synthetic Monitoring http check for https://mcp.goagain.dev/. Suggested configuration: job "mcp.goagain.dev", frequency 1m0s, timeout 2s, expect HTTP status [200], fail if not SSL, probe IDs [].',
+      },
+    ]);
+
+    const { user } = render(<ReliabilityInboxPage />, {
+      path: generateRoutePath(AppRoutes.ReliabilityInbox),
+      route: getRoute(AppRoutes.ReliabilityInbox),
+    });
+
+    const suggestedCheck = await screen.findByRole('region', { name: 'Create an HTTP check' });
+    expect(within(suggestedCheck).queryByText('Probe selection required')).not.toBeInTheDocument();
+    await user.click(within(suggestedCheck).getByText('View configuration details'));
+    expect(within(suggestedCheck).getByText('Probe locations will be selected during review.')).toBeVisible();
   });
 });

--- a/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
@@ -86,12 +86,11 @@ describe('ReliabilityInboxPage', () => {
     });
   });
 
-  it('leads with a decision-oriented recommendation and neutral coverage status', async () => {
+  it('leads with an actionable recommendation and the evidence behind it', async () => {
     const { user } = renderPage();
 
     expect(await screen.findByRole('heading', { name: 'Add an HTTP check for mcp.goagain.dev' })).toBeInTheDocument();
     expect(screen.getByText('Recommended next step')).toBeInTheDocument();
-    expect(screen.getByText('Highest priority')).toBeInTheDocument();
 
     const endpoint = screen.getByLabelText('Recommended endpoint');
     expect(within(endpoint).getByText('GET')).toBeInTheDocument();
@@ -101,19 +100,20 @@ describe('ReliabilityInboxPage', () => {
     const queueSubject = within(screen.getByLabelText('Review queue')).getByText('mcp.goagain.dev');
     expect(queueSubject).toHaveAttribute('title', 'https://mcp.goagain.dev/');
 
-    const queueSignals = screen.getByLabelText('Decision signals for mcp.goagain.dev');
-    expect(within(queueSignals).getByText('High value')).toBeInTheDocument();
-    expect(within(queueSignals).getByText('High confidence')).toBeInTheDocument();
-
-    const recommendationSignals = screen.getByLabelText('Recommendation signals');
-    expect(within(recommendationSignals).getByText('High value')).toBeInTheDocument();
-    expect(within(recommendationSignals).getByText('High confidence')).toBeInTheDocument();
+    const queue = screen.getByLabelText('Review queue');
+    expect(within(queue).getByText('Recommended next')).toBeInTheDocument();
+    expect(within(queue).getByText('No matching check found')).toBeInTheDocument();
+    expect(within(queue).getByText('Public HTTP · 1.6 req/s')).toBeInTheDocument();
 
     expect(
       screen.getByText(
-        'Synthetic Monitoring does not appear to monitor this traffic yet, so we recommend adding this check.'
+        'We observed 5.8k requests in the last hour, and no matching Synthetic Monitoring check was found.'
       )
     ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'No matching check found' })).toBeInTheDocument();
+    expect(screen.queryByText('High value')).not.toBeInTheDocument();
+    expect(screen.queryByText('High confidence')).not.toBeInTheDocument();
+    expect(screen.queryByText('Ready to review')).not.toBeInTheDocument();
     expect(screen.getByText('5.8k')).toBeInTheDocument();
     expect(screen.getByText('estimated requests in the last hour')).toBeInTheDocument();
     expect(screen.getByText('5xx responses')).toBeInTheDocument();

--- a/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
@@ -45,8 +45,8 @@ export function ReliabilityInboxPage() {
     <PluginPage pageNav={RELIABILITY_INBOX_PAGE_NAV} renderTitle={() => <ReliabilityInboxTitle />}>
       <Stack direction="column" gap={2}>
         <Text element="p" color="secondary">
-          Prioritized monitoring opportunities from observed traffic. Review first; nothing is created without your
-          confirmation.
+          Actionable monitoring recommendations from observed traffic, ordered by technical signals—not business
+          criticality. Nothing is created without your confirmation.
         </Text>
         <ReliabilityInboxReview />
       </Stack>
@@ -108,7 +108,7 @@ function ReliabilityInboxReview() {
             No reviewable opportunities
           </Text>
           <Text element="p" color="secondary" textAlignment="center">
-            Private, development-only, non-HTTP, and incomplete targets are excluded from this experiment.
+            Only public HTTP endpoints with enough evidence of missing coverage are shown.
           </Text>
         </Stack>
       </Box>
@@ -175,29 +175,19 @@ function ReliabilityInboxReview() {
             onClick={() => setSelectedId(opportunity.id)}
           >
             <Stack direction="column" alignItems="flex-start" gap={0.5}>
-              <Text variant="bodySmall" color="info" weight="bold">
-                {index === 0 ? 'Highest priority' : `Priority ${index + 1}`}
-              </Text>
+              {index === 0 && (
+                <Text variant="bodySmall" color="info" weight="bold">
+                  Recommended next
+                </Text>
+              )}
               <Text weight="bold" truncate title={opportunity.proposedCheck.target}>
                 {opportunity.subject}
               </Text>
-              <Stack
-                direction="column"
-                alignItems="flex-start"
-                gap={0.5}
-                aria-label={`Decision signals for ${opportunity.subject}`}
-              >
-                <Badge
-                  color={opportunity.value === 'high' ? 'orange' : 'darkgrey'}
-                  text={`${capitalize(opportunity.value)} value`}
-                />
-                <Badge
-                  color={opportunity.confidence === 'high' ? 'green' : 'darkgrey'}
-                  text={`${capitalize(opportunity.confidence)} confidence`}
-                />
-              </Stack>
+              <Text variant="bodySmall" color="secondary">
+                No matching check found
+              </Text>
               <Text color="secondary">
-                Public HTTP traffic{opportunity.requestRate ? ` · ${opportunity.requestRate}` : ''}
+                Public HTTP{opportunity.requestRate ? ` · ${opportunity.requestRate}` : ''}
               </Text>
             </Stack>
           </button>
@@ -225,28 +215,10 @@ function ReliabilityInboxReview() {
                   <Text truncate>{selected.subject}</Text>
                 </Stack>
                 <Text element="p">
-                  Review a ready-to-customize check that can continuously verify this public endpoint.
+                  {selected.requestVolume
+                    ? `We observed ${selected.requestVolume} requests in the last hour, and no matching Synthetic Monitoring check was found.`
+                    : 'We observed recent traffic, and no matching Synthetic Monitoring check was found.'}
                 </Text>
-                <Stack direction="column" alignItems="flex-start" gap={1} aria-label="Recommendation signals">
-                  <Stack alignItems="center" gap={1}>
-                    <Badge
-                      color={selected.value === 'high' ? 'orange' : 'darkgrey'}
-                      text={`${capitalize(selected.value)} value`}
-                    />
-                    <Text variant="bodySmall" color="secondary">
-                      Observed demand and endpoint relevance make this worth reviewing.
-                    </Text>
-                  </Stack>
-                  <Stack alignItems="center" gap={1}>
-                    <Badge
-                      color={selected.confidence === 'high' ? 'green' : 'darkgrey'}
-                      text={`${capitalize(selected.confidence)} confidence`}
-                    />
-                    <Text variant="bodySmall" color="secondary">
-                      Endpoint and traffic signals agree.
-                    </Text>
-                  </Stack>
-                </Stack>
               </Stack>
               <Stack direction="column" alignItems={{ xs: 'flex-start', md: 'flex-end' }} gap={1} maxWidth={280}>
                 <Button
@@ -298,16 +270,6 @@ function ReliabilityInboxReview() {
               No aggregate traffic values were returned for this suggestion.
             </Text>
           )}
-          <details className={styles.disclosure}>
-            <summary>
-              <Icon name="angle-right" />
-              <span>Why this recommendation?</span>
-            </summary>
-            <div className={styles.disclosureContent}>
-              <p>{selected.rationale}</p>
-              <p>Evidence covers the last hour and came from {formatList(selected.suggestion.evidence.families)}.</p>
-            </div>
-          </details>
         </Box>
 
         <Divider spacing={0} />
@@ -317,10 +279,10 @@ function ReliabilityInboxReview() {
               <Icon name="info-circle" />
               <Stack direction="column" gap={0.5}>
                 <Text variant="bodySmall" color="secondary" weight="bold">
-                  Monitoring status
+                  Coverage check
                 </Text>
                 <Text element="h3" variant="h5">
-                  Synthetic Monitoring does not appear to monitor this traffic yet, so we recommend adding this check.
+                  No matching check found
                 </Text>
               </Stack>
             </Stack>
@@ -343,16 +305,13 @@ function ReliabilityInboxReview() {
         <Divider spacing={0} />
         <Box element="section" backgroundColor="secondary" paddingTop={2.5}>
           <Box paddingX={2.5}>
-            <Stack alignItems="center" justifyContent="space-between" gap={2}>
-              <Stack direction="column" gap={0.5}>
-                <Text variant="bodySmall" color="secondary" weight="bold">
-                  Proposed check
-                </Text>
-                <Text element="h3" variant="h3">
-                  {selected.proposedCheck.method} {selected.subject}
-                </Text>
-              </Stack>
-              <Badge color="green" text="Ready to review" />
+            <Stack direction="column" gap={0.5}>
+              <Text variant="bodySmall" color="secondary" weight="bold">
+                Proposed check
+              </Text>
+              <Text element="h3" variant="h3">
+                {selected.proposedCheck.method} {selected.subject}
+              </Text>
             </Stack>
           </Box>
 
@@ -443,14 +402,6 @@ function ReliabilityInboxTitle() {
       <Badge color="blue" text="Experimental" />
     </Stack>
   );
-}
-
-function formatList(values: string[]) {
-  return values.length > 0 ? values.join(', ').replaceAll('_', ' ') : 'available request telemetry';
-}
-
-function capitalize(value: string) {
-  return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({

--- a/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
@@ -8,7 +8,6 @@ import {
   Box,
   Button,
   ClipboardButton,
-  Divider,
   Grid,
   Icon,
   LinkButton,
@@ -45,8 +44,7 @@ export function ReliabilityInboxPage() {
     <PluginPage pageNav={RELIABILITY_INBOX_PAGE_NAV} renderTitle={() => <ReliabilityInboxTitle />}>
       <Stack direction="column" gap={2}>
         <Text element="p" color="secondary">
-          Actionable monitoring recommendations from observed traffic, ordered by technical signals—not business
-          criticality. Nothing is created without your confirmation.
+          Review monitoring gaps discovered from recent traffic.
         </Text>
         <ReliabilityInboxReview />
       </Stack>
@@ -122,6 +120,9 @@ function ReliabilityInboxReview() {
       ? 'Grafana Assistant is unavailable'
       : undefined;
   const evidenceExploreUrl = getEvidenceExploreUrl(selected.suggestion.evidence);
+  const hasAggregateEvidence = Boolean(
+    selected.requestVolume || selected.requestRate || selected.errorRate || selected.p99
+  );
 
   const setUpWithAssistant = () => {
     if (!openAssistant) {
@@ -159,47 +160,50 @@ function ReliabilityInboxReview() {
 
   return (
     <div className={styles.reviewLayout}>
-      <aside className={styles.queue} aria-label="Review queue">
-        <Box padding={1.5}>
-          <Stack alignItems="center" justifyContent="space-between" gap={1}>
-            <strong>Review queue</strong>
-            <Badge color="blue" text={`${sortedOpportunities.length}`} />
-          </Stack>
-        </Box>
-        {sortedOpportunities.map((opportunity, index) => (
-          <button
-            className={cx(styles.queueItem, { [styles.selectedQueueItem]: opportunity.id === selected.id })}
-            key={opportunity.id}
-            type="button"
-            aria-pressed={opportunity.id === selected.id}
-            onClick={() => setSelectedId(opportunity.id)}
-          >
-            <Stack direction="column" alignItems="flex-start" gap={0.5}>
-              {index === 0 && (
-                <Text variant="bodySmall" color="info" weight="bold">
-                  Recommended next
-                </Text>
-              )}
-              <Text weight="bold" truncate title={opportunity.proposedCheck.target}>
-                {opportunity.subject}
-              </Text>
-              <Text variant="bodySmall" color="secondary">
-                No matching check found
-              </Text>
-              <Text color="secondary">
-                Public HTTP{opportunity.requestRate ? ` · ${opportunity.requestRate}` : ''}
-              </Text>
+      <aside className={styles.queue} aria-label="Recommendations">
+        <div className={styles.queueHeader}>
+          <Stack direction="column" gap={0.5}>
+            <Stack alignItems="center" justifyContent="space-between" gap={1}>
+              <strong>Recommendations</strong>
+              <Badge color="blue" text={`${sortedOpportunities.length}`} />
             </Stack>
-          </button>
-        ))}
+            <Text variant="bodySmall" color="secondary">
+              Ordered by technical signals
+            </Text>
+          </Stack>
+        </div>
+        <ol className={styles.queueList}>
+          {sortedOpportunities.map((opportunity, index) => (
+            <li className={styles.queueListItem} key={opportunity.id}>
+              <button
+                className={cx(styles.queueItem, {
+                  [styles.selectedQueueItem]: opportunity.id === selected.id,
+                })}
+                type="button"
+                aria-pressed={opportunity.id === selected.id}
+                onClick={() => setSelectedId(opportunity.id)}
+              >
+                <Badge aria-hidden="true" className={styles.queueRank} color="darkgrey" text={`${index + 1}`} />
+                <Stack direction="column" alignItems="flex-start" gap={0.5} minWidth={0}>
+                  <span className={styles.queueSubject} title={opportunity.proposedCheck.target}>
+                    {opportunity.subject}
+                  </span>
+                  <Text variant="bodySmall" color="secondary">
+                    Missing check{opportunity.requestRate ? ` · ${opportunity.requestRate}` : ''}
+                  </Text>
+                </Stack>
+              </button>
+            </li>
+          ))}
+        </ol>
       </aside>
 
       <article className={styles.review}>
-        <Box element="header" padding={2.5}>
+        <section
+          className={cx(styles.panel, styles.recommendationPanel)}
+          aria-labelledby="reliability-inbox-suggested-check-title"
+        >
           <Stack direction="column" gap={1}>
-            <Text variant="bodySmall" color="secondary" weight="bold">
-              Recommended next step
-            </Text>
             <Stack
               direction={{ xs: 'column', md: 'row' }}
               justifyContent="space-between"
@@ -207,18 +211,24 @@ function ReliabilityInboxReview() {
               gap={2}
             >
               <Stack direction="column" gap={1} minWidth={0} flex={1}>
-                <Text element="h2" variant="h3">
-                  Add an HTTP check for {selected.subject}
+                <Text variant="bodySmall" color="info" weight="bold">
+                  Suggested check
                 </Text>
-                <Stack alignItems="center" gap={1} aria-label="Recommended endpoint" minWidth={0}>
-                  <Badge color="darkgrey" text={selected.proposedCheck.method} />
-                  <Text truncate>{selected.subject}</Text>
-                </Stack>
-                <Text element="p">
-                  {selected.requestVolume
-                    ? `We observed ${selected.requestVolume} requests in the last hour, and no matching Synthetic Monitoring check was found.`
-                    : 'We observed recent traffic, and no matching Synthetic Monitoring check was found.'}
+                <Text element="h2" id="reliability-inbox-suggested-check-title" variant="h3">
+                  Create an HTTP check
                 </Text>
+                <dl className={styles.endpointSummary} aria-label="Suggested check endpoint">
+                  <div>
+                    <dt>Method</dt>
+                    <dd>
+                      <Badge color="darkgrey" text={selected.proposedCheck.method} />
+                    </dd>
+                  </div>
+                  <div className={styles.endpointTarget}>
+                    <dt>Target</dt>
+                    <dd title={selected.proposedCheck.target}>{selected.subject}</dd>
+                  </div>
+                </dl>
               </Stack>
               <Stack direction="column" alignItems={{ xs: 'flex-start', md: 'flex-end' }} gap={1} maxWidth={280}>
                 <Button
@@ -230,7 +240,7 @@ function ReliabilityInboxReview() {
                   variant="secondary"
                   onClick={setUpWithAssistant}
                 >
-                  Review and customize check
+                  Review and customize
                 </Button>
                 <Text id="reliability-inbox-assistant-action-help" variant="bodySmall" color="secondary">
                   Assistant will guide setup and recommend a configuration from this proposal. Nothing is created or
@@ -238,143 +248,113 @@ function ReliabilityInboxReview() {
                 </Text>
               </Stack>
             </Stack>
-          </Stack>
-        </Box>
-
-        <Divider spacing={0} />
-        <Box element="section" padding={2.5}>
-          <Stack alignItems="center" justifyContent="space-between" gap={1}>
-            <Text element="h3" variant="h3">
-              Evidence at a glance
-            </Text>
-            {evidenceExploreUrl && (
-              <LinkButton href={evidenceExploreUrl} icon="compass" variant="secondary">
-                Investigate in Explore
-              </LinkButton>
-            )}
-          </Stack>
-          <Grid columns={{ xs: 2, lg: 4 }} gap={1}>
-            {selected.requestVolume && (
-              <EvidenceMetric value={selected.requestVolume} label="estimated requests in the last hour" />
-            )}
-            {selected.requestRate && <EvidenceMetric value={selected.requestRate} label="observed request rate" />}
-            {selected.errorRate && <EvidenceMetric value={selected.errorRate} label="5xx responses" />}
-            {selected.p99 && <EvidenceMetric value={selected.p99} label="p99 response time" />}
-          </Grid>
-          {selected.requestVolume || selected.requestRate || selected.errorRate || selected.p99 ? (
-            <Text element="p" color="secondary">
-              These values come from recent request telemetry.
-            </Text>
-          ) : (
-            <Text element="p" color="secondary" role="status">
-              No aggregate traffic values were returned for this suggestion.
-            </Text>
-          )}
-        </Box>
-
-        <Divider spacing={0} />
-        <Box element="section" padding={2.5} backgroundColor="secondary">
-          <Stack direction="column" gap={1}>
-            <Stack alignItems="flex-start" gap={1}>
-              <Icon name="info-circle" />
-              <Stack direction="column" gap={0.5}>
-                <Text variant="bodySmall" color="secondary" weight="bold">
-                  Coverage check
-                </Text>
-                <Text element="h3" variant="h5">
-                  No matching check found
-                </Text>
+            <div className={styles.checkSummary}>
+              <Stack alignItems="center" gap={1} wrap="wrap">
+                <Badge color="darkgrey" icon="globe" text="Public HTTP" />
+                <Badge
+                  color="darkgrey"
+                  icon="clock-nine"
+                  text={`Every ${formatDuration(selected.proposedCheck.frequencyMs)}`}
+                />
+                {selected.proposedCheck.failIfNotSSL && <Badge color="darkgrey" icon="lock" text="Require HTTPS" />}
               </Stack>
-            </Stack>
+            </div>
             <details className={styles.disclosure}>
-              <summary>
-                <Icon name="angle-right" />
-                <span>How we checked</span>
-              </summary>
-              <div className={styles.disclosureContent}>
-                <p>We compared this endpoint and path with the HTTP checks available to us.</p>
-                <p>
-                  Similar or indirect monitoring may still exist through aliases, redirects, upstream checks, checks we
-                  cannot access, or other paths.
-                </p>
-              </div>
+              <summary>View configuration details</summary>
+              <dl className={styles.proposalSummary}>
+                <div className={styles.exactTarget}>
+                  <dt>Target URL</dt>
+                  <dd className={styles.targetValue}>
+                    <code>{selected.proposedCheck.target}</code>
+                    <ClipboardButton
+                      aria-label="Copy target URL"
+                      fill="text"
+                      getText={() => selected.proposedCheck.target}
+                      icon="clipboard-alt"
+                      size="sm"
+                      variant="secondary"
+                    >
+                      Copy
+                    </ClipboardButton>
+                  </dd>
+                </div>
+                <div>
+                  <dt>Timeout</dt>
+                  <dd>{formatDuration(selected.proposedCheck.timeoutMs)}</dd>
+                </div>
+                <div>
+                  <dt>Expected response</dt>
+                  <dd>HTTP {selected.proposedCheck.validStatusCodes.join(', ')}</dd>
+                </div>
+                <div>
+                  <dt>TLS requirement</dt>
+                  <dd>{selected.proposedCheck.failIfNotSSL ? 'Require HTTPS' : 'Not required'}</dd>
+                </div>
+                <div>
+                  <dt>Probe / location policy</dt>
+                  <dd>{selected.proposedCheck.locationPolicy}</dd>
+                </div>
+              </dl>
             </details>
           </Stack>
-        </Box>
+        </section>
 
-        <Divider spacing={0} />
-        <Box element="section" backgroundColor="secondary" paddingTop={2.5}>
-          <Box paddingX={2.5}>
-            <Stack direction="column" gap={0.5}>
-              <Text variant="bodySmall" color="secondary" weight="bold">
-                Proposed check
+        <section className={styles.panel} aria-labelledby="reliability-inbox-recommendation-evidence-title">
+          <Stack direction="column" gap={1.5}>
+            <Stack alignItems="center" justifyContent="space-between" gap={1}>
+              <Text element="h2" id="reliability-inbox-recommendation-evidence-title" variant="h3">
+                Why this recommendation
               </Text>
-              <Text element="h3" variant="h3">
-                {selected.proposedCheck.method} {selected.subject}
+              {evidenceExploreUrl && (
+                <LinkButton href={evidenceExploreUrl} icon="compass" variant="secondary">
+                  Explore telemetry
+                </LinkButton>
+              )}
+            </Stack>
+            <Text element="p">
+              {selected.requestVolume
+                ? `We observed ${selected.requestVolume} requests in the last hour, and no matching Synthetic Monitoring check was found.`
+                : 'We observed recent traffic, and no matching Synthetic Monitoring check was found.'}
+            </Text>
+            <Text element="h3" variant="h4">
+              Observed traffic evidence
+            </Text>
+            {hasAggregateEvidence && (
+              <Text element="p" variant="bodySmall" color="secondary">
+                Based on Prometheus telemetry from the last hour.
               </Text>
-            </Stack>
-          </Box>
-
-          <Box
-            marginX={2.5}
-            marginTop={2}
-            padding={1.5}
-            borderStyle="solid"
-            borderColor="weak"
-            borderRadius="default"
-            backgroundColor="primary"
-          >
-            <Stack alignItems="flex-start" gap={1}>
-              <Icon name="globe" />
-              <Stack direction="column" gap={0.5} minWidth={0}>
-                <Text weight="bold">
-                  HTTP {selected.proposedCheck.method} · Every {formatDuration(selected.proposedCheck.frequencyMs)}
-                </Text>
-                <Text color="secondary">{selected.proposedCheck.locationPolicy}</Text>
-              </Stack>
-            </Stack>
-          </Box>
-          <details className={cx(styles.disclosure, styles.configurationDisclosure)}>
-            <summary>
-              <Icon name="angle-right" />
-              <span>View configuration details</span>
-            </summary>
-            <dl className={styles.proposalSummary}>
-              <div className={styles.exactTarget}>
-                <dt>Target URL</dt>
-                <dd className={styles.targetValue}>
-                  <code>{selected.proposedCheck.target}</code>
-                  <ClipboardButton
-                    aria-label="Copy target URL"
-                    fill="text"
-                    getText={() => selected.proposedCheck.target}
-                    icon="clipboard-alt"
-                    size="sm"
-                    variant="secondary"
-                  >
-                    Copy
-                  </ClipboardButton>
-                </dd>
-              </div>
-              <div>
-                <dt>Timeout</dt>
-                <dd>{formatDuration(selected.proposedCheck.timeoutMs)}</dd>
-              </div>
-              <div>
-                <dt>Expected response</dt>
-                <dd>HTTP {selected.proposedCheck.validStatusCodes.join(', ')}</dd>
-              </div>
-              <div>
-                <dt>TLS requirement</dt>
-                <dd>{selected.proposedCheck.failIfNotSSL ? 'Require HTTPS' : 'Not required'}</dd>
-              </div>
-              <div>
-                <dt>Probe / location policy</dt>
-                <dd>{selected.proposedCheck.locationPolicy}</dd>
-              </div>
-            </dl>
-          </details>
-        </Box>
+            )}
+            <Grid columns={{ xs: 2, lg: 4 }} gap={1}>
+              {selected.requestVolume && (
+                <EvidenceMetric value={selected.requestVolume} label="estimated requests in the last hour" />
+              )}
+              {selected.requestRate && <EvidenceMetric value={selected.requestRate} label="observed request rate" />}
+              {selected.errorRate && <EvidenceMetric value={selected.errorRate} label="5xx responses" />}
+              {selected.p99 && <EvidenceMetric value={selected.p99} label="p99 response time" />}
+            </Grid>
+            {!hasAggregateEvidence && (
+              <Text element="p" color="secondary" role="status">
+                No aggregate traffic values were returned for this suggestion.
+              </Text>
+            )}
+            <div className={styles.coverageAssessment}>
+              <Text element="h3" variant="h4">
+                Coverage assessment
+              </Text>
+              <Text element="p" color="secondary">
+                We found no matching HTTP check for this endpoint and path among the checks available to us. Indirect or
+                inaccessible monitoring may still exist.
+              </Text>
+              <details className={cx(styles.disclosure, styles.inlineDisclosure)}>
+                <summary>How we checked</summary>
+                <p className={styles.disclosureContent}>
+                  We compared the endpoint and path with accessible HTTP checks. Aliases, redirects, upstream checks,
+                  and checks for other paths may not match directly.
+                </p>
+              </details>
+            </div>
+          </Stack>
+        </section>
       </article>
     </div>
   );
@@ -382,7 +362,7 @@ function ReliabilityInboxReview() {
 
 function EvidenceMetric({ value, label }: { value: string; label: string }) {
   return (
-    <Box padding={1.5} borderRadius="default" backgroundColor="secondary">
+    <Box padding={1.5} borderStyle="solid" borderColor="weak" borderRadius="default" backgroundColor="secondary">
       <Stack direction="column" gap={0.5}>
         <Text variant="h4" weight="bold">
           {value}
@@ -399,7 +379,7 @@ function ReliabilityInboxTitle() {
   return (
     <Stack alignItems="center" gap={1.5}>
       <h1>Reliability Inbox</h1>
-      <Badge color="blue" text="Experimental" />
+      <Badge color="blue" icon="ai-sparkle" text="Experimental" />
     </Stack>
   );
 }
@@ -408,11 +388,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
   assistantAction: getAssistantActionStyle(theme),
   reviewLayout: css({
     display: 'grid',
-    gridTemplateColumns: 'minmax(220px, 280px) minmax(0, 1fr)',
+    gridTemplateColumns: 'minmax(320px, 360px) minmax(0, 1fr)',
     gap: theme.spacing(2),
-    alignItems: 'start',
+    alignItems: 'stretch',
+    minHeight: `calc(100vh - ${theme.spacing(22)})`,
     [`@media (max-width: ${theme.breakpoints.values.md}px)`]: {
       gridTemplateColumns: '1fr',
+      minHeight: 'auto',
     },
   }),
   queue: css({
@@ -421,47 +403,75 @@ const getStyles = (theme: GrafanaTheme2) => ({
     background: theme.colors.background.secondary,
     overflow: 'hidden',
   }),
-  queueItem: css({
-    width: '100%',
+  queueHeader: css({
+    background: theme.colors.background.primary,
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
     padding: theme.spacing(1.5),
+  }),
+  queueList: css({
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+  }),
+  queueListItem: css({
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
+    '&:last-child': { borderBottom: 0 },
+  }),
+  queueItem: css({
+    alignItems: 'flex-start',
+    display: 'grid',
+    gap: theme.spacing(1),
+    gridTemplateColumns: '24px minmax(0, 1fr)',
+    width: '100%',
+    padding: theme.spacing(1.25, 1.5),
     color: theme.colors.text.secondary,
     background: 'transparent',
     border: 0,
-    borderBottom: `1px solid ${theme.colors.border.weak}`,
     textAlign: 'left',
     cursor: 'pointer',
-    '&:last-child': { borderBottom: 0 },
     '&:hover': { background: theme.colors.action.hover },
+  }),
+  queueRank: css({
+    boxSizing: 'border-box',
+    fontVariantNumeric: 'tabular-nums',
+    fontWeight: theme.typography.fontWeightBold,
+    justifyContent: 'center',
+    minWidth: theme.spacing(3),
+  }),
+  queueSubject: css({
+    fontWeight: theme.typography.fontWeightBold,
+    overflowWrap: 'anywhere',
+    width: '100%',
   }),
   selectedQueueItem: css({
     background: theme.colors.info.transparent,
+    color: theme.colors.text.primary,
     boxShadow: `inset 3px 0 0 ${theme.colors.info.border}`,
   }),
   review: css({
-    display: 'flex',
-    flexDirection: 'column',
+    display: 'grid',
+    gap: theme.spacing(2),
+    minWidth: 0,
+    alignSelf: 'start',
+  }),
+  panel: css({
     border: `1px solid ${theme.colors.border.medium}`,
     borderRadius: theme.shape.radius.default,
     background: theme.colors.background.primary,
-    overflow: 'hidden',
+    padding: theme.spacing(2.5),
+  }),
+  recommendationPanel: css({
+    borderLeft: `3px solid ${theme.colors.info.border}`,
   }),
   disclosure: css({
     borderTop: `1px solid ${theme.colors.border.weak}`,
     marginTop: theme.spacing(1.5),
     '& summary': {
-      alignItems: 'center',
-      boxSizing: 'border-box',
       color: theme.colors.text.secondary,
       cursor: 'pointer',
-      display: 'flex',
       fontSize: theme.typography.bodySmall.fontSize,
       fontWeight: theme.typography.fontWeightMedium,
-      gap: theme.spacing(0.75),
-      listStyle: 'none',
       padding: theme.spacing(1.25, 0),
-      transition: 'background-color 0.1s ease, color 0.1s ease',
-      width: '100%',
-      '&::-webkit-details-marker': { display: 'none' },
       '&:hover': {
         background: theme.colors.action.hover,
         color: theme.colors.text.primary,
@@ -471,25 +481,75 @@ const getStyles = (theme: GrafanaTheme2) => ({
         outline: `2px solid ${theme.colors.primary.border}`,
         outlineOffset: -2,
       },
-      '& svg': {
-        flexShrink: 0,
-        transition: 'transform 0.1s ease',
-      },
-    },
-    '&[open] > summary svg': {
-      transform: 'rotate(90deg)',
     },
   }),
   disclosureContent: css({
+    color: theme.colors.text.secondary,
+    margin: 0,
+    padding: theme.spacing(1, 0, 0, 2.5),
+  }),
+  inlineDisclosure: css({
+    borderTop: 0,
+    marginTop: 0,
+    '& summary': {
+      padding: theme.spacing(0.5, 0),
+    },
+  }),
+  endpointSummary: css({
+    display: 'grid',
+    gap: theme.spacing(2),
+    gridTemplateColumns: 'max-content minmax(0, 1fr)',
+    margin: 0,
+    minWidth: 0,
+    '& > div': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(0.25),
+      minWidth: 0,
+    },
+    '& dt': {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+    },
+    '& dd': {
+      margin: 0,
+      minWidth: 0,
+    },
+    [`@media (max-width: ${theme.breakpoints.values.md}px)`]: {
+      gridTemplateColumns: '1fr',
+    },
+  }),
+  endpointTarget: css({
+    '& dd': {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+  }),
+  checkSummary: css({
+    alignItems: 'center',
+    background: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+    display: 'flex',
+    gap: theme.spacing(2),
+    justifyContent: 'flex-start',
+    marginTop: theme.spacing(2),
+    padding: theme.spacing(1.5),
+    [`@media (max-width: ${theme.breakpoints.values.md}px)`]: {
+      alignItems: 'flex-start',
+      flexDirection: 'column',
+    },
+  }),
+  coverageAssessment: css({
+    borderTop: `1px solid ${theme.colors.border.weak}`,
     display: 'flex',
     flexDirection: 'column',
-    gap: theme.spacing(1),
-    padding: theme.spacing(1, 0, 0, 2.5),
-    '& p': { color: theme.colors.text.secondary, margin: 0 },
-  }),
-  configurationDisclosure: css({
-    margin: theme.spacing(1.5, 2.5, 0),
-    paddingBottom: theme.spacing(1.5),
+    gap: theme.spacing(0.5),
+    paddingTop: theme.spacing(1.5),
+    '& > p': {
+      margin: 0,
+    },
   }),
   proposalSummary: css({
     display: 'grid',

--- a/src/features/reliabilityInbox/model.test.ts
+++ b/src/features/reliabilityInbox/model.test.ts
@@ -103,31 +103,24 @@ describe('Reliability Inbox model', () => {
     );
   });
 
-  it('prioritizes confidence, then value, before the raw suggestion score', () => {
+  it('orders reviewable recommendations by technical relevance', () => {
     const opportunities = [
-      { id: 'high-value-low-confidence', relevance: 99, confidence: 'low' },
-      { id: 'lower-value-high-confidence', relevance: 20, confidence: 'high' },
-      { id: 'high-value-medium-confidence', relevance: 95, confidence: 'medium' },
-      { id: 'medium-value-high-confidence', relevance: 55, confidence: 'high' },
-      { id: 'high-value-high-confidence', relevance: 75, confidence: 'high' },
+      { id: 'lower-technical-relevance', relevance: 20 },
+      { id: 'higher-technical-relevance', relevance: 75 },
     ]
-      .map(({ id, relevance, confidence }) =>
+      .map(({ id, relevance }) =>
         toReliabilityOpportunity({
           ...HTTP_SUGGESTION,
           id,
           target: `https://${id}.example.com/`,
           relevance,
-          confidence,
         })
       )
       .sort(compareReliabilityOpportunities);
 
     expect(opportunities.map(({ id }) => id)).toEqual([
-      'high-value-high-confidence',
-      'medium-value-high-confidence',
-      'lower-value-high-confidence',
-      'high-value-medium-confidence',
-      'high-value-low-confidence',
+      'higher-technical-relevance',
+      'lower-technical-relevance',
     ]);
   });
 
@@ -166,5 +159,10 @@ describe('Reliability Inbox model', () => {
   it('suppresses suggestions the service no longer considers uncovered', () => {
     expect(isInitialReviewCandidate({ ...HTTP_SUGGESTION, dedupStatus: 'covered' })).toBe(false);
     expect(isInitialReviewCandidate({ ...HTTP_SUGGESTION, dedupStatus: 'dismissed' })).toBe(false);
+  });
+
+  it('suppresses coverage gaps without high confidence', () => {
+    expect(isInitialReviewCandidate({ ...HTTP_SUGGESTION, confidence: 'medium' })).toBe(false);
+    expect(isInitialReviewCandidate({ ...HTTP_SUGGESTION, confidence: 'low' })).toBe(false);
   });
 });

--- a/src/features/reliabilityInbox/model.test.ts
+++ b/src/features/reliabilityInbox/model.test.ts
@@ -118,10 +118,26 @@ describe('Reliability Inbox model', () => {
       )
       .sort(compareReliabilityOpportunities);
 
-    expect(opportunities.map(({ id }) => id)).toEqual([
-      'higher-technical-relevance',
-      'lower-technical-relevance',
-    ]);
+    expect(opportunities.map(({ id }) => id)).toEqual(['higher-technical-relevance', 'lower-technical-relevance']);
+  });
+
+  it('falls back to the service score when technical relevance is unavailable', () => {
+    const opportunities = [
+      { id: 'lower-service-score', score: 0.2 },
+      { id: 'higher-service-score', score: 0.8 },
+    ]
+      .map(({ id, score }) =>
+        toReliabilityOpportunity({
+          ...HTTP_SUGGESTION,
+          id,
+          score,
+          relevance: undefined,
+          target: `https://${id}.example.com/`,
+        })
+      )
+      .sort(compareReliabilityOpportunities);
+
+    expect(opportunities.map(({ id }) => id)).toEqual(['higher-service-score', 'lower-service-score']);
   });
 
   it('uses hostname, non-default port, and meaningful path as the human-readable endpoint identity', () => {
@@ -132,14 +148,17 @@ describe('Reliability Inbox model', () => {
     expect(opportunity.proposedCheck.target).toBe(target);
   });
 
-  it('builds the proposal deterministically before Assistant is involved', () => {
-    expect(getProposedHttpCheckDraft(HTTP_SUGGESTION)).toEqual(
+  it('defers probe location selection to review when the suggestion does not specify probes', () => {
+    const draft = getProposedHttpCheckDraft({
+      ...HTTP_SUGGESTION,
+      prompt:
+        'Create a Grafana Synthetic Monitoring http check for https://mcp.goagain.dev/. Suggested configuration: job "mcp.goagain.dev", frequency 1m0s, timeout 2s, expect HTTP status [200], fail if not SSL, probe IDs [].',
+    });
+
+    expect(draft).toEqual(
       expect.objectContaining({
-        job: 'mcp.goagain.dev',
-        frequencyMs: 60_000,
-        timeoutMs: 2000,
-        validStatusCodes: [200],
-        probeIds: [7],
+        probeIds: [],
+        locationPolicy: 'Probe locations will be selected during review.',
       })
     );
   });

--- a/src/features/reliabilityInbox/model.ts
+++ b/src/features/reliabilityInbox/model.ts
@@ -1,10 +1,4 @@
-import {
-  OpportunityConfidence,
-  OpportunityValue,
-  ProposedHttpCheckDraft,
-  ReliabilityOpportunity,
-  ReliabilitySuggestion,
-} from './types';
+import { ProposedHttpCheckDraft, ReliabilityOpportunity, ReliabilitySuggestion } from './types';
 import { CheckType } from 'types';
 
 const ONE_MINUTE_IN_MS = 60 * 1000;
@@ -35,9 +29,6 @@ export function toReliabilityOpportunity(suggestion: ReliabilitySuggestion): Rel
     id: suggestion.id,
     suggestion,
     subject: getSubject(suggestion.target),
-    rationale: suggestion.rationale ?? 'Observed demand appears to have no equivalent synthetic coverage.',
-    value: getValue(suggestion.relevance),
-    confidence: getConfidence(suggestion.confidence),
     sortScore: suggestion.relevance ?? suggestion.score * 100,
     requestVolume:
       suggestion.evidence.reqPerS === undefined
@@ -50,34 +41,16 @@ export function toReliabilityOpportunity(suggestion: ReliabilitySuggestion): Rel
   };
 }
 
-/**
- * Orders the inbox by confidence first, then value, before using the backend
- * score as a tie-breaker. This keeps the high-confidence review set together
- * while ensuring high-value/high-confidence opportunities lead that set.
- */
+/** Orders eligible recommendations by technical relevance. */
 export function compareReliabilityOpportunities(a: ReliabilityOpportunity, b: ReliabilityOpportunity) {
-  const confidenceDifference = getConfidencePriority(b.confidence) - getConfidencePriority(a.confidence);
-  if (confidenceDifference !== 0) {
-    return confidenceDifference;
-  }
-
-  const valueDifference = getValuePriority(b.value) - getValuePriority(a.value);
-  if (valueDifference !== 0) {
-    return valueDifference;
-  }
-
-  const scoreDifference = b.sortScore - a.sortScore;
-  if (scoreDifference !== 0) {
-    return scoreDifference;
-  }
-
-  return a.id.localeCompare(b.id);
+  return b.sortScore - a.sortScore || a.id.localeCompare(b.id);
 }
 
 export function isInitialReviewCandidate(suggestion: ReliabilitySuggestion) {
   if (
     suggestion.checkType !== CheckType.Http ||
     suggestion.dedupStatus !== 'uncovered' ||
+    suggestion.confidence.toLowerCase() !== 'high' ||
     suggestion.reachability !== 'public' ||
     suggestion.authRequired ||
     suggestion.needsConfiguration
@@ -157,40 +130,6 @@ function isPrivateOrDevelopmentHost(hostname: string) {
     (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
     (octets[0] === 192 && octets[1] === 168)
   );
-}
-
-function getValue(relevance = 0): OpportunityValue {
-  if (relevance >= 70) {
-    return 'high';
-  }
-  if (relevance >= 40) {
-    return 'medium';
-  }
-  return 'lower';
-}
-
-function getConfidence(confidence: string): OpportunityConfidence {
-  const normalized = confidence.toLowerCase();
-  if (normalized === 'high' || normalized === 'medium') {
-    return normalized;
-  }
-  return 'low';
-}
-
-function getConfidencePriority(confidence: OpportunityConfidence) {
-  return {
-    high: 3,
-    medium: 2,
-    low: 1,
-  }[confidence];
-}
-
-function getValuePriority(value: OpportunityValue) {
-  return {
-    high: 3,
-    medium: 2,
-    lower: 1,
-  }[value];
 }
 
 function parseNumberList(value?: string) {

--- a/src/features/reliabilityInbox/model.ts
+++ b/src/features/reliabilityInbox/model.ts
@@ -1,3 +1,5 @@
+import { durationToMilliseconds, isValidDuration, parseDuration } from '@grafana/data';
+
 import { ProposedHttpCheckDraft, ReliabilityOpportunity, ReliabilitySuggestion } from './types';
 import { CheckType } from 'types';
 
@@ -12,8 +14,8 @@ export function parseSuggestedCheckConfig(prompt: string) {
 
   return {
     job,
-    frequencyMs: frequency ? parseDuration(frequency) : undefined,
-    timeoutMs: timeout ? parseDuration(timeout) : undefined,
+    frequencyMs: frequency ? parsePromptDuration(frequency) : undefined,
+    timeoutMs: timeout ? parsePromptDuration(timeout) : undefined,
     validStatusCodes: parseNumberList(statusCodes),
     failIfNotSSL: /fail if not SSL/i.test(prompt),
     probeIds: parseNumberList(probeIds),
@@ -86,7 +88,7 @@ export function getProposedHttpCheckDraft(suggestion: ReliabilitySuggestion): Pr
     locationPolicy:
       probeIds.length > 0
         ? `Run from the configured public probe${probeIds.length === 1 ? '' : 's'} with ID${probeIds.length === 1 ? '' : 's'} ${probeIds.join(', ')}.`
-        : 'Select at least one public probe before creating the check.',
+        : 'Probe locations will be selected during review.',
   };
 }
 
@@ -143,15 +145,9 @@ function parseNumberList(value?: string) {
     .filter(Number.isFinite);
 }
 
-function parseDuration(value: string) {
-  const units: Record<string, number> = { ms: 1, s: 1000, m: ONE_MINUTE_IN_MS, h: 60 * ONE_MINUTE_IN_MS };
-  const matches = [...value.matchAll(/(\d+(?:\.\d+)?)(ms|h|m|s)/g)];
-
-  if (matches.length === 0) {
-    return undefined;
-  }
-
-  return matches.reduce((total, [, amount, unit]) => total + Number(amount) * units[unit], 0);
+function parsePromptDuration(value: string) {
+  const duration = value.replace(/([hms])(?=\d)/g, '$1 ');
+  return isValidDuration(duration) ? durationToMilliseconds(parseDuration(duration)) : undefined;
 }
 
 function formatCompactNumber(value: number) {

--- a/src/features/reliabilityInbox/types.ts
+++ b/src/features/reliabilityInbox/types.ts
@@ -46,9 +46,6 @@ export const reliabilitySuggestionsSchema = z.object({
 export type ReliabilitySuggestion = z.infer<typeof reliabilitySuggestionSchema>;
 export type ReliabilityEvidence = ReliabilitySuggestion['evidence'];
 
-export type OpportunityValue = 'high' | 'medium' | 'lower';
-export type OpportunityConfidence = 'high' | 'medium' | 'low';
-
 export interface ProposedHttpCheckDraft {
   job: string;
   target: string;
@@ -66,9 +63,6 @@ export interface ReliabilityOpportunity {
   id: string;
   suggestion: ReliabilitySuggestion;
   subject: string;
-  rationale: string;
-  value: OpportunityValue;
-  confidence: OpportunityConfidence;
   sortScore: number;
   requestVolume?: string;
   requestRate?: string;


### PR DESCRIPTION
## Summary

- removes the High value, High confidence, numbered priority, and Ready to review labels
- presents one review-order cue alongside the observable coverage and traffic evidence
- treats confidence as an eligibility gate for missing coverage and orders eligible recommendations by technical relevance
- removes generated business-value rationale because the product only has technical signals

<img width="2106" height="1251" alt="CleanShot 2026-08-18 at 16 59 14" src="https://github.com/user-attachments/assets/e958d72a-b287-434e-b217-0eea9af2062b" />


## Why

Every item in the Reliability Inbox is intended to be actionable, while the system cannot determine business criticality. Ratings therefore duplicated the queue ordering and asked users to trust unsupported judgments. This change shows what was observed and what coverage matching found instead.

## User impact

Users see a simpler review queue with “Recommended next,” “No matching check found,” and recent traffic evidence. The detail view explains that no matching Synthetic Monitoring check was found and keeps the existing “How we checked” limitations. Suggestions without high confidence in missing coverage are not surfaced.

## Validation

- `yarn test src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx src/features/reliabilityInbox/model.test.ts src/features/reliabilityInbox/ReliabilityInboxBanner.test.tsx --runInBand`
- `yarn typecheck`
- `yarn lint` (passes with 13 pre-existing `no-console` warnings)
- `yarn build`

Stacked on #1773.
