### PR TITLE
feat: dismiss Reliability Inbox suggestions

### DIFF
--- a/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
@@ -9,11 +9,12 @@ import { ReliabilitySuggestion } from './types';
 import { AppRoutes } from 'routing/types';
 import { generateRoutePath, getRoute } from 'routing/utils';
 
-import { useReliabilityInboxSuggestions } from './data';
+import { useReliabilityInboxDismissals, useReliabilityInboxSuggestions } from './data';
 import { toReliabilityOpportunity } from './model';
 import { ReliabilityInboxPage } from './ReliabilityInboxPage';
 
 jest.mock('./data', () => ({
+  useReliabilityInboxDismissals: jest.fn(),
   useReliabilityInboxSuggestions: jest.fn(),
 }));
 
@@ -34,6 +35,8 @@ const LOWER_PRIORITY_HTTP_SUGGESTION: ReliabilitySuggestion = {
 };
 
 const openAssistant = jest.fn();
+const dismissSuggestion = jest.fn();
+const restoreSuggestion = jest.fn();
 
 function renderPage(
   suggestions: ReliabilitySuggestion[] = [HTTP_RELIABILITY_SUGGESTION],
@@ -59,6 +62,11 @@ function renderPage(
 describe('ReliabilityInboxPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(useReliabilityInboxDismissals).mockReturnValue({
+      dismissedSuggestionIds: [],
+      dismissSuggestion,
+      restoreSuggestion,
+    });
     jest.mocked(useAssistant).mockReturnValue({
       isAvailable: true,
       isLoading: false,
@@ -161,6 +169,72 @@ describe('ReliabilityInboxPage', () => {
     expect(await screen.findByText('Suggestions could not be refreshed')).toBeInTheDocument();
     expect(screen.getByText('Showing saved suggestions. Try again later for newer opportunities.')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Create an HTTP check' })).toBeInTheDocument();
+  });
+
+  it('dismisses suggestions from the card header, advances, and supports undo', async () => {
+    const first = toReliabilityOpportunity(HTTP_RELIABILITY_SUGGESTION);
+    const second = toReliabilityOpportunity({
+      ...HTTP_RELIABILITY_SUGGESTION,
+      id: 'api-suggestion',
+      target: 'https://api.example.com/',
+      score: 1.3,
+      relevance: 50,
+      prompt: HTTP_RELIABILITY_SUGGESTION.prompt.replaceAll('mcp.goagain.dev', 'api.example.com'),
+    });
+    let suggestions = [first, second];
+
+    dismissSuggestion.mockImplementation((id) => {
+      suggestions = suggestions.filter((suggestion) => suggestion.id !== id);
+    });
+    restoreSuggestion.mockImplementation((id) => {
+      const restored = [first, second].find((suggestion) => suggestion.id === id);
+
+      if (restored && !suggestions.some((suggestion) => suggestion.id === id)) {
+        suggestions = [restored, ...suggestions];
+      }
+    });
+    jest.mocked(useReliabilityInboxSuggestions).mockImplementation(
+      () =>
+        ({
+          data: suggestions,
+          isLoading: false,
+          isFetching: false,
+          isError: false,
+          refetch: jest.fn(),
+        }) as unknown as ReturnType<typeof useReliabilityInboxSuggestions>
+    );
+
+    const { user } = render(<ReliabilityInboxPage />, {
+      path: generateRoutePath(AppRoutes.ReliabilityInbox),
+      route: getRoute(AppRoutes.ReliabilityInbox),
+    });
+
+    const dismissButton = await screen.findByRole('button', { name: 'Dismiss suggestion' });
+    expect(dismissButton).not.toHaveTextContent('Dismiss suggestion');
+    await user.click(dismissButton);
+
+    expect(dismissSuggestion).toHaveBeenCalledWith('http-suggestion');
+    expect(within(screen.getByLabelText('Suggested check endpoint')).getByText('api.example.com')).toBeInTheDocument();
+    const dismissalToast = await screen.findByRole('status', { name: 'Suggestion dismissed in this browser' });
+    expect(within(dismissalToast).getByRole('button', { name: 'Undo' })).toBeInTheDocument();
+
+    await user.click(within(dismissalToast).getByRole('button', { name: 'Undo' }));
+
+    expect(restoreSuggestion).toHaveBeenCalledWith('http-suggestion');
+    expect(within(screen.getByLabelText('Suggested check endpoint')).getByText('mcp.goagain.dev')).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'Suggestion dismissed in this browser' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss suggestion' }));
+    expect(within(screen.getByLabelText('Suggested check endpoint')).getByText('api.example.com')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss suggestion' }));
+    expect(await screen.findByText('No reviewable opportunities')).toBeInTheDocument();
+
+    const finalDismissalToast = screen.getByRole('status', { name: 'Suggestion dismissed in this browser' });
+    await user.click(within(finalDismissalToast).getByRole('button', { name: 'Undo' }));
+
+    expect(restoreSuggestion).toHaveBeenLastCalledWith('api-suggestion');
+    expect(within(screen.getByLabelText('Suggested check endpoint')).getByText('api.example.com')).toBeInTheDocument();
   });
 
   it('shows a compact proposed check with configuration details on demand', async () => {

--- a/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
@@ -35,12 +35,17 @@ const LOWER_PRIORITY_HTTP_SUGGESTION: ReliabilitySuggestion = {
 
 const openAssistant = jest.fn();
 
-function renderPage(suggestions: ReliabilitySuggestion[] = [HTTP_RELIABILITY_SUGGESTION]) {
+function renderPage(
+  suggestions: ReliabilitySuggestion[] = [HTTP_RELIABILITY_SUGGESTION],
+  overrides: Partial<ReturnType<typeof useReliabilityInboxSuggestions>> = {}
+) {
   const result = {
     data: suggestions.map(toReliabilityOpportunity),
     isLoading: false,
+    isFetching: false,
     isError: false,
     refetch: jest.fn(),
+    ...overrides,
   } as unknown as ReturnType<typeof useReliabilityInboxSuggestions>;
 
   jest.mocked(useReliabilityInboxSuggestions).mockReturnValue(result);
@@ -141,6 +146,21 @@ describe('ReliabilityInboxPage', () => {
 
     expect(await screen.findByText('Loading Reliability Inbox…')).toBeInTheDocument();
     expect(screen.queryByText('Why this recommendation')).not.toBeInTheDocument();
+  });
+
+  it('keeps saved suggestions usable while looking for new opportunities', async () => {
+    renderPage(undefined, { isFetching: true });
+
+    expect(await screen.findByText('Showing saved suggestions · Looking for new opportunities…')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Create an HTTP check' })).toBeInTheDocument();
+  });
+
+  it('keeps saved suggestions usable when the refresh fails', async () => {
+    renderPage(undefined, { isError: true });
+
+    expect(await screen.findByText('Suggestions could not be refreshed')).toBeInTheDocument();
+    expect(screen.getByText('Showing saved suggestions. Try again later for newer opportunities.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Create an HTTP check' })).toBeInTheDocument();
   });
 
   it('shows a compact proposed check with configuration details on demand', async () => {

--- a/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
@@ -3,14 +3,17 @@ import { createAssistantContextItem, useAssistant } from '@grafana/assistant';
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { PluginPage } from '@grafana/runtime';
 import {
+  Alert,
   Badge,
   Box,
   Button,
   ClipboardButton,
   EmptyState,
   Grid,
+  IconButton,
   LinkButton,
   LoadingPlaceholder,
+  Portal,
   Spinner,
   Stack,
   Text,
@@ -26,7 +29,7 @@ import { getUserPermissions } from 'data/permissions';
 import { ErrorAlert } from 'components/ErrorAlert';
 
 import { getAssistantActionStyle } from './assistantActionStyles';
-import { useReliabilityInboxSuggestions } from './data';
+import { useReliabilityInboxDismissals, useReliabilityInboxSuggestions } from './data';
 import { getEvidenceExploreUrl } from './evidence';
 
 const ASSISTANT_ORIGIN = 'grafana-synthetic-monitoring-app/reliability-inbox';
@@ -65,8 +68,10 @@ function ReliabilityInboxReview() {
   const { canWriteChecks } = getUserPermissions();
   const { isAvailable: isAssistantAvailable, isLoading: isAssistantLoading, openAssistant } = useAssistant();
   const { data, isLoading, isFetching, isError, refetch } = useReliabilityInboxSuggestions();
+  const { dismissSuggestion, restoreSuggestion } = useReliabilityInboxDismissals();
   const opportunities = data ?? [];
   const [selectedId, setSelectedId] = useState<string>();
+  const [lastDismissedId, setLastDismissedId] = useState<string>();
   const reviewedIds = useRef(new Set<string>());
 
   const selected = opportunities.find((opportunity) => opportunity.id === selectedId) ?? opportunities[0];
@@ -111,6 +116,33 @@ function ReliabilityInboxReview() {
     />
   ) : null;
 
+  const dismissalToast = lastDismissedId ? (
+    <Portal>
+      <Alert
+        className={styles.dismissalToast}
+        severity="success"
+        title="Suggestion dismissed in this browser"
+        elevated
+        bottomSpacing={0}
+        action={
+          <Button
+            variant="secondary"
+            fill="text"
+            size="sm"
+            onClick={() => {
+              restoreSuggestion(lastDismissedId);
+              setSelectedId(lastDismissedId);
+              setLastDismissedId(undefined);
+            }}
+          >
+            Undo
+          </Button>
+        }
+        onRemove={() => setLastDismissedId(undefined)}
+      />
+    </Portal>
+  ) : null;
+
   if (!selected) {
     return (
       <Stack direction="column" gap={1}>
@@ -118,6 +150,7 @@ function ReliabilityInboxReview() {
         <EmptyState message="No reviewable opportunities" variant="completed">
           Only public HTTP endpoints with enough evidence of missing coverage are shown.
         </EmptyState>
+        {dismissalToast}
       </Stack>
     );
   }
@@ -132,6 +165,10 @@ function ReliabilityInboxReview() {
   const hasAggregateEvidence = Boolean(
     selected.requestVolume || selected.requestRate || selected.errorRate || selected.p99
   );
+  const dismissSelected = () => {
+    dismissSuggestion(selected.id);
+    setLastDismissedId(selected.id);
+  };
 
   const setUpWithAssistant = () => {
     if (!openAssistant) {
@@ -211,6 +248,19 @@ function ReliabilityInboxReview() {
           aria-labelledby="reliability-inbox-suggested-check-title"
         >
           <Stack direction="column" gap={1}>
+            <Stack alignItems="center" justifyContent="space-between" gap={1}>
+              <Text variant="bodySmall" color="info" weight="bold">
+                Suggested check
+              </Text>
+              <IconButton
+                name="times"
+                size="sm"
+                variant="secondary"
+                tooltip="Dismiss suggestion"
+                tooltipPlacement="left"
+                onClick={dismissSelected}
+              />
+            </Stack>
             <Stack
               direction={{ xs: 'column', md: 'row' }}
               justifyContent="space-between"
@@ -218,9 +268,6 @@ function ReliabilityInboxReview() {
               gap={2}
             >
               <Stack direction="column" gap={1} minWidth={0} flex={1}>
-                <Text variant="bodySmall" color="info" weight="bold">
-                  Suggested check
-                </Text>
                 <Text element="h2" id="reliability-inbox-suggested-check-title" variant="h3">
                   Create an HTTP check
                 </Text>
@@ -363,6 +410,7 @@ function ReliabilityInboxReview() {
           </Stack>
         </section>
       </article>
+      {dismissalToast}
     </div>
   );
 }
@@ -384,6 +432,13 @@ function EvidenceMetric({ value, label }: { value: string; label: string }) {
 
 const getStyles = (theme: GrafanaTheme2) => ({
   assistantAction: getAssistantActionStyle(theme),
+  dismissalToast: css({
+    position: 'fixed',
+    right: theme.spacing(2),
+    bottom: theme.spacing(2),
+    width: `calc(100vw - ${theme.spacing(4)})`,
+    maxWidth: 420,
+  }),
   refreshStatus: css({ gridColumn: '1 / -1' }),
   reviewLayout: css({
     display: 'grid',

--- a/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
@@ -11,6 +11,7 @@ import {
   Grid,
   LinkButton,
   LoadingPlaceholder,
+  Spinner,
   Stack,
   Text,
   useStyles2,
@@ -63,7 +64,8 @@ function ReliabilityInboxReview() {
   const styles = useStyles2(getStyles);
   const { canWriteChecks } = getUserPermissions();
   const { isAvailable: isAssistantAvailable, isLoading: isAssistantLoading, openAssistant } = useAssistant();
-  const { data: opportunities = [], isLoading, isError, refetch } = useReliabilityInboxSuggestions();
+  const { data, isLoading, isFetching, isError, refetch } = useReliabilityInboxSuggestions();
+  const opportunities = data ?? [];
   const [selectedId, setSelectedId] = useState<string>();
   const reviewedIds = useRef(new Set<string>());
 
@@ -82,7 +84,7 @@ function ReliabilityInboxReview() {
     return <LoadingPlaceholder text="Loading Reliability Inbox…" />;
   }
 
-  if (isError) {
+  if (isError && !data) {
     return (
       <ErrorAlert
         buttonText="Retry"
@@ -93,11 +95,30 @@ function ReliabilityInboxReview() {
     );
   }
 
+  const refreshStatus = isFetching ? (
+    <Stack role="status" alignItems="center" gap={1}>
+      <Spinner size="xs" inline />
+      <Text color="secondary" variant="bodySmall">
+        Showing saved suggestions · Looking for new opportunities…
+      </Text>
+    </Stack>
+  ) : isError ? (
+    <ErrorAlert
+      buttonText="Retry"
+      content="Showing saved suggestions. Try again later for newer opportunities."
+      onClick={() => refetch()}
+      title="Suggestions could not be refreshed"
+    />
+  ) : null;
+
   if (!selected) {
     return (
-      <EmptyState message="No reviewable opportunities" variant="completed">
-        Only public HTTP endpoints with enough evidence of missing coverage are shown.
-      </EmptyState>
+      <Stack direction="column" gap={1}>
+        {refreshStatus}
+        <EmptyState message="No reviewable opportunities" variant="completed">
+          Only public HTTP endpoints with enough evidence of missing coverage are shown.
+        </EmptyState>
+      </Stack>
     );
   }
 
@@ -145,6 +166,7 @@ function ReliabilityInboxReview() {
 
   return (
     <div className={styles.reviewLayout}>
+      {refreshStatus && <div className={styles.refreshStatus}>{refreshStatus}</div>}
       <aside className={styles.queue} aria-label="Recommendations">
         <div className={styles.queueHeader}>
           <Stack direction="column" gap={0.5}>
@@ -362,6 +384,7 @@ function EvidenceMetric({ value, label }: { value: string; label: string }) {
 
 const getStyles = (theme: GrafanaTheme2) => ({
   assistantAction: getAssistantActionStyle(theme),
+  refreshStatus: css({ gridColumn: '1 / -1' }),
   reviewLayout: css({
     display: 'grid',
     gridTemplateColumns: 'minmax(320px, 360px) minmax(0, 1fr)',

--- a/src/features/reliabilityInbox/data.test.tsx
+++ b/src/features/reliabilityInbox/data.test.tsx
@@ -5,21 +5,28 @@ import { createWrapper } from 'test/render';
 import { getQueryClient } from 'data/queryClient';
 import { useSMDS } from 'hooks/useSMDS';
 
-import { reliabilityInboxQueryKey, useCachedReliabilityInboxSuggestions, useReliabilityInboxSuggestions } from './data';
+import {
+  reliabilityInboxQueryKey,
+  reliabilityInboxStorageKey,
+  useCachedReliabilityInboxSuggestions,
+  useReliabilityInboxSuggestions,
+} from './data';
 
 jest.mock('hooks/useSMDS', () => ({
   useSMDS: jest.fn(),
 }));
 
 const API_HOST = 'https://synthetic-monitoring-api-dev.grafana-dev.net';
+const STACK_ID = 15629;
 const getReliabilityInboxSuggestions = jest.fn();
 
 describe('Reliability Inbox data', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    window.localStorage.clear();
     jest.mocked(useSMDS).mockReturnValue({
       uid: undefined,
-      instanceSettings: { jsonData: { apiHost: API_HOST } },
+      instanceSettings: { jsonData: { apiHost: API_HOST, metrics: { hostedId: STACK_ID } } },
       supportsReliabilityInbox: () => true,
       getReliabilityInboxSuggestions,
       getMetricsDS: () => undefined,
@@ -44,7 +51,7 @@ describe('Reliability Inbox data', () => {
   it('returns generated suggestions from the cache without another service call', async () => {
     const queryClient = getQueryClient();
     const { Wrapper } = createWrapper({ queryClient });
-    queryClient.setQueryData(reliabilityInboxQueryKey(API_HOST), []);
+    queryClient.setQueryData(reliabilityInboxQueryKey(API_HOST, STACK_ID), []);
 
     const { result } = renderHook(() => useCachedReliabilityInboxSuggestions(), {
       wrapper: Wrapper,
@@ -71,6 +78,42 @@ describe('Reliability Inbox data', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(getReliabilityInboxSuggestions).toHaveBeenCalledTimes(1);
     expect(result.current.data?.map(({ id }) => id)).toEqual(['http-suggestion', 'lower-relevance']);
-    expect(queryClient.getQueryData(reliabilityInboxQueryKey(API_HOST))).toEqual(result.current.data);
+    expect(queryClient.getQueryData(reliabilityInboxQueryKey(API_HOST, STACK_ID))).toEqual(result.current.data);
+    expect(
+      JSON.parse(window.localStorage.getItem(reliabilityInboxStorageKey(API_HOST, STACK_ID))!).suggestions.map(
+        ({ id }: { id: string }) => id
+      )
+    ).toEqual(['lower-relevance', 'http-suggestion']);
+  });
+
+  it('returns a saved browser snapshot without generating suggestions', async () => {
+    window.localStorage.setItem(
+      reliabilityInboxStorageKey(API_HOST, STACK_ID),
+      JSON.stringify({ savedAt: Date.now(), suggestions: [HTTP_RELIABILITY_SUGGESTION] })
+    );
+    const queryClient = getQueryClient();
+    const { Wrapper } = createWrapper({ queryClient });
+
+    const { result } = renderHook(() => useCachedReliabilityInboxSuggestions(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.data?.[0].subject).toBe('mcp.goagain.dev'));
+    expect(getReliabilityInboxSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('keeps a stale saved snapshot when its background refresh degrades', async () => {
+    const storageKey = reliabilityInboxStorageKey(API_HOST, STACK_ID);
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({ savedAt: Date.now() - 7 * 60 * 60 * 1000, suggestions: [HTTP_RELIABILITY_SUGGESTION] })
+    );
+    getReliabilityInboxSuggestions.mockResolvedValue({ suggestions: [], warnings: ['telemetry unavailable'] });
+    const queryClient = getQueryClient();
+    const { Wrapper } = createWrapper({ queryClient });
+
+    const { result } = renderHook(() => useReliabilityInboxSuggestions(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data?.[0].subject).toBe('mcp.goagain.dev');
+    expect(JSON.parse(window.localStorage.getItem(storageKey)!).suggestions).toEqual([HTTP_RELIABILITY_SUGGESTION]);
   });
 });

--- a/src/features/reliabilityInbox/data.test.tsx
+++ b/src/features/reliabilityInbox/data.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { HTTP_RELIABILITY_SUGGESTION } from 'test/fixtures/reliabilityInbox';
 import { createWrapper } from 'test/render';
 
@@ -7,8 +7,10 @@ import { useSMDS } from 'hooks/useSMDS';
 
 import {
   reliabilityInboxQueryKey,
+  reliabilityInboxDismissalsKey,
   reliabilityInboxStorageKey,
   useCachedReliabilityInboxSuggestions,
+  useReliabilityInboxDismissals,
   useReliabilityInboxSuggestions,
 } from './data';
 
@@ -97,6 +99,30 @@ describe('Reliability Inbox data', () => {
     const { result } = renderHook(() => useCachedReliabilityInboxSuggestions(), { wrapper: Wrapper });
 
     await waitFor(() => expect(result.current.data?.[0].subject).toBe('mcp.goagain.dev'));
+    expect(getReliabilityInboxSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('persists dismissed suggestions, filters them from cache, and supports undo', async () => {
+    const dismissalsKey = reliabilityInboxDismissalsKey(API_HOST, STACK_ID);
+    window.localStorage.setItem(
+      reliabilityInboxStorageKey(API_HOST, STACK_ID),
+      JSON.stringify({ savedAt: Date.now(), suggestions: [HTTP_RELIABILITY_SUGGESTION] })
+    );
+    window.localStorage.setItem(dismissalsKey, JSON.stringify([HTTP_RELIABILITY_SUGGESTION.id]));
+    const queryClient = getQueryClient();
+    const { Wrapper } = createWrapper({ queryClient });
+
+    const { result } = renderHook(
+      () => ({ suggestions: useCachedReliabilityInboxSuggestions(), dismissals: useReliabilityInboxDismissals() }),
+      { wrapper: Wrapper }
+    );
+
+    await waitFor(() => expect(result.current.suggestions.data).toEqual([]));
+    act(() => result.current.dismissals.restoreSuggestion(HTTP_RELIABILITY_SUGGESTION.id));
+    expect(result.current.suggestions.data).toHaveLength(1);
+    act(() => result.current.dismissals.dismissSuggestion(HTTP_RELIABILITY_SUGGESTION.id));
+    expect(result.current.suggestions.data).toEqual([]);
+    expect(JSON.parse(window.localStorage.getItem(dismissalsKey)!)).toEqual([HTTP_RELIABILITY_SUGGESTION.id]);
     expect(getReliabilityInboxSuggestions).not.toHaveBeenCalled();
   });
 

--- a/src/features/reliabilityInbox/data.ts
+++ b/src/features/reliabilityInbox/data.ts
@@ -1,11 +1,23 @@
 import { useQuery } from '@tanstack/react-query';
+import { z } from 'zod';
 
-import { reliabilitySuggestionsSchema } from './types';
+import { reliabilitySuggestionSchema, reliabilitySuggestionsSchema } from './types';
 import { useSMDS } from 'hooks/useSMDS';
 
 import { compareReliabilityOpportunities, isInitialReviewCandidate, toReliabilityOpportunity } from './model';
 
-export const reliabilityInboxQueryKey = (apiHost: string) => ['reliability-inbox', 'suggestions', apiHost] as const;
+const STALE_TIME = 6 * 60 * 60 * 1000;
+
+const reliabilityInboxSnapshotSchema = z.object({
+  savedAt: z.number(),
+  suggestions: z.array(reliabilitySuggestionSchema),
+});
+
+export const reliabilityInboxQueryKey = (apiHost: string, stackId: number) =>
+  ['reliability-inbox', 'suggestions', apiHost, stackId] as const;
+
+export const reliabilityInboxStorageKey = (apiHost: string, stackId: number) =>
+  `synthetic-monitoring:reliability-inbox:v1:${apiHost}:${stackId}`;
 
 /**
  * Fetches suggestions from the reliability-inbox experiment.
@@ -25,26 +37,56 @@ export function useCachedReliabilityInboxSuggestions() {
 function useReliabilityInboxQuery(generateSuggestions: boolean) {
   const smDS = useSMDS();
   const apiHost = smDS.instanceSettings.jsonData.apiHost;
+  const stackId = smDS.instanceSettings.jsonData.metrics.hostedId;
+  const storageKey = reliabilityInboxStorageKey(apiHost, stackId);
+  const snapshot = readSnapshot(storageKey);
 
   return useQuery({
     // apiHost is in the key because it selects the region, and therefore which
     // instance answered.
-    queryKey: reliabilityInboxQueryKey(apiHost),
+    queryKey: reliabilityInboxQueryKey(apiHost, stackId),
     enabled: generateSuggestions && smDS.supportsReliabilityInbox(),
+    initialData: snapshot ? toOpportunities(snapshot.suggestions) : undefined,
+    initialDataUpdatedAt: snapshot?.savedAt,
     queryFn: async () => {
-      const result = await smDS.getReliabilityInboxSuggestions();
+      const result = reliabilitySuggestionsSchema.parse(await smDS.getReliabilityInboxSuggestions());
 
-      return reliabilitySuggestionsSchema
-        .parse(result)
-        .suggestions.filter(isInitialReviewCandidate)
-        .map(toReliabilityOpportunity)
-        .sort(compareReliabilityOpportunities);
+      // The experiment reports degraded failures as HTTP 200 with warnings.
+      // Keep the last useful inbox instead of replacing it with that empty response.
+      if (result.suggestions.length === 0 && result.warnings.length > 0) {
+        throw new Error(result.warnings.join('; '));
+      }
+
+      writeSnapshot(storageKey, result.suggestions);
+
+      return toOpportunities(result.suggestions);
     },
     retry: false,
-    staleTime: Infinity,
+    staleTime: STALE_TIME,
     // Suggestion generation creates a token and invokes a paid service. Retain
     // the result for the lifetime of the SPA session, even when no component is
     // temporarily subscribed, so navigation cannot cause accidental regeneration.
     gcTime: Infinity,
   });
+}
+
+function toOpportunities(suggestions: Array<z.infer<typeof reliabilitySuggestionSchema>>) {
+  return suggestions.filter(isInitialReviewCandidate).map(toReliabilityOpportunity).sort(compareReliabilityOpportunities);
+}
+
+function readSnapshot(key: string) {
+  try {
+    const value = window.localStorage.getItem(key);
+    return value ? reliabilityInboxSnapshotSchema.parse(JSON.parse(value)) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeSnapshot(key: string, suggestions: Array<z.infer<typeof reliabilitySuggestionSchema>>) {
+  try {
+    window.localStorage.setItem(key, JSON.stringify({ savedAt: Date.now(), suggestions }));
+  } catch {
+    // Browser storage is an optimization; generation still works without it.
+  }
 }

--- a/src/features/reliabilityInbox/data.ts
+++ b/src/features/reliabilityInbox/data.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useLocalStorage } from 'usehooks-ts';
 import { z } from 'zod';
 
 import { reliabilitySuggestionSchema, reliabilitySuggestionsSchema } from './types';
@@ -12,12 +13,19 @@ const reliabilityInboxSnapshotSchema = z.object({
   savedAt: z.number(),
   suggestions: z.array(reliabilitySuggestionSchema),
 });
+const dismissedSuggestionIdsSchema = z.array(z.string());
+const dismissedSuggestionIdsStorageOptions = {
+  deserializer: (value: string) => dismissedSuggestionIdsSchema.parse(JSON.parse(value)),
+};
 
 export const reliabilityInboxQueryKey = (apiHost: string, stackId: number) =>
   ['reliability-inbox', 'suggestions', apiHost, stackId] as const;
 
 export const reliabilityInboxStorageKey = (apiHost: string, stackId: number) =>
   `synthetic-monitoring:reliability-inbox:v1:${apiHost}:${stackId}`;
+
+export const reliabilityInboxDismissalsKey = (apiHost: string, stackId: number) =>
+  `synthetic-monitoring:reliability-inbox-dismissals:v1:${apiHost}:${stackId}`;
 
 /**
  * Fetches suggestions from the reliability-inbox experiment.
@@ -34,12 +42,21 @@ export function useCachedReliabilityInboxSuggestions() {
   return useReliabilityInboxQuery(false);
 }
 
+export function useReliabilityInboxDismissals() {
+  const smDS = useSMDS();
+  return useScopedReliabilityInboxDismissals(
+    smDS.instanceSettings.jsonData.apiHost,
+    smDS.instanceSettings.jsonData.metrics.hostedId
+  );
+}
+
 function useReliabilityInboxQuery(generateSuggestions: boolean) {
   const smDS = useSMDS();
   const apiHost = smDS.instanceSettings.jsonData.apiHost;
   const stackId = smDS.instanceSettings.jsonData.metrics.hostedId;
   const storageKey = reliabilityInboxStorageKey(apiHost, stackId);
   const snapshot = readSnapshot(storageKey);
+  const { dismissedSuggestionIds } = useScopedReliabilityInboxDismissals(apiHost, stackId);
 
   return useQuery({
     // apiHost is in the key because it selects the region, and therefore which
@@ -67,7 +84,25 @@ function useReliabilityInboxQuery(generateSuggestions: boolean) {
     // the result for the lifetime of the SPA session, even when no component is
     // temporarily subscribed, so navigation cannot cause accidental regeneration.
     gcTime: Infinity,
+    select: (opportunities) => opportunities.filter(({ id }) => !dismissedSuggestionIds.includes(id)),
   });
+}
+
+function useScopedReliabilityInboxDismissals(apiHost: string, stackId: number) {
+  const [dismissedSuggestionIds, setDismissedSuggestionIds] = useLocalStorage<string[]>(
+    reliabilityInboxDismissalsKey(apiHost, stackId),
+    [],
+    dismissedSuggestionIdsStorageOptions
+  );
+  return {
+    dismissedSuggestionIds,
+    dismissSuggestion: (id: string) =>
+      setDismissedSuggestionIds((dismissedIds) =>
+        dismissedIds.includes(id) ? dismissedIds : [...dismissedIds, id]
+      ),
+    restoreSuggestion: (id: string) =>
+      setDismissedSuggestionIds((dismissedIds) => dismissedIds.filter((dismissedId) => dismissedId !== id)),
+  };
 }
 
 function toOpportunities(suggestions: Array<z.infer<typeof reliabilitySuggestionSchema>>) {

--- a/src/features/reliabilityInbox/types.ts
+++ b/src/features/reliabilityInbox/types.ts
@@ -41,6 +41,7 @@ export const reliabilitySuggestionSchema = z
 
 export const reliabilitySuggestionsSchema = z.object({
   suggestions: z.array(reliabilitySuggestionSchema),
+  warnings: z.array(z.string()).default([]),
 });
 
 export type ReliabilitySuggestion = z.infer<typeof reliabilitySuggestionSchema>;


### PR DESCRIPTION
## Summary

- persists dismissed suggestion IDs in browser storage, scoped by SM region and metrics instance
- filters dismissed suggestions from the Reliability Inbox, homepage banner, cached snapshots, and refreshed responses
- adds a low-emphasis Dismiss action that advances to the next suggestion
- provides immediate Undo, including after dismissing the final visible suggestion

<img width="2538" height="1303" alt="CleanShot 2026-08-19 at 16 21 36" src="https://github.com/user-attachments/assets/02ff377c-b061-4cb5-89cb-ea4bb2b9870b" />


## Why

Reliability Inbox users need a lightweight way to remove recommendations that are not relevant to them without seeing those recommendations return after every refresh.

## MVP scope

This intentionally remains browser-local for the experiment. It does not add backend persistence, cross-device synchronization, expiry rules, a dismissed-items manager, or suggestion-engine exclusion parameters.

## Validation

- `yarn test src/features/reliabilityInbox/data.test.tsx src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx src/features/reliabilityInbox/ReliabilityInboxBanner.test.tsx --runInBand` — 3 suites, 16 tests passed
- `yarn typecheck`
- `yarn lint` — passes with 13 pre-existing `no-console` warnings
- `git diff --check`

Stacked directly on #1811.