### PR TITLE
fix: populate the KG graph search from the connected-services drawer links

### DIFF
--- a/src/features/knowledgeGraph/ConnectedServices.utils.test.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.utils.test.ts
@@ -253,17 +253,50 @@ describe('getEntityDrawerUrl', () => {
     };
   }
 
+  function paramsOf(url: string): URLSearchParams {
+    return new URLSearchParams(url.split('?')[1]);
+  }
+
   it('builds the KG entity-drawer link with type, name and the non-empty scope values', () => {
     const url = getEntityDrawerUrl(buildNode());
+    const params = paramsOf(url);
 
-    expect(url).toBe(
-      '/a/grafana-asserts-app/entities?ed%5Btype%5D=Service&ed%5Bname%5D=frontend&ed%5Bscope%5D%5Benv%5D=prod&ed%5Bscope%5D%5Bnamespace%5D=otel-demo'
-    );
+    expect(url.startsWith('/a/grafana-asserts-app/entities?')).toBe(true);
+    expect(params.get('ed[type]')).toBe('Service');
+    expect(params.get('ed[name]')).toBe('frontend');
+    expect(params.get('ed[scope][env]')).toBe('prod');
+    expect(params.get('ed[scope][namespace]')).toBe('otel-demo');
+    expect(params.get('ed[scope][site]')).toBeNull();
   });
 
-  it('omits empty scope values', () => {
-    const url = getEntityDrawerUrl(buildNode({ scope: { env: '', site: '', namespace: '' } }));
+  it('includes a filterCriteria search so the KG graph page loads the entity underneath the drawer', () => {
+    const params = paramsOf(getEntityDrawerUrl(buildNode()));
 
-    expect(url).toBe('/a/grafana-asserts-app/entities?ed%5Btype%5D=Service&ed%5Bname%5D=frontend');
+    expect(params.get('filterCriteria[0][entityType]')).toBe('Service');
+    expect(params.get('filterCriteria[0][connectToEntityTypes][0]')).toBe('Service');
+
+    // name matcher always present; env/namespace matchers mirror the scope
+    expect(params.get('filterCriteria[0][propertyMatchers][0][name]')).toBe('name');
+    expect(params.get('filterCriteria[0][propertyMatchers][0][value]')).toBe('frontend');
+    expect(params.get('filterCriteria[0][propertyMatchers][0][op]')).toBe('=');
+    expect(params.get('filterCriteria[0][propertyMatchers][0][type]')).toBe('String');
+    expect(params.get('filterCriteria[0][propertyMatchers][1][name]')).toBe('env');
+    expect(params.get('filterCriteria[0][propertyMatchers][1][value]')).toBe('prod');
+    expect(params.get('filterCriteria[0][propertyMatchers][2][name]')).toBe('namespace');
+    expect(params.get('filterCriteria[0][propertyMatchers][2][value]')).toBe('otel-demo');
+  });
+
+  it('omits empty scope values from both the drawer params and the search matchers', () => {
+    const params = paramsOf(getEntityDrawerUrl(buildNode({ scope: { env: '', site: '', namespace: '' } })));
+
+    expect(params.get('ed[type]')).toBe('Service');
+    expect(params.get('ed[name]')).toBe('frontend');
+    expect(params.get('ed[scope][env]')).toBeNull();
+    expect(params.get('ed[scope][site]')).toBeNull();
+    expect(params.get('ed[scope][namespace]')).toBeNull();
+
+    expect(params.get('filterCriteria[0][propertyMatchers][0][name]')).toBe('name');
+    expect(params.get('filterCriteria[0][propertyMatchers][0][value]')).toBe('frontend');
+    expect(params.get('filterCriteria[0][propertyMatchers][1][name]')).toBeNull();
   });
 });

--- a/src/features/knowledgeGraph/ConnectedServices.utils.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.utils.ts
@@ -184,9 +184,14 @@ export function parseGraphFrames(frames: DataFrame[]): ServiceNeighbourhood {
 }
 
 /**
- * Deep link into the Knowledge Graph app's entity drawer — the same URL shape the KG datasource
- * attaches to its node data links, so clicking any node opens exactly that entity (scoped by
- * env/site/namespace, which disambiguates same-name entities across environments).
+ * Deep link into the Knowledge Graph app's entity drawer, scoped by env/site/namespace (which
+ * disambiguates same-name entities across environments).
+ *
+ * The `ed` params alone only open the drawer: the KG entities page derives its underlying graph
+ * search from `filterCriteria`, not from `ed`, so an ed-only link lands on an empty page with a
+ * floating drawer. The `filterCriteria` params mirror what the KG's own "Explore connected
+ * entities" → "View Graph" action dispatches (an EQUALS search on name/env/namespace, connected
+ * to Services), so the link also populates the graph underneath the drawer.
  */
 export function getEntityDrawerUrl(node: NeighbourhoodNode): string {
   const params = new URLSearchParams();
@@ -202,6 +207,24 @@ export function getEntityDrawerUrl(node: NeighbourhoodNode): string {
   if (node.scope.namespace) {
     params.set('ed[scope][namespace]', node.scope.namespace);
   }
+
+  params.set('filterCriteria[0][entityType]', node.entityType);
+  params.set('filterCriteria[0][connectToEntityTypes][0]', KG_SERVICE_ENTITY_TYPE);
+
+  const matchers: Array<[name: string, value: string]> = [['name', node.name]];
+  if (node.scope.env) {
+    matchers.push(['env', node.scope.env]);
+  }
+  if (node.scope.namespace) {
+    matchers.push(['namespace', node.scope.namespace]);
+  }
+  matchers.forEach(([name, value], index) => {
+    const prefix = `filterCriteria[0][propertyMatchers][${index}]`;
+    params.set(`${prefix}[name]`, name);
+    params.set(`${prefix}[type]`, 'String');
+    params.set(`${prefix}[op]`, '=');
+    params.set(`${prefix}[value]`, value);
+  });
 
   return `/a/${KG_PLUGIN_ID}/entities?${params.toString()}`;
 }


### PR DESCRIPTION
## What

The **Open in Knowledge Graph** links in the connected-services graph popover only carried the `ed[...]` drawer params:

```
/a/grafana-asserts-app/entities?ed[type]=Service&ed[name]=checkoutservice&ed[scope][env]=...
```

In the KG app, `ed` maps only to the entity-details drawer state. The entities page derives its underlying graph search from `filterCriteria` — nothing derives a search from `ed`. So the link opened the drawer floating over an empty page, and the incomplete URL also broke the KG app's back-button handling (its URL-sync rewrites the URL with the full serialized state, stacking a history entry the back button can never escape).

## Fix

`getEntityDrawerUrl` now also appends the `filterCriteria` params that the KG's own **Explore connected entities → View Graph** action dispatches: an `EQUALS` search on `name` (plus `env`/`namespace` when scoped), connected to Services. The KG page hydrates that into its search state, so the graph loads underneath the drawer — same result as navigating from inside the KG app.

## Testing

- `ConnectedServices.utils.test.ts` updated: asserts drawer params, search matchers, and empty-scope handling via parsed `URLSearchParams`.
- Verified the param shape round-trips through the KG app's `qs.parse` hydration (`fillSliceWithQueryParams` → `searchObject.filterCriteria`) against the asserts-app-plugin source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)