### PR TITLE
feat: add feature feedback widget to the Connected services section

### DIFF
--- a/src/features/knowledgeGraph/ConnectedServices.test.tsx
+++ b/src/features/knowledgeGraph/ConnectedServices.test.tsx
@@ -120,6 +120,15 @@ it('is expanded on load and shows the zero state for an unlinked check', async (
   );
 });
 
+it('renders the feature feedback widget in the section header', async () => {
+  setKgInstalled(true);
+  await renderSection(checkWithLabels([{ name: 'Team', value: 'platform' }]));
+
+  expect(screen.getByText('New feature!')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'I love this feature' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: "I don't like this feature" })).toBeInTheDocument();
+});
+
 it('can be collapsed and expanded again', async () => {
   setKgInstalled(true);
   const { user } = await renderSection(checkWithLabels([{ name: 'Team', value: 'platform' }]));

--- a/src/features/knowledgeGraph/ConnectedServices.tsx
+++ b/src/features/knowledgeGraph/ConnectedServices.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, IconButton, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
+import { Icon, IconButton, LinkButton, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { Check } from 'types';
@@ -10,6 +10,7 @@ import { CenteredSpinner } from 'components/CenteredSpinner/CenteredSpinner';
 import { FORM_SECTION_QUERY_PARAM } from 'components/Checkster/constants';
 import { FormSectionName } from 'components/Checkster/types';
 import { ErrorAlert } from 'components/ErrorAlert/ErrorAlert';
+import { Feedback } from 'components/Feedback';
 
 import {
   CONNECTED_SERVICES_SUBTITLE,
@@ -76,10 +77,17 @@ function ConnectedServicesSection({ check }: ConnectedServicesProps) {
             {CONNECTED_SERVICES_SUBTITLE}
           </Text>
         </div>
+        <Feedback feature="knowledge-graph" about={{ text: `New feature!` }} />
         {serviceName && (
-          <TextLink href={getServiceEntityUrl(serviceName, namespace)} external icon="external-link-alt">
+          <LinkButton
+            variant="secondary"
+            size="sm"
+            icon="external-link-alt"
+            href={getServiceEntityUrl(serviceName, namespace)}
+            target="_blank"
+          >
             Open in Knowledge Graph
-          </TextLink>
+          </LinkButton>
         )}
       </div>
 

--- a/src/features/knowledgeGraph/ConnectedServices.tsx
+++ b/src/features/knowledgeGraph/ConnectedServices.tsx
@@ -77,7 +77,7 @@ function ConnectedServicesSection({ check }: ConnectedServicesProps) {
             {CONNECTED_SERVICES_SUBTITLE}
           </Text>
         </div>
-        <Feedback feature="knowledge-graph" about={{ text: `New feature!` }} />
+        <Feedback feature="knowledge-graph-connected-services" about={{ text: `New feature!` }} />
         {serviceName && (
           <LinkButton
             variant="secondary"


### PR DESCRIPTION
## Problem

The Connected services section (the Knowledge Graph service neighbourhood shown on a check's dashboard) recently shipped, but we have no way of knowing how users feel about it. Other new features like the Timepoint Explorer and per-check alerts surface our feature feedback widget so users can react and leave comments, and this section should follow the same pattern while it's still new.

Additionally, the "Open in Knowledge Graph" action in the section header was rendered as a plain text link, making it easy to miss as the primary way to jump into the Knowledge Graph app.

## Solution

The section header now includes the shared feedback widget — a "New feature!" badge with thumbs up/down buttons and an optional comment form — tracked under the `knowledge-graph` feature name via the existing `feature_feedback` analytics events. It renders in all section states (graph, zero state, error), so users can leave feedback even before linking a check to a service.

<img width="2195" height="353" alt="image" src="https://github.com/user-attachments/assets/bbec982e-3a95-46da-8d80-5abcb36a74cb" />

The "Open in Knowledge Graph" link has also been promoted to a secondary button (keeping anchor semantics via `LinkButton`), matching how prominent navigation is presented elsewhere in the app.

An integration test covers the widget rendering in the section header; the feedback form and tracking behaviour are already covered by the `Feedback` component's own tests.