### PR TITLE
fix: preserve Reliability Inbox assistant hover style

### DIFF
--- a/src/features/reliabilityInbox/assistantActionStyles.test.ts
+++ b/src/features/reliabilityInbox/assistantActionStyles.test.ts
@@ -1,0 +1,37 @@
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+
+import { getAssistantActionStyle } from './assistantActionStyles';
+
+jest.mock('@emotion/css', () => ({
+  css: jest.fn(() => 'assistant-action'),
+}));
+
+const theme = {
+  colors: {
+    secondary: {
+      main: 'rgb(34, 37, 43)',
+    },
+    text: {
+      primary: 'rgb(204, 204, 220)',
+    },
+  },
+} as GrafanaTheme2;
+
+describe('getAssistantActionStyle', () => {
+  it('keeps the assistant gradient background on hover', () => {
+    getAssistantActionStyle(theme);
+
+    const background =
+      'linear-gradient(rgb(34, 37, 43), rgb(34, 37, 43)) padding-box, linear-gradient(90deg, rgb(168, 85, 247), rgb(249, 115, 22)) border-box';
+
+    expect(css).toHaveBeenCalledWith(
+      expect.objectContaining({
+        background,
+        '&&:hover': {
+          background,
+        },
+      })
+    );
+  });
+});

--- a/src/features/reliabilityInbox/assistantActionStyles.ts
+++ b/src/features/reliabilityInbox/assistantActionStyles.ts
@@ -5,14 +5,18 @@ const ASSISTANT_GRADIENT = 'linear-gradient(90deg, rgb(168, 85, 247), rgb(249, 1
 
 export function getAssistantActionStyle(theme: GrafanaTheme2) {
   const baseBackground = theme.colors.secondary.main;
+  const background = `linear-gradient(${baseBackground}, ${baseBackground}) padding-box, ${ASSISTANT_GRADIENT} border-box`;
 
   return css({
     label: 'reliability-inbox-assistant-action',
     width: 'fit-content',
     maxWidth: '100%',
     border: '1px solid transparent',
-    background: `linear-gradient(${baseBackground}, ${baseBackground}) padding-box, ${ASSISTANT_GRADIENT} border-box`,
+    background,
     color: theme.colors.text.primary,
+    '&&:hover': {
+      background,
+    },
     '& > span': {
       color: `${theme.colors.text.primary} !important`,
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The assistant actions on the home screen and Reliability Inbox lose their gradient styling and appear grey when hovered.

## Solution
Keep the shared assistant action background unchanged during hover, with a higher-specificity rule that overrides the secondary Grafana button hover style. Add focused coverage for the shared style used by both actions.

## Validation
- `yarn test assistantActionStyles.test.ts ReliabilityInboxBanner.test.tsx ReliabilityInboxPage.test.tsx --runInBand`
- `yarn eslint src/features/reliabilityInbox/assistantActionStyles.ts src/features/reliabilityInbox/assistantActionStyles.test.ts`
- `yarn typecheck`
- `yarn build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc4915cd-0594-493c-8c0c-f4160ce2d04e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc4915cd-0594-493c-8c0c-f4160ce2d04e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

