### PR TITLE
fix: dedupe probe_success join in response latency panel

### DIFF
--- a/src/scenes/Common/ResponseLatencyByProbe.tsx
+++ b/src/scenes/Common/ResponseLatencyByProbe.tsx
@@ -27,7 +27,7 @@ export const ResponseLatencyByProbe = () => {
     maxDataPoints: 100,
     queries: [
       {
-        expr: 'avg(probe_duration_seconds{probe=~"$probe", instance="$instance", job="$job"} * on (instance, job,probe,config_version) group_left probe_success{probe=~"$probe",instance="$instance", job="$job"} > 0) by (probe)',
+        expr: 'avg(probe_duration_seconds{probe=~"$probe", instance="$instance", job="$job"} * on (instance, job,probe,config_version) group_left max by (instance, job, probe, config_version) (probe_success{probe=~"$probe",instance="$instance", job="$job"}) > 0) by (probe)',
         instant: false,
         interval: '',
         intervalFactor: 1,


### PR DESCRIPTION
Relates to https://github.com/grafana/synthetic-monitoring/issues/549

Closes https://github.com/grafana/synthetic-monitoring/issues/653

When a tenant triggers the label migration, `probe_success`'s label set changes (`region` → `sm_region`, plus dual-written user labels). For the ~5-minute staleness window both series generations are live and share the same `(instance, job, probe, config_version)` match group, so the panel's `group_left` join fails with *found duplicate series on the right hand-side* and the panel errors for the whole window.

Aggregating the right side down to exactly the match-group labels collapses both generations into one series per group. `max` is semantically neutral here (same underlying 0/1 value), duplicate left-hand series are legal under many-to-one matching, and the outer `avg by (probe)` absorbs the doubled duration series without changing the result.

This conforms the one outlier to the pattern the other joining panels already use — `SummaryTableViz`, `ErrorRateMapViz`, and `SummaryErrorPctgViz` all aggregate their right-hand side with `max by (instance, job, probe, config_version, …)`.

----

With fix:
<img width="1550" height="550" alt="image" src="https://github.com/user-attachments/assets/1d7925c1-70d3-4f01-9b93-a045e80b53c7" />


Without fix:
<img width="1554" height="565" alt="image" src="https://github.com/user-attachments/assets/7c6ce3bd-049d-469f-a6cc-826815382875" />
