### PR TITLE
feat: show partial probe failures on uptime timepoint bars

### DIFF
--- a/src/scenes/components/TimepointExplorer/TimepointExplorer.constants.ts
+++ b/src/scenes/components/TimepointExplorer/TimepointExplorer.constants.ts
@@ -45,5 +45,6 @@ export const ANNOTATION_COLOR_ALERTS_FIRING = `red`;
 
 // Selection styling constants
 export const NON_SELECTED_BAR_OPACITY = 0.7;
+export const PARTIAL_FAILURE_SEGMENT_ALPHA = 0.5;
 export const SELECTED_BAR_BORDER_WIDTH = 3;
 export const BAR_BORDER_WIDTH = 2;

--- a/src/scenes/components/TimepointExplorer/TimepointExplorer.utils.test.ts
+++ b/src/scenes/components/TimepointExplorer/TimepointExplorer.utils.test.ts
@@ -1,4 +1,4 @@
-import { succeededLogFactory } from 'test/factories/executionLogs';
+import { failedLogFactory, succeededLogFactory } from 'test/factories/executionLogs';
 
 import { LokiFieldNames } from 'features/parseLokiLogs/parseLokiLogs.types';
 import {
@@ -15,6 +15,7 @@ import {
   buildTimepoints,
   buildTimepointsForConfig,
   findNearestPageIndex,
+  getFailureRatio,
   getMiniMapPages,
   getMiniMapSections,
   getNonRoundedYAxisMax,
@@ -280,6 +281,49 @@ describe(`buildlistLogsMap`, () => {
     expect(listLogsMap).toEqual({
       [firstEntry.adjustedTime]: expectedEntry,
     });
+  });
+});
+
+describe(`getFailureRatio`, () => {
+  it(`should return 0 when there are no probe results`, () => {
+    expect(getFailureRatio({})).toBe(0);
+  });
+
+  it(`should return 0 when all executions succeeded`, () => {
+    const probeResults = {
+      london: [succeededLogFactory.build()],
+      ohio: [succeededLogFactory.build()],
+    };
+
+    expect(getFailureRatio(probeResults)).toBe(0);
+  });
+
+  it(`should return the proportion of failed executions`, () => {
+    const probeResults = {
+      london: [succeededLogFactory.build()],
+      ohio: [succeededLogFactory.build()],
+      singapore: [failedLogFactory.build()],
+    };
+
+    expect(getFailureRatio(probeResults)).toBeCloseTo(1 / 3);
+  });
+
+  it(`should count multiple executions from the same probe individually`, () => {
+    const probeResults = {
+      london: [succeededLogFactory.build(), failedLogFactory.build()],
+      ohio: [succeededLogFactory.build(), succeededLogFactory.build()],
+    };
+
+    expect(getFailureRatio(probeResults)).toBeCloseTo(1 / 4);
+  });
+
+  it(`should return 1 when all executions failed`, () => {
+    const probeResults = {
+      london: [failedLogFactory.build()],
+      ohio: [failedLogFactory.build()],
+    };
+
+    expect(getFailureRatio(probeResults)).toBe(1);
   });
 });
 

--- a/src/scenes/components/TimepointExplorer/TimepointExplorer.utils.ts
+++ b/src/scenes/components/TimepointExplorer/TimepointExplorer.utils.ts
@@ -108,6 +108,20 @@ export function getTimepointStatus(probeResults: ProbeResults): TimepointStatus 
   return executions.every((execution) => execution === '0') ? 'failure' : 'success';
 }
 
+export function getFailureRatio(probeResults: ProbeResults): number {
+  const executions = Object.values(probeResults).flat();
+
+  if (executions.length === 0) {
+    return 0;
+  }
+
+  const failedExecutions = executions.filter(
+    (execution) => execution[LokiFieldNames.Labels].probe_success === '0'
+  );
+
+  return failedExecutions.length / executions.length;
+}
+
 export function getMaxProbeDuration(probeResults: ProbeResults) {
   const executionDurations = Object.values(probeResults)
     .flat()

--- a/src/scenes/components/TimepointExplorer/TimepointListEntryBar.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointListEntryBar.tsx
@@ -27,6 +27,9 @@ interface TimepointListEntryPendingProps {
   children: ReactNode;
   timepoint: StatelessTimepoint;
   status: TimepointStatus;
+  // overrides the default `vizDisplay.includes(status)` visibility check,
+  // e.g. a success bar with partial failures should stay visible when filtering on failures
+  isVisible?: boolean;
 }
 
 const GLOBAL_CLASS = `list_entry_bar`;
@@ -36,6 +39,7 @@ export const TimepointListEntryBar = ({
   children,
   status,
   timepoint,
+  isVisible,
 }: TimepointListEntryPendingProps) => {
   const statefulTimepoint = useStatefulTimepoint(timepoint);
   const { checkType, handleViewerStateChange, handleSetScrollToViewer, yAxisMax, viewerState, timepointWidth, vizDisplay } = useTimepointExplorerContext();
@@ -58,7 +62,7 @@ export const TimepointListEntryBar = ({
     handleViewerStateChange([timepoint, probeNameToView, 0]);
   }, [analyticsEventName, checkType, status, timepoint, probeNameToView, handleViewerStateChange, handleSetScrollToViewer]);
 
-  if (!vizDisplay.includes(status)) {
+  if (!(isVisible ?? vizDisplay.includes(status))) {
     return <div />;
   }
 

--- a/src/scenes/components/TimepointExplorer/TimepointListEntryUptime.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointListEntryUptime.tsx
@@ -49,15 +49,17 @@ export const TimepointListEntryUptime = ({ timepoint }: TimepointListEntryProps)
           data-testid={`${SCENES_TEST_ID.timepoint.listEntryFailureSegment}-${timepoint.index}`}
         />
       )}
-      {isFailure ? (
-        <Icon name={`times`} key={`times`} />
-      ) : showPartialFailure ? (
-        <Icon name={`exclamation-triangle`} key={`exclamation-triangle`} />
-      ) : isSuccess ? (
-        <Icon name={`check`} key={`check`} />
-      ) : (
-        `?`
-      )}
+      <span className={styles.statusIcon}>
+        {isFailure ? (
+          <Icon name={`times`} key={`times`} />
+        ) : showPartialFailure ? (
+          <Icon name={`exclamation-triangle`} key={`exclamation-triangle`} />
+        ) : isSuccess ? (
+          <Icon name={`check`} key={`check`} />
+        ) : (
+          `?`
+        )}
+      </span>
     </TimepointListEntryBar>
   );
 };
@@ -70,5 +72,11 @@ const getStyles = (theme: GrafanaTheme2, failureVizOption: TimepointVizOption) =
     width: 100%;
     background-color: ${colorManipulator.alpha(failureVizOption.statusColor, PARTIAL_FAILURE_SEGMENT_ALPHA)};
     pointer-events: none;
+  `,
+  // positioned so the icon paints above the partial-failure overlay, which is
+  // absolutely positioned and would otherwise sit on top of in-flow content
+  statusIcon: css`
+    position: relative;
+    display: inline-flex;
   `,
 });

--- a/src/scenes/components/TimepointExplorer/TimepointListEntryUptime.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointListEntryUptime.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
-import { Icon } from '@grafana/ui';
+import { colorManipulator, GrafanaTheme2 } from '@grafana/data';
+import { Icon, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { SCENES_TEST_ID } from 'test/dataTestIds';
 
+import { PARTIAL_FAILURE_SEGMENT_ALPHA } from 'scenes/components/TimepointExplorer/TimepointExplorer.constants';
 import { useTimepointExplorerContext } from 'scenes/components/TimepointExplorer/TimepointExplorer.context';
-import { useStatefulTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.hooks';
-import { StatelessTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
+import {
+  useStatefulTimepoint,
+  useTimepointVizOptions,
+} from 'scenes/components/TimepointExplorer/TimepointExplorer.hooks';
+import { StatelessTimepoint, TimepointVizOption } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
+import { getFailureRatio } from 'scenes/components/TimepointExplorer/TimepointExplorer.utils';
 import { TimepointListEntryBar } from 'scenes/components/TimepointExplorer/TimepointListEntryBar';
 
 interface TimepointListEntryProps {
@@ -11,18 +19,56 @@ interface TimepointListEntryProps {
 }
 
 export const TimepointListEntryUptime = ({ timepoint }: TimepointListEntryProps) => {
-  const { status } = useStatefulTimepoint(timepoint);
+  const statefulTimepoint = useStatefulTimepoint(timepoint);
+  const { status } = statefulTimepoint;
   const { vizDisplay } = useTimepointExplorerContext();
+  const failureVizOption = useTimepointVizOptions('failure');
+  const styles = useStyles2(getStyles, failureVizOption);
   const isSuccess = status === 'success';
   const isFailure = status === 'failure';
+  const failureRatio = isSuccess ? getFailureRatio(statefulTimepoint.probeResults) : 0;
+  const showPartialFailure = failureRatio > 0 && vizDisplay.includes('failure');
+  // a success bar with partial failures counts as a failure result when filtering
+  const isVisible = vizDisplay.includes(status) || showPartialFailure;
 
-  if (!vizDisplay.includes(status)) {
+  if (!isVisible) {
     return <div />;
   }
 
   return (
-    <TimepointListEntryBar analyticsEventName={`uptime-entry`} timepoint={timepoint} status={status}>
-      {isFailure ? <Icon name={`times`} key={`times`} /> : isSuccess ? <Icon name={`check`} key={`check`} /> : `?`}
+    <TimepointListEntryBar
+      analyticsEventName={`uptime-entry`}
+      timepoint={timepoint}
+      status={status}
+      isVisible={isVisible}
+    >
+      {showPartialFailure && (
+        <div
+          className={styles.partialFailure}
+          style={{ height: `${failureRatio * 100}%` }}
+          data-testid={`${SCENES_TEST_ID.timepoint.listEntryFailureSegment}-${timepoint.index}`}
+        />
+      )}
+      {isFailure ? (
+        <Icon name={`times`} key={`times`} />
+      ) : showPartialFailure ? (
+        <Icon name={`exclamation-triangle`} key={`exclamation-triangle`} />
+      ) : isSuccess ? (
+        <Icon name={`check`} key={`check`} />
+      ) : (
+        `?`
+      )}
     </TimepointListEntryBar>
   );
 };
+
+const getStyles = (theme: GrafanaTheme2, failureVizOption: TimepointVizOption) => ({
+  partialFailure: css`
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-color: ${colorManipulator.alpha(failureVizOption.statusColor, PARTIAL_FAILURE_SEGMENT_ALPHA)};
+    pointer-events: none;
+  `,
+});

--- a/src/scenes/components/TimepointExplorer/__tests__/TimepointExplorer.test.tsx
+++ b/src/scenes/components/TimepointExplorer/__tests__/TimepointExplorer.test.tsx
@@ -8,6 +8,8 @@ import { render } from 'test/render';
 import { apiRoute } from 'test/handlers';
 import { server } from 'test/server';
 import { checksLogs1 } from 'test/fixtures/httpCheck/checkLogs';
+import { createExecutionLogsResponse } from 'test/fixtures/httpCheck/executionLogsResponse';
+import { PRIVATE_PROBE, PUBLIC_PROBE } from 'test/fixtures/probes';
 import {
   createUniqueConfigFrame,
   createUniqueConfigsResponse,
@@ -36,7 +38,7 @@ const TIME_MODIFIED_HTTP_CHECK: HTTPCheck = {
   modified: Math.floor((baseTime - 10 * 60 * 1000) / 1000),
 };
 
-function setupMSWHandlers() {
+function setupMSWHandlers(executionLogs: (refId: string) => object = checksLogs1) {
   server.use(
     apiRoute('getHttpDashboard', {
       result: async (req) => {
@@ -72,11 +74,11 @@ function setupMSWHandlers() {
         }
 
         if (refId?.startsWith(REF_ID_EXECUTION_LIST_LOGS)) {
-          return { json: checksLogs1(refId) };
+          return { json: executionLogs(refId) };
         }
 
         if (refId?.startsWith(REF_ID_EXECUTION_VIEWER_LOGS)) {
-          return { json: checksLogs1(refId) };
+          return { json: executionLogs(refId) };
         }
 
         return { json: { results: {} } };
@@ -131,6 +133,99 @@ describe('TimepointExplorer', () => {
     expect(mockScrollIntoView).toHaveBeenCalledWith({
       behavior: 'smooth',
       block: 'start',
+    });
+  });
+
+  describe(`partial failures in uptime view`, () => {
+    const frequency = TIME_MODIFIED_HTTP_CHECK.frequency;
+    // in jsdom the list has no width, so only the latest timepoint is visible — target that one
+    const latestTimepointTime = baseTime - (baseTime % frequency);
+    const logTime = latestTimepointTime + 1000;
+
+    function setupExecutionLogs(logs: Array<{ probe: string; probeSuccess: '0' | '1' }>) {
+      setupMSWHandlers((refId) =>
+        createExecutionLogsResponse(refId, {
+          job: TIME_MODIFIED_HTTP_CHECK.job,
+          instance: TIME_MODIFIED_HTTP_CHECK.target,
+          logs: logs.map((log) => ({ ...log, time: logTime })),
+        })
+      );
+    }
+
+    it(`should render a failure segment proportional to the failed executions when some (but not all) probes fail`, async () => {
+      mockFeatureToggles({ [FeatureName.TimepointExplorer]: true });
+
+      setupExecutionLogs([
+        { probe: PRIVATE_PROBE.name, probeSuccess: '1' },
+        { probe: PUBLIC_PROBE.name, probeSuccess: '0' },
+      ]);
+
+      render(renderTimepointExplorer());
+
+      const failureSegments = await screen.findAllByTestId(
+        new RegExp(`${SCENES_TEST_ID.timepoint.listEntryFailureSegment}-`)
+      );
+
+      expect(failureSegments).toHaveLength(1);
+      expect(failureSegments[0]).toHaveStyle({ height: `${(1 / 2) * 100}%` });
+      // the bar swaps its success tick for a warning icon (Icon is mocked as <svg name="..." /> in tests)
+      expect(failureSegments[0].parentElement?.querySelector('svg[name="exclamation-triangle"]')).toBeInTheDocument();
+    });
+
+    it(`should keep showing a partially failed bar when filtering on failures`, async () => {
+      mockFeatureToggles({ [FeatureName.TimepointExplorer]: true });
+
+      setupExecutionLogs([
+        { probe: PRIVATE_PROBE.name, probeSuccess: '1' },
+        { probe: PUBLIC_PROBE.name, probeSuccess: '0' },
+      ]);
+
+      const { user } = render(renderTimepointExplorer());
+
+      await screen.findAllByTestId(new RegExp(`${SCENES_TEST_ID.timepoint.listEntryFailureSegment}-`));
+
+      // filter down to failures only via the viz legend
+      await user.click(screen.getByRole('button', { name: 'failure' }));
+
+      expect(
+        await screen.findByTestId(new RegExp(`${SCENES_TEST_ID.timepoint.listEntryFailureSegment}-`))
+      ).toBeInTheDocument();
+    });
+
+    it(`should not render a failure segment when all probes succeed`, async () => {
+      mockFeatureToggles({ [FeatureName.TimepointExplorer]: true });
+
+      setupExecutionLogs([
+        { probe: PRIVATE_PROBE.name, probeSuccess: '1' },
+        { probe: PUBLIC_PROBE.name, probeSuccess: '1' },
+      ]);
+
+      render(renderTimepointExplorer());
+
+      // wait for the success tick so we know the logs have been mapped to the timepoint
+      await waitFor(() => expect(document.querySelector('svg[name="check"]')).toBeInTheDocument());
+
+      expect(
+        screen.queryByTestId(new RegExp(`${SCENES_TEST_ID.timepoint.listEntryFailureSegment}-`))
+      ).not.toBeInTheDocument();
+    });
+
+    it(`should not render a failure segment when all probes fail`, async () => {
+      mockFeatureToggles({ [FeatureName.TimepointExplorer]: true });
+
+      setupExecutionLogs([
+        { probe: PRIVATE_PROBE.name, probeSuccess: '0' },
+        { probe: PUBLIC_PROBE.name, probeSuccess: '0' },
+      ]);
+
+      render(renderTimepointExplorer());
+
+      // wait for the failure cross so we know the logs have been mapped to the timepoint
+      await waitFor(() => expect(document.querySelector('svg[name="times"]')).toBeInTheDocument());
+
+      expect(
+        screen.queryByTestId(new RegExp(`${SCENES_TEST_ID.timepoint.listEntryFailureSegment}-`))
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/test/dataTestIds.ts
+++ b/src/test/dataTestIds.ts
@@ -169,6 +169,7 @@ export const SCENES_TEST_ID = {
   timepoint: {
     list: 'scenes timepoint list',
     listEntryBar: 'scenes timepoint list-entry-bar',
+    listEntryFailureSegment: 'scenes timepoint list-entry-failure-segment',
     viewer: 'scenes timepoint viewer',
   },
 } as const;

--- a/src/test/fixtures/httpCheck/executionLogsResponse.ts
+++ b/src/test/fixtures/httpCheck/executionLogsResponse.ts
@@ -1,0 +1,83 @@
+export interface ExecutionLogSpec {
+  probe: string;
+  probeSuccess: '0' | '1';
+  time: number;
+  durationSeconds?: string;
+}
+
+interface CreateExecutionLogsResponseOptions {
+  job: string;
+  instance: string;
+  logs: ExecutionLogSpec[];
+}
+
+// Builds a minimal Loki response containing one execution-ended log per spec,
+// in the same frame shape as the recorded `checkLogs.ts` fixture but with
+// controllable timestamps and probe_success values.
+export function createExecutionLogsResponse(
+  refId: string,
+  { job, instance, logs }: CreateExecutionLogsResponseOptions
+) {
+  const labels = logs.map(({ probe, probeSuccess, durationSeconds = '0.5' }) => {
+    const level = probeSuccess === '1' ? 'info' : 'error';
+    const msg = probeSuccess === '1' ? 'Check succeeded' : 'Check failed';
+
+    return {
+      check_name: 'http',
+      detected_level: level,
+      duration_seconds: durationSeconds,
+      instance,
+      job,
+      level,
+      msg,
+      probe,
+      probe_success: probeSuccess,
+      region: 'EMEA',
+      source: 'synthetic-monitoring-agent',
+      target: instance,
+    };
+  });
+
+  return {
+    results: {
+      [refId]: {
+        status: 200,
+        frames: [
+          {
+            schema: {
+              refId,
+              meta: {
+                typeVersion: [0, 0],
+                custom: {
+                  frameType: 'LabeledTimeValues',
+                },
+                executedQueryString: `Expr: {job="${job}", instance="${instance}"} | logfmt |="duration_seconds="`,
+              },
+              fields: [
+                { name: 'labels', type: 'other', typeInfo: { frame: 'json.RawMessage' } },
+                { name: 'Time', type: 'time', typeInfo: { frame: 'time.Time' } },
+                { name: 'Line', type: 'string', typeInfo: { frame: 'string' } },
+                { name: 'tsNs', type: 'string', typeInfo: { frame: 'string' } },
+                { name: 'labelTypes', type: 'other', typeInfo: { frame: 'json.RawMessage' } },
+                { name: 'id', type: 'string', typeInfo: { frame: 'string' } },
+              ],
+            },
+            data: {
+              values: [
+                labels,
+                logs.map(({ time }) => time),
+                labels.map(
+                  ({ msg, level, duration_seconds, probe_success }) =>
+                    `level=${level} msg="${msg}" probe_success=${probe_success} duration_seconds=${duration_seconds}`
+                ),
+                logs.map(({ time }) => `${time}000000`),
+                logs.map(() => ({})),
+                logs.map(({ time, probe }) => `${time}000000_${probe}`),
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Problem

In the Timepoint Explorer's uptime view, a timepoint bar only turns red when **every** probe execution fails. A timepoint where 1 of 6 probes failed renders as a fully green, successful bar — the only way to discover the failure is to hover each bar and read the tooltip. Users scanning the chart for problems can miss real failures entirely.

Filtering the viz legend down to `failure` makes this worse: partially failed timepoints are classed as successes, so they disappear along with the healthy bars and the view can end up empty even though failures occurred.

## Solution

Uptime bars now surface partial failures in proportion to how much of the timepoint failed:

- A translucent red segment is anchored to the bottom of the bar, sized to the failed-execution ratio — 1 of 3 executions failed fills the bottom 1/3 of the bar, 2 of 3 fills 2/3, and so on.
- The success tick swaps to a warning icon, which sits inside the red section, so partial failures also read without relying on colour alone.
- Partially failed bars now count as failure results when filtering the viz legend, so filtering on `failure` keeps them visible instead of hiding them. The segment itself also respects the legend: toggling `failure` off hides it.

Fully failed and fully successful bars are unchanged.

## Testing

Covered by unit tests for the new failure-ratio util and integration tests for the partial, all-success, all-fail, and legend-filtering journeys. Includes a new reusable fixture builder (`createExecutionLogsResponse`) that generates Loki execution-log responses with controllable timestamps and `probe_success` values, so future Timepoint Explorer tests don't need the large recorded fixture.

## Out of scope (possible follow-ups)

- The minimap canvas still renders timepoints as binary success/failure.
- The viz legend has no explicit "partial failure" entry.

## screenshot
<img width="1113" height="697" alt="image" src="https://github.com/user-attachments/assets/7c29ff2d-1f3b-4d35-8942-77c9a188408f" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)