### PR TITLE
fix: support publishing releases from vX.Y.Z tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: Branch to publish from (can be used to deploy PRs to dev)
+        description: Branch or tag to publish from.
         default: main
       environment:
         description: Environment to publish to
@@ -23,8 +23,29 @@ on:
 permissions: {}
 
 jobs:
+  # GitHub expressions cannot regex-match, and startsWith(branch, 'v') would
+  # also match feature branches like "validate-x". Do an exact match instead:
+  # only `main` and vX.Y.Z release tags count as release refs. Keep this
+  # pattern in sync with the `release-reference-regex` input below.
+  check-ref:
+    name: Check ref type
+    runs-on: ubuntu-latest
+    outputs:
+      is-release-ref: ${{ steps.check.outputs.is-release-ref }}
+    env:
+      REF: ${{ github.event.inputs.branch }}
+    steps:
+      - id: check
+        run: |
+          if [[ "$REF" =~ ^(main|v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "is-release-ref=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-release-ref=false" >> "$GITHUB_OUTPUT"
+          fi
+
   cd:
     name: CD
+    needs: check-ref
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v11.1.0
     #  About permissions below.
     #
@@ -44,6 +65,14 @@ jobs:
     with:
       branch: ${{ github.event.inputs.branch }}
 
+      # Treat release tags (vX.Y.Z) like main: publish the clean version from plugin.json
+      # without the "+<commit SHA>" suffix. Everything else (PR branches) still gets the
+      # suffix, keeping dev preview deploys unique. Dev auto-deploys are unaffected: they
+      # run via validate_main.yml, which sets plugin-version-suffix explicitly.
+      # Anchored (^...$) because cd.yml substring-matches with RegExp.test(); must stay
+      # in sync with the check-ref job above so trigger-argo and versioning agree.
+      release-reference-regex: ^(main|v\d+\.\d+\.\d+)$
+
       environment: ${{ github.event.inputs.environment }}
 
       docs-only: false
@@ -52,7 +81,10 @@ jobs:
 
       # Argo CD inputs
       grafana-cloud-deployment-type: provisioned
-      trigger-argo: ${{ github.event.inputs.branch == 'main' }}
+      # Trigger the Grafana Cloud rollout for main, release tags, and any deploy to
+      # dev. Without this, a deploy publishes to the catalog but never reaches
+      # instances
+      trigger-argo: ${{ needs.check-ref.outputs.is-release-ref == 'true' || github.event.inputs.environment == 'dev' }}
       argo-workflow-slack-channel: '#sm-ops-deploys'
 
       auto-merge-environments: dev,ops,prod-canary,prod


### PR DESCRIPTION
## Problem

The manual deployment workflow deploys whatever `main`'s HEAD is at the time it runs. Because ops and prod are deployed at different times, merges landing in between mean the two environments can ship **different builds under the same version number**. This is exactly what broke [ops](https://raintank-corp.slack.com/archives/C0162C1K9E1/p1787323607369809) on 1.59.0: the ops catalog ended up expecting the prod build's `moduleHash` while the ops CDN served the earlier ops build, so SRI checks blocked `module.js` and users saw "App not found".

Separately, deploying a PR branch to dev has been silently broken since `trigger-argo` was narrowed to `main` only (#1689): the deploy publishes to the dev catalog but the Argo rollout never runs, so the preview never reaches instances. The same gap made tag deploys (e.g. `v1.45.0`) appear to succeed while never rolling out.

## Solution

Release tags (`vX.Y.Z`) are now treated as release references alongside `main`:

- **Ops and prod releases should be deployed from the release tag**, guaranteeing both environments build from the exact same commit and produce identical artifacts for a given version.
- Tag deploys get the clean version from `plugin.json` (no `+<sha>` suffix) and trigger the Argo rollout, so they actually reach instances.
- Deploying a PR branch to dev triggers the Argo rollout again, restoring dev previews. Branch deploys keep the `+<commit SHA>` suffix so preview versions stay unique.

Dev auto-deploys from `main` are unaffected: they run via `validate_main.yml`, which sets `plugin-version-suffix` explicitly.

## Behavior matrix

| Ref | Environment | Version | Argo rollout |
|---|---|---|---|
| `main` | any | clean | yes |
| `vX.Y.Z` tag | any | clean | yes |
| PR branch | dev | `+<sha>` suffix | yes (restored) |
| PR branch | ops/prod | blocked by `cd.yml` (non-release ref) | — |

## Follow-ups

- Update `docs/synthetic-monitoring/release-process.md` in `deployment_tools` to document deploying from tags (separate PR).
- After the next release, dry-run by deploying its `vX.Y.Z` tag to dev and confirming the clean version publishes and Argo triggers.