### PR TITLE
Add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,3 +200,4 @@ Agent skill (auto-trigger workflow): [`.agents/skills/write-tests/SKILL.md`](./.
 - `yarn test <filename>` runs a single file; `yarn test:changed` watches changed files.
 - Tests use MSW handlers from `src/test/handlers` for API mocking.
 - The test suite passes cleanly with no configuration needed beyond `yarn install`.
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
