### PR TITLE
feat: rename colliding labels from the label migration tab

### DIFF
--- a/src/data/useRenameCheckLabels.ts
+++ b/src/data/useRenameCheckLabels.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { QUERY_KEYS as CHECK_QUERY_KEYS } from 'data/useChecks';
+import { useSMDS } from 'hooks/useSMDS';
+
+export function useRenameCheckLabels() {
+  const smDS = useSMDS();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ from, to }: { from: string; to: string }) => smDS.renameCheckLabels(from, to),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: CHECK_QUERY_KEYS.list });
+    },
+  });
+}

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -30,6 +30,7 @@ import {
   ListTenantLimitsResponse,
   ListTenantSettingsResult,
   LogsQueryResponse,
+  RenameCheckLabelsResponse,
   type ResetProbeTokenResult,
   TenantResponse,
   UpdateCheckResult,
@@ -391,6 +392,16 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
       method: 'PUT',
       data: { mode },
     });
+  }
+
+  async renameCheckLabels(key: string, name: string) {
+    return this.fetchAPI<RenameCheckLabelsResponse>(
+      `${this.instanceSettings.url}/sm/check/labels/${encodeURIComponent(key)}`,
+      {
+        method: 'POST',
+        data: { name },
+      }
+    );
   }
 
   //--------------------------------------------------------------------------------

--- a/src/datasource/responses.types.ts
+++ b/src/datasource/responses.types.ts
@@ -193,6 +193,10 @@ export type LabelModeResponse = {
   systemLabels: string[];
 };
 
+export type RenameCheckLabelsResponse = {
+  updated_ids: number[];
+};
+
 export type CheckAlertsResponse = {
   alerts: CheckAlertPublished[];
 };

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/CollidingLabelRename.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/CollidingLabelRename.tsx
@@ -6,6 +6,7 @@ import { useRenameCheckLabels } from 'data/useRenameCheckLabels';
 
 interface RowState {
   value: string;
+  pending?: boolean;
   renamed?: boolean;
   updatedCount?: number;
   error?: string;
@@ -65,7 +66,9 @@ export function CollidingLabelRename({ labels, systemLabels, disabled, retrying,
       return;
     }
 
-    patchRow(label, { error: undefined });
+    // pending freezes the row's input for the duration of the request, so the
+    // locked row always displays the name that was actually sent.
+    patchRow(label, { error: undefined, pending: true });
     inflight.current.add(label);
 
     try {
@@ -75,6 +78,7 @@ export function CollidingLabelRename({ labels, systemLabels, disabled, retrying,
       const e = err as { data?: { msg?: string } };
       patchRow(label, { error: e?.data?.msg ?? 'Failed to rename label' });
     } finally {
+      patchRow(label, { pending: false });
       inflight.current.delete(label);
     }
   };
@@ -101,7 +105,7 @@ export function CollidingLabelRename({ labels, systemLabels, disabled, retrying,
               <Input
                 width={30}
                 placeholder="New label name"
-                disabled={disabled || row.renamed}
+                disabled={disabled || row.pending || row.renamed}
                 invalid={!!row.error}
                 value={row.value}
                 onChange={(e) => patchRow(label, { value: e.currentTarget.value, error: undefined })}
@@ -111,7 +115,7 @@ export function CollidingLabelRename({ labels, systemLabels, disabled, retrying,
                 size="sm"
                 variant="secondary"
                 onClick={() => rename(label)}
-                disabled={disabled || row.renamed || renameMutation.isPending}
+                disabled={disabled || row.pending || row.renamed || renameMutation.isPending}
               >
                 Rename
               </Button>

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/CollidingLabelRename.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/CollidingLabelRename.tsx
@@ -1,0 +1,137 @@
+import React, { useRef, useState } from 'react';
+import { Button, Field, Input, Space, Stack, Text } from '@grafana/ui';
+
+import { validateLabelName } from 'validation';
+import { useRenameCheckLabels } from 'data/useRenameCheckLabels';
+
+interface RowState {
+  value: string;
+  renamed?: boolean;
+  updatedCount?: number;
+  error?: string;
+}
+
+interface CollidingLabelRenameProps {
+  labels: string[];
+  systemLabels: string[];
+  disabled: boolean;
+  retrying: boolean;
+  onRetry: () => void;
+}
+
+// CollidingLabelRename renders one rename row per colliding label and gates the
+// transition retry on every label having been renamed. Renames only cover
+// checks: a label that reports zero updated checks most likely lives on a
+// probe, which must be edited directly.
+export function CollidingLabelRename({ labels, systemLabels, disabled, retrying, onRetry }: CollidingLabelRenameProps) {
+  const renameMutation = useRenameCheckLabels();
+  const [rows, setRows] = useState<Record<string, RowState>>({});
+  // Guards a same-row double click: isPending only disables the button after a
+  // re-render, so a second click in the same tick would fire a second POST
+  // whose empty result overwrites the first one's updatedCount.
+  const inflight = useRef(new Set<string>());
+
+  const rowFor = (label: string): RowState => rows[label] ?? { value: '' };
+  const patchRow = (label: string, patch: Partial<RowState>) =>
+    setRows((prev) => ({ ...prev, [label]: { ...rowFor(label), ...prev[label], ...patch } }));
+
+  const validate = (label: string, value: string): string | undefined => {
+    if (!value) {
+      return 'Enter a new label name';
+    }
+
+    if (systemLabels.includes(value)) {
+      return `"${value}" is also a reserved system name`;
+    }
+
+    const otherTargets = labels.filter((l) => l !== label).map((l) => rowFor(l).value);
+    if (otherTargets.includes(value)) {
+      return `"${value}" is already the target of another rename`;
+    }
+
+    return validateLabelName(value, []);
+  };
+
+  const rename = async (label: string) => {
+    if (inflight.current.has(label) || rowFor(label).renamed) {
+      return;
+    }
+
+    const value = rowFor(label).value;
+
+    const validationError = validate(label, value);
+    if (validationError) {
+      patchRow(label, { error: validationError });
+      return;
+    }
+
+    patchRow(label, { error: undefined });
+    inflight.current.add(label);
+
+    try {
+      const result = await renameMutation.mutateAsync({ from: label, to: value });
+      patchRow(label, { renamed: true, updatedCount: result.updated_ids.length });
+    } catch (err: unknown) {
+      const e = err as { data?: { msg?: string } };
+      patchRow(label, { error: e?.data?.msg ?? 'Failed to rename label' });
+    } finally {
+      inflight.current.delete(label);
+    }
+  };
+
+  const allRenamed = labels.every((label) => rowFor(label).renamed);
+
+  return (
+    <Stack direction="column" gap={1}>
+      {labels.map((label) => {
+        const row = rowFor(label);
+
+        return (
+          <Field
+            key={label}
+            invalid={!!row.error}
+            error={row.error}
+            label={
+              <Text>
+                <code>{label}</code>
+              </Text>
+            }
+          >
+            <Stack direction="row" gap={1} alignItems="center">
+              <Input
+                width={30}
+                placeholder="New label name"
+                disabled={disabled || row.renamed}
+                invalid={!!row.error}
+                value={row.value}
+                onChange={(e) => patchRow(label, { value: e.currentTarget.value, error: undefined })}
+                data-testid={`rename-input-${label}`}
+              />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => rename(label)}
+                disabled={disabled || row.renamed || renameMutation.isPending}
+              >
+                Rename
+              </Button>
+              {row.renamed && (
+                <Text color="secondary">
+                  {row.updatedCount === 0
+                    ? '✓ no checks carried this label — it may be set on a probe, which must be edited directly'
+                    : `✓ renamed on ${row.updatedCount} check${row.updatedCount === 1 ? '' : 's'}`}
+                </Text>
+              )}
+            </Stack>
+          </Field>
+        );
+      })}
+      <Space v={1} />
+      <div>
+        <Button onClick={onRetry} disabled={disabled || !allRenamed || retrying}>
+          Retry enabling dual-write
+        </Button>
+      </div>
+    </Stack>
+  );
+}

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
@@ -482,4 +482,211 @@ describe('LabelMigrationTab', () => {
       expect(screen.getAllByText('You can change your label mode in 1 hour 10 minutes').length).toBeGreaterThan(0);
     });
   });
+
+  // triggerCollision drives the PREFIXED → DUAL_WRITE attempt into the 409
+  // collision state with the given labels; setLabelMode succeeds on the retry.
+  async function triggerCollision(collidingLabels: string[]) {
+    let attempts = 0;
+    const putBodies: Array<{ mode: number }> = [];
+
+    server.use(
+      apiRoute(
+        'setLabelMode',
+        {
+          result: () => {
+            attempts++;
+            if (attempts === 1) {
+              return { status: 409, json: { msg: 'labels conflict', collidingLabels } };
+            }
+            return { json: { ...TENANT_LABEL_MODE, mode: 1 } };
+          },
+        },
+        async (req) => {
+          putBodies.push((await req.clone().json()) as { mode: number });
+        }
+      )
+    );
+
+    await renderTab();
+    await userEvent.click(await screen.findByRole('button', { name: /Enable dual-write/i }));
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^Enable dual-write$/i }));
+    await waitFor(() => expect(screen.getByText(/Label name conflicts/i)).toBeInTheDocument());
+
+    return putBodies;
+  }
+
+  it('renames colliding labels and retries the transition end to end', async () => {
+    runTestAsSMAdmin();
+    const renameRequests: Array<{ url: string; body: { name: string } }> = [];
+    server.use(
+      apiRoute('renameCheckLabels', {}, async (req) => {
+        renameRequests.push({ url: req.url, body: (await req.clone().json()) as { name: string } });
+      })
+    );
+
+    const putBodies = await triggerCollision(['probe', 'instance']);
+
+    // The retry is gated until every colliding label has been renamed.
+    expect(screen.getByRole('button', { name: /Retry enabling dual-write/i })).toBeDisabled();
+
+    await userEvent.type(screen.getByTestId('rename-input-probe'), 'probe_alias');
+    await userEvent.click(screen.getAllByRole('button', { name: /^Rename$/i })[0]);
+    await waitFor(() => expect(screen.getByText(/renamed on 2 checks/i)).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /Retry enabling dual-write/i })).toBeDisabled();
+
+    await userEvent.type(screen.getByTestId('rename-input-instance'), 'instance_alias');
+    await userEvent.click(screen.getAllByRole('button', { name: /^Rename$/i })[1]);
+    await waitFor(() => expect(screen.getAllByText(/renamed on 2 checks/i)).toHaveLength(2));
+
+    expect(renameRequests).toHaveLength(2);
+    expect(renameRequests[0].url).toContain('/sm/check/labels/probe');
+    expect(renameRequests[0].body).toEqual({ name: 'probe_alias' });
+    expect(renameRequests[1].url).toContain('/sm/check/labels/instance');
+    expect(renameRequests[1].body).toEqual({ name: 'instance_alias' });
+
+    const retry = screen.getByRole('button', { name: /Retry enabling dual-write/i });
+    await waitFor(() => expect(retry).toBeEnabled());
+    await userEvent.click(retry);
+
+    await waitFor(() => expect(screen.getByText(/Dual-write is active/i)).toBeInTheDocument());
+    expect(putBodies).toEqual([{ mode: 1 }, { mode: 1 }]);
+  });
+
+  it('rejects reserved, duplicate, and invalid rename targets client-side', async () => {
+    runTestAsSMAdmin();
+    const renameRequests: string[] = [];
+    server.use(
+      apiRoute('renameCheckLabels', {}, async (req) => {
+        renameRequests.push(req.url);
+      })
+    );
+
+    await triggerCollision(['probe', 'instance']);
+
+    // Reserved: "geohash" is in the fixture's systemLabels.
+    await userEvent.type(screen.getByTestId('rename-input-probe'), 'geohash');
+    await userEvent.click(screen.getAllByRole('button', { name: /^Rename$/i })[0]);
+    await waitFor(() => expect(screen.getByText(/"geohash" is also a reserved system name/i)).toBeInTheDocument());
+
+    // Invalid label syntax.
+    await userEvent.clear(screen.getByTestId('rename-input-probe'));
+    await userEvent.type(screen.getByTestId('rename-input-probe'), '0bad-name');
+    await userEvent.click(screen.getAllByRole('button', { name: /^Rename$/i })[0]);
+    await waitFor(() => expect(screen.getByText(/Invalid label name/i)).toBeInTheDocument());
+
+    // Duplicate target across rows.
+    await userEvent.clear(screen.getByTestId('rename-input-probe'));
+    await userEvent.type(screen.getByTestId('rename-input-probe'), 'same_target');
+    await userEvent.type(screen.getByTestId('rename-input-instance'), 'same_target');
+    await userEvent.click(screen.getAllByRole('button', { name: /^Rename$/i })[1]);
+    await waitFor(() =>
+      expect(screen.getByText(/"same_target" is already the target of another rename/i)).toBeInTheDocument()
+    );
+
+    // None of the rejected attempts reached the API.
+    expect(renameRequests).toHaveLength(0);
+  });
+
+  it('surfaces the API conflict when a check already carries both label keys', async () => {
+    runTestAsSMAdmin();
+    server.use(
+      apiRoute('renameCheckLabels', {
+        result: () => ({
+          status: 409,
+          json: { msg: 'cannot rename "probe" to "probe_alias": one or more checks already carry both label keys' },
+        }),
+      })
+    );
+
+    await triggerCollision(['probe']);
+
+    await userEvent.type(screen.getByTestId('rename-input-probe'), 'probe_alias');
+    await userEvent.click(screen.getByRole('button', { name: /^Rename$/i }));
+    await waitFor(() => expect(screen.getByText(/already carry both label keys/i)).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /Retry enabling dual-write/i })).toBeDisabled();
+  });
+
+  it('hints at probe labels when a rename matches no checks', async () => {
+    runTestAsSMAdmin();
+    server.use(
+      apiRoute('renameCheckLabels', {
+        result: () => ({ json: { updated_ids: [] } }),
+      })
+    );
+
+    await triggerCollision(['probe']);
+
+    await userEvent.type(screen.getByTestId('rename-input-probe'), 'probe_alias');
+    await userEvent.click(screen.getByRole('button', { name: /^Rename$/i }));
+    await waitFor(() => expect(screen.getByText(/it may be set on a probe/i)).toBeInTheDocument());
+    // The gate opens even though nothing was fixed: the retry will 409 again
+    // and remount the flow — deliberate, since only the API knows the truth.
+    expect(screen.getByRole('button', { name: /Retry enabling dual-write/i })).toBeEnabled();
+  });
+
+  it('locks a row after a successful rename', async () => {
+    runTestAsSMAdmin();
+    await triggerCollision(['probe']);
+
+    await userEvent.type(screen.getByTestId('rename-input-probe'), 'probe_alias');
+    await userEvent.click(screen.getByRole('button', { name: /^Rename$/i }));
+    await waitFor(() => expect(screen.getByText(/renamed on 2 checks/i)).toBeInTheDocument());
+
+    expect(screen.getByTestId('rename-input-probe')).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^Rename$/i })).toBeDisabled();
+  });
+
+  it('falls back to a generic error when a rename failure carries no message', async () => {
+    runTestAsSMAdmin();
+    server.use(
+      apiRoute('renameCheckLabels', {
+        result: () => ({ status: 500, json: {} }),
+      })
+    );
+
+    await triggerCollision(['probe']);
+
+    await userEvent.type(screen.getByTestId('rename-input-probe'), 'probe_alias');
+    await userEvent.click(screen.getByRole('button', { name: /^Rename$/i }));
+    await waitFor(() => expect(screen.getByText(/Failed to rename label/i)).toBeInTheDocument());
+  });
+
+  it('mounts a fresh rename flow when the retry collides again', async () => {
+    runTestAsSMAdmin();
+
+    // First attempt collides on "probe"; the retry collides on "instance"
+    // (e.g. a probe-borne label surfaced after the check rename).
+    let attempts = 0;
+    server.use(
+      apiRoute('setLabelMode', {
+        result: () => {
+          attempts++;
+          if (attempts === 1) {
+            return { status: 409, json: { msg: 'labels conflict', collidingLabels: ['probe'] } };
+          }
+          return { status: 409, json: { msg: 'labels conflict', collidingLabels: ['instance'] } };
+        },
+      })
+    );
+
+    await renderTab();
+    await userEvent.click(await screen.findByRole('button', { name: /Enable dual-write/i }));
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^Enable dual-write$/i }));
+    await waitFor(() => expect(screen.getByTestId('rename-input-probe')).toBeInTheDocument());
+
+    await userEvent.type(screen.getByTestId('rename-input-probe'), 'probe_alias');
+    await userEvent.click(screen.getByRole('button', { name: /^Rename$/i }));
+    await waitFor(() => expect(screen.getByText(/renamed on 2 checks/i)).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /Retry enabling dual-write/i }));
+
+    // The second 409 remounts the flow against the new label list: no stale
+    // renamed markers, empty input, gate closed again.
+    await waitFor(() => expect(screen.getByTestId('rename-input-instance')).toBeInTheDocument());
+    expect(screen.queryByTestId('rename-input-probe')).not.toBeInTheDocument();
+    expect(screen.queryByText(/renamed on 2 checks/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('rename-input-instance')).toHaveValue('');
+    expect(screen.getByRole('button', { name: /Retry enabling dual-write/i })).toBeDisabled();
+  });
 });

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
@@ -274,7 +274,7 @@ describe('LabelMigrationTab', () => {
     expect(putCount).toBe(0);
   });
 
-  it('keeps the collision list through reopen and cancel, clearing it on the next attempt', async () => {
+  it('clears the collision state when a fresh attempt after dismissal succeeds', async () => {
     runTestAsSMAdmin();
     let calls = 0;
     server.use(
@@ -296,15 +296,11 @@ describe('LabelMigrationTab', () => {
     await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
     await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^Enable dual-write$/i }));
     await waitFor(() => expect(screen.getByText(/Label name conflicts/i)).toBeInTheDocument());
-    // Reopening and cancelling must not discard the rename guidance.
-    await userEvent.click(screen.getByRole('button', { name: /Enable dual-write/i }));
-    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
-    expect(screen.getByText(/Label name conflicts/i)).toBeInTheDocument();
-    await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /Cancel/i }));
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-    expect(screen.getByText(/Label name conflicts/i)).toBeInTheDocument();
-    // A new attempt replaces the outcome: this one succeeds and the alert clears.
-    await userEvent.click(screen.getByRole('button', { name: /Enable dual-write/i }));
+    // The original Enable button is hidden while the alert is up; dismissing
+    // the alert restores it, and a fresh successful attempt replaces the
+    // collision outcome.
+    await userEvent.click(screen.getByLabelText('Close alert'));
+    await userEvent.click(await screen.findByRole('button', { name: /Enable dual-write/i }));
     await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
     await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^Enable dual-write$/i }));
     await waitFor(() => expect(screen.getByText(/Dual-write is active/i)).toBeInTheDocument());
@@ -635,6 +631,49 @@ describe('LabelMigrationTab', () => {
 
     expect(screen.getByTestId('rename-input-probe')).toBeDisabled();
     expect(screen.getByRole('button', { name: /^Rename$/i })).toBeDisabled();
+  });
+
+  it('hides the original Enable dual-write button while the conflicts alert is shown', async () => {
+    runTestAsSMAdmin();
+    await triggerCollision(['probe']);
+
+    // The alert's "Retry enabling dual-write" is the only path into dual-write
+    // while conflicts are unresolved.
+    expect(screen.queryByRole('button', { name: /^Enable dual-write$/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Retry enabling dual-write/i })).toBeInTheDocument();
+
+    // Dismissing the alert restores the original button.
+    await userEvent.click(screen.getByLabelText('Close alert'));
+    expect(await screen.findByRole('button', { name: /Enable dual-write/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Retry enabling dual-write/i })).not.toBeInTheDocument();
+  });
+
+  it('freezes a row while its rename request is in flight', async () => {
+    runTestAsSMAdmin();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    server.use(
+      apiRoute('renameCheckLabels', {
+        result: async () => {
+          await gate;
+          return { json: { updated_ids: [1, 2] } };
+        },
+      })
+    );
+
+    await triggerCollision(['probe']);
+
+    await userEvent.type(screen.getByTestId('rename-input-probe'), 'probe_alias');
+    await userEvent.click(screen.getByRole('button', { name: /^Rename$/i }));
+
+    // The input locks for the duration of the request, so the value shown on
+    // the locked row is exactly the name that was sent.
+    await waitFor(() => expect(screen.getByTestId('rename-input-probe')).toBeDisabled());
+    expect(screen.getByRole('button', { name: /^Rename$/i })).toBeDisabled();
+
+    release();
+    await waitFor(() => expect(screen.getByText(/renamed on 2 checks/i)).toBeInTheDocument());
+    expect(screen.getByTestId('rename-input-probe')).toHaveValue('probe_alias');
   });
 
   it('falls back to a generic error when a rename failure carries no message', async () => {

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
@@ -117,7 +117,9 @@ export function LabelMigrationTab() {
                   labels. Enabling dual-write is permanent: you cannot return to prefixed-only labels afterwards.
                 </Text>
                 <Space v={2} />
-                {isAdmin && (
+                {/* While the conflicts alert is up, its "Retry enabling dual-write"
+                    button is the only sanctioned path into dual-write. */}
+                {isAdmin && !collisionError && (
                   <Button
                     onClick={() =>
                       openConfirm(

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
@@ -9,6 +9,7 @@ import { ConfirmModal } from 'components/ConfirmModal';
 import { ContactAdminAlert } from 'page/ContactAdminAlert';
 
 import { ConfigContent } from '../../ConfigContent';
+import { CollidingLabelRename } from './CollidingLabelRename';
 import { getMigrationCooldown } from './migrationCooldown';
 import { SeriesPreview } from './SeriesPreview';
 import { useCheckInfoLabels } from './useCheckInfoLabels';
@@ -234,17 +235,17 @@ export function LabelMigrationTab() {
                   onRemove={() => setCollisionError(undefined)}
                 >
                   <Text>
-                    The following labels conflict with reserved system names. Rename or remove them from your checks and
-                    probes, then try again:
+                    The following labels conflict with reserved system names. Rename them across your checks below, then
+                    retry. Labels set on probes are not covered by the rename and must be edited on the probe itself.
                   </Text>
                   <Space v={1} />
-                  <ul>
-                    {collisionError.collidingLabels.map((name) => (
-                      <li key={name}>
-                        <code>{name}</code>
-                      </li>
-                    ))}
-                  </ul>
+                  <CollidingLabelRename
+                    labels={collisionError.collidingLabels}
+                    systemLabels={state.systemLabels}
+                    disabled={!isAdmin}
+                    retrying={busy}
+                    onRetry={() => applyMode(LabelMode.DualWrite)}
+                  />
                 </Alert>
               </>
             )}

--- a/src/test/handlers/checks.ts
+++ b/src/test/handlers/checks.ts
@@ -8,6 +8,7 @@ import {
   CheckInfoResult,
   DeleteCheckResult,
   ListCheckResult,
+  RenameCheckLabelsResponse,
   UpdateCheckResult,
 } from 'datasource/responses.types';
 
@@ -85,6 +86,16 @@ export const testCheck: ApiEntry<AdHocCheckResponse> = {
   result: () => {
     return {
       json: ADHOC_CHECK_RESULT,
+    };
+  },
+};
+
+export const renameCheckLabels: ApiEntry<RenameCheckLabelsResponse> = {
+  route: `/sm/check/labels/([^/]+)`,
+  method: `post`,
+  result: () => {
+    return {
+      json: { updated_ids: [1, 2] },
     };
   },
 };

--- a/src/test/handlers/index.ts
+++ b/src/test/handlers/index.ts
@@ -6,6 +6,7 @@ import {
   checkInfo,
   deleteCheck,
   listChecks,
+  renameCheckLabels,
   testCheck,
   updateCheck,
 } from 'test/handlers/checks';
@@ -72,6 +73,7 @@ const API_ROUTES = {
   listProbes,
   listSecrets,
   moveFolder,
+  renameCheckLabels,
   setLabelMode,
   testCheck,
   updateAlertsForCheck,


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring/issues/657

The Label Migration UI allows users to attempt to change the state of labelling in the synthetic-monitoring-agent and eventually move off of the `label_` prefix.

The API call to do so returns a `409` if any of the user's custom labels clash with our system-reserved labels.

This enhances the UI by providing an interface for users to rename custom labels across their checks to assist them in resolving the clash so they can proceed with the label migration.

Backed by the bulk rename endpoint (`POST /check/labels/{key}`, [OpenAPI spec](https://synthetic-monitoring-api.grafana.net/api/v1/swagger#/operations/POST_/api/v1/check/labels/:key)), and a **Retry enabling dual-write** button gated until every label has been renamed.

## Behavior

- Rename targets are validated client-side (label syntax, not a reserved name, not the target of another row) before any request; the API's both-keys 409 renders inline on the row.
- A successful rename locks its row and reports how many checks changed.
- **Scope: checks only.** The collision pre-check also scans probe labels, but the rename endpoint covers checks; a rename that matches no checks shows a hint that the label may live on a probe, which must be edited directly (accepted v1 limitation — the 409 response doesn't distinguish sources). The retry gate still opens in that case: the retry simply 409s again with the remaining labels and the flow remounts fresh against the new list.
- Each new 409 remounts the rename flow, so state never goes stale across attempts.

## Testing

Seven new tests: the full collide → rename (path + body asserted) → retry → dual-write flow; client-side rejection of reserved/duplicate/invalid targets with zero API calls; inline both-keys conflict; probe hint with the gate deliberately open; row lock after success; fallback error text; and the second-409 remount asserting no stale state survives.