### PR TITLE
fix: prevent creating checks in folders the user cannot edit

### DIFF
--- a/src/components/Checkster/components/form/FormFolderField.tsx
+++ b/src/components/Checkster/components/form/FormFolderField.tsx
@@ -9,21 +9,24 @@ import { StyledField } from '../ui/StyledField';
 
 export function FormFolderField() {
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
-  const { control, formState: { disabled } } = useFormContext<CheckFormValues>();
-  const { field } = useController({ name: 'folderUid', control });
+  const {
+    control,
+    formState: { disabled },
+  } = useFormContext<CheckFormValues>();
+  const { field, fieldState } = useController({ name: 'folderUid', control });
 
   if (!isFoldersEnabled) {
     return null;
   }
 
   return (
-    <StyledField label="Folder" description="Choose a folder where you want to store the check.">
-      <FolderSelector
-        value={field.value}
-        onChange={field.onChange}
-        disabled={disabled}
-        aria-label="Select folder"
-      />
+    <StyledField
+      label="Folder"
+      description="Choose a folder where you want to store the check."
+      invalid={!!fieldState.error}
+      error={fieldState.error?.message}
+    >
+      <FolderSelector value={field.value} onChange={field.onChange} disabled={disabled} aria-label="Select folder" />
     </StyledField>
   );
 }

--- a/src/components/Checkster/components/form/FormFolderField.tsx
+++ b/src/components/Checkster/components/form/FormFolderField.tsx
@@ -4,6 +4,7 @@ import { useController, useFormContext } from 'react-hook-form';
 import { CheckFormValues, FeatureName } from 'types';
 import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 import { FolderSelector } from 'components/FolderSelector/FolderSelector';
+import { useFolderSelection } from 'components/FolderSelector/FolderSelector.hooks';
 
 import { StyledField } from '../ui/StyledField';
 
@@ -14,17 +15,23 @@ export function FormFolderField() {
     formState: { disabled },
   } = useFormContext<CheckFormValues>();
   const { field, fieldState } = useController({ name: 'folderUid', control });
+  const { noStorableFolders } = useFolderSelection({ value: field.value, enabled: isFoldersEnabled });
 
   if (!isFoldersEnabled) {
     return null;
   }
 
+  // When nothing can be selected, FolderSelector replaces the picker with an
+  // alert that already explains the missing permissions, so the "select a
+  // folder" error would only add noise.
+  const showError = !!fieldState.error && !(noStorableFolders && !field.value);
+
   return (
     <StyledField
       label="Folder"
       description="Choose a folder where you want to store the check."
-      invalid={!!fieldState.error}
-      error={fieldState.error?.message}
+      invalid={showError}
+      error={showError ? fieldState.error?.message : undefined}
     >
       <FolderSelector value={field.value} onChange={field.onChange} disabled={disabled} aria-label="Select folder" />
     </StyledField>

--- a/src/components/Checkster/components/form/generic/GenericNameValueField.test.tsx
+++ b/src/components/Checkster/components/form/generic/GenericNameValueField.test.tsx
@@ -37,6 +37,15 @@ jest.mock('data/useDefaultFolder', () => ({
   })),
 }));
 
+// ChecksterProvider is rendered without a QueryClient here, so the folder
+// selection hook (react-query based) must be mocked like useDefaultFolder above.
+jest.mock('components/FolderSelector/FolderSelector.hooks', () => ({
+  useFolderSelection: jest.fn(() => ({
+    preselectUid: undefined,
+    isPreselectReady: true,
+  })),
+}));
+
 const defaultProps = {
   field: 'labels',
   label: 'Labels',

--- a/src/components/Checkster/components/form/layouts/BrowserCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/BrowserCheckContent.tsx
@@ -6,7 +6,7 @@ import { BROWSER_EXAMPLES } from 'components/WelcomeTabs/constants';
 
 import { ScriptedCheckContent } from './ScriptedCheckContent';
 
-export const BROWSER_CHECK_FIELDS = ['job', 'target', 'channels.k6', 'settings.browser.script'];
+export const BROWSER_CHECK_FIELDS = ['job', 'target', 'folderUid', 'channels.k6', 'settings.browser.script'];
 
 const SCREENSHOT_EXAMPLE_VALUES = ['screenshotsLoki.js', 'screenshotsGCS.js'];
 

--- a/src/components/Checkster/components/form/layouts/DnsCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/DnsCheckContent.tsx
@@ -22,7 +22,7 @@ const DNS_CHECK_REQUEST_OPTIONS_FIELDS = DNS_REQUEST_OPTIONS_TAB_FIELDS.filter((
   return field !== undefined;
 }).flat();
 
-export const DNS_CHECK_FIELDS = ['job', 'target', ...DNS_CHECK_REQUEST_OPTIONS_FIELDS];
+export const DNS_CHECK_FIELDS = ['job', 'target', 'folderUid', ...DNS_CHECK_REQUEST_OPTIONS_FIELDS];
 
 export function DnsCheckContent() {
   const hasRequestOptionError = useHasFieldsError(DNS_CHECK_REQUEST_OPTIONS_FIELDS);

--- a/src/components/Checkster/components/form/layouts/GrpcCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/GrpcCheckContent.tsx
@@ -22,7 +22,7 @@ const GRPC_REQUEST_OPTIONS_FIELDS = GRPC_REQUEST_OPTIONS_TAB_FIELDS.filter((fiel
   return field !== undefined;
 }).flat();
 
-export const GRPC_CHECK_FIELDS = ['job', 'target', ...GRPC_REQUEST_OPTIONS_FIELDS];
+export const GRPC_CHECK_FIELDS = ['job', 'target', 'folderUid', ...GRPC_REQUEST_OPTIONS_FIELDS];
 
 export function GrpcCheckContent() {
   const hasRequestOptionError = useHasFieldsError(GRPC_REQUEST_OPTIONS_FIELDS);

--- a/src/components/Checkster/components/form/layouts/HttpCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/HttpCheckContent.tsx
@@ -30,7 +30,7 @@ const REQUEST_OPTIONS_FIELDS = REQUEST_OPTIONS_TAB_FIELDS.filter((field) => {
   return field !== undefined;
 }).flat();
 
-export const HTTP_CHECK_FIELDS = ['job', 'target', ...REQUEST_OPTIONS_FIELDS];
+export const HTTP_CHECK_FIELDS = ['job', 'target', 'folderUid', ...REQUEST_OPTIONS_FIELDS];
 
 export function HttpCheckContent() {
   const hasRequestOptionError = useHasFieldsError(REQUEST_OPTIONS_FIELDS);

--- a/src/components/Checkster/components/form/layouts/MultiHttpCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/MultiHttpCheckContent.tsx
@@ -6,7 +6,7 @@ import { FormJobField } from '../FormJobField';
 import { FormMultiHttpEntriesField } from '../FormMultiHttpEntriesField';
 
 // Any field path that belongs to the multi http check section
-export const MULTI_HTTP_CHECK_REG_EXP_LIST = ['job', /\.entries\.\d+\.request/, /\.entries\.\d+\.variables/];
+export const MULTI_HTTP_CHECK_REG_EXP_LIST = ['job', 'folderUid', /\.entries\.\d+\.request/, /\.entries\.\d+\.variables/];
 
 export function MultiHttpCheckContent() {
   return (

--- a/src/components/Checkster/components/form/layouts/ScriptedCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/ScriptedCheckContent.tsx
@@ -26,7 +26,7 @@ interface ScriptedCheckSectionProps {
   examples?: ExampleScript[];
 }
 
-export const SCRIPTED_CHECK_FIELDS = ['job', 'target', 'channels.k6', 'settings.scripted.script'];
+export const SCRIPTED_CHECK_FIELDS = ['job', 'target', 'folderUid', 'channels.k6', 'settings.scripted.script'];
 
 // Don't set label here, set it explicitly, where the component is used (for readability)
 export function ScriptedCheckContent({

--- a/src/components/Checkster/components/form/layouts/TcpCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/TcpCheckContent.tsx
@@ -22,7 +22,7 @@ const REQUEST_OPTIONS_FIELDS = REQUEST_OPTIONS_TAB_FIELDS.filter((field) => {
   return field !== undefined;
 }).flat();
 
-export const TCP_REQUEST_OPTIONS_FIELDS = ['job', 'target', ...REQUEST_OPTIONS_FIELDS];
+export const TCP_REQUEST_OPTIONS_FIELDS = ['job', 'target', 'folderUid', ...REQUEST_OPTIONS_FIELDS];
 
 export function TcpCheckContent() {
   const hasRequestOptionError = useHasFieldsError(REQUEST_OPTIONS_FIELDS);

--- a/src/components/Checkster/components/form/layouts/TracerouteCheckContent.tsx
+++ b/src/components/Checkster/components/form/layouts/TracerouteCheckContent.tsx
@@ -20,7 +20,7 @@ const REQUEST_OPTIONS_FIELDS = REQUEST_OPTIONS_TAB_FIELDS.filter((field) => {
   return field !== undefined;
 }).flat();
 
-export const TRACEROUTE_CHECK_FIELDS = ['job', 'target', ...REQUEST_OPTIONS_FIELDS];
+export const TRACEROUTE_CHECK_FIELDS = ['job', 'target', 'folderUid', ...REQUEST_OPTIONS_FIELDS];
 
 export function TracerouteCheckContent() {
   const hasRequestOptionError = useHasFieldsError(REQUEST_OPTIONS_FIELDS);

--- a/src/components/Checkster/components/form/sections/CheckSection.tsx
+++ b/src/components/Checkster/components/form/sections/CheckSection.tsx
@@ -15,7 +15,7 @@ import { SCRIPTED_CHECK_FIELDS,ScriptedCheckContent } from '../layouts/ScriptedC
 import { TCP_REQUEST_OPTIONS_FIELDS,TcpCheckContent } from '../layouts/TcpCheckContent';
 import { TRACEROUTE_CHECK_FIELDS,TracerouteCheckContent } from '../layouts/TracerouteCheckContent';
 
-const DEFAULT_CHECK_FIELDS = ['job', 'target'];
+const DEFAULT_CHECK_FIELDS = ['job', 'target', 'folderUid'];
 
 function getCheckTypeFields(checkType: CheckType) {
   switch (checkType) {

--- a/src/components/Checkster/contexts/ChecksterContext.tsx
+++ b/src/components/Checkster/contexts/ChecksterContext.tsx
@@ -75,12 +75,18 @@ interface StashedValues {
   settings: Record<string, unknown> | undefined;
 }
 
-function useFormValuesMeta(checkType: CheckType, check: Check | undefined, probesWithMetadata: ProbeWithMetadata[], defaultFolderUid?: string) {
+function useFormValuesMeta(
+  checkType: CheckType,
+  check: Check | undefined,
+  probesWithMetadata: ProbeWithMetadata[],
+  defaultFolderUid?: string,
+  requiresFolder = false
+) {
   const probeCompatibilityKey = useProbeCompatibilityKey(probesWithMetadata);
 
   return useMemo(() => {
     const schema = createCheckSchema(checkType, probesWithMetadata);
-    const refinedSchema = addRefinements<CheckFormValues>(schema);
+    const refinedSchema = addRefinements<CheckFormValues>(schema, { requiresFolder });
     const formValues = check ? toFormValues(check) : getDefaultFormValues(checkType);
 
     if (defaultFolderUid && !formValues.folderUid) {
@@ -94,7 +100,7 @@ function useFormValuesMeta(checkType: CheckType, check: Check | undefined, probe
     // Use probeCompatibilityKey instead of probesWithMetadata array reference
     // This ensures schema only recreates when probe compatibility actually changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [checkType, check, probeCompatibilityKey, defaultFolderUid]);
+  }, [checkType, check, probeCompatibilityKey, defaultFolderUid, requiresFolder]);
 }
 
 export function ChecksterProvider({
@@ -110,8 +116,21 @@ export function ChecksterProvider({
   const check = isCheck(externalCheck) ? externalCheck : undefined;
   const { data: probesWithMetadata = [] } = useProbesWithMetadata();
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
-  const { defaultFolderUid, isLoading: isFolderLoading, isError: isFolderError } = useDefaultFolder(isFoldersEnabled);
+  const {
+    defaultFolder,
+    defaultFolderUid,
+    status: defaultFolderStatus,
+    isLoading: isFolderLoading,
+    isError: isFolderError,
+  } = useDefaultFolder(isFoldersEnabled);
   const isFolderReady = !isFoldersEnabled || !isFolderLoading || isFolderError;
+  // Pre-fill the default folder only if the user can edit it; seeding via form
+  // defaults keeps a new form pristine (FolderSelector handles fallbacks).
+  const seedFolderUid = defaultFolder?.canEdit ? defaultFolderUid : undefined;
+  // A folder-less check effectively lives in the default folder, which the
+  // user may not be able to edit — so a folder is required when folder data
+  // is available. When it isn't, checks save without one, as before.
+  const requiresFolder = isFoldersEnabled && defaultFolderStatus === 'available';
 
   const [checkType, setCheckType] = useState<CheckType>(
     isCheck(externalCheck) ? getCheckType(externalCheck.settings) : (externalCheckType ?? DEFAULT_CHECK_TYPE)
@@ -129,7 +148,13 @@ export function ChecksterProvider({
     check_is_duplicate: isDuplicate,
   });
 
-  const { schema, defaultFormValues } = useFormValuesMeta(checkType, check, probesWithMetadata, defaultFolderUid);
+  const { schema, defaultFormValues } = useFormValuesMeta(
+    checkType,
+    check,
+    probesWithMetadata,
+    seedFolderUid,
+    requiresFolder
+  );
 
   const [stashedValues, setStashedValues] = useState<Partial<StashedValues>>({});
 

--- a/src/components/Checkster/contexts/ChecksterContext.tsx
+++ b/src/components/Checkster/contexts/ChecksterContext.tsx
@@ -25,6 +25,7 @@ import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 import { useDefaultFolder } from 'data/useDefaultFolder';
 import { useProbesWithMetadata } from 'data/useProbes';
 import { useDOMId } from 'hooks/useDOMId';
+import { useFolderSelection } from 'components/FolderSelector/FolderSelector.hooks';
 
 import { ASSISTED_FORM_MERGE_FIELDS, DEFAULT_CHECK_TYPE, K6_CHECK_TYPES } from '../constants';
 import { useFormNavigationState } from '../hooks/useFormNavigationState';
@@ -117,16 +118,15 @@ export function ChecksterProvider({
   const { data: probesWithMetadata = [] } = useProbesWithMetadata();
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
   const {
-    defaultFolder,
-    defaultFolderUid,
     status: defaultFolderStatus,
     isLoading: isFolderLoading,
     isError: isFolderError,
   } = useDefaultFolder(isFoldersEnabled);
   const isFolderReady = !isFoldersEnabled || !isFolderLoading || isFolderError;
-  // Pre-fill the default folder only if the user can edit it; seeding via form
-  // defaults keeps a new form pristine (FolderSelector handles fallbacks).
-  const seedFolderUid = defaultFolder?.canEdit ? defaultFolderUid : undefined;
+  // Seed the folder through the form defaults so a new form stays pristine:
+  // the default folder when the user can edit it, else their only editable
+  // folder. With several candidates nothing is seeded — the choice is theirs.
+  const { preselectUid: seedFolderUid } = useFolderSelection({ enabled: isFoldersEnabled });
   // A folder-less check effectively lives in the default folder, which the
   // user may not be able to edit — so a folder is required when folder data
   // is available. When it isn't, checks save without one, as before.

--- a/src/components/Checkster/contexts/ChecksterContext.tsx
+++ b/src/components/Checkster/contexts/ChecksterContext.tsx
@@ -25,6 +25,7 @@ import { isFeatureEnabled } from 'contexts/FeatureFlagContext';
 import { useDefaultFolder } from 'data/useDefaultFolder';
 import { useProbesWithMetadata } from 'data/useProbes';
 import { useDOMId } from 'hooks/useDOMId';
+import { CenteredSpinner } from 'components/CenteredSpinner';
 import { useFolderSelection } from 'components/FolderSelector/FolderSelector.hooks';
 
 import { ASSISTED_FORM_MERGE_FIELDS, DEFAULT_CHECK_TYPE, K6_CHECK_TYPES } from '../constants';
@@ -297,9 +298,10 @@ export function ChecksterProvider({
     canChangeCheckType,
   ]);
 
-  // Don't mount the form until we know which folder to pre-fill.
-  if (!isPreselectReady) {
-    return null;
+  // Don't mount the form until we know which folder to pre-fill. Checks that
+  // already have a folder don't need the pre-fill, so they don't wait.
+  if (!isPreselectReady && !check?.folderUid) {
+    return <CenteredSpinner aria-label="Loading check form" />;
   }
 
   return (

--- a/src/components/Checkster/contexts/ChecksterContext.tsx
+++ b/src/components/Checkster/contexts/ChecksterContext.tsx
@@ -117,16 +117,11 @@ export function ChecksterProvider({
   const check = isCheck(externalCheck) ? externalCheck : undefined;
   const { data: probesWithMetadata = [] } = useProbesWithMetadata();
   const isFoldersEnabled = isFeatureEnabled(FeatureName.Folders);
-  const {
-    status: defaultFolderStatus,
-    isLoading: isFolderLoading,
-    isError: isFolderError,
-  } = useDefaultFolder(isFoldersEnabled);
-  const isFolderReady = !isFoldersEnabled || !isFolderLoading || isFolderError;
-  // Seed the folder through the form defaults so a new form stays pristine:
-  // the default folder when the user can edit it, else their only editable
-  // folder. With several candidates nothing is seeded — the choice is theirs.
-  const { preselectUid: seedFolderUid } = useFolderSelection({ enabled: isFoldersEnabled });
+  const { status: defaultFolderStatus } = useDefaultFolder(isFoldersEnabled);
+  // Pre-fill the folder through the form defaults so a new form stays
+  // pristine: the default folder when the user can edit it, else their only
+  // editable folder. With several candidates the choice is theirs.
+  const { preselectUid: seedFolderUid, isPreselectReady } = useFolderSelection({ enabled: isFoldersEnabled });
   // A folder-less check effectively lives in the default folder, which the
   // user may not be able to edit — so a folder is required when folder data
   // is available. When it isn't, checks save without one, as before.
@@ -302,7 +297,8 @@ export function ChecksterProvider({
     canChangeCheckType,
   ]);
 
-  if (!isFolderReady) {
+  // Don't mount the form until we know which folder to pre-fill.
+  if (!isPreselectReady) {
     return null;
   }
 

--- a/src/components/FolderSelector/FolderSelector.hooks.ts
+++ b/src/components/FolderSelector/FolderSelector.hooks.ts
@@ -1,0 +1,98 @@
+import { useMemo } from 'react';
+
+import { useDefaultFolder } from 'data/useDefaultFolder';
+import { useFolderPermissions } from 'data/useFolderPermissions';
+import { useFolderChildren } from 'data/useFolders';
+
+interface UseFolderSelectionOptions {
+  /**
+   * The currently selected folder UID, if any. It is looked up alongside the
+   * default subtree because it can reference a folder outside of it (assigned
+   * via the API/Terraform) that still needs a proper label.
+   */
+  value?: string;
+  enabled?: boolean;
+}
+
+/**
+ * Folder data behind the check folder picker: the default SM folder and its
+ * children, their permissions, and the selection decisions derived from them.
+ * Shared by FolderSelector (rendering) and FormFolderField (form seeding and
+ * validation display), which stay in sync through the query cache.
+ */
+export function useFolderSelection({ value, enabled = true }: UseFolderSelectionOptions = {}) {
+  const {
+    defaultFolder,
+    defaultFolderUid,
+    isLoading: isDefaultLoading,
+    isError: isDefaultError,
+    refetch: refetchDefault,
+  } = useDefaultFolder(enabled);
+  const {
+    data: childFolders = [],
+    isLoading: isChildrenLoading,
+    isError: isChildrenError,
+    refetch: refetchChildren,
+  } = useFolderChildren(defaultFolderUid);
+
+  const allFolders = useMemo(() => (defaultFolder ? [defaultFolder, ...childFolders] : []), [defaultFolder, childFolders]);
+  const allFolderUids = useMemo(() => {
+    const uids = allFolders.map((f) => f.uid);
+    if (value && !uids.includes(value)) {
+      uids.push(value);
+    }
+    return uids;
+  }, [allFolders, value]);
+  const { folderDetailsByUid } = useFolderPermissions(allFolderUids);
+
+  // Only editable folders are offered: a check must be manageable by its creator.
+  const editableFolders = useMemo(
+    () =>
+      allFolders.filter((folder) => {
+        const state = folderDetailsByUid.get(folder.uid);
+        return state?.type === 'accessible' && state.permissions.canEdit;
+      }),
+    [allFolders, folderDetailsByUid]
+  );
+
+  // Decisions that depend on the full editable set must wait for every
+  // permission lookup to settle, so they don't fire on partial data.
+  const permissionsSettled =
+    allFolders.length > 0 &&
+    allFolders.every((folder) => {
+      const state = folderDetailsByUid.get(folder.uid);
+      return state !== undefined && state.type !== 'loading';
+    });
+
+  // Preselect the default folder if editable, else the user's only editable
+  // folder; with several candidates the choice is theirs.
+  const preselectUid = useMemo(() => {
+    if (defaultFolder?.canEdit) {
+      return defaultFolder.uid;
+    }
+    if (permissionsSettled && editableFolders.length === 1) {
+      return editableFolders[0].uid;
+    }
+    return undefined;
+  }, [defaultFolder, permissionsSettled, editableFolders]);
+
+  // No folder to store checks in and no rights to create one: the picker
+  // renders an explanatory alert instead of an empty dropdown.
+  const noStorableFolders = permissionsSettled && editableFolders.length === 0 && !defaultFolder?.canSave;
+
+  return {
+    defaultFolder,
+    defaultFolderUid,
+    allFolders,
+    folderDetailsByUid,
+    editableFolders,
+    permissionsSettled,
+    preselectUid,
+    noStorableFolders,
+    isLoading: isDefaultLoading || isChildrenLoading,
+    isDefaultError,
+    isChildrenError,
+    refetchDefault,
+    refetchChildren,
+  };
+}

--- a/src/components/FolderSelector/FolderSelector.hooks.ts
+++ b/src/components/FolderSelector/FolderSelector.hooks.ts
@@ -55,9 +55,13 @@ export function useFolderSelection({ value, enabled = true }: UseFolderSelection
     [allFolders, folderDetailsByUid]
   );
 
-  // Decisions that depend on the full editable set must wait for every
-  // permission lookup to settle, so they don't fire on partial data.
+  const isLoading = isDefaultLoading || isChildrenLoading;
+
+  // Decisions that depend on the full editable set must wait for the folder
+  // list and every permission lookup to settle, so they don't fire on
+  // partial data.
   const permissionsSettled =
+    !isLoading &&
     allFolders.length > 0 &&
     allFolders.every((folder) => {
       const state = folderDetailsByUid.get(folder.uid);
@@ -80,6 +84,14 @@ export function useFolderSelection({ value, enabled = true }: UseFolderSelection
   // renders an explanatory alert instead of an empty dropdown.
   const noStorableFolders = permissionsSettled && editableFolders.length === 0 && !defaultFolder?.canSave;
 
+  // True once we know which folder to preselect, or that there is none.
+  // An editable default folder decides it right away; a read-only one means
+  // waiting for the other folders' permissions.
+  const isPreselectReady =
+    !enabled ||
+    isDefaultError ||
+    (!isDefaultLoading && (!defaultFolder || defaultFolder.canEdit || permissionsSettled));
+
   return {
     defaultFolder,
     defaultFolderUid,
@@ -89,7 +101,8 @@ export function useFolderSelection({ value, enabled = true }: UseFolderSelection
     permissionsSettled,
     preselectUid,
     noStorableFolders,
-    isLoading: isDefaultLoading || isChildrenLoading,
+    isPreselectReady,
+    isLoading,
     isDefaultError,
     isChildrenError,
     refetchDefault,

--- a/src/components/FolderSelector/FolderSelector.test.tsx
+++ b/src/components/FolderSelector/FolderSelector.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { renderHook, screen, waitFor } from '@testing-library/react';
 import { DEFAULT_FOLDER, FOLDER_EXTERNAL, FOLDER_PRODUCTION, FOLDER_READONLY } from 'test/fixtures/folders';
-import { render } from 'test/render';
+import { createWrapper, render } from 'test/render';
 import {
   runTestWithNoEditableFolders,
   runTestWithReadOnlyDefaultFolder,
@@ -9,6 +9,7 @@ import {
 } from 'test/utils';
 
 import { FolderSelector } from './FolderSelector';
+import { useFolderSelection } from './FolderSelector.hooks';
 
 describe('FolderSelector', () => {
   it('renders with placeholder', async () => {
@@ -31,32 +32,6 @@ describe('FolderSelector', () => {
 
     await screen.findByPlaceholderText(/Select a folder/);
     expect(screen.queryByRole('button', { name: /Create folder/ })).not.toBeInTheDocument();
-  });
-
-  it('auto-selects the default folder when the user can edit it', async () => {
-    const onChange = jest.fn();
-    render(<FolderSelector onChange={onChange} />);
-
-    await waitFor(() => expect(onChange).toHaveBeenCalledWith(DEFAULT_FOLDER.uid));
-  });
-
-  it('does not preselect anything when the default folder is read-only and several folders are editable', async () => {
-    runTestWithReadOnlyDefaultFolder();
-
-    const onChange = jest.fn();
-    render(<FolderSelector onChange={onChange} />);
-
-    expect(await screen.findByPlaceholderText(/Select a folder/)).toBeInTheDocument();
-    expect(onChange).not.toHaveBeenCalled();
-  });
-
-  it('preselects the only editable folder when the default folder is read-only', async () => {
-    runTestWithSingleEditableFolder();
-
-    const onChange = jest.fn();
-    render(<FolderSelector onChange={onChange} />);
-
-    await waitFor(() => expect(onChange).toHaveBeenCalledWith(FOLDER_PRODUCTION.uid));
   });
 
   it('explains the dead end when the user cannot edit any folder', async () => {
@@ -90,5 +65,45 @@ describe('FolderSelector', () => {
     render(<FolderSelector value={FOLDER_EXTERNAL.uid} onChange={onChange} />);
 
     expect(await screen.findByDisplayValue(FOLDER_EXTERNAL.title)).toBeInTheDocument();
+  });
+});
+
+describe('useFolderSelection', () => {
+  function renderFolderSelection() {
+    const { Wrapper } = createWrapper();
+    return renderHook(() => useFolderSelection(), { wrapper: Wrapper });
+  }
+
+  it('preselects the default folder when the user can edit it', async () => {
+    const { result } = renderFolderSelection();
+
+    await waitFor(() => expect(result.current.preselectUid).toBe(DEFAULT_FOLDER.uid));
+  });
+
+  it('preselects nothing when the default folder is read-only and several folders are editable', async () => {
+    runTestWithReadOnlyDefaultFolder();
+
+    const { result } = renderFolderSelection();
+
+    await waitFor(() => expect(result.current.permissionsSettled).toBe(true));
+    expect(result.current.preselectUid).toBeUndefined();
+    expect(result.current.noStorableFolders).toBe(false);
+  });
+
+  it('preselects the only editable folder when the default folder is read-only', async () => {
+    runTestWithSingleEditableFolder();
+
+    const { result } = renderFolderSelection();
+
+    await waitFor(() => expect(result.current.preselectUid).toBe(FOLDER_PRODUCTION.uid));
+  });
+
+  it('reports no storable folders when the user cannot edit any folder', async () => {
+    runTestWithNoEditableFolders();
+
+    const { result } = renderFolderSelection();
+
+    await waitFor(() => expect(result.current.noStorableFolders).toBe(true));
+    expect(result.current.preselectUid).toBeUndefined();
   });
 });

--- a/src/components/FolderSelector/FolderSelector.test.tsx
+++ b/src/components/FolderSelector/FolderSelector.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import { DEFAULT_FOLDER, FOLDER_EXTERNAL, FOLDER_PRODUCTION, FOLDER_READONLY } from 'test/fixtures/folders';
 import { render } from 'test/render';
+import {
+  runTestWithNoEditableFolders,
+  runTestWithReadOnlyDefaultFolder,
+  runTestWithSingleEditableFolder,
+} from 'test/utils';
 
 import { FolderSelector } from './FolderSelector';
 
@@ -27,10 +33,62 @@ describe('FolderSelector', () => {
     expect(screen.queryByRole('button', { name: /Create folder/ })).not.toBeInTheDocument();
   });
 
+  it('auto-selects the default folder when the user can edit it', async () => {
+    const onChange = jest.fn();
+    render(<FolderSelector onChange={onChange} />);
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(DEFAULT_FOLDER.uid));
+  });
+
+  it('does not preselect anything when the default folder is read-only and several folders are editable', async () => {
+    runTestWithReadOnlyDefaultFolder();
+
+    const onChange = jest.fn();
+    render(<FolderSelector onChange={onChange} />);
+
+    expect(await screen.findByPlaceholderText(/Select a folder/)).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('preselects the only editable folder when the default folder is read-only', async () => {
+    runTestWithSingleEditableFolder();
+
+    const onChange = jest.fn();
+    render(<FolderSelector onChange={onChange} />);
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(FOLDER_PRODUCTION.uid));
+  });
+
+  it('explains the dead end when the user cannot edit any folder', async () => {
+    runTestWithNoEditableFolders();
+
+    const onChange = jest.fn();
+    render(<FolderSelector onChange={onChange} />);
+
+    expect(await screen.findByText(/You don't have permission to store checks in any folder/)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`Edit access to the "${DEFAULT_FOLDER.title}" folder`))).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/Select a folder/)).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('shows a not found label for a deleted or missing folder', async () => {
     const onChange = jest.fn();
     render(<FolderSelector value="deleted-folder-uid" onChange={onChange} />);
 
     expect(await screen.findByDisplayValue('deleted-folder-uid (folder not found)')).toBeInTheDocument();
+  });
+
+  it('shows the folder title with a read-only suffix for a readable folder the user cannot edit', async () => {
+    const onChange = jest.fn();
+    render(<FolderSelector value={FOLDER_READONLY.uid} onChange={onChange} />);
+
+    expect(await screen.findByDisplayValue(`${FOLDER_READONLY.title} (read-only)`)).toBeInTheDocument();
+  });
+
+  it('shows the folder title for an editable folder outside the default subtree', async () => {
+    const onChange = jest.fn();
+    render(<FolderSelector value={FOLDER_EXTERNAL.uid} onChange={onChange} />);
+
+    expect(await screen.findByDisplayValue(FOLDER_EXTERNAL.title)).toBeInTheDocument();
   });
 });

--- a/src/components/FolderSelector/FolderSelector.tsx
+++ b/src/components/FolderSelector/FolderSelector.tsx
@@ -3,6 +3,7 @@ import { Alert, Button, Combobox, ComboboxOption, Field, Input, LoadingPlacehold
 import { trackFolderCreated, trackFolderSelected } from 'features/tracking/folderEvents';
 
 import { GrafanaFolder } from 'types';
+import { FolderAccessState } from 'data/folderPermissions';
 import { useDefaultFolder } from 'data/useDefaultFolder';
 import { useFolderPermissions } from 'data/useFolderPermissions';
 import { getFolderPathParts, useCreateFolder, useFolderChildren } from 'data/useFolders';
@@ -21,11 +22,38 @@ export function FolderSelector({ value, onChange, disabled, autoSelectDefault = 
   const [showCreateModal, setShowCreateModal] = useState(false);
 
   const allFolders = useMemo(() => (defaultFolder ? [defaultFolder, ...childFolders] : []), [defaultFolder, childFolders]);
-  const allFolderUids = useMemo(() => allFolders.map((f) => f.uid), [allFolders]);
+  // Include the selected value: it can reference a folder outside the default
+  // subtree (assigned via the API/Terraform) that still needs a proper label.
+  const allFolderUids = useMemo(() => {
+    const uids = allFolders.map((f) => f.uid);
+    if (value && !uids.includes(value)) {
+      uids.push(value);
+    }
+    return uids;
+  }, [allFolders, value]);
   const { folderDetailsByUid } = useFolderPermissions(allFolderUids);
 
   const isLoading = isDefaultLoading || isChildrenLoading;
   const isError = isDefaultError || isChildrenError;
+
+  // Only editable folders are offered: a check must be manageable by its creator.
+  const editableFolders = useMemo(
+    () =>
+      allFolders.filter((folder) => {
+        const state = folderDetailsByUid.get(folder.uid);
+        return state?.type === 'accessible' && state.permissions.canEdit;
+      }),
+    [allFolders, folderDetailsByUid]
+  );
+
+  // Decisions that depend on the full editable set must wait for every
+  // permission lookup to settle, so they don't fire on partial data.
+  const permissionsSettled =
+    allFolders.length > 0 &&
+    allFolders.every((folder) => {
+      const state = folderDetailsByUid.get(folder.uid);
+      return state !== undefined && state.type !== 'loading';
+    });
 
   const options: Array<ComboboxOption<string>> = useMemo(() => {
     if (!defaultFolder) {
@@ -33,11 +61,6 @@ export function FolderSelector({ value, onChange, disabled, autoSelectDefault = 
     }
 
     const foldersMap = new Map(allFolders.map((f) => [f.uid, f]));
-
-    const editableFolders = allFolders.filter((folder) => {
-      const state = folderDetailsByUid.get(folder.uid);
-      return state?.type === 'accessible' && state.permissions.canEdit;
-    });
 
     const result: Array<ComboboxOption<string>> = editableFolders.map((folder) => {
       if (folder.uid === defaultFolder.uid) {
@@ -60,17 +83,29 @@ export function FolderSelector({ value, onChange, disabled, autoSelectDefault = 
     });
 
     if (value && !result.some((opt) => opt.value === value)) {
-      result.push({ label: `${value} (folder not found)`, value });
+      result.push(toSelectedFolderOption(value, folderDetailsByUid.get(value)));
     }
 
     return result;
-  }, [allFolders, defaultFolder, value, folderDetailsByUid]);
+  }, [allFolders, editableFolders, defaultFolder, value, folderDetailsByUid]);
+
+  // Preselect the default folder if editable, else the user's only editable
+  // folder; with several candidates the choice is theirs.
+  const preselectUid = useMemo(() => {
+    if (defaultFolder?.canEdit) {
+      return defaultFolder.uid;
+    }
+    if (permissionsSettled && editableFolders.length === 1) {
+      return editableFolders[0].uid;
+    }
+    return undefined;
+  }, [defaultFolder, permissionsSettled, editableFolders]);
 
   useEffect(() => {
-    if (autoSelectDefault && value === undefined && defaultFolderUid) {
-      onChange(defaultFolderUid);
+    if (autoSelectDefault && value === undefined && preselectUid) {
+      onChange(preselectUid);
     }
-  }, [autoSelectDefault, value, defaultFolderUid, onChange]);
+  }, [autoSelectDefault, value, preselectUid, onChange]);
 
   const handleChange = (selected: ComboboxOption<string> | null) => {
     if (selected?.value) {
@@ -85,7 +120,7 @@ export function FolderSelector({ value, onChange, disabled, autoSelectDefault = 
     setShowCreateModal(false);
   };
 
-  const selectedValue = value ?? (autoSelectDefault ? defaultFolderUid : null) ?? null;
+  const selectedValue = value ?? (autoSelectDefault ? preselectUid : null) ?? null;
 
   if (isLoading) {
     return <LoadingPlaceholder text="Loading folders..." />;
@@ -103,6 +138,18 @@ export function FolderSelector({ value, onChange, disabled, autoSelectDefault = 
 
     return (
       <Alert title="Unable to load folders" severity="warning" buttonContent="Retry" onRemove={handleRetry} />
+    );
+  }
+
+  // No editable folder and no rights to create one: explain the dead end
+  // instead of rendering an empty dropdown. The suggestion points at the
+  // default subtree because that is all this picker can list.
+  if (permissionsSettled && editableFolders.length === 0 && !value && !defaultFolder?.canSave) {
+    return (
+      <Alert title="You don't have permission to store checks in any folder" severity="warning">
+        Storing a check requires Edit permission on a folder. Ask an administrator to grant you Edit access to the
+        &quot;{defaultFolder?.title}&quot; folder or one of its subfolders.
+      </Alert>
     );
   }
 
@@ -140,6 +187,42 @@ export function FolderSelector({ value, onChange, disabled, autoSelectDefault = 
       )}
     </Stack>
   );
+}
+
+/**
+ * Labels a selected folder the picker doesn't list (read-only, inaccessible,
+ * or deleted). The suffix lives in the label because the closed combobox only
+ * shows the label; the description explains it in the dropdown.
+ */
+function toSelectedFolderOption(value: string, state: FolderAccessState | undefined): ComboboxOption<string> {
+  switch (state?.type) {
+    case 'accessible': {
+      const title = state.folder?.title ?? value;
+      if (state.permissions.canEdit) {
+        return { label: title, value };
+      }
+      return {
+        label: `${title} (read-only)`,
+        value,
+        description: 'You can view this folder but not save checks into it.',
+      };
+    }
+    case 'forbidden':
+      return {
+        label: `${value} (no access)`,
+        value,
+        description: "You don't have permission to view this folder, so its identifier is shown instead of its name.",
+      };
+    case 'loading':
+      // Lookup in flight: don't flash a false "not found".
+      return { label: value, value };
+    default:
+      return {
+        label: `${value} (folder not found)`,
+        value,
+        description: 'This folder no longer exists. It may have been deleted.',
+      };
+  }
 }
 
 interface CreateFolderModalProps {

--- a/src/components/FolderSelector/FolderSelector.tsx
+++ b/src/components/FolderSelector/FolderSelector.tsx
@@ -1,59 +1,37 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Alert, Button, Combobox, ComboboxOption, Field, Input, LoadingPlaceholder, Modal, Stack } from '@grafana/ui';
 import { trackFolderCreated, trackFolderSelected } from 'features/tracking/folderEvents';
 
 import { GrafanaFolder } from 'types';
 import { FolderAccessState } from 'data/folderPermissions';
-import { useDefaultFolder } from 'data/useDefaultFolder';
-import { useFolderPermissions } from 'data/useFolderPermissions';
-import { getFolderPathParts, useCreateFolder, useFolderChildren } from 'data/useFolders';
+import { getFolderPathParts, useCreateFolder } from 'data/useFolders';
+
+import { useFolderSelection } from './FolderSelector.hooks';
 
 interface FolderSelectorProps {
   value?: string;
   onChange: (folderUid: string | undefined) => void;
   disabled?: boolean;
-  autoSelectDefault?: boolean;
   'aria-label'?: string;
 }
 
-export function FolderSelector({ value, onChange, disabled, autoSelectDefault = true, 'aria-label': ariaLabel }: FolderSelectorProps) {
-  const { defaultFolder, defaultFolderUid, isLoading: isDefaultLoading, isError: isDefaultError, refetch: refetchDefault } = useDefaultFolder();
-  const { data: childFolders = [], isLoading: isChildrenLoading, isError: isChildrenError, refetch: refetchChildren } = useFolderChildren(defaultFolderUid);
+export function FolderSelector({ value, onChange, disabled, 'aria-label': ariaLabel }: FolderSelectorProps) {
+  const {
+    defaultFolder,
+    defaultFolderUid,
+    allFolders,
+    folderDetailsByUid,
+    editableFolders,
+    noStorableFolders,
+    isLoading,
+    isDefaultError,
+    isChildrenError,
+    refetchDefault,
+    refetchChildren,
+  } = useFolderSelection({ value });
   const [showCreateModal, setShowCreateModal] = useState(false);
 
-  const allFolders = useMemo(() => (defaultFolder ? [defaultFolder, ...childFolders] : []), [defaultFolder, childFolders]);
-  // Include the selected value: it can reference a folder outside the default
-  // subtree (assigned via the API/Terraform) that still needs a proper label.
-  const allFolderUids = useMemo(() => {
-    const uids = allFolders.map((f) => f.uid);
-    if (value && !uids.includes(value)) {
-      uids.push(value);
-    }
-    return uids;
-  }, [allFolders, value]);
-  const { folderDetailsByUid } = useFolderPermissions(allFolderUids);
-
-  const isLoading = isDefaultLoading || isChildrenLoading;
   const isError = isDefaultError || isChildrenError;
-
-  // Only editable folders are offered: a check must be manageable by its creator.
-  const editableFolders = useMemo(
-    () =>
-      allFolders.filter((folder) => {
-        const state = folderDetailsByUid.get(folder.uid);
-        return state?.type === 'accessible' && state.permissions.canEdit;
-      }),
-    [allFolders, folderDetailsByUid]
-  );
-
-  // Decisions that depend on the full editable set must wait for every
-  // permission lookup to settle, so they don't fire on partial data.
-  const permissionsSettled =
-    allFolders.length > 0 &&
-    allFolders.every((folder) => {
-      const state = folderDetailsByUid.get(folder.uid);
-      return state !== undefined && state.type !== 'loading';
-    });
 
   const options: Array<ComboboxOption<string>> = useMemo(() => {
     if (!defaultFolder) {
@@ -89,24 +67,6 @@ export function FolderSelector({ value, onChange, disabled, autoSelectDefault = 
     return result;
   }, [allFolders, editableFolders, defaultFolder, value, folderDetailsByUid]);
 
-  // Preselect the default folder if editable, else the user's only editable
-  // folder; with several candidates the choice is theirs.
-  const preselectUid = useMemo(() => {
-    if (defaultFolder?.canEdit) {
-      return defaultFolder.uid;
-    }
-    if (permissionsSettled && editableFolders.length === 1) {
-      return editableFolders[0].uid;
-    }
-    return undefined;
-  }, [defaultFolder, permissionsSettled, editableFolders]);
-
-  useEffect(() => {
-    if (autoSelectDefault && value === undefined && preselectUid) {
-      onChange(preselectUid);
-    }
-  }, [autoSelectDefault, value, preselectUid, onChange]);
-
   const handleChange = (selected: ComboboxOption<string> | null) => {
     if (selected?.value) {
       trackFolderSelected({ isDefault: selected.value === defaultFolderUid });
@@ -120,7 +80,7 @@ export function FolderSelector({ value, onChange, disabled, autoSelectDefault = 
     setShowCreateModal(false);
   };
 
-  const selectedValue = value ?? (autoSelectDefault ? preselectUid : null) ?? null;
+  const selectedValue = value ?? null;
 
   if (isLoading) {
     return <LoadingPlaceholder text="Loading folders..." />;
@@ -144,7 +104,7 @@ export function FolderSelector({ value, onChange, disabled, autoSelectDefault = 
   // No editable folder and no rights to create one: explain the dead end
   // instead of rendering an empty dropdown. The suggestion points at the
   // default subtree because that is all this picker can list.
-  if (permissionsSettled && editableFolders.length === 0 && !value && !defaultFolder?.canSave) {
+  if (noStorableFolders && !value) {
     return (
       <Alert title="You don't have permission to store checks in any folder" severity="warning">
         Storing a check requires Edit permission on a folder. Ask an administrator to grant you Edit access to the

--- a/src/page/CheckList/components/BulkMoveToFolderModal.tsx
+++ b/src/page/CheckList/components/BulkMoveToFolderModal.tsx
@@ -52,12 +52,7 @@ function BulkMoveToFolderModalContent({ checks, isOpen, onDismiss, onMoved }: Bu
         </Alert>
       )}
       <Field label="Target folder" description="All selected checks will be moved to this folder.">
-        <FolderSelector
-          value={targetFolderUid}
-          onChange={setTargetFolderUid}
-          autoSelectDefault={false}
-          aria-label="Select target folder"
-        />
+        <FolderSelector value={targetFolderUid} onChange={setTargetFolderUid} aria-label="Select target folder" />
       </Field>
       <Modal.ButtonRow>
         <Button variant="secondary" onClick={onDismiss} type="button">

--- a/src/page/CheckList/components/CheckItemActionButtons.tsx
+++ b/src/page/CheckList/components/CheckItemActionButtons.tsx
@@ -104,6 +104,7 @@ export const CheckItemActionButtons = ({
         disabled={!canWriteChecks}
         variant="secondary"
         fill={`text`}
+        className={cx({ [styles.disabledLinkButton]: !canWriteChecks })}
         onClick={() => trackFaroUserAction(FaroUserAction.CheckEditClicked)}
       />
       <LinkButton
@@ -117,6 +118,7 @@ export const CheckItemActionButtons = ({
         }}
         variant="secondary"
         fill="text"
+        className={cx({ [styles.disabledLinkButton]: !canWriteChecks })}
       />
       <IconButton
         tooltip="Delete check"
@@ -169,6 +171,13 @@ const getStyles = (theme: GrafanaTheme2) => {
       [containerQuery]: {
         display: 'inline-flex',
       },
+    }),
+    // Disabled text-fill LinkButtons use text.disabled, which is nearly
+    // indistinguishable from the enabled text.secondary in the dark theme.
+    // Match IconButton's disabled treatment (which adds opacity) so all
+    // disabled row actions read the same.
+    disabledLinkButton: css({
+      opacity: 0.65,
     }),
   };
 };

--- a/src/page/NewCheck/__tests__/v2/NewCheckV2.journey.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/NewCheckV2.journey.test.tsx
@@ -11,6 +11,7 @@ import {
   mockFeatureToggles,
   probeToMetadataProbe,
   runTestAsHGFreeUserOverLimit,
+  runTestWithNoEditableFolders,
   runTestWithoutLogsAccess,
   runTestWithReadOnlyDefaultFolder,
   runTestWithSingleEditableFolder,
@@ -84,6 +85,21 @@ describe(`<NewCheckV2 /> journey`, () => {
 
     const { body } = await read();
     expect(body.folderUid).toBe(FOLDER_PRODUCTION.uid);
+  });
+
+  it(`should not show a folder field error when the user cannot store checks in any folder`, async () => {
+    mockFeatureToggles({ [FeatureName.Folders]: true });
+    // With no editable folder the picker is replaced by a permissions alert,
+    // so the "select a folder" error would point at a picker that isn't
+    // there. Submission stays blocked, only the alert explains why.
+    runTestWithNoEditableFolders();
+    const { user } = await renderNewForm(CheckType.Http);
+
+    await fillMandatoryFields({ user, checkType: CheckType.Http });
+    await submitForm(user);
+
+    expect(await screen.findByText(/You don't have permission to store checks in any folder/)).toBeInTheDocument();
+    expect(screen.queryByText(/Select a folder to store this check in/)).not.toBeInTheDocument();
   });
 
   it(`should show an error message when it fails to save a check`, async () => {

--- a/src/page/NewCheck/__tests__/v2/NewCheckV2.journey.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/NewCheckV2.journey.test.tsx
@@ -3,16 +3,24 @@ import { emitCheckCreatedEvent } from 'features/tracking/appEvents';
 import { trackCheckCreated } from 'features/tracking/checkFormEvents';
 import { CHECKSTER_TEST_ID, ROUTER_TEST_ID } from 'test/dataTestIds';
 import { BASIC_HTTP_CHECK } from 'test/fixtures/checks';
+import { DEFAULT_FOLDER, FOLDER_PRODUCTION } from 'test/fixtures/folders';
 import { PUBLIC_PROBE } from 'test/fixtures/probes';
 import { apiRoute } from 'test/handlers';
 import { server } from 'test/server';
-import { probeToMetadataProbe, runTestAsHGFreeUserOverLimit, runTestWithoutLogsAccess } from 'test/utils';
+import {
+  mockFeatureToggles,
+  probeToMetadataProbe,
+  runTestAsHGFreeUserOverLimit,
+  runTestWithoutLogsAccess,
+  runTestWithReadOnlyDefaultFolder,
+  runTestWithSingleEditableFolder,
+} from 'test/utils';
 
 import { FormSectionName } from '../../../../components/Checkster/types';
-import { CheckAlertType, CheckType } from 'types';
+import { CheckAlertType, CheckType, FeatureName } from 'types';
 import { AppRoutes } from 'routing/types';
 import { generateRoutePath } from 'routing/utils';
-import { gotoSection, submitForm } from 'components/Checkster/__testHelpers__/formHelpers';
+import { gotoSection, selectComboboxOption, submitForm } from 'components/Checkster/__testHelpers__/formHelpers';
 import { renderNewForm, selectBasicFrequency } from 'page/__testHelpers__/checkForm';
 
 import { fillMandatoryFields } from '../../../__testHelpers__/v2.utils';
@@ -30,6 +38,54 @@ jest.mock('features/tracking/appEvents', () => ({
 }));
 
 describe(`<NewCheckV2 /> journey`, () => {
+  it(`should save the check into the default folder when the user can edit it`, async () => {
+    mockFeatureToggles({ [FeatureName.Folders]: true });
+    const { user, read } = await renderNewForm(CheckType.Http);
+
+    await fillMandatoryFields({ user, checkType: CheckType.Http });
+    await submitForm(user);
+
+    const { body } = await read();
+    expect(body.folderUid).toBe(DEFAULT_FOLDER.uid);
+  });
+
+  it(`should require picking an editable folder when the user cannot edit the default folder`, async () => {
+    mockFeatureToggles({ [FeatureName.Folders]: true });
+    // A user with folder Edit on several subfolders, holding View on the
+    // default SM folder. Nothing is preselected (the choice is theirs), and
+    // saving without a pick is blocked instead of silently stranding the
+    // check in the read-only default folder.
+    runTestWithReadOnlyDefaultFolder();
+    const { user, read } = await renderNewForm(CheckType.Http);
+
+    await fillMandatoryFields({ user, checkType: CheckType.Http });
+    await submitForm(user);
+
+    expect(await screen.findByText(/Select a folder to store this check in/)).toBeInTheDocument();
+
+    await selectComboboxOption(user, screen.getByPlaceholderText(/Select a folder/), FOLDER_PRODUCTION.title);
+    await submitForm(user);
+
+    const { body } = await read();
+    expect(body.folderUid).toBe(FOLDER_PRODUCTION.uid);
+  });
+
+  it(`should preselect the user's only editable folder when the default folder is read-only`, async () => {
+    mockFeatureToggles({ [FeatureName.Folders]: true });
+    // A user with folder Edit on a single subfolder, holding View on the
+    // default SM folder (the support escalation setup). Their folder is
+    // preselected, so saving just works and the check lands somewhere they
+    // can manage.
+    runTestWithSingleEditableFolder();
+    const { user, read } = await renderNewForm(CheckType.Http);
+
+    await fillMandatoryFields({ user, checkType: CheckType.Http });
+    await submitForm(user);
+
+    const { body } = await read();
+    expect(body.folderUid).toBe(FOLDER_PRODUCTION.uid);
+  });
+
   it(`should show an error message when it fails to save a check`, async () => {
     const { user } = await renderNewForm(CheckType.Http);
 

--- a/src/page/NewCheck/__tests__/v2/apiEndpointChecks/CommonFields.ui.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/apiEndpointChecks/CommonFields.ui.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
-import { mockFeatureToggles } from 'test/utils';
+import { DEFAULT_FOLDER } from 'test/fixtures/folders';
+import { mockFeatureToggles, runTestWithReadOnlyDefaultFolder } from 'test/utils';
 
 import { CheckType, FeatureName } from 'types';
 
@@ -19,6 +20,22 @@ describe('Api endpoint checks - common fields UI', () => {
       await renderNewForm(CheckType.Http);
 
       expect(screen.queryByText('Folder')).not.toBeInTheDocument();
+    });
+
+    it('preselects the default folder when the user can edit it', async () => {
+      mockFeatureToggles({ [FeatureName.Folders]: true });
+      await renderNewForm(CheckType.Http);
+
+      expect(await screen.findByDisplayValue(`${DEFAULT_FOLDER.title} (Default)`)).toBeInTheDocument();
+    });
+
+    it('does not preselect a default folder the user cannot edit', async () => {
+      mockFeatureToggles({ [FeatureName.Folders]: true });
+      runTestWithReadOnlyDefaultFolder();
+      await renderNewForm(CheckType.Http);
+
+      const folderInput = await screen.findByPlaceholderText(/Select a folder/);
+      expect(folderInput).toHaveValue('');
     });
   });
 });

--- a/src/page/NewCheck/__tests__/v2/apiEndpointChecks/CommonFields.ui.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/apiEndpointChecks/CommonFields.ui.test.tsx
@@ -42,6 +42,19 @@ describe('Api endpoint checks - common fields UI', () => {
       expect(screen.getByTestId(CHECKSTER_TEST_ID.form.submitButton)).toBeDisabled();
     });
 
+    it('seeds the folder before the form mounts even when permission lookups are slow', async () => {
+      mockFeatureToggles({ [FeatureName.Folders]: true });
+      runTestWithSingleEditableFolder({ delayMs: 100 });
+      await renderNewForm(CheckType.Http);
+
+      // The form must not mount until the seed decision is final: mounting
+      // earlier would let a submit record a folder error that the later
+      // defaults reset leaves stale. So the moment the picker exists, the
+      // seeded folder must already be in it.
+      const folderInput = await screen.findByPlaceholderText(/Select a folder/);
+      expect(folderInput).toHaveValue(FOLDER_PRODUCTION.title);
+    });
+
     it('does not preselect a default folder the user cannot edit', async () => {
       mockFeatureToggles({ [FeatureName.Folders]: true });
       runTestWithReadOnlyDefaultFolder();

--- a/src/page/NewCheck/__tests__/v2/apiEndpointChecks/CommonFields.ui.test.tsx
+++ b/src/page/NewCheck/__tests__/v2/apiEndpointChecks/CommonFields.ui.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
-import { DEFAULT_FOLDER } from 'test/fixtures/folders';
-import { mockFeatureToggles, runTestWithReadOnlyDefaultFolder } from 'test/utils';
+import { CHECKSTER_TEST_ID } from 'test/dataTestIds';
+import { DEFAULT_FOLDER, FOLDER_PRODUCTION } from 'test/fixtures/folders';
+import { mockFeatureToggles, runTestWithReadOnlyDefaultFolder, runTestWithSingleEditableFolder } from 'test/utils';
 
 import { CheckType, FeatureName } from 'types';
 
@@ -22,11 +23,23 @@ describe('Api endpoint checks - common fields UI', () => {
       expect(screen.queryByText('Folder')).not.toBeInTheDocument();
     });
 
-    it('preselects the default folder when the user can edit it', async () => {
+    it('preselects the default folder when the user can edit it, without dirtying the form', async () => {
       mockFeatureToggles({ [FeatureName.Folders]: true });
       await renderNewForm(CheckType.Http);
 
       expect(await screen.findByDisplayValue(`${DEFAULT_FOLDER.title} (Default)`)).toBeInTheDocument();
+      // Preselection goes through the form defaults: an untouched form must not
+      // enable Save or warn about unsaved changes.
+      expect(screen.getByTestId(CHECKSTER_TEST_ID.form.submitButton)).toBeDisabled();
+    });
+
+    it(`preselects the user's only editable folder without dirtying the form`, async () => {
+      mockFeatureToggles({ [FeatureName.Folders]: true });
+      runTestWithSingleEditableFolder();
+      await renderNewForm(CheckType.Http);
+
+      expect(await screen.findByDisplayValue(FOLDER_PRODUCTION.title)).toBeInTheDocument();
+      expect(screen.getByTestId(CHECKSTER_TEST_ID.form.submitButton)).toBeDisabled();
     });
 
     it('does not preselect a default folder the user cannot edit', async () => {

--- a/src/page/__testHelpers__/checkForm.tsx
+++ b/src/page/__testHelpers__/checkForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, screen, waitFor } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
-import { UI_TEST_ID } from 'test/dataTestIds';
+import { CHECKSTER_TEST_ID, UI_TEST_ID } from 'test/dataTestIds';
 import { apiRoute, getServerRequests } from 'test/handlers';
 import { render } from 'test/render';
 import { server } from 'test/server';
@@ -55,6 +55,9 @@ export async function renderNewForm(
   });
 
   await waitFor(async () => await screen.findByTestId(UI_TEST_ID.page.ready), { timeout: 10000 });
+  // The Checkster form mounts only once folder data has settled (when the
+  // folders feature is on), which can be later than the page-ready marker.
+  await screen.findByTestId(CHECKSTER_TEST_ID.navigation.root, {}, { timeout: 10000 });
 
   const typeButReallyPaste = async (target: Element, value: string, args?: any) => {
     if (target instanceof HTMLElement) {
@@ -91,6 +94,8 @@ export async function renderEditForm(id: Check['id']) {
   });
 
   await waitFor(async () => screen.getByTestId(UI_TEST_ID.page.ready), { timeout: 10000 });
+  // See renderNewForm: the form can mount later than the page-ready marker.
+  await screen.findByTestId(CHECKSTER_TEST_ID.navigation.root, {}, { timeout: 10000 });
 
   return {
     ...res,

--- a/src/schemas/forms/BaseCheckSchema.ts
+++ b/src/schemas/forms/BaseCheckSchema.ts
@@ -28,8 +28,29 @@ export const baseCheckSchema = z.object({
   folderUid: z.string().optional(),
 });
 
-export function addRefinements<T extends CheckFormValuesBase>(schema: ZodType<T, any, any>) {
+export interface CheckSchemaRefinementOptions {
+  /**
+   * Whether a folder must be assigned to the check. The base schema keeps
+   * `folderUid` optional because folder availability is runtime state (feature
+   * flag + folder API/permissions), which the form layer resolves and passes in.
+   */
+  requiresFolder?: boolean;
+}
+
+export function addRefinements<T extends CheckFormValuesBase>(
+  schema: ZodType<T, any, any>,
+  { requiresFolder = false }: CheckSchemaRefinementOptions = {}
+) {
   return schema
+    .superRefine((data, ctx) => {
+      if (requiresFolder && !data.folderUid) {
+        ctx.addIssue({
+          path: ['folderUid'],
+          code: 'custom',
+          message: 'Select a folder to store this check in.',
+        });
+      }
+    })
     .superRefine((data, ctx) => {
       const { frequency, timeout } = data;
       if (frequency < timeout) {

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -12,6 +12,7 @@ import {
 import { ExtendedProbe, FeatureName, type Probe, ProbeProvider, ProbeWithMetadata } from 'types';
 import { pascalCaseToSentence } from 'utils';
 
+import { DEFAULT_FOLDER, FOLDER_PRODUCTION, MOCK_FOLDERS } from './fixtures/folders';
 import {
   FULL_ADMIN_ACCESS,
   FULL_READONLY_ACCESS,
@@ -23,7 +24,6 @@ import {
   SECRETS_READ_ONLY_ACCESS,
   WRITER_NO_DELETE_ACCESS,
 } from './fixtures/rbacPermissions';
-import { DEFAULT_FOLDER, FOLDER_PRODUCTION, MOCK_FOLDERS } from './fixtures/folders';
 import { apiRoute } from './handlers';
 import { setTestFlag } from './openFeatureTestProvider';
 import { server } from './server';

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -197,10 +197,13 @@ export function runTestWithReadOnlyDefaultFolder() {
  * folder and a folder-level Edit grant on a single subfolder (Production),
  * e.g. a team member whose admin segments checks per team.
  */
-export function runTestWithSingleEditableFolder() {
+export function runTestWithSingleEditableFolder({ delayMs = 0 }: { delayMs?: number } = {}) {
   server.use(
     apiRoute(`getFolder`, {
-      result: (req: Request) => {
+      result: async (req: Request) => {
+        if (delayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
         const uid = new URL(req.url).pathname.split('/').pop();
         const folder = uid === DEFAULT_FOLDER.uid ? DEFAULT_FOLDER : MOCK_FOLDERS.find((f) => f.uid === uid);
         if (!folder) {

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -23,6 +23,7 @@ import {
   SECRETS_READ_ONLY_ACCESS,
   WRITER_NO_DELETE_ACCESS,
 } from './fixtures/rbacPermissions';
+import { DEFAULT_FOLDER, FOLDER_PRODUCTION, MOCK_FOLDERS } from './fixtures/folders';
 import { apiRoute } from './handlers';
 import { setTestFlag } from './openFeatureTestProvider';
 import { server } from './server';
@@ -168,6 +169,70 @@ export function runTestWithoutMetricsAccess() {
       [LOGS_DATASOURCE.name]: LOGS_DATASOURCE,
     },
   });
+}
+
+/**
+ * The user holds View (but not Edit) on the default Synthetic Monitoring
+ * folder, e.g. a Viewer with the SM checks writer role and a folder-level
+ * Edit grant on a subfolder only. Folders in MOCK_FOLDERS keep their own
+ * permission flags.
+ */
+export function runTestWithReadOnlyDefaultFolder() {
+  server.use(
+    apiRoute(`getFolder`, {
+      result: (req: Request) => {
+        const uid = new URL(req.url).pathname.split('/').pop();
+        if (uid === DEFAULT_FOLDER.uid) {
+          return { json: { ...DEFAULT_FOLDER, canEdit: false, canSave: false } };
+        }
+        const folder = MOCK_FOLDERS.find((f) => f.uid === uid);
+        return folder ? { json: folder } : { status: 404, json: { message: 'Folder not found' } };
+      },
+    })
+  );
+}
+
+/**
+ * The user holds View (but not Edit) on the default Synthetic Monitoring
+ * folder and a folder-level Edit grant on a single subfolder (Production),
+ * e.g. a team member whose admin segments checks per team.
+ */
+export function runTestWithSingleEditableFolder() {
+  server.use(
+    apiRoute(`getFolder`, {
+      result: (req: Request) => {
+        const uid = new URL(req.url).pathname.split('/').pop();
+        const folder = uid === DEFAULT_FOLDER.uid ? DEFAULT_FOLDER : MOCK_FOLDERS.find((f) => f.uid === uid);
+        if (!folder) {
+          return { status: 404, json: { message: 'Folder not found' } };
+        }
+        if (folder.uid === FOLDER_PRODUCTION.uid) {
+          return { json: folder };
+        }
+        return { json: { ...folder, canEdit: false, canSave: false } };
+      },
+    })
+  );
+}
+
+/**
+ * The user holds View (but not Edit) on the default Synthetic Monitoring
+ * folder and every other folder, e.g. a Viewer with the SM checks writer
+ * role and no folder-level grants.
+ */
+export function runTestWithNoEditableFolders() {
+  server.use(
+    apiRoute(`getFolder`, {
+      result: (req: Request) => {
+        const uid = new URL(req.url).pathname.split('/').pop();
+        const folder = uid === DEFAULT_FOLDER.uid ? DEFAULT_FOLDER : MOCK_FOLDERS.find((f) => f.uid === uid);
+        if (!folder) {
+          return { status: 404, json: { message: 'Folder not found' } };
+        }
+        return { json: { ...folder, canEdit: false, canSave: false } };
+      },
+    })
+  );
 }
 
 export function runTestWithoutLogsAccess() {


### PR DESCRIPTION
Addresses: https://github.com/grafana/support-escalations/issues/23773

## Problem

A user with Synthetic Monitoring checks writer role but only **View** permission on the default `Grafana Synthetic Monitoring` folder (valid cases are their folder Edit grants live on subfolders) gets a misleading check-creation experience:

- The form opens with the read-only default folder preselected (remember the folder exists and is readable, but not editable).
- Saving succeeds, but the check is then governed by the default folder's permissions — so its own creator cannot edit, pause or delete it. Only Editors can modify it.

The folder dropdown already offered only editable folders, but the the default folder was a special case that was pre-selected regardless of its permissions.

## Solution

Preselection is now permission-aware, and a folder is required whenever folder data is available:

- **Edit on the default folder (the vast majority)** 
Preselected as before — no change 
<img width="799" height="686" alt="image" src="https://github.com/user-attachments/assets/af60cd04-d262-44d5-b3b3-a4b33c892757" />

- **Edit on exactly one folder** 
That folder is preselected
<img width="797" height="677" alt="image" src="https://github.com/user-attachments/assets/8f12d242-d591-41a7-98ca-75e5c512bf84" />

- **Edit on several folders, not the default** 
No preselection, lists all the editable folders.
<img width="817" height="638" alt="image" src="https://github.com/user-attachments/assets/03b4677e-69dc-4ae1-b709-3054f2c18366" />

- **Edit on no folder**
 The picker is replaced by an explanation asking an administrator for Edit access to the default folder or one of its subfolders 
<img width="811" height="497" alt="image" src="https://github.com/user-attachments/assets/8234d5a5-bc84-4aed-bc32-f9e5cbe5e86d" />


**Note:**
When the feature flag is off, the folder isn't provisioned, or the user lacks `folders:read`, the rule is inert and checks save without a folder exactly as before.


## Notes for reviewers
- Disabled Edit/Duplicate actions in the check list now get the same dimmed styling as the neighboring icon buttons, so read-only checks read as read-only.
- This is deliberately scoped to preselection, validation and labeling. The picker still lists only the default folder's subtree; broader folder support (any editable folder, server-side permission filtering via the standard `FolderPicker`) is actively worked on in [#1790](https://github.com/grafana/synthetic-monitoring-app/pull/1790), which replaces the `FolderSelector` internals. 
- This is UI-level guidance, not enforcement: the SM API and Terraform accept any `folderUid` regardless of folder permissions. True enforcement would be an API-side decision.

## Testing

- New test helpers simulate the three permission setups (read-only default with several/single/no editable folders).
- Coverage for every row of the behavior matrix: `FolderSelector` unit tests, form UI tests, and two end-to-end journeys.
