### PR TITLE
feat(faro): instrument user actions across check and probe flows

### DIFF
--- a/src/components/AddNewCheckButton/AddNewCheckButton.tsx
+++ b/src/components/AddNewCheckButton/AddNewCheckButton.tsx
@@ -4,9 +4,12 @@ import { LinkButton } from '@grafana/ui';
 import { trackAddNewCheckButtonClicked } from 'features/tracking/checkCreationEvents';
 import { ACTIONS_TEST_ID } from 'test/dataTestIds';
 
+import { FaroUserAction } from 'faro';
 import { AppRoutes } from 'routing/types';
 import { generateRoutePath } from 'routing/utils';
 import { getUserPermissions } from 'data/permissions';
+
+import { trackFaroUserAction } from '../../features/tracking/userAction';
 
 interface AddNewCheckButtonProps {
   source: 'check-list-empty-state' | 'check-list' | 'homepage';
@@ -17,6 +20,7 @@ export function AddNewCheckButton({ source }: AddNewCheckButtonProps) {
 
   const handleClick = useCallback(() => {
     trackAddNewCheckButtonClicked({ source });
+    trackFaroUserAction(FaroUserAction.CreateNewCheckClicked, { source: source });
   }, [source]);
 
   return (
@@ -28,9 +32,7 @@ export function AddNewCheckButton({ source }: AddNewCheckButtonProps) {
       onClick={handleClick}
       variant="primary"
     >
-      <Trans i18nKey="addNewCheckButton.createNewCheck">
-        Create new check
-      </Trans>
+      <Trans i18nKey="addNewCheckButton.createNewCheck">Create new check</Trans>
     </LinkButton>
   );
 }

--- a/src/components/AddNewCheckButton/AddNewCheckButton.tsx
+++ b/src/components/AddNewCheckButton/AddNewCheckButton.tsx
@@ -20,7 +20,7 @@ export function AddNewCheckButton({ source }: AddNewCheckButtonProps) {
 
   const handleClick = useCallback(() => {
     trackAddNewCheckButtonClicked({ source });
-    trackFaroUserAction(FaroUserAction.CreateNewCheckClicked, { source: source });
+    trackFaroUserAction(FaroUserAction.CreateNewCheckClicked, { source });
   }, [source]);
 
   return (

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -24,37 +24,38 @@ import { SMOpenFeatureProvider } from './SMOpenFeatureProvider';
 
 const { env, url, name } = getFaroConfig();
 
-// Used to be disabled on localhost because it was filling up the console with error logs.
-// That's no longer the case, so it's safe to leave enabled everywhere - which we now need
-// to actually test user action tracking during local development.
-getAppPluginVersion('grafana-synthetic-monitoring-app').then((version) => {
-  const faro = initializeFaro({
-    url,
-    app: {
-      name,
-      version: version ?? undefined,
-      environment: env,
-    },
-    isolate: true,
-    user: {
-      id: config.bootData.user.orgName,
-    },
-    instrumentations: getWebInstrumentations(),
-    // only send signals emitted while the user is on this plugin's pages
-    beforeSend: (event) => {
-      if ((event.meta.page?.url ?? '').includes('grafana-synthetic-monitoring-app')) {
-        return event;
-      }
+// faro was filling up the console with error logs, and it annoyed me, so I disabled it for localhost
+// To test Faro events while developing, either comment out this check
+if (window.location.hostname !== 'localhost') {
+  getAppPluginVersion('grafana-synthetic-monitoring-app').then((version) => {
+    const faro = initializeFaro({
+      url,
+      app: {
+        name,
+        version: version ?? undefined,
+        environment: env,
+      },
+      isolate: true,
+      user: {
+        id: config.bootData.user.orgName,
+      },
+      instrumentations: getWebInstrumentations(),
+      // only send signals emitted while the user is on this plugin's pages
+      beforeSend: (event) => {
+        if ((event.meta.page?.url ?? '').includes('grafana-synthetic-monitoring-app')) {
+          return event;
+        }
 
-      return null;
-    },
-    experimental: {
-      trackNavigation: true,
-    },
+        return null;
+      },
+      experimental: {
+        trackNavigation: true,
+      },
+    });
+
+    registerFaroInteractionEchoBackend(faro);
   });
-
-  registerFaroInteractionEchoBackend(faro);
-});
+}
 
 const App = (props: AppRootProps<ProvisioningJsonData>) => {
   const { meta } = props;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -24,37 +24,37 @@ import { SMOpenFeatureProvider } from './SMOpenFeatureProvider';
 
 const { env, url, name } = getFaroConfig();
 
-// faro was filling up the console with error logs, and it annoyed me, so I disabled it for localhost
-if (window.location.hostname !== 'localhost') {
-  getAppPluginVersion('grafana-synthetic-monitoring-app').then((version) => {
-    const faro = initializeFaro({
-      url,
-      app: {
-        name,
-        version: version ?? undefined,
-        environment: env,
-      },
-      isolate: true,
-      user: {
-        id: config.bootData.user.orgName,
-      },
-      instrumentations: getWebInstrumentations(),
-      // only send signals emitted while the user is on this plugin's pages
-      beforeSend: (event) => {
-        if ((event.meta.page?.url ?? '').includes('grafana-synthetic-monitoring-app')) {
-          return event;
-        }
+// Used to be disabled on localhost because it was filling up the console with error logs.
+// That's no longer the case, so it's safe to leave enabled everywhere - which we now need
+// to actually test user action tracking during local development.
+getAppPluginVersion('grafana-synthetic-monitoring-app').then((version) => {
+  const faro = initializeFaro({
+    url,
+    app: {
+      name,
+      version: version ?? undefined,
+      environment: env,
+    },
+    isolate: true,
+    user: {
+      id: config.bootData.user.orgName,
+    },
+    instrumentations: getWebInstrumentations(),
+    // only send signals emitted while the user is on this plugin's pages
+    beforeSend: (event) => {
+      if ((event.meta.page?.url ?? '').includes('grafana-synthetic-monitoring-app')) {
+        return event;
+      }
 
-        return null;
-      },
-      experimental: {
-        trackNavigation: true,
-      },
-    });
-
-    registerFaroInteractionEchoBackend(faro);
+      return null;
+    },
+    experimental: {
+      trackNavigation: true,
+    },
   });
-}
+
+  registerFaroInteractionEchoBackend(faro);
+});
 
 const App = (props: AppRootProps<ProvisioningJsonData>) => {
   const { meta } = props;

--- a/src/components/Checkster/components/FormSectionNavigation/FormSectionNavigation.tsx
+++ b/src/components/Checkster/components/FormSectionNavigation/FormSectionNavigation.tsx
@@ -6,8 +6,8 @@ import { css, cx } from '@emotion/css';
 import { trackNavigateWizardForm } from 'features/tracking/checkFormEvents';
 import { CHECKSTER_TEST_ID } from 'test/dataTestIds';
 
-import { FormSectionName } from '../../types';
-
+import { FaroUserAction } from '../../../../faro';
+import { trackFaroUserAction } from '../../../../features/tracking/userAction';
 import { CSS_PRIMARY_CONTAINER_NAME } from '../../constants';
 import { useChecksterContext } from '../../contexts/ChecksterContext';
 import { useLiveErrors } from '../../hooks/useLiveErrors';
@@ -53,7 +53,12 @@ export function FormSectionNavigation() {
                     checkState: isNew ? 'new' : 'existing',
                     checkType,
                     component: 'stepper',
-                    step: FormSectionName.Check,
+                    step: sectionName,
+                  });
+                  trackFaroUserAction(FaroUserAction.CheckWizardTabClicked, {
+                    step: sectionName,
+                    checkType: checkType,
+                    checkState: isNew ? 'new' : 'existing',
                   });
                   setSectionActive(sectionName);
                 }}

--- a/src/components/Checkster/components/form/FormFooter.tsx
+++ b/src/components/Checkster/components/form/FormFooter.tsx
@@ -79,9 +79,6 @@ export function FormFooter() {
           data-testid={CHECKSTER_TEST_ID.form.submitButton}
           variant={isStepsComplete || !next ? 'primary' : 'secondary'}
           disabled={disableSubmit}
-          // Do not add data-faro-user-action-name="save" here: this shared submit button
-          // is used for both create and edit flows, so the action must be named where
-          // the submit handler can distinguish create vs. update. (@see useHandleSubmitCheckster)
         >
           Save
         </Button>

--- a/src/components/Checkster/components/form/FormFooter.tsx
+++ b/src/components/Checkster/components/form/FormFooter.tsx
@@ -4,6 +4,8 @@ import { Button, useTheme2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { CHECKSTER_TEST_ID } from 'test/dataTestIds';
 
+import { FaroUserAction } from '../../../../faro';
+import { trackFaroUserAction } from '../../../../features/tracking/userAction';
 import { useChecksterContext } from '../../contexts/ChecksterContext';
 
 export function FormFooter() {
@@ -38,7 +40,15 @@ export function FormFooter() {
     >
       <div>
         {previous && (
-          <Button type="button" icon="arrow-left" variant="secondary" onClick={() => setSectionActive(previous.name)}>
+          <Button
+            type="button"
+            icon="arrow-left"
+            variant="secondary"
+            onClick={() => {
+              trackFaroUserAction(FaroUserAction.CheckWizardPrevClicked);
+              setSectionActive(previous.name);
+            }}
+          >
             {previous.label}
           </Button>
         )}
@@ -54,7 +64,10 @@ export function FormFooter() {
           <Button
             type="button"
             variant={isStepsComplete ? 'secondary' : 'primary'}
-            onClick={() => setSectionActive(next.name)}
+            onClick={() => {
+              trackFaroUserAction(FaroUserAction.CheckWizardNextClicked);
+              setSectionActive(next.name);
+            }}
             iconPlacement="right"
             icon="arrow-right"
           >
@@ -66,6 +79,9 @@ export function FormFooter() {
           data-testid={CHECKSTER_TEST_ID.form.submitButton}
           variant={isStepsComplete || !next ? 'primary' : 'secondary'}
           disabled={disableSubmit}
+          // Do not add data-faro-user-action-name="save" here: this shared submit button
+          // is used for both create and edit flows, so the action must be named where
+          // the submit handler can distinguish create vs. update. (@see useHandleSubmitCheckster)
         >
           Save
         </Button>

--- a/src/components/Checkster/feature/adhoc-check/AdhocCheckPanel.tsx
+++ b/src/components/Checkster/feature/adhoc-check/AdhocCheckPanel.tsx
@@ -8,6 +8,8 @@ import { AdHocCheckState, ProbeStateStatus } from './types.adhoc-check';
 import { useProbes } from 'data/useProbes';
 import { useCanReadLogs } from 'hooks/useDSPermission';
 
+import { FaroUserAction } from '../../../../faro';
+import { trackFaroUserAction } from '../../../../features/tracking/userAction';
 import { CenteredSpinner } from '../../../CenteredSpinner';
 import { Column } from '../../components/ui/Column';
 import {
@@ -129,6 +131,7 @@ export function AdhocCheckPanel() {
   }, [newHocCheckRequest, probes]);
 
   const handleAdHocCheck = () => {
+    trackFaroUserAction(FaroUserAction.AdhocCheckTestClicked);
     doAdhocCheck();
   };
 

--- a/src/components/DeleteProbeButton/DeleteProbeButton.tsx
+++ b/src/components/DeleteProbeButton/DeleteProbeButton.tsx
@@ -9,6 +9,8 @@ import { useCanEditProbe } from 'hooks/useCanEditProbe';
 import { ConfirmModal } from 'components/ConfirmModal';
 import { ProbeUsageLink } from 'components/ProbeUsageLink';
 
+import { FaroUserAction } from '../../faro';
+import { trackFaroUserAction } from '../../features/tracking/userAction';
 import { getPrettyError } from './DeleteProbeButton.utils';
 
 export function DeleteProbeButton({ probe, onDeleteSuccess: _onDeleteSuccess }: DeleteProbeButtonProps) {
@@ -35,6 +37,7 @@ export function DeleteProbeButton({ probe, onDeleteSuccess: _onDeleteSuccess }: 
   };
 
   const handleOnClick = () => {
+    trackFaroUserAction(FaroUserAction.DeletePrivateProbeClicked);
     setShowDeleteModal(true);
   };
 
@@ -86,8 +89,14 @@ export function DeleteProbeButton({ probe, onDeleteSuccess: _onDeleteSuccess }: 
           }
           description="This action cannot be undone."
           confirmText="Delete probe"
-          onConfirm={() => deleteProbe(probe)}
-          onDismiss={() => setShowDeleteModal(false)}
+          onConfirm={() => {
+            trackFaroUserAction(FaroUserAction.DeletePrivateProbeConfirmationClicked);
+            deleteProbe(probe);
+          }}
+          onDismiss={() => {
+            trackFaroUserAction(FaroUserAction.DeletePrivateProbeCancellationClicked);
+            setShowDeleteModal(false);
+          }}
           error={error}
           onError={handleError}
         />,

--- a/src/components/DeleteProbeButton/DeleteProbeButton.tsx
+++ b/src/components/DeleteProbeButton/DeleteProbeButton.tsx
@@ -91,7 +91,7 @@ export function DeleteProbeButton({ probe, onDeleteSuccess: _onDeleteSuccess }: 
           confirmText="Delete probe"
           onConfirm={() => {
             trackFaroUserAction(FaroUserAction.DeletePrivateProbeConfirmationClicked);
-            deleteProbe(probe);
+            return deleteProbe(probe);
           }}
           onDismiss={() => {
             trackFaroUserAction(FaroUserAction.DeletePrivateProbeCancellationClicked);

--- a/src/components/ProbeCard/ProbeCard.tsx
+++ b/src/components/ProbeCard/ProbeCard.tsx
@@ -12,6 +12,8 @@ import { DeprecationNotice } from 'components/DeprecationNotice/DeprecationNotic
 import { FeatureFlag } from 'components/FeatureFlag';
 import { ProbeCheckExecutionStats } from 'components/ProbeCheckExecutionStats';
 
+import { FaroUserAction } from '../../faro';
+import { trackFaroUserAction } from '../../features/tracking/userAction';
 import { ProbeUsageLink } from '../ProbeUsageLink';
 import { formatK6VersionsInline } from './ProbeCard.utils';
 import { ProbeDisabledCapabilities } from './ProbeDisabledCapabilities';
@@ -92,6 +94,7 @@ export const ProbeCard = ({ probe }: { probe: ExtendedProbe }) => {
               href={probeEditHref}
               aria-label={`Edit probe ${probe.displayName}`}
               tooltip="Edit probe"
+              onClick={() => trackFaroUserAction(FaroUserAction.EditPrivateProbeClicked)}
             >
               Edit
             </LinkButton>

--- a/src/components/ProbeEditor/ProbeEditor.tsx
+++ b/src/components/ProbeEditor/ProbeEditor.tsx
@@ -15,6 +15,9 @@ import { LabelField } from 'components/LabelField';
 import { ProbeRegionsSelect } from 'components/ProbeRegionsSelect';
 import { SimpleMap } from 'components/SimpleMap';
 
+import { FaroUserAction } from '../../faro';
+import { trackFaroUserAction } from '../../features/tracking/userAction';
+
 type ProbeEditorProps = {
   actions?: ReactNode;
   errorInfo?: { title: string; message: string };
@@ -185,6 +188,7 @@ export const ProbeEditor = ({
                         icon={loading ? 'fa fa-spinner' : undefined}
                         type="submit"
                         disabled={!writeMode || isSubmitting || Object.keys(errors ?? {}).length > 0}
+                        onClick={() => trackFaroUserAction(FaroUserAction.ProbeEditorSubmitClicked)}
                       >
                         {submitText}
                       </Button>

--- a/src/components/ProbeSetupModal/ProbeSetupModal.tsx
+++ b/src/components/ProbeSetupModal/ProbeSetupModal.tsx
@@ -3,11 +3,13 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Button, Modal, Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
-import { FaroEvent, reportEvent } from 'faro';
+import { FaroEvent, FaroUserAction, reportEvent } from 'faro';
 import { useProbeApiServer } from 'hooks/useProbeApiServer';
 import { CopyToClipboard } from 'components/Clipboard/CopyToClipboard';
 import { DocsLink } from 'components/DocsLink';
 import { Table } from 'components/Table';
+
+import { trackFaroUserAction } from '../../features/tracking/userAction';
 
 type TokenModalProps = {
   actionText: string;
@@ -69,7 +71,15 @@ const EnvsTable = ({ token }: { token: string }) => {
           name: 'Copy',
           cell: (row) =>
             row.value && (
-              <CopyToClipboard content={row.value} buttonText="Copy" buttonTextCopied="Copied" fill="text" />
+              <CopyToClipboard
+                content={row.value}
+                buttonText="Copy"
+                buttonTextCopied="Copied"
+                fill="text"
+                onClipboardCopy={() => {
+                  trackFaroUserAction(FaroUserAction.ProbeSetupModalCopyValueClicked);
+                }}
+              />
             ),
         },
       ]}

--- a/src/components/ProbeStatus/ProbeStatus.tsx
+++ b/src/components/ProbeStatus/ProbeStatus.tsx
@@ -24,6 +24,8 @@ import { formatK6VersionsInline } from 'components/ProbeCard/ProbeCard.utils';
 import { ProbeMetaPillsRow } from 'components/ProbeCard/ProbeMetaPillsRow';
 import { ProbeCheckExecutionStats } from 'components/ProbeCheckExecutionStats';
 
+import { FaroUserAction } from '../../faro';
+import { trackFaroUserAction } from '../../features/tracking/userAction';
 import { ProbeUsageLink } from '../ProbeUsageLink';
 
 interface ProbeStatusProps {
@@ -97,7 +99,14 @@ export const ProbeStatus = ({ probe, onReset, readOnly }: ProbeStatusProps) => {
         </div>
         {canWriteProbes && (
           <Container>
-            <Button variant="destructive" disabled={!writeMode} onClick={() => setShowResetModal(true)}>
+            <Button
+              variant="destructive"
+              disabled={!writeMode}
+              onClick={() => {
+                trackFaroUserAction(FaroUserAction.ResetAccessTokenClicked);
+                setShowResetModal(true);
+              }}
+            >
               Reset Access Token
             </Button>
             <ConfirmModal
@@ -105,8 +114,14 @@ export const ProbeStatus = ({ probe, onReset, readOnly }: ProbeStatusProps) => {
               title="Reset Probe Access Token"
               body="Are you sure you want to reset the access token for this Probe?"
               confirmText="Reset Token"
-              onConfirm={() => onResetToken(probe)}
-              onDismiss={() => setShowResetModal(false)}
+              onConfirm={() => {
+                trackFaroUserAction(FaroUserAction.ResetAccessTokenConfirmationClicked);
+                onResetToken(probe);
+              }}
+              onDismiss={() => {
+                trackFaroUserAction(FaroUserAction.ResetAccessTokenCancellationClicked);
+                setShowResetModal(false);
+              }}
             />
           </Container>
         )}

--- a/src/faro.test.ts
+++ b/src/faro.test.ts
@@ -82,7 +82,9 @@ function collectAppSource(dir: string): string {
 }
 
 function unusedMembers(enumName: string, members: string[], source: string) {
-  return members.filter((member) => !source.includes(`${enumName}.${member}`));
+  // \b after the member name stops `Init` from matching inside `InitializeAccessToken`
+  // (plain `.includes` would count that as a use and hide a genuinely dead member).
+  return members.filter((member) => !new RegExp(`\\b${enumName}\\.${member}\\b`).test(source));
 }
 
 describe(`Faro enums are referenced in the app`, () => {

--- a/src/faro.test.ts
+++ b/src/faro.test.ts
@@ -1,6 +1,8 @@
+import fs from 'fs';
+import path from 'path';
 import { faro } from '@grafana/faro-web-sdk';
 
-import { FaroEvent, reportError } from 'faro';
+import { FaroEvent, FaroUserAction, reportError } from 'faro';
 
 const mockPushError = jest.fn();
 
@@ -53,5 +55,44 @@ describe(`reportError`, () => {
     });
 
     expect(() => reportError('test')).not.toThrow();
+  });
+});
+
+function collectAppSource(dir: string): string {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__' || entry.name === 'node_modules') {
+          return [];
+        }
+
+        return collectAppSource(fullPath);
+      }
+
+      if (entry.name === 'faro.ts' || /\.test\.(ts|tsx)$/.test(entry.name) || !/\.(ts|tsx)$/.test(entry.name)) {
+        return [];
+      }
+
+      return [fs.readFileSync(fullPath, 'utf8')];
+    })
+    .join('\n');
+}
+
+function unusedMembers(enumName: string, members: string[], source: string) {
+  return members.filter((member) => !source.includes(`${enumName}.${member}`));
+}
+
+describe(`Faro enums are referenced in the app`, () => {
+  const source = collectAppSource(path.join(__dirname));
+
+  it(`uses every FaroEvent at least once`, () => {
+    expect(unusedMembers('FaroEvent', Object.keys(FaroEvent), source)).toEqual([]);
+  });
+
+  it(`uses every FaroUserAction at least once`, () => {
+    expect(unusedMembers('FaroUserAction', Object.keys(FaroUserAction), source)).toEqual([]);
   });
 });

--- a/src/faro.ts
+++ b/src/faro.ts
@@ -14,7 +14,6 @@ export enum FaroEvent {
   UpdateProbe = 'update_probe',
   DeleteProbe = 'delete_probe',
   ResetProbeToken = 'reset_probe_token',
-  DisablePlugin = 'disable_plugin',
   CreateAccessToken = 'create_access_token',
   SaveThresholds = 'save_thresholds',
   ShowTerraformConfig = 'show_terraform_config',

--- a/src/faro.ts
+++ b/src/faro.ts
@@ -24,6 +24,36 @@ export enum FaroEvent {
   NoProbeMappingFound = 'no_probe_mapping_found',
 }
 
+export enum FaroUserAction {
+  CreateNewCheckClicked = 'create-new-check-clicked',
+  CheckWizardNextClicked = 'check-wizard-next-clicked',
+  CheckWizardPrevClicked = 'check-wizard-prev-clicked',
+  CheckWizardTabClicked = 'check-wizard-tab-clicked',
+  CheckCreateSubmitClicked = 'check-create-submit-clicked',
+  CheckUpdateSubmitClicked = 'check-update-submit-clicked',
+  CheckEditClicked = 'check-edit-clicked',
+  CheckDuplicateClicked = 'check-duplicate-clicked',
+  CheckDisableClicked = 'check-disable-clicked',
+  CheckEnableClicked = 'check-enable-clicked',
+  CheckDeleteClicked = 'check-delete-clicked',
+  CheckDeleteConfirmationClicked = 'check-delete-confirmation-clicked',
+  CheckDeleteCancellationClicked = 'check-delete-cancelation-clicked',
+  AdhocCheckTestClicked = 'adhoc-check-test-clicked',
+  ProbeEditorSubmitClicked = 'probe-editor-submit-clicked',
+  ProbeSetupModalCopyValueClicked = 'probe-setup-modal-copy-value-clicked',
+  SelectCheckTypeClicked = 'select-check-type-clicked',
+  EditProbeSetupModalDismissClicked = 'edit-probe-setup-modal-dismiss-clicked',
+  NewProbeCreateModalDismissClicked = 'new-probe-create-probe-modal-dismiss-clicked',
+  EditPrivateProbeClicked = 'edit-private-probe-clicked',
+  AddPrivateProbeClicked = 'add-private-probe-clicked',
+  DeletePrivateProbeClicked = 'delete-private-probe-clicked',
+  DeletePrivateProbeConfirmationClicked = 'delete-private-probe-confirmation-clicked',
+  DeletePrivateProbeCancellationClicked = 'delete-private-probe-cancelation-clicked',
+  ResetAccessTokenClicked = 'reset-access-token-clicked',
+  ResetAccessTokenConfirmationClicked = 'reset-access-token-confirmation-clicked',
+  ResetAccessTokenCancellationClicked = 'reset-access-token-cancelation-clicked',
+}
+
 export enum FaroEnv {
   Dev = 'development',
   Staging = 'staging',

--- a/src/features/tracking/userAction.ts
+++ b/src/features/tracking/userAction.ts
@@ -2,6 +2,9 @@ import { faro } from '@grafana/faro-web-sdk';
 
 import { FaroUserAction } from '../../faro';
 
+// Prefer calling this directly in the handler over the `data-faro-user-action-name` attribute:
+// shared components (e.g. a submit button used for both create and edit) often can't tell which
+// action fired from a static attribute alone, so the manual API keeps naming correct everywhere.
 export function trackFaroUserAction(name: FaroUserAction, attributes?: Record<string, string>) {
   try {
     faro.api.startUserAction(name, attributes);

--- a/src/features/tracking/userAction.ts
+++ b/src/features/tracking/userAction.ts
@@ -1,0 +1,11 @@
+import { faro } from '@grafana/faro-web-sdk';
+
+import { FaroUserAction } from '../../faro';
+
+export function trackFaroUserAction(name: FaroUserAction, attributes?: Record<string, string>) {
+  try {
+    faro.api.startUserAction(name, attributes);
+  } catch (e) {
+    // todo: report an error?
+  }
+}

--- a/src/hooks/useCheckTypeGroupOptions.tsx
+++ b/src/hooks/useCheckTypeGroupOptions.tsx
@@ -28,11 +28,8 @@ export interface CheckTypeGroupOption {
 }
 
 function trackAndStartUserAction(checkTypeGroup: CheckTypeGroup, protocol: string) {
-  trackAddCheckTypeButtonClicked({ checkTypeGroup: checkTypeGroup, protocol: protocol });
-  trackFaroUserAction(FaroUserAction.SelectCheckTypeClicked, {
-    checkTypeGroup: checkTypeGroup,
-    protocol: protocol,
-  });
+  trackAddCheckTypeButtonClicked({ checkTypeGroup, protocol });
+  trackFaroUserAction(FaroUserAction.SelectCheckTypeClicked, { checkTypeGroup, protocol });
 }
 
 export const CHECK_TYPE_GROUP_OPTIONS: CheckTypeGroupOption[] = [

--- a/src/hooks/useCheckTypeGroupOptions.tsx
+++ b/src/hooks/useCheckTypeGroupOptions.tsx
@@ -6,6 +6,8 @@ import { CheckType, CheckTypeGroup, FeatureName } from 'types';
 import { AppRoutes } from 'routing/types';
 import { getRoute } from 'routing/utils';
 
+import { FaroUserAction } from '../faro';
+import { trackFaroUserAction } from '../features/tracking/userAction';
 import { CHECK_TYPE_OPTIONS } from './useCheckTypeOptions';
 import { useFeatureFlagContext } from './useFeatureFlagContext';
 
@@ -25,6 +27,14 @@ export interface CheckTypeGroupOption {
   protocols: ProtocolOption[];
 }
 
+function trackAndStartUserAction(checkTypeGroup: CheckTypeGroup, protocol: string) {
+  trackAddCheckTypeButtonClicked({ checkTypeGroup: checkTypeGroup, protocol: protocol });
+  trackFaroUserAction(FaroUserAction.SelectCheckTypeClicked, {
+    checkTypeGroup: checkTypeGroup,
+    protocol: protocol,
+  });
+}
+
 export const CHECK_TYPE_GROUP_OPTIONS: CheckTypeGroupOption[] = [
   {
     label: 'API Endpoint',
@@ -35,7 +45,7 @@ export const CHECK_TYPE_GROUP_OPTIONS: CheckTypeGroupOption[] = [
       label: option.label,
       href: `${getRoute(AppRoutes.NewCheck)}/${CheckTypeGroup.ApiTest}?checkType=${option.value}`,
       featureToggle: option.featureToggle,
-      onClick: () => trackAddCheckTypeButtonClicked({ checkTypeGroup: CheckTypeGroup.ApiTest, protocol: option.value }),
+      onClick: () => trackAndStartUserAction(CheckTypeGroup.ApiTest, option.value),
     })),
   },
   {
@@ -47,7 +57,7 @@ export const CHECK_TYPE_GROUP_OPTIONS: CheckTypeGroupOption[] = [
       {
         label: `HTTP`,
         href: `${getRoute(AppRoutes.NewCheck)}/${CheckTypeGroup.MultiStep}?checkType=${CheckType.MultiHttp}`,
-        onClick: () => trackAddCheckTypeButtonClicked({ checkTypeGroup: CheckTypeGroup.MultiStep, protocol: `HTTP` }),
+        onClick: () => trackAndStartUserAction(CheckTypeGroup.MultiStep, `HTTP`),
       },
     ],
   },
@@ -60,7 +70,7 @@ export const CHECK_TYPE_GROUP_OPTIONS: CheckTypeGroupOption[] = [
       {
         label: `HTTP`,
         href: `${getRoute(AppRoutes.NewCheck)}/${CheckTypeGroup.Scripted}`,
-        onClick: () => trackAddCheckTypeButtonClicked({ checkTypeGroup: CheckTypeGroup.Scripted, protocol: `HTTP` }),
+        onClick: () => trackAndStartUserAction(CheckTypeGroup.Scripted, `HTTP`),
       },
       // todo: we don't support these yet
       // { label: `gRPC` },
@@ -92,7 +102,7 @@ export const CHECK_TYPE_GROUP_OPTIONS: CheckTypeGroupOption[] = [
       {
         label: `HTTP`,
         href: `${getRoute(AppRoutes.NewCheck)}/${CheckTypeGroup.Browser}`,
-        onClick: () => trackAddCheckTypeButtonClicked({ checkTypeGroup: CheckTypeGroup.Browser, protocol: `HTTP` }),
+        onClick: () => trackAndStartUserAction(CheckTypeGroup.Browser, `HTTP`),
       },
     ],
   },

--- a/src/hooks/useHandleSubmitCheckster.ts
+++ b/src/hooks/useHandleSubmitCheckster.ts
@@ -6,6 +6,8 @@ import { getAlertsPayload } from '../components/Checkster/transformations/toPayl
 import { queryClient } from '../data/queryClient';
 import { useUpdateAlertsForCheck } from '../data/useCheckAlerts';
 import { QUERY_KEYS, useCUDChecks } from '../data/useChecks';
+import { FaroUserAction } from '../faro';
+import { trackFaroUserAction } from '../features/tracking/userAction';
 import { useNavigateToCheckDashboard } from './useNavigateToCheckDashboard';
 
 export function useHandleSubmitCheckster(initialCheck?: Check) {
@@ -31,8 +33,10 @@ export function useHandleSubmitCheckster(initialCheck?: Check) {
     async (payload: Check, formValues: CheckFormValues) => {
       // todo: add try-catch
       let result;
+      const isUpdate = initialCheck && 'id' in initialCheck && initialCheck?.id;
+      trackFaroUserAction(isUpdate ? FaroUserAction.CheckUpdateSubmitClicked : FaroUserAction.CheckCreateSubmitClicked);
       // TODO: Perhaps getting the Check by id and source the tenant ID from there is better than relying on a "global" variable?
-      if (initialCheck && 'id' in initialCheck && initialCheck?.id) {
+      if (isUpdate) {
         result = await updateCheck({
           id: initialCheck.id,
           tenantId: initialCheck.tenantId,

--- a/src/page/CheckList/components/CheckItemActionButtons.tsx
+++ b/src/page/CheckList/components/CheckItemActionButtons.tsx
@@ -14,6 +14,9 @@ import { useDeleteCheck, useUpdateCheck } from 'data/useChecks';
 import { useDuplicateCheckUrl } from 'hooks/useDuplicateCheck';
 import { CHECK_LIST_CARD_CONTAINER_NAME } from 'page/CheckList/CheckList.constants';
 
+import { FaroUserAction } from '../../../faro';
+import { trackFaroUserAction } from '../../../features/tracking/userAction';
+
 interface CheckItemActionButtonsProps {
   check: Check;
   viewDashboardAsIcon?: boolean;
@@ -37,6 +40,7 @@ export const CheckItemActionButtons = ({
   const { duplicateCheckUrl } = useDuplicateCheckUrl();
 
   const handleToggleEnabled = useCallback(async () => {
+    trackFaroUserAction(check.enabled ? FaroUserAction.CheckDisableClicked : FaroUserAction.CheckEnableClicked);
     setIsPending(true);
     await updateCheck(
       { ...check, enabled: !check.enabled },
@@ -100,6 +104,7 @@ export const CheckItemActionButtons = ({
         disabled={!canWriteChecks}
         variant="secondary"
         fill={`text`}
+        onClick={() => trackFaroUserAction(FaroUserAction.CheckEditClicked)}
       />
       <LinkButton
         href={duplicateCheckUrl(check)}
@@ -107,6 +112,7 @@ export const CheckItemActionButtons = ({
         tooltip="Duplicate check"
         disabled={!canWriteChecks}
         onClick={() => {
+          trackFaroUserAction(FaroUserAction.CheckDuplicateClicked);
           trackDuplicateCheckButtonClicked({ checkType: getCheckType(check.settings) });
         }}
         variant="secondary"
@@ -115,7 +121,10 @@ export const CheckItemActionButtons = ({
       <IconButton
         tooltip="Delete check"
         name="trash-alt"
-        onClick={() => setShowDeleteModal(true)}
+        onClick={() => {
+          trackFaroUserAction(FaroUserAction.CheckDeleteClicked);
+          setShowDeleteModal(true);
+        }}
         disabled={!canDeleteChecks}
       />
       <ConfirmModal
@@ -124,10 +133,14 @@ export const CheckItemActionButtons = ({
         body="Are you sure you want to delete this check?"
         confirmText="Delete check"
         onConfirm={() => {
+          trackFaroUserAction(FaroUserAction.CheckDeleteConfirmationClicked);
           deleteCheck(check);
           setShowDeleteModal(false);
         }}
-        onDismiss={() => setShowDeleteModal(false)}
+        onDismiss={() => {
+          trackFaroUserAction(FaroUserAction.CheckDeleteCancellationClicked);
+          setShowDeleteModal(false);
+        }}
       />
     </div>
   );

--- a/src/page/ChooseCheckGroup/components/CheckGroupCard.tsx
+++ b/src/page/ChooseCheckGroup/components/CheckGroupCard.tsx
@@ -15,6 +15,8 @@ import { Card } from 'components/Card';
 import { CheckStatusInfo } from 'components/CheckStatusInfo';
 import { NewStatusBadge } from 'components/NewStatusBadge';
 
+import { FaroUserAction } from '../../../faro';
+import { trackFaroUserAction } from '../../../features/tracking/userAction';
 import { Protocol } from './Protocol';
 
 export const CheckGroupCard = ({ group }: { group: CheckTypeGroupOption }) => {
@@ -50,7 +52,10 @@ export const CheckGroupCard = ({ group }: { group: CheckTypeGroupOption }) => {
             disabled={disabled}
             href={`${getRoute(AppRoutes.NewCheck)}/${group.value}`}
             tooltip={getTooltip(limits, group.value)}
-            onClick={() => trackAddCheckTypeGroupButtonClicked({ checkTypeGroup: group.value })}
+            onClick={() => {
+              trackAddCheckTypeGroupButtonClicked({ checkTypeGroup: group.value });
+              trackFaroUserAction(FaroUserAction.SelectCheckTypeClicked, { checkTypeGroup: group.value });
+            }}
           >
             {group.label}
           </LinkButton>

--- a/src/page/EditProbe/EditProbe.tsx
+++ b/src/page/EditProbe/EditProbe.tsx
@@ -15,6 +15,8 @@ import { ProbeSetupModal } from 'components/ProbeSetupModal';
 import { ProbeStatus } from 'components/ProbeStatus';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
 
+import { FaroUserAction } from '../../faro';
+import { trackFaroUserAction } from '../../features/tracking/userAction';
 import { PluginPageNotFound } from '../NotFound/NotFound';
 import { getErrorInfo, getTitle } from './EditProbe.utils';
 
@@ -143,7 +145,10 @@ const EditProbeContent = ({ probe, forceViewMode }: { forceViewMode?: boolean; p
       <ProbeSetupModal
         actionText="Close"
         isOpen={showTokenModal}
-        onDismiss={() => setShowTokenModal(false)}
+        onDismiss={() => {
+          trackFaroUserAction(FaroUserAction.EditProbeSetupModalDismissClicked);
+          setShowTokenModal(false);
+        }}
         token={probeToken}
       />
     </>

--- a/src/page/NewProbe/NewProbe.tsx
+++ b/src/page/NewProbe/NewProbe.tsx
@@ -11,6 +11,9 @@ import { ProbeAPIServer } from 'components/ProbeAPIServer';
 import { ProbeEditor } from 'components/ProbeEditor';
 import { ProbeSetupModal } from 'components/ProbeSetupModal';
 
+import { FaroUserAction } from '../../faro';
+import { trackFaroUserAction } from '../../features/tracking/userAction';
+
 export const TEMPLATE_PROBE: ExtendedProbe = {
   name: '',
   public: false,
@@ -74,6 +77,7 @@ export const NewProbe = () => {
         isOpen={showTokenModal}
         actionText="Go back to probes list"
         onDismiss={() => {
+          trackFaroUserAction(FaroUserAction.NewProbeCreateModalDismissClicked);
           navigate(AppRoutes.Probes);
           setShowTokenModal(false);
         }}

--- a/src/page/Probes/Probes.tsx
+++ b/src/page/Probes/Probes.tsx
@@ -14,6 +14,9 @@ import { DocsLink } from 'components/DocsLink';
 import { ProbeList } from 'components/ProbeList';
 import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
 
+import { FaroUserAction } from '../../faro';
+import { trackFaroUserAction } from '../../features/tracking/userAction';
+
 export const Probes = () => {
   const theme = useTheme2();
 
@@ -44,7 +47,14 @@ const Actions = () => {
     return null;
   }
 
-  return <LinkButton href={getRoute(AppRoutes.NewProbe)}>Add Private Probe</LinkButton>;
+  return (
+    <LinkButton
+      href={getRoute(AppRoutes.NewProbe)}
+      onClick={() => trackFaroUserAction(FaroUserAction.AddPrivateProbeClicked)}
+    >
+      Add Private Probe
+    </LinkButton>
+  );
 };
 
 const ProbesContent = () => {


### PR DESCRIPTION
Addresses: https://github.com/grafana/synthetic-monitoring/issues/650

## Problem

We have no visibility into what people actually click through the check and probe
flows - check creation, the check wizard, check list actions, probe setup/reset/delete.
Without that, we cannot build user journeys later on.

## Solution

Instruments those flows with Faro user actions via `trackFaroUserAction(FaroUserAction, attributes)`,
which wraps `faro.api.startUserAction()`. See: https://grafana.com/docs/grafana-cloud/observe-and-act/monitor-applications/frontend-observability/instrument/user-actions/

Went with the imperative API instead of the declarative `data-faro-user-action-name`
attribute - that path is broken upstream (I opened https://github.com/grafana/faro-web-sdk/pull/2239
to fix it), so imperative was the only way not to block this work.

Tracks clicks through:
- check creation entry point + type selection
- check wizard navigation (next/prev/tab) and create vs. update submit
- check list actions: edit, duplicate, enable/disable, delete + confirm/cancel
- probe list/edit/delete/reset + confirm/cancel, ad hoc check test, probe setup modal copy

Also removes the localhost opt-out in `App.tsx` - Faro doesn't spam the console with
errors anymore, so it's fine to leave enabled everywhere, and we need it locally to
actually verify this instrumentation.
