### PR TITLE
feat(check-suggestions): Gate behind OpenFeature feature flag

### DIFF
--- a/src/routing/InitialisedRouter.test.tsx
+++ b/src/routing/InitialisedRouter.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { UI_TEST_ID } from 'test/dataTestIds';
 import { BASIC_HTTP_CHECK } from 'test/fixtures/checks';
 import { SM_DATASOURCE } from 'test/fixtures/datasources';
 import { type CustomRenderOptions, render } from 'test/render';
@@ -107,6 +108,12 @@ describe('Routes to pages correctly', () => {
     jest.mocked(useFeatureFlagModule.useFeatureFlag).mockReturnValue({ isEnabled: false, isReady: false });
 
     renderInitialisedRouting({ path: getRoute(AppRoutes.ReliabilityInbox) });
+
+    // The datasource/permissions providers show their own loading spinner first, and Grafana's
+    // generic spinner looks the same everywhere it's used, so wait for that one to clear first,
+    // otherwise we might catch it instead of the one for the expected routing below.
+    await waitForElementToBeRemoved(() => screen.queryByTestId(UI_TEST_ID.centeredSpinner));
+
     const spinner = await screen.findByTestId('Spinner');
     expect(spinner).toBeInTheDocument();
 

--- a/src/routing/InitialisedRouter.test.tsx
+++ b/src/routing/InitialisedRouter.test.tsx
@@ -25,7 +25,7 @@ jest.mock('page/SceneHomepage', () => ({
 }));
 
 jest.mock('features/reliabilityInbox', () => ({
-  ReliabilityInboxPage: () => <h1>Reliability inbox page</h1>,
+  ReliabilityInboxPage: () => <h1>Check suggestions page</h1>,
 }));
 
 const notaRoute = `${PLUGIN_URL_PATH}/404`;
@@ -83,14 +83,14 @@ describe('Routes to pages correctly', () => {
     expect(sceneText).toBeInTheDocument();
   });
 
-  test('Reliability inbox route renders when the flag is enabled', async () => {
-    mockFeatureToggles({ [FeatureName.ReliabilityInbox]: true });
+  test('Check suggestions route renders when the flag is enabled', async () => {
+    mockFeatureToggles({ [FeatureName.CheckSuggestions]: true });
     renderInitialisedRouting({ path: getRoute(AppRoutes.ReliabilityInbox) });
-    const pageText = await screen.findByText('Reliability inbox page', { selector: 'h1' });
+    const pageText = await screen.findByText('Check suggestions page', { selector: 'h1' });
     expect(pageText).toBeInTheDocument();
   });
 
-  test('Reliability inbox route shows a 404 page when the flag is disabled', async () => {
+  test('Check suggestions route shows a 404 page when the flag is disabled', async () => {
     renderInitialisedRouting({ path: getRoute(AppRoutes.ReliabilityInbox) });
     const notFoundText = await screen.findByText('Not found', { selector: 'span' });
     expect(notFoundText).toBeInTheDocument();

--- a/src/routing/InitialisedRouter.test.tsx
+++ b/src/routing/InitialisedRouter.test.tsx
@@ -10,6 +10,12 @@ import { PLUGIN_URL_PATH } from 'routing/constants';
 import { InitialisedRouter } from 'routing/InitialisedRouter';
 import { AppRoutes } from 'routing/types';
 import { getRoute } from 'routing/utils';
+import * as useFeatureFlagModule from 'hooks/useFeatureFlag';
+
+jest.mock('hooks/useFeatureFlag', () => {
+  const actual = jest.requireActual('hooks/useFeatureFlag');
+  return { ...actual, useFeatureFlag: jest.fn(actual.useFeatureFlag) };
+});
 
 function renderInitialisedRouting(options?: CustomRenderOptions) {
   return render(<InitialisedRouter />, options);
@@ -94,5 +100,16 @@ describe('Routes to pages correctly', () => {
     renderInitialisedRouting({ path: getRoute(AppRoutes.ReliabilityInbox) });
     const notFoundText = await screen.findByText('Not found', { selector: 'span' });
     expect(notFoundText).toBeInTheDocument();
+  });
+
+  test('Check suggestions route shows a spinner while the flag is not ready', async () => {
+    const actualUseFeatureFlag = jest.requireActual('hooks/useFeatureFlag').useFeatureFlag;
+    jest.mocked(useFeatureFlagModule.useFeatureFlag).mockReturnValue({ isEnabled: false, isReady: false });
+
+    renderInitialisedRouting({ path: getRoute(AppRoutes.ReliabilityInbox) });
+    const spinner = await screen.findByTestId('Spinner');
+    expect(spinner).toBeInTheDocument();
+
+    jest.mocked(useFeatureFlagModule.useFeatureFlag).mockImplementation(actualUseFeatureFlag);
   });
 });

--- a/src/routing/InitialisedRouter.test.tsx
+++ b/src/routing/InitialisedRouter.test.tsx
@@ -3,7 +3,9 @@ import { screen } from '@testing-library/react';
 import { BASIC_HTTP_CHECK } from 'test/fixtures/checks';
 import { SM_DATASOURCE } from 'test/fixtures/datasources';
 import { type CustomRenderOptions, render } from 'test/render';
+import { mockFeatureToggles } from 'test/utils';
 
+import { FeatureName } from 'types';
 import { PLUGIN_URL_PATH } from 'routing/constants';
 import { InitialisedRouter } from 'routing/InitialisedRouter';
 import { AppRoutes } from 'routing/types';
@@ -20,6 +22,10 @@ jest.mock('page/DashboardPage', () => ({
 
 jest.mock('page/SceneHomepage', () => ({
   SceneHomepage: () => <h1>Home page</h1>,
+}));
+
+jest.mock('features/reliabilityInbox', () => ({
+  ReliabilityInboxPage: () => <h1>Reliability inbox page</h1>,
 }));
 
 const notaRoute = `${PLUGIN_URL_PATH}/404`;
@@ -75,5 +81,18 @@ describe('Routes to pages correctly', () => {
     });
     const sceneText = await screen.findByText('Dashboard page');
     expect(sceneText).toBeInTheDocument();
+  });
+
+  test('Reliability inbox route renders when the flag is enabled', async () => {
+    mockFeatureToggles({ [FeatureName.ReliabilityInbox]: true });
+    renderInitialisedRouting({ path: getRoute(AppRoutes.ReliabilityInbox) });
+    const pageText = await screen.findByText('Reliability inbox page', { selector: 'h1' });
+    expect(pageText).toBeInTheDocument();
+  });
+
+  test('Reliability inbox route shows a 404 page when the flag is disabled', async () => {
+    renderInitialisedRouting({ path: getRoute(AppRoutes.ReliabilityInbox) });
+    const notFoundText = await screen.findByText('Not found', { selector: 'span' });
+    expect(notFoundText).toBeInTheDocument();
   });
 });

--- a/src/routing/InitialisedRouter.tsx
+++ b/src/routing/InitialisedRouter.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { Navigate, Route, Routes } from 'react-router';
-import { TextLink } from '@grafana/ui';
+import { Spinner, TextLink } from '@grafana/ui';
 import { ReliabilityInboxPage } from 'features/reliabilityInbox';
 
 import { FeatureName } from 'types';
@@ -40,7 +40,9 @@ export const InitialisedRouter = () => {
   const urlSearchParams = useURLSearchParams();
   const navigate = useNavigation();
   const { isFeatureEnabled } = useFeatureFlagContext();
-  const { isEnabled: isCheckSuggestionsEnabled } = useFeatureFlag(FeatureName.CheckSuggestions);
+  const { isEnabled: isCheckSuggestionsEnabled, isReady: isCheckSuggestionsReady } = useFeatureFlag(
+    FeatureName.CheckSuggestions
+  );
 
   const page = urlSearchParams.get('page');
   useLimits();
@@ -135,18 +137,23 @@ export const InitialisedRouter = () => {
 
       <Route path={AppRoutes.Alerts} element={<AlertingPage />} />
 
-      {isCheckSuggestionsEnabled && (
-        <Route
-          path={AppRoutes.ReliabilityInbox}
-          element={
-            canReadChecks ? (
-              <ReliabilityInboxPage />
-            ) : (
-              <UnauthorizedPage permissions={['grafana-synthetic-monitoring-app.checks:read']} />
-            )
-          }
-        />
-      )}
+      <Route
+        path={AppRoutes.ReliabilityInbox}
+        element={
+          !isCheckSuggestionsReady ? (
+            <Spinner />
+          ) : !isCheckSuggestionsEnabled ? (
+            <PluginPageNotFound>
+              The page you are looking for does not exist. Here is a working link to{' '}
+              <TextLink href={getRoute(AppRoutes.Home)}>home</TextLink>.
+            </PluginPageNotFound>
+          ) : canReadChecks ? (
+            <ReliabilityInboxPage />
+          ) : (
+            <UnauthorizedPage permissions={['grafana-synthetic-monitoring-app.checks:read']} />
+          )
+        }
+      />
 
       <Route path={`${AppRoutes.Config}`} element={<ConfigPageLayout />}>
         <Route index element={<GeneralTab />} />

--- a/src/routing/InitialisedRouter.tsx
+++ b/src/routing/InitialisedRouter.tsx
@@ -40,7 +40,7 @@ export const InitialisedRouter = () => {
   const urlSearchParams = useURLSearchParams();
   const navigate = useNavigation();
   const { isFeatureEnabled } = useFeatureFlagContext();
-  const { isEnabled: isReliabilityInboxEnabled } = useFeatureFlag(FeatureName.ReliabilityInbox);
+  const { isEnabled: isCheckSuggestionsEnabled } = useFeatureFlag(FeatureName.CheckSuggestions);
 
   const page = urlSearchParams.get('page');
   useLimits();
@@ -135,7 +135,7 @@ export const InitialisedRouter = () => {
 
       <Route path={AppRoutes.Alerts} element={<AlertingPage />} />
 
-      {isReliabilityInboxEnabled && (
+      {isCheckSuggestionsEnabled && (
         <Route
           path={AppRoutes.ReliabilityInbox}
           element={

--- a/src/routing/InitialisedRouter.tsx
+++ b/src/routing/InitialisedRouter.tsx
@@ -8,6 +8,7 @@ import { LegacyEditRedirect } from 'routing/LegacyEditRedirect';
 import { AppRoutes } from 'routing/types';
 import { getNewCheckTypeRedirects, getRoute } from 'routing/utils';
 import { getUserPermissions } from 'data/permissions';
+import { useFeatureFlag } from 'hooks/useFeatureFlag';
 import { useFeatureFlagContext } from 'hooks/useFeatureFlagContext';
 import { useLimits } from 'hooks/useLimits';
 import { QueryParamMap, useNavigation } from 'hooks/useNavigation';
@@ -39,6 +40,7 @@ export const InitialisedRouter = () => {
   const urlSearchParams = useURLSearchParams();
   const navigate = useNavigation();
   const { isFeatureEnabled } = useFeatureFlagContext();
+  const { isEnabled: isReliabilityInboxEnabled } = useFeatureFlag(FeatureName.ReliabilityInbox);
 
   const page = urlSearchParams.get('page');
   useLimits();
@@ -133,7 +135,7 @@ export const InitialisedRouter = () => {
 
       <Route path={AppRoutes.Alerts} element={<AlertingPage />} />
 
-      {isFeatureEnabled(FeatureName.ReliabilityInbox) && (
+      {isReliabilityInboxEnabled && (
         <Route
           path={AppRoutes.ReliabilityInbox}
           element={

--- a/src/scenes/Summary/SummaryDashboard.test.tsx
+++ b/src/scenes/Summary/SummaryDashboard.test.tsx
@@ -21,7 +21,7 @@ jest.mock('hooks/useMetricsDS', () => ({
 
 describe('SummaryDashboard', () => {
   it('keeps Reliability Inbox and manual creation available when the unfiltered check inventory is empty', async () => {
-    mockFeatureToggles({ [FeatureName.ReliabilityInbox]: true });
+    mockFeatureToggles({ [FeatureName.CheckSuggestions]: true });
     render(<SummaryDashboard checks={[]} />);
 
     expect(await screen.findByTestId('reliability-inbox-banner')).toBeInTheDocument();
@@ -29,8 +29,8 @@ describe('SummaryDashboard', () => {
     expect(await screen.findByText('Create new check')).toBeInTheDocument();
   });
 
-  it('hides the Reliability Inbox banner when the flag is disabled', async () => {
-    mockFeatureToggles({ [FeatureName.ReliabilityInbox]: false });
+  it('hides the check suggestions banner when the flag is disabled', async () => {
+    mockFeatureToggles({ [FeatureName.CheckSuggestions]: false });
     render(<SummaryDashboard checks={[]} />);
 
     expect(screen.queryByTestId('reliability-inbox-banner')).not.toBeInTheDocument();

--- a/src/scenes/Summary/SummaryDashboard.test.tsx
+++ b/src/scenes/Summary/SummaryDashboard.test.tsx
@@ -28,4 +28,13 @@ describe('SummaryDashboard', () => {
     expect(await screen.findByText("You haven't created any checks yet")).toBeInTheDocument();
     expect(await screen.findByText('Create new check')).toBeInTheDocument();
   });
+
+  it('hides the Reliability Inbox banner when the flag is disabled', async () => {
+    mockFeatureToggles({ [FeatureName.ReliabilityInbox]: false });
+    render(<SummaryDashboard checks={[]} />);
+
+    expect(screen.queryByTestId('reliability-inbox-banner')).not.toBeInTheDocument();
+    expect(await screen.findByText("You haven't created any checks yet")).toBeInTheDocument();
+    expect(await screen.findByText('Create new check')).toBeInTheDocument();
+  });
 });

--- a/src/scenes/Summary/SummaryDashboard.tsx
+++ b/src/scenes/Summary/SummaryDashboard.tsx
@@ -40,7 +40,7 @@ const SummaryDashboardContent = ({ checks }: SummaryDashboardProps) => {
   const metricsDS = useMetricsDS();
   const styles = useStyles2(getStyles);
   const annotations = useSummaryDashboardAnnotations();
-  const { isEnabled: isReliabilityInboxEnabled } = useFeatureFlag(FeatureName.ReliabilityInbox);
+  const { isEnabled: isCheckSuggestionsEnabled } = useFeatureFlag(FeatureName.CheckSuggestions);
   const scene = useSceneContext();
   const [filtersAdded, setFiltersAdded] = useState(false);
 
@@ -92,7 +92,7 @@ const SummaryDashboardContent = ({ checks }: SummaryDashboardProps) => {
     <>
       <PluginPage pageNav={{ text: 'Home' }} renderTitle={() => <h1>Home</h1>}>
         <Stack direction="column" gap={1}>
-          {isReliabilityInboxEnabled && <ReliabilityInboxBanner />}
+          {isCheckSuggestionsEnabled && <ReliabilityInboxBanner />}
           <DashboardContainerAnnotations annotations={annotations}>
             <div className={styles.header}>
               <VariableControl name="region" />
@@ -132,12 +132,12 @@ const SummaryDashboardContent = ({ checks }: SummaryDashboardProps) => {
 export const SummaryDashboard = ({ checks }: SummaryDashboardProps) => {
   const metricsDS = useMetricsDS();
   const styles = useStyles2(getStyles);
-  const { isEnabled: isReliabilityInboxEnabled } = useFeatureFlag(FeatureName.ReliabilityInbox);
+  const { isEnabled: isCheckSuggestionsEnabled } = useFeatureFlag(FeatureName.CheckSuggestions);
 
   if (checks.length === 0) {
     return (
       <Stack direction="column" gap={1}>
-        {isReliabilityInboxEnabled && <ReliabilityInboxBanner />}
+        {isCheckSuggestionsEnabled && <ReliabilityInboxBanner />}
         <ChecksEmptyState className={styles.emptyState} />
       </Stack>
     );

--- a/src/services/featureFlags.ts
+++ b/src/services/featureFlags.ts
@@ -10,7 +10,7 @@ export const SM_OPEN_FEATURE_DOMAIN = pluginJson.id;
 // Adding an entry routes all consumers of that FeatureName through OpenFeature instead
 // of legacy config.featureToggles. See docs/development/openfeature-migration.md
 export const OPEN_FEATURE_KEYS: Partial<Record<FeatureName, string>> = {
-  [FeatureName.ReliabilityInbox]: 'synthetic-monitoring-reliability-inbox',
+  [FeatureName.CheckSuggestions]: 'synthetic-monitoring.check-suggestions',
 };
 
 let initPromise: Promise<void> | undefined;

--- a/src/services/featureFlags.ts
+++ b/src/services/featureFlags.ts
@@ -9,7 +9,9 @@ export const SM_OPEN_FEATURE_DOMAIN = pluginJson.id;
 
 // Adding an entry routes all consumers of that FeatureName through OpenFeature instead
 // of legacy config.featureToggles. See docs/development/openfeature-migration.md
-export const OPEN_FEATURE_KEYS: Partial<Record<FeatureName, string>> = {};
+export const OPEN_FEATURE_KEYS: Partial<Record<FeatureName, string>> = {
+  [FeatureName.ReliabilityInbox]: 'synthetic-monitoring-reliability-inbox',
+};
 
 let initPromise: Promise<void> | undefined;
 let client: Client | undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -753,11 +753,11 @@ export enum HTTPCompressionAlgo {
 
 export enum FeatureName {
   CALs = 'synthetic-monitoring-cost-attribution',
+  CheckSuggestions = 'synthetic-monitoring-check-suggestions',
   Folders = 'synthetic-monitoring-folders',
   GRPCChecks = 'grpc-checks',
   KnowledgeGraph = 'synthetic-monitoring-knowledge-graph',
   LabelMigration = 'synthetic-monitoring-label-migration',
-  ReliabilityInbox = 'synthetic-monitoring-reliability-inbox',
   Screenshots = 'synthetic-monitoring-screenshots',
   SecretsManagement = 'synthetic-monitoring-secrets-management',
   TimepointExplorer = 'synthetic-monitoring-timepoint-explorer',


### PR DESCRIPTION
Add the ReliabilityInbox OpenFeature flag and use it to gate both the `/reliability-inbox` route and the summary banner, so the feature stays hidden until the flag is enabled.