### PR TITLE
chore: bump grafana github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v11.1.0
     #  About permissions below.
     #
     # - attestations: write: publish attestations.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: sm-release-app
 

--- a/.github/workflows/validate_main.yml
+++ b/.github/workflows/validate_main.yml
@@ -23,7 +23,7 @@ jobs:
     # - pull-requests: read: list PRs to determine if the branch from which the
     #   release is created is an open PR. We don't need this because we set
     #   branch=main. Remove this as soon as possible.
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v11.1.0
     permissions:
       attestations: write
       contents: write

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -10,7 +10,7 @@ jobs:
   ci:
     name: CI
     # Documentation: https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v11.1.0
     permissions:
       contents: read # write is only needed if we publish docs to the website.
       id-token: write


### PR DESCRIPTION
## Problem

GitHub is rejecting `grafana/shared-workflows/actions/create-github-app-token` at SHA `259ba21` (v0.2.3). That digest is on Grafana's denied-actions list, so Renovate cannot land the next patch and release-please stays on the older v0.2.2 pin.

CI/CD is also still on `plugin-ci-workflows` v8.0.1 while other Grafana plugins are on v11.1.0.

## Solution

Pin `create-github-app-token` to v0.3.1 (`46f48da`). Inputs are unchanged; v0.3.0 adds post-job token revocation.

Move the shared CI and CD workflows from `ci-cd-workflows/v8.0.1` to `v11.1.0`. The inputs we pass are still valid. Playwright stays off, so the v10 e2e-version bump does not apply. v11 publishes plugin docs to `latest/` instead of versioned directories; our workflows already set `docs-only: false` and Slack still goes to `#sm-ops-deploys`.

`publish-techdocs.yaml` is left on `@main` because that workflow is not version-tagged.

## Test plan

- [ ] PR CI (`plugin-ci-workflows` v11.1.0) goes green
- [ ] Policy bot / allowed-actions check no longer flags `create-github-app-token`