### PR TITLE
feat(reliability-inbox): Gate the feature on Assistant availability

### DIFF
--- a/src/components/AssistantContext/AssistantContext.constants.ts
+++ b/src/components/AssistantContext/AssistantContext.constants.ts
@@ -5,12 +5,12 @@ import { AppRoutes } from 'routing/types';
 
 /**
  * Routes that are intentionally not registered with the Grafana Assistant
- * because they have no user-facing surface area (they immediately redirect
- * elsewhere on mount; see SceneRedirecter).
+ * because they redirect immediately or provide action-scoped context.
  */
 export const ASSISTANT_CONTEXT_EXCLUDED_ROUTES: ReadonlySet<AppRoutes> = new Set([
   AppRoutes.Redirect,
   AppRoutes.Scene,
+  AppRoutes.ReliabilityInbox,
 ]);
 
 interface AssistantPageContextEntry {

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -42,6 +42,7 @@ import { DEFAULT_LOGS_DS_UID, DEFAULT_METRICS_DS_UID } from 'datasource/constant
 import { ExtendedBulkUpdateCheckResult } from 'data/useChecks';
 
 import { LokiQueryResults } from '../components/Checkster/feature/adhoc-check/useAdHocLogs';
+import { reliabilityInboxURL } from './reliabilityInboxRegion';
 import { parseTracerouteLogs } from './traceroute-utils';
 
 export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
@@ -268,6 +269,51 @@ export class SMDataSource extends DataSourceApi<SMQuery, SMOptions> {
         to: String(to),
       },
     });
+  }
+
+  //--------------------------------------------------------------------------------
+  // RELIABILITY INBOX (experimental)
+  //--------------------------------------------------------------------------------
+
+  /**
+   * Whether a reliability-inbox instance serves this stack's region. Callers
+   * should hide the feature when this is false, rather than calling and handling
+   * the error.
+   */
+  supportsReliabilityInbox(): boolean {
+    return reliabilityInboxURL(this.instanceSettings.jsonData.apiHost) !== undefined;
+  }
+
+  /**
+   * Asks which checks this tenant should consider adding.
+   */
+  async getReliabilityInboxSuggestions(): Promise<unknown> {
+    const url = reliabilityInboxURL(this.instanceSettings.jsonData.apiHost);
+    if (!url) {
+      throw new Error('The reliability inbox is not available in this region');
+    }
+
+    // Called directly instead of through the datasource proxy. The proxy would
+    // inject the token from secureJsonData, but its route cannot exist until
+    // these plugin.json changes ship in a released plugin version — Grafana
+    // registers proxy routes server-side from the installed plugin. So we mint a
+    // token ourselves and the service accepts our origin via CORS.
+    //
+    // createApiToken adds a token rather than rotating the stored one, so this
+    // does not disturb the datasource.
+    const token = await this.createApiToken();
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+
+    if (!response.ok) {
+      throw new Error(`The reliability inbox returned ${response.status}`);
+    }
+
+    return response.json();
   }
 
   //--------------------------------------------------------------------------------

--- a/src/datasource/reliabilityInboxRegion.test.ts
+++ b/src/datasource/reliabilityInboxRegion.test.ts
@@ -1,0 +1,57 @@
+import { reliabilityInboxURL } from './reliabilityInboxRegion';
+
+const suggestions = (host: string) => `https://${host}/api/v1alpha1/reliability-inbox/suggestions`;
+
+describe('reliabilityInboxURL', () => {
+  describe('dev', () => {
+    it.each([
+      ['synthetic-monitoring-api-eu-west-2.grafana-dev.net', 'k6-experiments-dev-eu-west-2.grafana-dev.net'],
+      ['synthetic-monitoring-api-us-east-0.grafana-dev.net', 'k6-experiments-dev-us-east-0.grafana-dev.net'],
+      [
+        'synthetic-monitoring-api-eu-west-6.gcp-europe-west10-0.grafana-dev.net',
+        'k6-experiments-dev-eu-west-6.gcp-europe-west10-0.grafana-dev.net',
+      ],
+      [
+        'synthetic-monitoring-api-us-east-3.dev-us-east-3.grafana-dev.net',
+        'k6-experiments-dev-us-east-3.dev-us-east-3.grafana-dev.net',
+      ],
+      ['synthetic-monitoring-api-dev.grafana-dev.net', 'k6-experiments-dev-us-central-0.grafana-dev.net'],
+    ])('%s', (apiHost, expected) => {
+      expect(reliabilityInboxURL(`https://${apiHost}`)).toBe(suggestions(expected));
+    });
+  });
+
+  describe('ops', () => {
+    it('derives the ops instance', () => {
+      expect(reliabilityInboxURL('https://synthetic-monitoring-api-eu-south-0.grafana-ops.net')).toBe(
+        suggestions('k6-experiments-ops-eu-south-0.grafana-ops.net')
+      );
+    });
+  });
+
+  describe('formatting tolerance', () => {
+    it.each([
+      'synthetic-monitoring-api-dev.grafana-dev.net',
+      'synthetic-monitoring-api-dev.grafana-dev.net/',
+      'https://synthetic-monitoring-api-dev.grafana-dev.net',
+      'HTTPS://Synthetic-Monitoring-API-DEV.grafana-dev.net',
+      '  https://synthetic-monitoring-api-dev.grafana-dev.net  ',
+    ])('%s', (apiHost) => {
+      expect(reliabilityInboxURL(apiHost)).toBe(suggestions('k6-experiments-dev-us-central-0.grafana-dev.net'));
+    });
+  });
+
+  describe('fails closed', () => {
+    it.each([
+      ['', 'empty'],
+      ['not a url', 'garbage'],
+      ['https://example.com', 'unknown domain'],
+      ['https://synthetic-monitoring-api-us-east-0.grafana.net', 'production is not deployed'],
+      ['https://grafana-dev.net', 'no host label'],
+      ['https://prometheus-dev-01-dev-us-central-0.grafana-dev.net', 'not the SM API'],
+      ['https://synthetic-monitoring-api.grafana-dev.net', 'bare prefix without an override'],
+    ])('%s (%s)', (apiHost) => {
+      expect(reliabilityInboxURL(apiHost)).toBeUndefined();
+    });
+  });
+});

--- a/src/datasource/reliabilityInboxRegion.ts
+++ b/src/datasource/reliabilityInboxRegion.ts
@@ -1,0 +1,37 @@
+const DEPLOYED_DOMAINS = [
+  ['.grafana-dev.net', 'dev'],
+  ['.grafana-ops.net', 'ops'],
+] as const;
+
+const SM_API_PREFIX = 'synthetic-monitoring-api-';
+const SUGGESTIONS_PATH = '/api/v1alpha1/reliability-inbox/suggestions';
+
+/** Returns the co-located experimental service URL, failing closed elsewhere. */
+export function reliabilityInboxURL(apiHost: string): string | undefined {
+  const trimmed = apiHost?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  let hostname: string;
+  try {
+    hostname = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+
+  const deployment = DEPLOYED_DOMAINS.find(([suffix]) => hostname.endsWith(suffix));
+  const [label, ...domain] = hostname.split('.');
+  if (!deployment || !label.startsWith(SM_API_PREFIX) || domain.length === 0) {
+    return undefined;
+  }
+
+  const [, environment] = deployment;
+  const smRegion = label.slice(SM_API_PREFIX.length);
+  const region = environment === 'dev' && smRegion === 'dev' ? 'us-central-0' : smRegion;
+  if (!region) {
+    return undefined;
+  }
+
+  return `https://k6-experiments-${environment}-${region}.${domain.join('.')}${SUGGESTIONS_PATH}`;
+}

--- a/src/features/reliabilityInbox/ReliabilityInboxBanner.test.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxBanner.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { trackInboxExposure, trackReviewEntryClicked } from 'features/tracking/reliabilityInboxEvents';
+import { HTTP_RELIABILITY_SUGGESTION } from 'test/fixtures/reliabilityInbox';
+
+import { AppRoutes } from 'routing/types';
+import { generateRoutePath } from 'routing/utils';
+
+import { useCachedReliabilityInboxSuggestions } from './data';
+import { toReliabilityOpportunity } from './model';
+import { ReliabilityInboxBanner } from './ReliabilityInboxBanner';
+
+jest.mock('./data', () => ({ useCachedReliabilityInboxSuggestions: jest.fn() }));
+jest.mock('features/tracking/reliabilityInboxEvents', () => ({
+  trackInboxExposure: jest.fn(),
+  trackReviewEntryClicked: jest.fn(),
+}));
+
+const OPPORTUNITY = toReliabilityOpportunity(HTTP_RELIABILITY_SUGGESTION);
+
+describe('ReliabilityInboxBanner', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('links the next recommendation to the review page', async () => {
+    jest.mocked(useCachedReliabilityInboxSuggestions).mockReturnValue({
+      data: [OPPORTUNITY],
+    } as ReturnType<typeof useCachedReliabilityInboxSuggestions>);
+    const user = userEvent.setup();
+
+    render(<ReliabilityInboxBanner />);
+
+    expect(screen.getByText('Reliability Inbox · 1 opportunity')).toBeInTheDocument();
+    expect(screen.getByText('Recommended next: mcp.goagain.dev')).toBeInTheDocument();
+    const reviewLink = screen.getByRole('link', { name: 'Review suggestions' });
+    expect(reviewLink).toHaveAttribute('href', generateRoutePath(AppRoutes.ReliabilityInbox));
+    await waitFor(() =>
+      expect(trackInboxExposure).toHaveBeenCalledWith({
+        opportunityCount: 1,
+        topOpportunityId: 'http-suggestion',
+      })
+    );
+
+    await user.click(reviewLink);
+    expect(trackReviewEntryClicked).toHaveBeenCalledWith({ opportunityId: 'http-suggestion' });
+  });
+
+  it('does not generate suggestions when the cache is empty', () => {
+    jest.mocked(useCachedReliabilityInboxSuggestions).mockReturnValue({
+      data: undefined,
+    } as ReturnType<typeof useCachedReliabilityInboxSuggestions>);
+
+    render(<ReliabilityInboxBanner />);
+
+    expect(screen.getByText('Generate actionable recommendations when you are ready to review them.')).toBeInTheDocument();
+    expect(screen.queryByText(/Recommended next:/)).not.toBeInTheDocument();
+    expect(trackInboxExposure).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/reliabilityInbox/ReliabilityInboxBanner.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxBanner.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from 'react';
+import { Box, Icon, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+import { trackInboxExposure, trackReviewEntryClicked } from 'features/tracking/reliabilityInboxEvents';
+
+import { AppRoutes } from 'routing/types';
+import { generateRoutePath } from 'routing/utils';
+
+import { getAssistantActionStyle } from './assistantActionStyles';
+import { useCachedReliabilityInboxSuggestions } from './data';
+
+export function ReliabilityInboxBanner() {
+  const assistantAction = useStyles2(getAssistantActionStyle);
+  const { data: opportunities = [] } = useCachedReliabilityInboxSuggestions();
+  const exposureTracked = useRef(false);
+  const topOpportunity = opportunities[0];
+
+  useEffect(() => {
+    if (!topOpportunity || exposureTracked.current) {
+      return;
+    }
+
+    exposureTracked.current = true;
+    trackInboxExposure({
+      opportunityCount: opportunities.length,
+      topOpportunityId: topOpportunity.id,
+    });
+  }, [opportunities.length, topOpportunity]);
+
+  return (
+    <Box
+      element="section"
+      aria-label="Reliability Inbox"
+      paddingY={1}
+      paddingX={2}
+      borderStyle="solid"
+      borderColor="medium"
+      borderRadius="default"
+      backgroundColor="secondary"
+    >
+      <Stack alignItems="center" justifyContent="space-between" gap={2} wrap="wrap">
+        <Stack alignItems="center" gap={1}>
+          <Icon name="ai-sparkle" aria-hidden="true" />
+          <Stack direction="column" alignItems="flex-start" gap={0.25}>
+            <Text weight="bold">
+              {topOpportunity
+                ? `Reliability Inbox · ${opportunities.length} ${opportunities.length === 1 ? 'opportunity' : 'opportunities'}`
+                : 'Reliability Inbox'}
+            </Text>
+            <Text color="secondary" variant="bodySmall">
+              {topOpportunity
+                ? `Recommended next: ${topOpportunity.subject}`
+                : 'Generate actionable recommendations when you are ready to review them.'}
+            </Text>
+          </Stack>
+        </Stack>
+        <LinkButton
+          className={assistantAction}
+          icon="ai-sparkle"
+          variant="secondary"
+          href={generateRoutePath(AppRoutes.ReliabilityInbox)}
+          onClick={() => {
+            if (topOpportunity) {
+              trackReviewEntryClicked({ opportunityId: topOpportunity.id });
+            }
+          }}
+        >
+          Review suggestions
+        </LinkButton>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/features/reliabilityInbox/ReliabilityInboxBanner.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxBanner.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import { useAssistant } from '@grafana/assistant';
 import { Box, Icon, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
 import { trackInboxExposure, trackReviewEntryClicked } from 'features/tracking/reliabilityInboxEvents';
 
@@ -10,11 +11,16 @@ import { useCachedReliabilityInboxSuggestions } from './data';
 
 export function ReliabilityInboxBanner() {
   const assistantAction = useStyles2(getAssistantActionStyle);
+  const { isAvailable: isAssistantAvailable, isLoading: isAssistantLoading } = useAssistant();
   const { data: opportunities = [] } = useCachedReliabilityInboxSuggestions();
   const exposureTracked = useRef(false);
   const topOpportunity = opportunities[0];
 
   useEffect(() => {
+    if (isAssistantLoading || !isAssistantAvailable) {
+      return;
+    }
+
     if (!topOpportunity || exposureTracked.current) {
       return;
     }
@@ -24,7 +30,11 @@ export function ReliabilityInboxBanner() {
       opportunityCount: opportunities.length,
       topOpportunityId: topOpportunity.id,
     });
-  }, [opportunities.length, topOpportunity]);
+  }, [opportunities.length, topOpportunity, isAssistantLoading, isAssistantAvailable]);
+
+  if (isAssistantLoading || !isAssistantAvailable) {
+    return null;
+  }
 
   return (
     <Box

--- a/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { useAssistant } from '@grafana/assistant';
+import { screen, within } from '@testing-library/react';
+import { trackRecommendationReviewed, trackSetupWithAssistant } from 'features/tracking/reliabilityInboxEvents';
+import { HTTP_RELIABILITY_SUGGESTION } from 'test/fixtures/reliabilityInbox';
+import { render } from 'test/render';
+
+import { ReliabilitySuggestion } from './types';
+import { AppRoutes } from 'routing/types';
+import { generateRoutePath, getRoute } from 'routing/utils';
+
+import { useReliabilityInboxSuggestions } from './data';
+import { toReliabilityOpportunity } from './model';
+import { ReliabilityInboxPage } from './ReliabilityInboxPage';
+
+jest.mock('./data', () => ({
+  useReliabilityInboxSuggestions: jest.fn(),
+}));
+
+jest.mock('features/tracking/reliabilityInboxEvents', () => ({
+  trackRecommendationReviewed: jest.fn(),
+  trackSetupWithAssistant: jest.fn(),
+}));
+
+const LOWER_PRIORITY_HTTP_SUGGESTION: ReliabilitySuggestion = {
+  ...HTTP_RELIABILITY_SUGGESTION,
+  id: 'lower-priority-http-suggestion',
+  target: 'https://secondary.goagain.dev/',
+  relevance: 20,
+  evidence: {
+    ...HTTP_RELIABILITY_SUGGESTION.evidence,
+    reqPerS: 0.5,
+  },
+};
+
+const openAssistant = jest.fn();
+
+function renderPage(suggestions: ReliabilitySuggestion[] = [HTTP_RELIABILITY_SUGGESTION]) {
+  const result = {
+    data: suggestions.map(toReliabilityOpportunity),
+    isLoading: false,
+    isError: false,
+    refetch: jest.fn(),
+  } as unknown as ReturnType<typeof useReliabilityInboxSuggestions>;
+
+  jest.mocked(useReliabilityInboxSuggestions).mockReturnValue(result);
+
+  return render(<ReliabilityInboxPage />, {
+    path: generateRoutePath(AppRoutes.ReliabilityInbox),
+    route: getRoute(AppRoutes.ReliabilityInbox),
+  });
+}
+
+describe('ReliabilityInboxPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useAssistant).mockReturnValue({
+      isAvailable: true,
+      isLoading: false,
+      openAssistant,
+      closeAssistant: jest.fn(),
+      toggleAssistant: jest.fn(),
+    });
+  });
+
+  it('separates the suggested check from the evidence behind it', async () => {
+    const { user } = renderPage();
+
+    await screen.findByRole('heading', { name: 'Create an HTTP check' });
+
+    const suggestedCheck = screen.getByRole('region', { name: 'Create an HTTP check' });
+    const evidence = screen.getByRole('region', { name: 'Why this recommendation' });
+    expect(within(suggestedCheck).getByText('Suggested check')).toBeInTheDocument();
+    expect(within(evidence).getByRole('heading', { name: 'Observed traffic evidence' })).toBeInTheDocument();
+    expect(within(suggestedCheck).getByLabelText('Suggested check endpoint')).toHaveTextContent(
+      'MethodGETTargetmcp.goagain.dev'
+    );
+    expect(within(evidence).getByRole('link', { name: 'Explore telemetry' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('/explore?')
+    );
+
+    await user.click(within(evidence).getByText('How we checked'));
+    expect(
+      within(evidence).getByText(
+        'We compared the endpoint and path with accessible HTTP checks. Aliases, redirects, upstream checks, and checks for other paths may not match directly.'
+      )
+    ).toBeVisible();
+    expect(trackRecommendationReviewed).toHaveBeenCalledWith({ opportunityId: 'http-suggestion' });
+  });
+
+  it('updates the detail pane when a different recommendation is selected', async () => {
+    const { user } = renderPage([HTTP_RELIABILITY_SUGGESTION, LOWER_PRIORITY_HTTP_SUGGESTION]);
+
+    await screen.findByRole('heading', { name: 'Create an HTTP check' });
+
+    const queue = screen.getByLabelText('Recommendations');
+    const queueItems = within(queue).getAllByRole('button');
+    await user.click(queueItems[1]);
+
+    expect(queueItems[0]).toHaveAttribute('aria-pressed', 'false');
+    expect(queueItems[1]).toHaveAttribute('aria-pressed', 'true');
+    expect(
+      within(screen.getByLabelText('Suggested check endpoint')).getByText('secondary.goagain.dev')
+    ).toBeInTheDocument();
+    expect(trackRecommendationReviewed).toHaveBeenCalledWith({ opportunityId: 'lower-priority-http-suggestion' });
+  });
+
+  it('does not render missing aggregate evidence as zero', async () => {
+    renderPage([
+      {
+        ...HTTP_RELIABILITY_SUGGESTION,
+        evidence: {
+          statusDistribution: {},
+          families: HTTP_RELIABILITY_SUGGESTION.evidence.families,
+        },
+      },
+    ]);
+
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'No aggregate traffic values were returned for this suggestion.'
+    );
+    expect(screen.queryByText('0 req/s')).not.toBeInTheDocument();
+    expect(screen.queryByText('0 ms')).not.toBeInTheDocument();
+    expect(screen.queryByText('0.0%')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Explore telemetry' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the existing page-level loading state while evidence is loading', async () => {
+    jest.mocked(useReliabilityInboxSuggestions).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      refetch: jest.fn(),
+    } as unknown as ReturnType<typeof useReliabilityInboxSuggestions>);
+
+    render(<ReliabilityInboxPage />, {
+      path: generateRoutePath(AppRoutes.ReliabilityInbox),
+      route: getRoute(AppRoutes.ReliabilityInbox),
+    });
+
+    expect(await screen.findByText('Loading Reliability Inbox…')).toBeInTheDocument();
+    expect(screen.queryByText('Why this recommendation')).not.toBeInTheDocument();
+  });
+
+  it('shows a compact proposed check with configuration details on demand', async () => {
+    const { user } = renderPage();
+
+    const suggestedCheck = await screen.findByRole('region', { name: 'Create an HTTP check' });
+    expect(within(suggestedCheck).getByText('Public HTTP')).toBeInTheDocument();
+    expect(within(suggestedCheck).getByText('Every 1 minute')).toBeInTheDocument();
+    expect(within(suggestedCheck).getAllByText('Require HTTPS')[0]).toBeInTheDocument();
+    expect(within(suggestedCheck).getByText('Run from the configured public probe with ID 7.')).not.toBeVisible();
+
+    const configurationDisclosure = within(suggestedCheck).getByText('View configuration details').closest('details');
+    expect(configurationDisclosure).not.toHaveAttribute('open');
+    expect(within(suggestedCheck).getByText('https://mcp.goagain.dev/')).not.toBeVisible();
+    await user.click(within(suggestedCheck).getByText('View configuration details'));
+    expect(configurationDisclosure).toHaveAttribute('open');
+    expect(within(suggestedCheck).getByText('https://mcp.goagain.dev/')).toBeVisible();
+    expect(within(suggestedCheck).getByRole('button', { name: 'Copy target URL' })).toBeVisible();
+    expect(within(suggestedCheck).getByText('2 seconds')).toBeVisible();
+    expect(within(configurationDisclosure!).getByText('Require HTTPS')).toBeVisible();
+    expect(within(configurationDisclosure!).getByText('Run from the configured public probe with ID 7.')).toBeVisible();
+
+    expect(within(suggestedCheck).getByRole('button', { name: 'Review and customize' })).toBeInTheDocument();
+    expect(within(suggestedCheck).getByRole('button', { name: 'Review and customize' })).toHaveAttribute(
+      'aria-describedby',
+      'reliability-inbox-assistant-action-help'
+    );
+    expect(
+      within(suggestedCheck).getByText(
+        'Assistant will guide setup and recommend a configuration from this proposal. Nothing is created or saved until you confirm.'
+      )
+    ).toBeInTheDocument();
+    expect(openAssistant).not.toHaveBeenCalled();
+  });
+
+  it('hands structured evidence and draft to Assistant as bounded setup guidance', async () => {
+    const { user } = renderPage();
+
+    await user.click(await screen.findByRole('button', { name: 'Review and customize' }));
+
+    expect(trackSetupWithAssistant).toHaveBeenCalledWith({ opportunityId: 'http-suggestion' });
+    expect(openAssistant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: 'grafana-synthetic-monitoring-app/reliability-inbox',
+        autoSend: true,
+        prompt: expect.stringMatching(/Do not create or save the check until I explicitly confirm/i),
+        context: [
+          expect.objectContaining({
+            type: 'structured',
+            title: 'Reliability Inbox setup: mcp.goagain.dev',
+            data: expect.objectContaining({
+              name: 'Reliability Inbox guided setup',
+              suggestion: HTTP_RELIABILITY_SUGGESTION,
+              suggestedDraft: expect.objectContaining({
+                target: 'https://mcp.goagain.dev/',
+                checkType: 'http',
+                frequencyMs: 60_000,
+                timeoutMs: 2000,
+                validStatusCodes: [200],
+                probeIds: [7],
+              }),
+            }),
+          }),
+        ],
+      })
+    );
+  });
+
+  it('defers probe location selection to the review flow', async () => {
+    const { user } = renderPage([
+      {
+        ...HTTP_RELIABILITY_SUGGESTION,
+        prompt:
+          'Create a Grafana Synthetic Monitoring http check for https://mcp.goagain.dev/. Suggested configuration: job "mcp.goagain.dev", frequency 1m0s, timeout 2s, expect HTTP status [200], fail if not SSL, probe IDs [].',
+      },
+    ]);
+
+    const suggestedCheck = await screen.findByRole('region', { name: 'Create an HTTP check' });
+    expect(within(suggestedCheck).queryByText('Probe selection required')).not.toBeInTheDocument();
+    await user.click(within(suggestedCheck).getByText('View configuration details'));
+    expect(within(suggestedCheck).getByText('Probe locations will be selected during review.')).toBeVisible();
+  });
+});

--- a/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.test.tsx
@@ -223,4 +223,36 @@ describe('ReliabilityInboxPage', () => {
     await user.click(within(suggestedCheck).getByText('View configuration details'));
     expect(within(suggestedCheck).getByText('Probe locations will be selected during review.')).toBeVisible();
   });
+
+  it('hides the banner when Assistant is unavailable', () => {
+    mockSuggestions();
+    jest.mocked(useAssistant).mockReturnValue({
+      isAvailable: false,
+      isLoading: false,
+      openAssistant: undefined,
+      closeAssistant: undefined,
+      toggleAssistant: undefined,
+    });
+
+    const { container } = renderWithoutApp(<ReliabilityInboxBanner />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(trackInboxExposure).not.toHaveBeenCalled();
+  });
+
+  it('hides the banner while Assistant availability is still resolving', () => {
+    mockSuggestions();
+    jest.mocked(useAssistant).mockReturnValue({
+      isAvailable: true,
+      isLoading: true,
+      openAssistant,
+      closeAssistant: jest.fn(),
+      toggleAssistant: jest.fn(),
+    });
+
+    const { container } = renderWithoutApp(<ReliabilityInboxBanner />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(trackInboxExposure).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
+++ b/src/features/reliabilityInbox/ReliabilityInboxPage.tsx
@@ -1,0 +1,567 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { createAssistantContextItem, useAssistant } from '@grafana/assistant';
+import { GrafanaTheme2, NavModelItem } from '@grafana/data';
+import { PluginPage } from '@grafana/runtime';
+import {
+  Badge,
+  Box,
+  Button,
+  ClipboardButton,
+  EmptyState,
+  Grid,
+  LinkButton,
+  LoadingPlaceholder,
+  Stack,
+  Text,
+  useStyles2,
+} from '@grafana/ui';
+import { css, cx } from '@emotion/css';
+import { trackRecommendationReviewed, trackSetupWithAssistant } from 'features/tracking/reliabilityInboxEvents';
+
+import { formatDuration } from 'utils';
+import { AppRoutes } from 'routing/types';
+import { generateRoutePath } from 'routing/utils';
+import { getUserPermissions } from 'data/permissions';
+import { ErrorAlert } from 'components/ErrorAlert';
+
+import { getAssistantActionStyle } from './assistantActionStyles';
+import { useReliabilityInboxSuggestions } from './data';
+import { getEvidenceExploreUrl } from './evidence';
+
+const ASSISTANT_ORIGIN = 'grafana-synthetic-monitoring-app/reliability-inbox';
+
+export const RELIABILITY_INBOX_PAGE_NAV: NavModelItem = {
+  text: 'Reliability Inbox',
+  parentItem: {
+    text: 'Synthetics',
+    url: generateRoutePath(AppRoutes.Home),
+  },
+};
+
+export function ReliabilityInboxPage() {
+  return (
+    <PluginPage
+      pageNav={RELIABILITY_INBOX_PAGE_NAV}
+      renderTitle={() => (
+        <Stack alignItems="center" gap={1.5}>
+          <h1>Reliability Inbox</h1>
+          <Badge color="blue" icon="ai-sparkle" text="Experimental" />
+        </Stack>
+      )}
+    >
+      <Stack direction="column" gap={2}>
+        <Text element="p" color="secondary">
+          Review monitoring gaps discovered from recent traffic.
+        </Text>
+        <ReliabilityInboxReview />
+      </Stack>
+    </PluginPage>
+  );
+}
+
+function ReliabilityInboxReview() {
+  const styles = useStyles2(getStyles);
+  const { canWriteChecks } = getUserPermissions();
+  const { isAvailable: isAssistantAvailable, isLoading: isAssistantLoading, openAssistant } = useAssistant();
+  const { data: opportunities = [], isLoading, isError, refetch } = useReliabilityInboxSuggestions();
+  const [selectedId, setSelectedId] = useState<string>();
+  const reviewedIds = useRef(new Set<string>());
+
+  const selected = opportunities.find((opportunity) => opportunity.id === selectedId) ?? opportunities[0];
+
+  useEffect(() => {
+    if (!selected || reviewedIds.current.has(selected.id)) {
+      return;
+    }
+
+    reviewedIds.current.add(selected.id);
+    trackRecommendationReviewed({ opportunityId: selected.id });
+  }, [selected]);
+
+  if (isLoading) {
+    return <LoadingPlaceholder text="Loading Reliability Inbox…" />;
+  }
+
+  if (isError) {
+    return (
+      <ErrorAlert
+        buttonText="Retry"
+        content="Check your permissions and the live Reliability Inbox service, then try again."
+        onClick={() => refetch()}
+        title="Unable to load Reliability Inbox"
+      />
+    );
+  }
+
+  if (!selected) {
+    return (
+      <EmptyState message="No reviewable opportunities" variant="completed">
+        Only public HTTP endpoints with enough evidence of missing coverage are shown.
+      </EmptyState>
+    );
+  }
+
+  const assistantDisabled = !canWriteChecks || isAssistantLoading || !isAssistantAvailable || !openAssistant;
+  const assistantTooltip = !canWriteChecks
+    ? 'You need permission to create checks'
+    : !isAssistantLoading && (!isAssistantAvailable || !openAssistant)
+      ? 'Grafana Assistant is unavailable'
+      : undefined;
+  const evidenceExploreUrl = getEvidenceExploreUrl(selected.suggestion.evidence);
+  const hasAggregateEvidence = Boolean(
+    selected.requestVolume || selected.requestRate || selected.errorRate || selected.p99
+  );
+
+  const setUpWithAssistant = () => {
+    if (!openAssistant) {
+      return;
+    }
+
+    trackSetupWithAssistant({ opportunityId: selected.id });
+
+    const suggestedDraft = selected.proposedCheck;
+    const context = createAssistantContextItem('structured', {
+      title: `Reliability Inbox setup: ${selected.subject}`,
+      bypassLimits: true,
+      data: {
+        name: 'Reliability Inbox guided setup',
+        suggestion: selected.suggestion,
+        suggestedDraft,
+      },
+    });
+
+    openAssistant({
+      origin: ASSISTANT_ORIGIN,
+      prompt: [
+        selected.suggestion.prompt,
+        'Review this suggestion with me and inspect available probes and existing checks where possible.',
+        'Do not invent credentials, private-network details, DNS resolvers, probe assignments, or business semantics.',
+        'Show the final configuration and do not create or save the check until I explicitly confirm it.',
+      ].join(' '),
+      context: [context],
+      autoSend: true,
+    });
+  };
+
+  return (
+    <div className={styles.reviewLayout}>
+      <aside className={styles.queue} aria-label="Recommendations">
+        <div className={styles.queueHeader}>
+          <Stack direction="column" gap={0.5}>
+            <Stack alignItems="center" justifyContent="space-between" gap={1}>
+              <strong>Recommendations</strong>
+              <Badge color="blue" text={`${opportunities.length}`} />
+            </Stack>
+            <Text variant="bodySmall" color="secondary">
+              Ordered by technical signals
+            </Text>
+          </Stack>
+        </div>
+        <ol className={styles.queueList}>
+          {opportunities.map((opportunity, index) => (
+            <li className={styles.queueListItem} key={opportunity.id}>
+              <button
+                className={cx(styles.queueItem, {
+                  [styles.selectedQueueItem]: opportunity.id === selected.id,
+                })}
+                type="button"
+                aria-pressed={opportunity.id === selected.id}
+                onClick={() => setSelectedId(opportunity.id)}
+              >
+                <Badge aria-hidden="true" className={styles.queueRank} color="darkgrey" text={`${index + 1}`} />
+                <Stack direction="column" alignItems="flex-start" gap={0.5} minWidth={0}>
+                  <span className={styles.queueSubject} title={opportunity.proposedCheck.target}>
+                    {opportunity.subject}
+                  </span>
+                  <Text variant="bodySmall" color="secondary">
+                    Missing check{opportunity.requestRate ? ` · ${opportunity.requestRate}` : ''}
+                  </Text>
+                </Stack>
+              </button>
+            </li>
+          ))}
+        </ol>
+      </aside>
+
+      <article className={styles.review}>
+        <section
+          className={cx(styles.panel, styles.recommendationPanel)}
+          aria-labelledby="reliability-inbox-suggested-check-title"
+        >
+          <Stack direction="column" gap={1}>
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              justifyContent="space-between"
+              alignItems="flex-start"
+              gap={2}
+            >
+              <Stack direction="column" gap={1} minWidth={0} flex={1}>
+                <Text variant="bodySmall" color="info" weight="bold">
+                  Suggested check
+                </Text>
+                <Text element="h2" id="reliability-inbox-suggested-check-title" variant="h3">
+                  Create an HTTP check
+                </Text>
+                <dl className={styles.endpointSummary} aria-label="Suggested check endpoint">
+                  <div>
+                    <dt>Method</dt>
+                    <dd>
+                      <Badge color="darkgrey" text={selected.proposedCheck.method} />
+                    </dd>
+                  </div>
+                  <div className={styles.endpointTarget}>
+                    <dt>Target</dt>
+                    <dd title={selected.proposedCheck.target}>{selected.subject}</dd>
+                  </div>
+                </dl>
+              </Stack>
+              <Stack direction="column" alignItems={{ xs: 'flex-start', md: 'flex-end' }} gap={1} maxWidth={280}>
+                <Button
+                  aria-describedby="reliability-inbox-assistant-action-help"
+                  className={styles.assistantAction}
+                  icon="ai-sparkle"
+                  disabled={assistantDisabled}
+                  tooltip={assistantTooltip}
+                  variant="secondary"
+                  onClick={setUpWithAssistant}
+                >
+                  Review and customize
+                </Button>
+                <Text id="reliability-inbox-assistant-action-help" variant="bodySmall" color="secondary">
+                  Assistant will guide setup and recommend a configuration from this proposal. Nothing is created or
+                  saved until you confirm.
+                </Text>
+              </Stack>
+            </Stack>
+            <div className={styles.checkSummary}>
+              <Stack alignItems="center" gap={1} wrap="wrap">
+                <Badge color="darkgrey" icon="globe" text="Public HTTP" />
+                <Badge
+                  color="darkgrey"
+                  icon="clock-nine"
+                  text={`Every ${formatDuration(selected.proposedCheck.frequencyMs)}`}
+                />
+                {selected.proposedCheck.failIfNotSSL && <Badge color="darkgrey" icon="lock" text="Require HTTPS" />}
+              </Stack>
+            </div>
+            <details className={styles.disclosure}>
+              <summary>View configuration details</summary>
+              <dl className={styles.proposalSummary}>
+                <div className={styles.exactTarget}>
+                  <dt>Target URL</dt>
+                  <dd className={styles.targetValue}>
+                    <code>{selected.proposedCheck.target}</code>
+                    <ClipboardButton
+                      aria-label="Copy target URL"
+                      fill="text"
+                      getText={() => selected.proposedCheck.target}
+                      icon="clipboard-alt"
+                      size="sm"
+                      variant="secondary"
+                    >
+                      Copy
+                    </ClipboardButton>
+                  </dd>
+                </div>
+                <div>
+                  <dt>Timeout</dt>
+                  <dd>{formatDuration(selected.proposedCheck.timeoutMs)}</dd>
+                </div>
+                <div>
+                  <dt>Expected response</dt>
+                  <dd>HTTP {selected.proposedCheck.validStatusCodes.join(', ')}</dd>
+                </div>
+                <div>
+                  <dt>TLS requirement</dt>
+                  <dd>{selected.proposedCheck.failIfNotSSL ? 'Require HTTPS' : 'Not required'}</dd>
+                </div>
+                <div>
+                  <dt>Probe / location policy</dt>
+                  <dd>{selected.proposedCheck.locationPolicy}</dd>
+                </div>
+              </dl>
+            </details>
+          </Stack>
+        </section>
+
+        <section className={styles.panel} aria-labelledby="reliability-inbox-recommendation-evidence-title">
+          <Stack direction="column" gap={1.5}>
+            <Stack alignItems="center" justifyContent="space-between" gap={1}>
+              <Text element="h2" id="reliability-inbox-recommendation-evidence-title" variant="h3">
+                Why this recommendation
+              </Text>
+              {evidenceExploreUrl && (
+                <LinkButton href={evidenceExploreUrl} icon="compass" variant="secondary">
+                  Explore telemetry
+                </LinkButton>
+              )}
+            </Stack>
+            <Text element="p">
+              {selected.requestVolume
+                ? `We observed ${selected.requestVolume} requests in the last hour, and no matching Synthetic Monitoring check was found.`
+                : 'We observed recent traffic, and no matching Synthetic Monitoring check was found.'}
+            </Text>
+            <Text element="h3" variant="h4">
+              Observed traffic evidence
+            </Text>
+            {hasAggregateEvidence && (
+              <Text element="p" variant="bodySmall" color="secondary">
+                Based on Prometheus telemetry from the last hour.
+              </Text>
+            )}
+            <Grid columns={{ xs: 2, lg: 4 }} gap={1}>
+              {selected.requestVolume && (
+                <EvidenceMetric value={selected.requestVolume} label="estimated requests in the last hour" />
+              )}
+              {selected.requestRate && <EvidenceMetric value={selected.requestRate} label="observed request rate" />}
+              {selected.errorRate && <EvidenceMetric value={selected.errorRate} label="5xx responses" />}
+              {selected.p99 && <EvidenceMetric value={selected.p99} label="p99 response time" />}
+            </Grid>
+            {!hasAggregateEvidence && (
+              <Text element="p" color="secondary" role="status">
+                No aggregate traffic values were returned for this suggestion.
+              </Text>
+            )}
+            <div className={styles.coverageAssessment}>
+              <Text element="h3" variant="h4">
+                Coverage assessment
+              </Text>
+              <Text element="p" color="secondary">
+                We found no matching HTTP check for this endpoint and path among the checks available to us. Indirect or
+                inaccessible monitoring may still exist.
+              </Text>
+              <details className={cx(styles.disclosure, styles.inlineDisclosure)}>
+                <summary>How we checked</summary>
+                <p className={styles.disclosureContent}>
+                  We compared the endpoint and path with accessible HTTP checks. Aliases, redirects, upstream checks,
+                  and checks for other paths may not match directly.
+                </p>
+              </details>
+            </div>
+          </Stack>
+        </section>
+      </article>
+    </div>
+  );
+}
+
+function EvidenceMetric({ value, label }: { value: string; label: string }) {
+  return (
+    <Box padding={1.5} borderStyle="solid" borderColor="weak" borderRadius="default" backgroundColor="secondary">
+      <Stack direction="column" gap={0.5}>
+        <Text variant="h4" weight="bold">
+          {value}
+        </Text>
+        <Text variant="bodySmall" color="secondary">
+          {label}
+        </Text>
+      </Stack>
+    </Box>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  assistantAction: getAssistantActionStyle(theme),
+  reviewLayout: css({
+    display: 'grid',
+    gridTemplateColumns: 'minmax(320px, 360px) minmax(0, 1fr)',
+    gap: theme.spacing(2),
+    alignItems: 'stretch',
+    minHeight: `calc(100vh - ${theme.spacing(22)})`,
+    [`@media (max-width: ${theme.breakpoints.values.md}px)`]: {
+      gridTemplateColumns: '1fr',
+      minHeight: 'auto',
+    },
+  }),
+  queue: css({
+    border: `1px solid ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+    background: theme.colors.background.secondary,
+    overflow: 'hidden',
+  }),
+  queueHeader: css({
+    background: theme.colors.background.primary,
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
+    padding: theme.spacing(1.5),
+  }),
+  queueList: css({
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+  }),
+  queueListItem: css({
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
+    '&:last-child': { borderBottom: 0 },
+  }),
+  queueItem: css({
+    alignItems: 'flex-start',
+    display: 'grid',
+    gap: theme.spacing(1),
+    gridTemplateColumns: '24px minmax(0, 1fr)',
+    width: '100%',
+    padding: theme.spacing(1.25, 1.5),
+    color: theme.colors.text.secondary,
+    background: 'transparent',
+    border: 0,
+    textAlign: 'left',
+    cursor: 'pointer',
+    '&:hover': { background: theme.colors.action.hover },
+  }),
+  queueRank: css({
+    boxSizing: 'border-box',
+    fontVariantNumeric: 'tabular-nums',
+    fontWeight: theme.typography.fontWeightBold,
+    justifyContent: 'center',
+    minWidth: theme.spacing(3),
+  }),
+  queueSubject: css({
+    fontWeight: theme.typography.fontWeightBold,
+    overflowWrap: 'anywhere',
+    width: '100%',
+  }),
+  selectedQueueItem: css({
+    background: theme.colors.info.transparent,
+    color: theme.colors.text.primary,
+    boxShadow: `inset 3px 0 0 ${theme.colors.info.border}`,
+  }),
+  review: css({
+    display: 'grid',
+    gap: theme.spacing(2),
+    minWidth: 0,
+    alignSelf: 'start',
+  }),
+  panel: css({
+    border: `1px solid ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+    background: theme.colors.background.primary,
+    padding: theme.spacing(2.5),
+  }),
+  recommendationPanel: css({
+    borderLeft: `3px solid ${theme.colors.info.border}`,
+  }),
+  disclosure: css({
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+    marginTop: theme.spacing(1.5),
+    '& summary': {
+      color: theme.colors.text.secondary,
+      cursor: 'pointer',
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+      padding: theme.spacing(1.25, 0),
+      '&:hover': {
+        background: theme.colors.action.hover,
+        color: theme.colors.text.primary,
+      },
+      '&:focus-visible': {
+        borderRadius: theme.shape.radius.default,
+        outline: `2px solid ${theme.colors.primary.border}`,
+        outlineOffset: -2,
+      },
+    },
+  }),
+  disclosureContent: css({
+    color: theme.colors.text.secondary,
+    margin: 0,
+    padding: theme.spacing(1, 0, 0, 2.5),
+  }),
+  inlineDisclosure: css({
+    borderTop: 0,
+    marginTop: 0,
+    '& summary': {
+      padding: theme.spacing(0.5, 0),
+    },
+  }),
+  endpointSummary: css({
+    display: 'grid',
+    gap: theme.spacing(2),
+    gridTemplateColumns: 'max-content minmax(0, 1fr)',
+    margin: 0,
+    minWidth: 0,
+    '& > div': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(0.25),
+      minWidth: 0,
+    },
+    '& dt': {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+    },
+    '& dd': {
+      margin: 0,
+      minWidth: 0,
+    },
+    [`@media (max-width: ${theme.breakpoints.values.md}px)`]: {
+      gridTemplateColumns: '1fr',
+    },
+  }),
+  endpointTarget: css({
+    '& dd': {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+  }),
+  checkSummary: css({
+    alignItems: 'center',
+    background: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+    display: 'flex',
+    gap: theme.spacing(2),
+    justifyContent: 'flex-start',
+    marginTop: theme.spacing(2),
+    padding: theme.spacing(1.5),
+    [`@media (max-width: ${theme.breakpoints.values.md}px)`]: {
+      alignItems: 'flex-start',
+      flexDirection: 'column',
+    },
+  }),
+  coverageAssessment: css({
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+    paddingTop: theme.spacing(1.5),
+    '& > p': {
+      margin: 0,
+    },
+  }),
+  proposalSummary: css({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+    gap: theme.spacing(1),
+    margin: theme.spacing(1, 0, 0),
+    padding: 0,
+    '& > div': {
+      padding: theme.spacing(1.25),
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default,
+      background: theme.colors.background.primary,
+    },
+    '& dt': {
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightBold,
+    },
+    '& dd': { margin: theme.spacing(0.5, 0, 0), overflowWrap: 'anywhere' },
+    [`@media (max-width: ${theme.breakpoints.values.md}px)`]: {
+      gridTemplateColumns: '1fr',
+    },
+  }),
+  exactTarget: css({
+    gridColumn: '1 / -1',
+  }),
+  targetValue: css({
+    alignItems: 'center',
+    display: 'flex',
+    gap: theme.spacing(1),
+    justifyContent: 'space-between',
+    minWidth: 0,
+    '& code': {
+      fontFamily: theme.typography.fontFamilyMonospace,
+      minWidth: 0,
+      overflowWrap: 'anywhere',
+    },
+  }),
+});

--- a/src/features/reliabilityInbox/assistantActionStyles.test.ts
+++ b/src/features/reliabilityInbox/assistantActionStyles.test.ts
@@ -1,0 +1,36 @@
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+
+import { getAssistantActionStyle } from './assistantActionStyles';
+
+jest.mock('@emotion/css', () => ({
+  css: jest.fn(() => 'assistant-action'),
+}));
+
+const theme = {
+  colors: {
+    secondary: { main: 'rgb(32, 36, 41)' },
+    background: { canvas: 'rgb(4, 6, 8)' },
+    text: { primary: 'rgb(185, 190, 198)' },
+    emphasize: jest.fn(() => 'rgb(43, 46, 51)'),
+  },
+  shape: { radius: { default: '8px' } },
+} as unknown as GrafanaTheme2;
+
+describe('getAssistantActionStyle', () => {
+  it('keeps its gradient border while the inner layer lightens on hover', () => {
+    getAssistantActionStyle(theme);
+
+    expect(css).toHaveBeenCalledWith(
+      expect.objectContaining({
+        background: 'none',
+        '&::before': expect.objectContaining({
+          background: 'linear-gradient(90deg, rgb(168, 85, 247), rgb(249, 115, 22))',
+        }),
+        '&:hover::after': {
+          background: 'linear-gradient(rgb(43, 46, 51), rgb(43, 46, 51)), rgb(4, 6, 8)',
+        },
+      })
+    );
+  });
+});

--- a/src/features/reliabilityInbox/assistantActionStyles.ts
+++ b/src/features/reliabilityInbox/assistantActionStyles.ts
@@ -5,14 +5,40 @@ const ASSISTANT_GRADIENT = 'linear-gradient(90deg, rgb(168, 85, 247), rgb(249, 1
 
 export function getAssistantActionStyle(theme: GrafanaTheme2) {
   const baseBackground = theme.colors.secondary.main;
+  const elevatedBackground = theme.colors.emphasize(baseBackground, 0.05);
+  const underlyingColor = theme.colors.background.canvas;
+  const outerRadius = theme.shape.radius.default;
 
   return css({
     label: 'reliability-inbox-assistant-action',
     width: 'fit-content',
     maxWidth: '100%',
-    border: '1px solid transparent',
-    background: `linear-gradient(${baseBackground}, ${baseBackground}) padding-box, ${ASSISTANT_GRADIENT} border-box`,
+    position: 'relative',
+    isolation: 'isolate',
+    border: 'none',
+    background: 'none',
     color: theme.colors.text.primary,
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      inset: 0,
+      borderRadius: outerRadius,
+      background: ASSISTANT_GRADIENT,
+      zIndex: -2,
+      pointerEvents: 'none',
+    },
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      inset: 1,
+      borderRadius: `calc(${outerRadius} - 1px)`,
+      background: `linear-gradient(${baseBackground}, ${baseBackground}), ${underlyingColor}`,
+      zIndex: -1,
+      pointerEvents: 'none',
+    },
+    '&:hover::after': {
+      background: `linear-gradient(${elevatedBackground}, ${elevatedBackground}), ${underlyingColor}`,
+    },
     '& > span': {
       color: `${theme.colors.text.primary} !important`,
     },

--- a/src/features/reliabilityInbox/assistantActionStyles.ts
+++ b/src/features/reliabilityInbox/assistantActionStyles.ts
@@ -1,0 +1,20 @@
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+
+const ASSISTANT_GRADIENT = 'linear-gradient(90deg, rgb(168, 85, 247), rgb(249, 115, 22))';
+
+export function getAssistantActionStyle(theme: GrafanaTheme2) {
+  const baseBackground = theme.colors.secondary.main;
+
+  return css({
+    label: 'reliability-inbox-assistant-action',
+    width: 'fit-content',
+    maxWidth: '100%',
+    border: '1px solid transparent',
+    background: `linear-gradient(${baseBackground}, ${baseBackground}) padding-box, ${ASSISTANT_GRADIENT} border-box`,
+    color: theme.colors.text.primary,
+    '& > span': {
+      color: `${theme.colors.text.primary} !important`,
+    },
+  });
+}

--- a/src/features/reliabilityInbox/data.test.tsx
+++ b/src/features/reliabilityInbox/data.test.tsx
@@ -1,0 +1,76 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HTTP_RELIABILITY_SUGGESTION } from 'test/fixtures/reliabilityInbox';
+import { createWrapper } from 'test/render';
+
+import { getQueryClient } from 'data/queryClient';
+import { useSMDS } from 'hooks/useSMDS';
+
+import { reliabilityInboxQueryKey, useCachedReliabilityInboxSuggestions, useReliabilityInboxSuggestions } from './data';
+
+jest.mock('hooks/useSMDS', () => ({
+  useSMDS: jest.fn(),
+}));
+
+const API_HOST = 'https://synthetic-monitoring-api-dev.grafana-dev.net';
+const getReliabilityInboxSuggestions = jest.fn();
+
+describe('Reliability Inbox data', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useSMDS).mockReturnValue({
+      uid: undefined,
+      instanceSettings: { jsonData: { apiHost: API_HOST } },
+      supportsReliabilityInbox: () => true,
+      getReliabilityInboxSuggestions,
+      getMetricsDS: () => undefined,
+      getLogsDS: () => undefined,
+    } as unknown as ReturnType<typeof useSMDS>);
+    getReliabilityInboxSuggestions.mockResolvedValue({ suggestions: [] });
+  });
+
+  it('does not generate suggestions when only the cache is observed', async () => {
+    const queryClient = getQueryClient();
+    const { Wrapper } = createWrapper({ queryClient });
+    const { result } = renderHook(() => useCachedReliabilityInboxSuggestions(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getReliabilityInboxSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('returns generated suggestions from the cache without another service call', async () => {
+    const queryClient = getQueryClient();
+    const { Wrapper } = createWrapper({ queryClient });
+    queryClient.setQueryData(reliabilityInboxQueryKey(API_HOST), []);
+
+    const { result } = renderHook(() => useCachedReliabilityInboxSuggestions(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current.data).toEqual([]);
+    expect(getReliabilityInboxSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('generates suggestions when the active page hook is mounted', async () => {
+    const queryClient = getQueryClient();
+    const { Wrapper } = createWrapper({ queryClient });
+    getReliabilityInboxSuggestions.mockResolvedValue({
+      suggestions: [
+        { ...HTTP_RELIABILITY_SUGGESTION, id: 'lower-relevance', relevance: 20 },
+        HTTP_RELIABILITY_SUGGESTION,
+      ],
+    });
+    const { result } = renderHook(() => useReliabilityInboxSuggestions(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getReliabilityInboxSuggestions).toHaveBeenCalledTimes(1);
+    expect(result.current.data?.map(({ id }) => id)).toEqual(['http-suggestion', 'lower-relevance']);
+    expect(queryClient.getQueryData(reliabilityInboxQueryKey(API_HOST))).toEqual(result.current.data);
+  });
+});

--- a/src/features/reliabilityInbox/data.ts
+++ b/src/features/reliabilityInbox/data.ts
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { reliabilitySuggestionsSchema } from './types';
+import { useSMDS } from 'hooks/useSMDS';
+
+import { compareReliabilityOpportunities, isInitialReviewCandidate, toReliabilityOpportunity } from './model';
+
+export const reliabilityInboxQueryKey = (apiHost: string) => ['reliability-inbox', 'suggestions', apiHost] as const;
+
+/**
+ * Fetches suggestions from the reliability-inbox experiment.
+ */
+export function useReliabilityInboxSuggestions() {
+  return useReliabilityInboxQuery(true);
+}
+
+/**
+ * Subscribes to generated suggestions already held by React Query without
+ * triggering the paid generation request. The homepage banner uses this hook.
+ */
+export function useCachedReliabilityInboxSuggestions() {
+  return useReliabilityInboxQuery(false);
+}
+
+function useReliabilityInboxQuery(generateSuggestions: boolean) {
+  const smDS = useSMDS();
+  const apiHost = smDS.instanceSettings.jsonData.apiHost;
+
+  return useQuery({
+    // apiHost is in the key because it selects the region, and therefore which
+    // instance answered.
+    queryKey: reliabilityInboxQueryKey(apiHost),
+    enabled: generateSuggestions && smDS.supportsReliabilityInbox(),
+    queryFn: async () => {
+      const result = await smDS.getReliabilityInboxSuggestions();
+
+      return reliabilitySuggestionsSchema
+        .parse(result)
+        .suggestions.filter(isInitialReviewCandidate)
+        .map(toReliabilityOpportunity)
+        .sort(compareReliabilityOpportunities);
+    },
+    retry: false,
+    staleTime: Infinity,
+    // Suggestion generation creates a token and invokes a paid service. Retain
+    // the result for the lifetime of the SPA session, even when no component is
+    // temporarily subscribed, so navigation cannot cause accidental regeneration.
+    gcTime: Infinity,
+  });
+}

--- a/src/features/reliabilityInbox/evidence.test.ts
+++ b/src/features/reliabilityInbox/evidence.test.ts
@@ -1,0 +1,45 @@
+import { ReliabilityEvidence } from './types';
+
+import { getEvidenceExploreUrl } from './evidence';
+
+const EVIDENCE: ReliabilityEvidence = {
+  reqPerS: 12.5,
+  errorRatio: 0.04,
+  p99Ms: 340,
+  statusDistribution: { '200': 12, '500': 0.5 },
+  families: ['http_server_request_duration_seconds_bucket'],
+  provenance: {
+    datasource: 'prometheus-uid',
+    range: { from: '1784800800000', to: '1784804400000' },
+    queries: [
+      { expr: 'sum(rate(http_requests_total[1h]))' },
+      { expr: 'sum by (status) (rate(http_requests_total[1h]))' },
+    ],
+  },
+};
+
+describe('Reliability Inbox evidence provenance', () => {
+  it('opens every evidence query in one Explore pane', () => {
+    const exploreUrl = getEvidenceExploreUrl(EVIDENCE);
+    const search = new URL(exploreUrl!, 'https://example.com').searchParams;
+
+    expect(JSON.parse(search.get('left')!)).toEqual(
+      expect.objectContaining({
+        datasource: 'prometheus-uid',
+        queries: [
+          { refId: 'A', expr: 'sum(rate(http_requests_total[1h]))' },
+          { refId: 'B', expr: 'sum by (status) (rate(http_requests_total[1h]))' },
+        ],
+      })
+    );
+  });
+
+  it.each([
+    ['provenance is absent', { ...EVIDENCE, provenance: undefined }],
+    ['range is invalid', { ...EVIDENCE, provenance: { ...EVIDENCE.provenance!, range: { from: '2', to: '1' } } }],
+    ['queries are absent', { ...EVIDENCE, provenance: { ...EVIDENCE.provenance!, queries: [] } }],
+    ['a query is empty', { ...EVIDENCE, provenance: { ...EVIDENCE.provenance!, queries: [{ expr: ' ' }] } }],
+  ])('does not construct a verification link when %s', (_, evidence) => {
+    expect(getEvidenceExploreUrl(evidence as ReliabilityEvidence)).toBeUndefined();
+  });
+});

--- a/src/features/reliabilityInbox/evidence.ts
+++ b/src/features/reliabilityInbox/evidence.ts
@@ -1,0 +1,21 @@
+import { ReliabilityEvidence } from './types';
+import { getExploreUrl } from 'utils';
+
+export function getEvidenceExploreUrl(evidence: ReliabilityEvidence): string | undefined {
+  const provenance = evidence.provenance;
+  const from = Number(provenance?.range.from);
+  const to = Number(provenance?.range.to);
+
+  if (
+    !provenance?.datasource.trim() ||
+    !provenance.queries.length ||
+    provenance.queries.some(({ expr }) => !expr.trim()) ||
+    !Number.isFinite(from) ||
+    !Number.isFinite(to) ||
+    from >= to
+  ) {
+    return undefined;
+  }
+
+  return getExploreUrl(provenance.datasource, provenance.queries, { from, to });
+}

--- a/src/features/reliabilityInbox/index.ts
+++ b/src/features/reliabilityInbox/index.ts
@@ -1,1 +1,2 @@
+export { ReliabilityInboxBanner } from './ReliabilityInboxBanner';
 export { ReliabilityInboxPage } from './ReliabilityInboxPage';

--- a/src/features/reliabilityInbox/index.ts
+++ b/src/features/reliabilityInbox/index.ts
@@ -1,0 +1,1 @@
+export { ReliabilityInboxPage } from './ReliabilityInboxPage';

--- a/src/features/reliabilityInbox/model.test.ts
+++ b/src/features/reliabilityInbox/model.test.ts
@@ -1,0 +1,179 @@
+import { HTTP_RELIABILITY_SUGGESTION } from 'test/fixtures/reliabilityInbox';
+
+import { ReliabilitySuggestion, reliabilitySuggestionSchema } from './types';
+import { CheckType } from 'types';
+
+import {
+  compareReliabilityOpportunities,
+  getProposedHttpCheckDraft,
+  isInitialReviewCandidate,
+  parseSuggestedCheckConfig,
+  toReliabilityOpportunity,
+} from './model';
+
+const DNS_SUGGESTION: ReliabilitySuggestion = {
+  id: 'dns-suggestion',
+  target: 'host.docker.internal',
+  checkType: 'dns',
+  evidence: {
+    reqPerS: 1.2870056497175142,
+    p99Ms: 4,
+    statusDistribution: { '200': 1.2870056497175142, '400': 0 },
+    families: ['http_server_request_duration_seconds_bucket'],
+  },
+  reachability: 'nxdomain',
+  reachabilitySource: 'service_dns_hint',
+  confidence: 'high',
+  score: 1.3592672374699362,
+  dedupStatus: 'uncovered',
+  authRequired: false,
+  needsConfiguration: true,
+  prompt:
+    'Create a Grafana Synthetic Monitoring dns check for host.docker.internal. Why: the endpoint served 1.3 req/s over the last hour.',
+};
+
+describe('Reliability Inbox model', () => {
+  it('parses the structured check configuration embedded in the prototype prompt', () => {
+    expect(parseSuggestedCheckConfig(HTTP_RELIABILITY_SUGGESTION.prompt)).toEqual({
+      job: 'mcp.goagain.dev',
+      frequencyMs: 60_000,
+      timeoutMs: 2000,
+      validStatusCodes: [200],
+      failIfNotSSL: true,
+      probeIds: [7],
+    });
+  });
+
+  it('derives user-facing evidence from structured telemetry instead of trusting prompt copy', () => {
+    const opportunity = toReliabilityOpportunity(HTTP_RELIABILITY_SUGGESTION);
+
+    expect(opportunity.errorRate).toBe('0.14%');
+    expect(opportunity.requestVolume).toBe('5.8k');
+    expect(opportunity.suggestion.checkType).toBe(CheckType.Http);
+    expect(opportunity.proposedCheck).toEqual(
+      expect.objectContaining({
+        target: 'https://mcp.goagain.dev/',
+        checkType: 'http',
+        method: 'GET',
+        validStatusCodes: [200],
+        locationPolicy: 'Run from the configured public probe with ID 7.',
+      })
+    );
+  });
+
+  it('preserves absent numeric evidence instead of presenting it as zero', () => {
+    const suggestion = reliabilitySuggestionSchema.parse({
+      ...HTTP_RELIABILITY_SUGGESTION,
+      evidence: {
+        families: HTTP_RELIABILITY_SUGGESTION.evidence.families,
+      },
+    });
+
+    expect(toReliabilityOpportunity(suggestion)).toEqual(
+      expect.objectContaining({
+        requestVolume: undefined,
+        requestRate: undefined,
+        errorRate: undefined,
+        p99: undefined,
+      })
+    );
+  });
+
+  it('orders reviewable recommendations by technical relevance', () => {
+    const opportunities = [
+      { id: 'lower-technical-relevance', relevance: 20 },
+      { id: 'higher-technical-relevance', relevance: 75 },
+    ]
+      .map(({ id, relevance }) =>
+        toReliabilityOpportunity({
+          ...HTTP_RELIABILITY_SUGGESTION,
+          id,
+          target: `https://${id}.example.com/`,
+          relevance,
+        })
+      )
+      .sort(compareReliabilityOpportunities);
+
+    expect(opportunities.map(({ id }) => id)).toEqual(['higher-technical-relevance', 'lower-technical-relevance']);
+  });
+
+  it('falls back to the service score when technical relevance is unavailable', () => {
+    const opportunities = [
+      { id: 'lower-service-score', score: 0.2 },
+      { id: 'higher-service-score', score: 0.8 },
+    ]
+      .map(({ id, score }) =>
+        toReliabilityOpportunity({
+          ...HTTP_RELIABILITY_SUGGESTION,
+          id,
+          score,
+          relevance: undefined,
+          target: `https://${id}.example.com/`,
+        })
+      )
+      .sort(compareReliabilityOpportunities);
+
+    expect(opportunities.map(({ id }) => id)).toEqual(['higher-service-score', 'lower-service-score']);
+  });
+
+  it('uses hostname, non-default port, and meaningful path as the human-readable endpoint identity', () => {
+    const target = 'https://api.example.com:8443/health?verbose=true#status';
+    const opportunity = toReliabilityOpportunity({ ...HTTP_RELIABILITY_SUGGESTION, target });
+
+    expect(opportunity.subject).toBe('api.example.com:8443/health');
+    expect(opportunity.proposedCheck.target).toBe(target);
+  });
+
+  it('defers probe location selection to review when the suggestion does not specify probes', () => {
+    const draft = getProposedHttpCheckDraft({
+      ...HTTP_RELIABILITY_SUGGESTION,
+      prompt:
+        'Create a Grafana Synthetic Monitoring http check for https://mcp.goagain.dev/. Suggested configuration: job "mcp.goagain.dev", frequency 1m0s, timeout 2s, expect HTTP status [200], fail if not SSL, probe IDs [].',
+    });
+
+    expect(draft).toEqual(
+      expect.objectContaining({
+        probeIds: [],
+        locationPolicy: 'Probe locations will be selected during review.',
+      })
+    );
+  });
+
+  it.each([
+    'http://localhost/',
+    'http://service.localhost/',
+    'http://service.local/',
+    'http://service.internal/',
+    'http://service.test/',
+    'http://host.docker.internal:3000/ready',
+    'http://10.0.0.1/',
+    'http://127.0.0.1/',
+    'http://169.254.0.1/',
+    'http://0.1.2.3/',
+    'http://[::]/',
+    'http://[::1]/',
+    'http://[fc00::1]/',
+    'http://[fe80::1]/',
+  ])('suppresses private and development-only target %s from the initial queue', (target) => {
+    expect(isInitialReviewCandidate({ ...HTTP_RELIABILITY_SUGGESTION, target })).toBe(false);
+  });
+
+  it('keeps public IPv4 and IPv6 targets in the initial queue', () => {
+    expect(isInitialReviewCandidate(HTTP_RELIABILITY_SUGGESTION)).toBe(true);
+    expect(isInitialReviewCandidate({ ...HTTP_RELIABILITY_SUGGESTION, target: 'http://8.8.8.8/' })).toBe(true);
+    expect(
+      isInitialReviewCandidate({ ...HTTP_RELIABILITY_SUGGESTION, target: 'http://[2606:4700:4700::1111]/' })
+    ).toBe(true);
+    expect(isInitialReviewCandidate(DNS_SUGGESTION)).toBe(false);
+  });
+
+  it('suppresses suggestions the service no longer considers uncovered', () => {
+    expect(isInitialReviewCandidate({ ...HTTP_RELIABILITY_SUGGESTION, dedupStatus: 'covered' })).toBe(false);
+    expect(isInitialReviewCandidate({ ...HTTP_RELIABILITY_SUGGESTION, dedupStatus: 'dismissed' })).toBe(false);
+  });
+
+  it('suppresses coverage gaps without high confidence', () => {
+    expect(isInitialReviewCandidate({ ...HTTP_RELIABILITY_SUGGESTION, confidence: 'medium' })).toBe(false);
+    expect(isInitialReviewCandidate({ ...HTTP_RELIABILITY_SUGGESTION, confidence: 'low' })).toBe(false);
+  });
+});

--- a/src/features/reliabilityInbox/model.ts
+++ b/src/features/reliabilityInbox/model.ts
@@ -1,0 +1,169 @@
+import { durationToMilliseconds, isValidDuration, parseDuration } from '@grafana/data';
+import { Address4, Address6 } from 'ip-address';
+
+import { ReliabilitySuggestion } from './types';
+import { CheckType } from 'types';
+
+const ONE_MINUTE_IN_MS = 60 * 1000;
+
+export function parseSuggestedCheckConfig(prompt: string) {
+  const job = prompt.match(/job "([^"]+)"/)?.[1];
+  const frequency = prompt.match(/frequency ([^,\s]+)/)?.[1];
+  const timeout = prompt.match(/timeout ([^,\s]+)/)?.[1];
+  const statusCodes = prompt.match(/expect HTTP status \[([^\]]*)\]/)?.[1];
+  const probeIds = prompt.match(/probe IDs \[([^\]]*)\]/)?.[1];
+
+  return {
+    job,
+    frequencyMs: frequency ? parsePromptDuration(frequency) : undefined,
+    timeoutMs: timeout ? parsePromptDuration(timeout) : undefined,
+    validStatusCodes: parseNumberList(statusCodes),
+    failIfNotSSL: /fail if not SSL/i.test(prompt),
+    probeIds: parseNumberList(probeIds),
+  };
+}
+
+export function toReliabilityOpportunity(suggestion: ReliabilitySuggestion) {
+  const proposedCheck = getProposedHttpCheckDraft(suggestion);
+  const requestRate =
+    suggestion.evidence.reqPerS === undefined ? undefined : `${formatDecimal(suggestion.evidence.reqPerS)} req/s`;
+
+  return {
+    id: suggestion.id,
+    suggestion,
+    subject: getSubject(suggestion.target),
+    sortScore: suggestion.relevance ?? suggestion.score * 100,
+    requestVolume:
+      suggestion.evidence.reqPerS === undefined
+        ? undefined
+        : formatCompactNumber(suggestion.evidence.reqPerS * 60 * 60),
+    requestRate,
+    errorRate: formatErrorRate(suggestion.evidence.errorRatio),
+    p99: suggestion.evidence.p99Ms === undefined ? undefined : `${formatDecimal(suggestion.evidence.p99Ms)} ms`,
+    proposedCheck,
+  };
+}
+
+export type ReliabilityOpportunity = ReturnType<typeof toReliabilityOpportunity>;
+
+/** Orders eligible recommendations by technical relevance. */
+export function compareReliabilityOpportunities(a: ReliabilityOpportunity, b: ReliabilityOpportunity) {
+  return b.sortScore - a.sortScore || a.id.localeCompare(b.id);
+}
+
+export function isInitialReviewCandidate(suggestion: ReliabilitySuggestion) {
+  if (
+    suggestion.checkType !== CheckType.Http ||
+    suggestion.dedupStatus !== 'uncovered' ||
+    suggestion.confidence.toLowerCase() !== 'high' ||
+    suggestion.reachability !== 'public' ||
+    suggestion.authRequired ||
+    suggestion.needsConfiguration
+  ) {
+    return false;
+  }
+
+  try {
+    const url = new URL(suggestion.target);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && !isPrivateOrDevelopmentHost(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function getProposedHttpCheckDraft(suggestion: ReliabilitySuggestion) {
+  const parsed = parseSuggestedCheckConfig(suggestion.prompt);
+  const frequencyMs = parsed.frequencyMs ?? ONE_MINUTE_IN_MS;
+  const timeoutMs = parsed.timeoutMs ?? 3000;
+  const validStatusCodes = parsed.validStatusCodes.length > 0 ? parsed.validStatusCodes : [200];
+  const probeIds = parsed.probeIds;
+
+  return {
+    job: parsed.job ?? getSubject(suggestion.target),
+    target: suggestion.target,
+    checkType: 'http' as const,
+    method: 'GET' as const,
+    frequencyMs,
+    timeoutMs,
+    validStatusCodes,
+    failIfNotSSL: parsed.failIfNotSSL || suggestion.target.toLowerCase().startsWith('https://'),
+    probeIds,
+    locationPolicy:
+      probeIds.length > 0
+        ? `Run from the configured public probe${probeIds.length === 1 ? '' : 's'} with ID${probeIds.length === 1 ? '' : 's'} ${probeIds.join(', ')}.`
+        : 'Probe locations will be selected during review.',
+  };
+}
+
+export type ProposedHttpCheckDraft = ReturnType<typeof getProposedHttpCheckDraft>;
+
+function getSubject(target: string) {
+  try {
+    const url = new URL(target);
+    const path = url.pathname === '/' ? '' : url.pathname;
+    return `${url.host}${path}`;
+  } catch {
+    return target;
+  }
+}
+
+function isPrivateOrDevelopmentHost(hostname: string) {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (
+    host === 'localhost' ||
+    host === 'host.docker.internal' ||
+    host.endsWith('.localhost') ||
+    host.endsWith('.local') ||
+    host.endsWith('.internal') ||
+    host.endsWith('.test')
+  ) {
+    return true;
+  }
+
+  if (Address4.isValid(host)) {
+    const address = new Address4(host);
+    return (
+      address.toArray()[0] === 0 ||
+      address.isPrivate() ||
+      address.isLoopback() ||
+      address.isLinkLocal() ||
+      address.isUnspecified()
+    );
+  }
+
+  if (Address6.isValid(host)) {
+    const address = new Address6(host);
+    return address.isPrivate() || address.isLoopback() || address.isLinkLocal() || address.isUnspecified();
+  }
+
+  return false;
+}
+
+function parseNumberList(value?: string) {
+  return value?.split(',').filter((item) => item.trim()).map(Number).filter(Number.isFinite) ?? [];
+}
+
+function parsePromptDuration(value: string) {
+  const duration = value.replace(/([hms])(?=\d)/g, '$1 ');
+  return isValidDuration(duration) ? durationToMilliseconds(parseDuration(duration)) : undefined;
+}
+
+function formatCompactNumber(value: number) {
+  return new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(value).replace('K', 'k');
+}
+
+function formatDecimal(value: number) {
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 1 }).format(value);
+}
+
+function formatErrorRate(ratio?: number) {
+  if (ratio === undefined) {
+    return undefined;
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'percent',
+    minimumFractionDigits: ratio > 0 && ratio < 0.001 ? 2 : 1,
+    maximumFractionDigits: 2,
+  }).format(ratio);
+}

--- a/src/features/reliabilityInbox/types.ts
+++ b/src/features/reliabilityInbox/types.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+export const reliabilitySuggestionSchema = z
+  .object({
+    id: z.string(),
+    target: z.string(),
+    // Not an enum: the service also emits grpc, tcp and multihttp. An enum makes a
+    // single such suggestion throw and discard the WHOLE response, because the
+    // array parses as a unit. isInitialReviewCandidate narrows to http anyway.
+    checkType: z.string(),
+    evidence: z
+      .object({
+        // Numeric evidence is optional because the service omits zero values.
+        // Preserve absence so the UI does not present missing telemetry as zero.
+        reqPerS: z.number().optional(),
+        errorRatio: z.number().optional(),
+        p99Ms: z.number().optional(),
+        statusDistribution: z.record(z.string(), z.number()).default({}),
+        families: z.array(z.string()).default([]),
+        provenance: z
+          .object({
+            datasource: z.string(),
+            queries: z.array(z.object({ expr: z.string(), instant: z.boolean().optional() }).loose()),
+            range: z.object({ from: z.string(), to: z.string() }),
+          })
+          .optional(),
+      })
+      .loose(),
+    reachability: z.string(),
+    reachabilitySource: z.string(),
+    confidence: z.string(),
+    score: z.number(),
+    dedupStatus: z.string(),
+    authRequired: z.boolean(),
+    needsConfiguration: z.boolean().optional(),
+    relevance: z.number().optional(),
+    rationale: z.string().optional(),
+    prompt: z.string(),
+  })
+  .loose();
+
+export const reliabilitySuggestionsSchema = z.object({
+  suggestions: z.array(reliabilitySuggestionSchema),
+});
+
+export type ReliabilitySuggestion = z.infer<typeof reliabilitySuggestionSchema>;
+export type ReliabilityEvidence = ReliabilitySuggestion['evidence'];

--- a/src/features/tracking/reliabilityInboxEvents.ts
+++ b/src/features/tracking/reliabilityInboxEvents.ts
@@ -1,0 +1,24 @@
+import { createSMEventFactory, TrackingEventProps } from 'features/tracking/utils';
+
+const reliabilityInboxEvents = createSMEventFactory('reliability_inbox');
+
+interface InboxExposureEvent extends TrackingEventProps {
+  /** Number of reviewable recommendations shown by the inbox entry point. */
+  opportunityCount: number;
+  /** Identifier for the highest-priority recommendation shown on exposure. */
+  topOpportunityId: string;
+}
+
+interface RecommendationEvent extends TrackingEventProps {
+  /** Identifier for the recommendation involved in the interaction. */
+  opportunityId: string;
+}
+
+/** Tracks when the compact Reliability Inbox entry point is shown. */
+export const trackInboxExposure = reliabilityInboxEvents<InboxExposureEvent>('exposed');
+/** Tracks when a user enters the dedicated review surface. */
+export const trackReviewEntryClicked = reliabilityInboxEvents<RecommendationEvent>('review_entry_clicked');
+/** Tracks when a recommendation becomes selected for review. */
+export const trackRecommendationReviewed = reliabilityInboxEvents<RecommendationEvent>('recommendation_reviewed');
+/** Tracks when a user explicitly hands a recommendation to Assistant for guided setup. */
+export const trackSetupWithAssistant = reliabilityInboxEvents<RecommendationEvent>('setup_with_assistant_clicked');

--- a/src/routing/InitialisedRouter.test.tsx
+++ b/src/routing/InitialisedRouter.test.tsx
@@ -3,7 +3,9 @@ import { screen } from '@testing-library/react';
 import { BASIC_HTTP_CHECK } from 'test/fixtures/checks';
 import { SM_DATASOURCE } from 'test/fixtures/datasources';
 import { type CustomRenderOptions, render } from 'test/render';
+import { mockFeatureToggles } from 'test/utils';
 
+import { FeatureName } from 'types';
 import { PLUGIN_URL_PATH } from 'routing/constants';
 import { InitialisedRouter } from 'routing/InitialisedRouter';
 import { AppRoutes } from 'routing/types';
@@ -20,6 +22,10 @@ jest.mock('page/DashboardPage', () => ({
 
 jest.mock('page/SceneHomepage', () => ({
   SceneHomepage: () => <h1>Home page</h1>,
+}));
+
+jest.mock('features/reliabilityInbox', () => ({
+  ReliabilityInboxPage: () => <h1>Reliability inbox page</h1>,
 }));
 
 const notaRoute = `${PLUGIN_URL_PATH}/404`;
@@ -75,5 +81,18 @@ describe('Routes to pages correctly', () => {
     });
     const sceneText = await screen.findByText('Dashboard page');
     expect(sceneText).toBeInTheDocument();
+  });
+
+  test('Reliability inbox route renders when the flag is enabled', async () => {
+    mockFeatureToggles({ [FeatureName.ReliabilityInbox]: true });
+    renderInitialisedRouting({ path: getRoute(AppRoutes.ReliabilityInbox) });
+    const pageText = await screen.findByText('Reliability inbox page', { selector: 'h1' });
+    expect(pageText).toBeInTheDocument();
+  });
+
+  test('Reliability inbox route shows a 404 page when the flag is disabled', async () => {
+    renderInitialisedRouting({ path: getRoute(AppRoutes.ReliabilityInbox) });
+    const notFoundText = await screen.findByText('Not found', { selector: 'span' });
+    expect(notFoundText).toBeInTheDocument();
   });
 });

--- a/src/routing/InitialisedRouter.tsx
+++ b/src/routing/InitialisedRouter.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { Navigate, Route, Routes } from 'react-router';
 import { TextLink } from '@grafana/ui';
+import { ReliabilityInboxPage } from 'features/reliabilityInbox';
 
 import { FeatureName } from 'types';
 import { LegacyEditRedirect } from 'routing/LegacyEditRedirect';
@@ -131,6 +132,19 @@ export const InitialisedRouter = () => {
       </Route>
 
       <Route path={AppRoutes.Alerts} element={<AlertingPage />} />
+
+      {isFeatureEnabled(FeatureName.ReliabilityInbox) && (
+        <Route
+          path={AppRoutes.ReliabilityInbox}
+          element={
+            canReadChecks ? (
+              <ReliabilityInboxPage />
+            ) : (
+              <UnauthorizedPage permissions={['grafana-synthetic-monitoring-app.checks:read']} />
+            )
+          }
+        />
+      )}
 
       <Route path={`${AppRoutes.Config}`} element={<ConfigPageLayout />}>
         <Route index element={<GeneralTab />} />

--- a/src/routing/InitialisedRouter.tsx
+++ b/src/routing/InitialisedRouter.tsx
@@ -8,6 +8,7 @@ import { LegacyEditRedirect } from 'routing/LegacyEditRedirect';
 import { AppRoutes } from 'routing/types';
 import { getNewCheckTypeRedirects, getRoute } from 'routing/utils';
 import { getUserPermissions } from 'data/permissions';
+import { useFeatureFlag } from 'hooks/useFeatureFlag';
 import { useFeatureFlagContext } from 'hooks/useFeatureFlagContext';
 import { useLimits } from 'hooks/useLimits';
 import { QueryParamMap, useNavigation } from 'hooks/useNavigation';
@@ -39,6 +40,7 @@ export const InitialisedRouter = () => {
   const urlSearchParams = useURLSearchParams();
   const navigate = useNavigation();
   const { isFeatureEnabled } = useFeatureFlagContext();
+  const { isEnabled: isReliabilityInboxEnabled } = useFeatureFlag(FeatureName.ReliabilityInbox);
 
   const page = urlSearchParams.get('page');
   useLimits();
@@ -133,7 +135,7 @@ export const InitialisedRouter = () => {
 
       <Route path={AppRoutes.Alerts} element={<AlertingPage />} />
 
-      {isFeatureEnabled(FeatureName.ReliabilityInbox) && (
+      {isReliabilityInboxEnabled && (
         <Route
           path={AppRoutes.ReliabilityInbox}
           element={

--- a/src/routing/types.ts
+++ b/src/routing/types.ts
@@ -11,6 +11,7 @@ export enum AppRoutes {
   NewCheck = 'checks/new',
   NewProbe = 'probes/new',
   Probes = 'probes',
+  ReliabilityInbox = 'reliability-inbox',
   Redirect = 'redirect',
   Scene = 'scene',
 }
@@ -22,6 +23,7 @@ export const AUTO_INITIALIZE_ROUTES = [
   AppRoutes.Probes,
   AppRoutes.NewProbe,
   AppRoutes.Alerts,
+  AppRoutes.ReliabilityInbox,
 ] as const;
 
 export type AutoInitializeRoute = (typeof AUTO_INITIALIZE_ROUTES)[number];

--- a/src/scenes/Summary/SummaryDashboard.test.tsx
+++ b/src/scenes/Summary/SummaryDashboard.test.tsx
@@ -28,4 +28,13 @@ describe('SummaryDashboard', () => {
     expect(await screen.findByText("You haven't created any checks yet")).toBeInTheDocument();
     expect(await screen.findByText('Create new check')).toBeInTheDocument();
   });
+
+  it('hides the Reliability Inbox banner when the flag is disabled', async () => {
+    mockFeatureToggles({ [FeatureName.ReliabilityInbox]: false });
+    render(<SummaryDashboard checks={[]} />);
+
+    expect(screen.queryByTestId('reliability-inbox-banner')).not.toBeInTheDocument();
+    expect(await screen.findByText("You haven't created any checks yet")).toBeInTheDocument();
+    expect(await screen.findByText('Create new check')).toBeInTheDocument();
+  });
 });

--- a/src/scenes/Summary/SummaryDashboard.test.tsx
+++ b/src/scenes/Summary/SummaryDashboard.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { render } from 'test/render';
+import { mockFeatureToggles } from 'test/utils';
+
+import { FeatureName } from 'types';
+
+import { SummaryDashboard } from './SummaryDashboard';
+
+jest.mock('features/reliabilityInbox', () => {
+  const React = jest.requireActual('react');
+
+  return {
+    ReliabilityInboxBanner: () => React.createElement('div', { 'data-testid': 'reliability-inbox-banner' }),
+  };
+});
+
+jest.mock('hooks/useMetricsDS', () => ({
+  useMetricsDS: () => undefined,
+}));
+
+describe('SummaryDashboard', () => {
+  it('keeps Reliability Inbox and manual creation available when the unfiltered check inventory is empty', async () => {
+    mockFeatureToggles({ [FeatureName.ReliabilityInbox]: true });
+    render(<SummaryDashboard checks={[]} />);
+
+    expect(await screen.findByTestId('reliability-inbox-banner')).toBeInTheDocument();
+    expect(await screen.findByText("You haven't created any checks yet")).toBeInTheDocument();
+    expect(await screen.findByText('Create new check')).toBeInTheDocument();
+  });
+});

--- a/src/scenes/Summary/SummaryDashboard.tsx
+++ b/src/scenes/Summary/SummaryDashboard.tsx
@@ -14,9 +14,11 @@ import { VariableRefresh } from '@grafana/schema';
 import { Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { TrackingTimeRangeScope } from 'features/tracking/TrackingTimeRangeScope';
+import { ReliabilityInboxBanner } from 'features/reliabilityInbox';
 
-import { Check } from 'types';
+import { Check, FeatureName } from 'types';
 import { useDemAssistantContext } from 'hooks/useDemAssistantContext';
+import { useFeatureFlag } from 'hooks/useFeatureFlag';
 import { useMetricsDS } from 'hooks/useMetricsDS';
 import { AddNewCheckButton } from 'components/AddNewCheckButton';
 import { ChecksEmptyState } from 'components/ChecksEmptyState';
@@ -38,6 +40,7 @@ const SummaryDashboardContent = ({ checks }: SummaryDashboardProps) => {
   const metricsDS = useMetricsDS();
   const styles = useStyles2(getStyles);
   const annotations = useSummaryDashboardAnnotations();
+  const { isEnabled: isReliabilityInboxEnabled } = useFeatureFlag(FeatureName.ReliabilityInbox);
   const scene = useSceneContext();
   const [filtersAdded, setFiltersAdded] = useState(false);
 
@@ -89,6 +92,7 @@ const SummaryDashboardContent = ({ checks }: SummaryDashboardProps) => {
     <>
       <PluginPage pageNav={{ text: 'Home' }} renderTitle={() => <h1>Home</h1>}>
         <Stack direction="column" gap={1}>
+          {isReliabilityInboxEnabled && <ReliabilityInboxBanner />}
           <DashboardContainerAnnotations annotations={annotations}>
             <div className={styles.header}>
               <VariableControl name="region" />
@@ -128,9 +132,15 @@ const SummaryDashboardContent = ({ checks }: SummaryDashboardProps) => {
 export const SummaryDashboard = ({ checks }: SummaryDashboardProps) => {
   const metricsDS = useMetricsDS();
   const styles = useStyles2(getStyles);
+  const { isEnabled: isReliabilityInboxEnabled } = useFeatureFlag(FeatureName.ReliabilityInbox);
 
   if (checks.length === 0) {
-    return <ChecksEmptyState className={styles.emptyState} />;
+    return (
+      <Stack direction="column" gap={1}>
+        {isReliabilityInboxEnabled && <ReliabilityInboxBanner />}
+        <ChecksEmptyState className={styles.emptyState} />
+      </Stack>
+    );
   }
 
   return (
@@ -224,4 +234,3 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
   };
 };
-

--- a/src/scenes/Summary/SummaryDashboard.tsx
+++ b/src/scenes/Summary/SummaryDashboard.tsx
@@ -13,8 +13,8 @@ import {
 import { VariableRefresh } from '@grafana/schema';
 import { Stack, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
-import { TrackingTimeRangeScope } from 'features/tracking/TrackingTimeRangeScope';
 import { ReliabilityInboxBanner } from 'features/reliabilityInbox';
+import { TrackingTimeRangeScope } from 'features/tracking/TrackingTimeRangeScope';
 
 import { Check, FeatureName } from 'types';
 import { useDemAssistantContext } from 'hooks/useDemAssistantContext';

--- a/src/services/featureFlags.ts
+++ b/src/services/featureFlags.ts
@@ -9,7 +9,9 @@ export const SM_OPEN_FEATURE_DOMAIN = pluginJson.id;
 
 // Adding an entry routes all consumers of that FeatureName through OpenFeature instead
 // of legacy config.featureToggles. See docs/development/openfeature-migration.md
-export const OPEN_FEATURE_KEYS: Partial<Record<FeatureName, string>> = {};
+export const OPEN_FEATURE_KEYS: Partial<Record<FeatureName, string>> = {
+  [FeatureName.ReliabilityInbox]: 'synthetic-monitoring-reliability-inbox',
+};
 
 let initPromise: Promise<void> | undefined;
 let client: Client | undefined;

--- a/src/test/fixtures/reliabilityInbox.ts
+++ b/src/test/fixtures/reliabilityInbox.ts
@@ -1,0 +1,32 @@
+import { ReliabilitySuggestion } from 'features/reliabilityInbox/types';
+
+export const HTTP_RELIABILITY_SUGGESTION: ReliabilitySuggestion = {
+  id: 'http-suggestion',
+  target: 'https://mcp.goagain.dev/',
+  checkType: 'http',
+  evidence: {
+    reqPerS: 1.6081232492997197,
+    errorRatio: 0.0014,
+    p99Ms: 4,
+    statusDistribution: {
+      '200': 1.6058823529411763,
+      '400': 0.002240896358543417,
+    },
+    families: ['http_server_request_duration_seconds_bucket'],
+    provenance: {
+      datasource: 'prometheus-uid',
+      range: { from: '1784800800000', to: '1784804400000' },
+      queries: [{ expr: 'sum(rate(http_server_request_duration_seconds_count[1h]))' }],
+    },
+  },
+  reachability: 'public',
+  reachabilitySource: 'service_dns_hint',
+  confidence: 'high',
+  score: 1.416328110536119,
+  dedupStatus: 'uncovered',
+  authRequired: false,
+  relevance: 75,
+  rationale: 'Public endpoint with steady traffic serving likely critical MCP protocol functions.',
+  prompt:
+    'Create a Grafana Synthetic Monitoring http check for https://mcp.goagain.dev/. Suggested configuration: job "mcp.goagain.dev", frequency 1m0s, timeout 2s, expect HTTP status [200], fail if not SSL, probe IDs [7]. Why: Public endpoint with steady traffic serving likely critical MCP protocol functions.; the endpoint served 1.6 req/s (0.00% errors) over the last hour.',
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -756,6 +756,7 @@ export enum FeatureName {
   Folders = 'synthetic-monitoring-folders',
   GRPCChecks = 'grpc-checks',
   LabelMigration = 'synthetic-monitoring-label-migration',
+  ReliabilityInbox = 'synthetic-monitoring-reliability-inbox',
   Screenshots = 'synthetic-monitoring-screenshots',
   SecretsManagement = 'synthetic-monitoring-secrets-management',
   TimepointExplorer = 'synthetic-monitoring-timepoint-explorer',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -474,7 +474,8 @@ export function getExploreUrl(datasourceUid: string, queries: Query[], { from, t
   const left = encodeURIComponent(
     JSON.stringify({
       datasource: datasourceUid,
-      queries: queries.map((query) => ({
+      queries: queries.map((query, index) => ({
+        refId: String.fromCharCode(65 + index),
         expr: query.expr,
         instant: query.instant,
         format: query.format,


### PR DESCRIPTION
## What
Hides the Reliability Inbox banner whenever the Grafana Assistant is unavailable or its availability is still resolving.

## Why
We need Assistant to use the feature in a functional way. This method also guarantees that the user accepted Assistant T&C.