### PR TITLE
fix: make validate-backend work without webpack output

### DIFF
--- a/scripts/validate-backend
+++ b/scripts/validate-backend
@@ -33,8 +33,8 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Grafana only instantiates a datasource backend for a configured datasource, so
-# provision one. Mounted as a single file *inside* the dev/provisioning bind so
-# the checked-in provisioning is left untouched.
+# provision one. Mount the temp directory over the container datasources path so
+# nothing is written under dev/provisioning on the host.
 cat > "$provisioning/sm-backend-validate.yaml" <<EOT
 apiVersion: 1
 datasources:
@@ -52,7 +52,7 @@ services:
     ports: !override
       - $PORT:3000
     volumes:
-      - $provisioning/sm-backend-validate.yaml:/etc/grafana/provisioning/datasources/sm-backend-validate.yaml
+      - $provisioning:/etc/grafana/provisioning/datasources
 EOT
 
 fail() {
@@ -69,7 +69,15 @@ else
 	go run github.com/magefile/mage -v buildAll >/dev/null
 fi
 
-echo "==> checking dist/ has a binary for linux (the container's OS)"
+echo "==> staging plugin metadata in dist/"
+mkdir -p dist/datasource
+cp src/plugin.json dist/plugin.json
+cp src/datasource/plugin.json dist/datasource/plugin.json
+
+echo "==> checking dist/ has plugin metadata and a linux binary (the container's OS)"
+test -f dist/plugin.json || fail "missing dist/plugin.json"
+test -f dist/datasource/plugin.json || fail "missing dist/datasource/plugin.json"
+echo "    found dist/plugin.json and dist/datasource/plugin.json"
 arch=$(docker version --format '{{.Server.Arch}}')
 case "$arch" in
 	amd64) want=dist/datasource/gpx_sm_datasource_linux_amd64 ;;


### PR DESCRIPTION
## Problem

`./scripts/validate-backend` is meant to verify the Go backend loads in Grafana without running the full frontend dev setup. After #1806 it only ran `mage buildAll`, which writes the linux binary into `dist/datasource/` but not the plugin metadata Grafana needs to register the nested datasource. On a clean tree the health and registration checks fail even when the binary is fine.

The script also bind-mounted its throwaway datasource YAML as a file onto a path inside `dev/provisioning/datasources/`. Docker created that file on the host, and cleanup did not remove it — so a later `yarn server` could pick up an extra empty SM datasource.

## Solution

Stage `src/plugin.json` and `src/datasource/plugin.json` into `dist/` after the build step, with fail-fast checks that both files exist before starting Grafana. Mount the temp provisioning directory over the container datasources path instead of a single file bind, so nothing is written under `dev/provisioning/` on the host.

## Test plan

- [x] `./scripts/validate-backend` passes on a clean tree (mage output only)
- [x] `SKIP_BUILD=1 ./scripts/validate-backend` passes after removing `dist/plugin.json` files (staging copies them back)
- [x] No `dev/provisioning/datasources/sm-backend-validate.yaml` left on the host after the script exits