### PR TITLE
fix: open the Knowledge Graph on the check's neighbourhood and namespace its labels

### DIFF
--- a/src/features/knowledgeGraph/ConnectedServices.constants.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.constants.ts
@@ -5,6 +5,7 @@ export const CONNECTED_SERVICES_TEST_ID = {
   section: 'connected-services-section',
   graph: 'connected-services-graph',
   node: 'connected-services-node',
+  nodeCard: 'connected-services-node-card',
   edge: 'connected-services-edge',
   loading: 'connected-services-loading',
   error: 'connected-services-error',

--- a/src/features/knowledgeGraph/ConnectedServices.test.tsx
+++ b/src/features/knowledgeGraph/ConnectedServices.test.tsx
@@ -92,6 +92,22 @@ async function renderSection(check: Check) {
   return result;
 }
 
+/**
+ * Renders the section for a linked check with the KG serving the fixture neighbourhood, waited on
+ * until the graph is up. Returns the datasource `query` spy alongside the render result.
+ */
+async function renderGraph(check: Check = LINKED_CHECK) {
+  setKgInstalled(true);
+  const { nodes, edges } = buildNeighbourhoodFrames();
+  const query = jest.fn().mockReturnValue(of({ data: [nodes, edges], state: LoadingState.Done }));
+  setKgDatasource(query);
+
+  const result = await renderSection(check);
+  await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.graph);
+
+  return { ...result, query };
+}
+
 it('renders nothing when the Knowledge Graph app is not installed', async () => {
   setKgInstalled(false);
   render(<ConnectedServices check={LINKED_CHECK} />);
@@ -146,20 +162,25 @@ it('can be collapsed and expanded again', async () => {
 });
 
 it('renders the neighbourhood graph from the Cypher query result (linked check)', async () => {
-  setKgInstalled(true);
-  const { nodes, edges } = buildNeighbourhoodFrames();
-  const query = jest.fn().mockReturnValue(of({ data: [nodes, edges], state: LoadingState.Done }));
-  setKgDatasource(query);
+  const { query } = await renderGraph();
 
-  await renderSection(LINKED_CHECK);
+  // Every node names itself in full on hover, namespaced the way the KG labels its own nodes.
+  const nodeGlyphs = screen.getAllByTestId(CONNECTED_SERVICES_TEST_ID.node);
+  expect(nodeGlyphs).toHaveLength(4);
+  const nodeNames = nodeGlyphs.map((node) => node.querySelector('title')?.textContent);
+  expect(nodeNames).toEqual(
+    expect.arrayContaining([
+      'my check__https://grafana.com',
+      'otel-demo/frontend',
+      'otel-demo/cart',
+      'otel-demo/gateway',
+    ])
+  );
 
-  expect(await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.graph)).toBeInTheDocument();
-  expect(screen.getAllByTestId(CONNECTED_SERVICES_TEST_ID.node)).toHaveLength(4);
-
-  // Node labels from the frames.
-  expect(screen.getByText('frontend')).toBeInTheDocument();
-  expect(screen.getByText('cart')).toBeInTheDocument();
-  expect(screen.getByText('gateway')).toBeInTheDocument();
+  // A check has no namespace to prefix, and its long composite name wraps rather than being cut off.
+  const checkNode = nodeGlyphs.find((node) => node.querySelector('title')?.textContent?.startsWith('my check'))!;
+  const checkLabelLines = Array.from(checkNode.querySelectorAll('tspan')).map((line) => line.textContent);
+  expect(checkLabelLines).toEqual(['my check__https://', 'grafana.com']);
 
   // The Cypher query was sent to the KG datasource, scoped to this check's entity name and
   // the dashboard's time range.
@@ -170,38 +191,66 @@ it('renders the neighbourhood graph from the Cypher query result (linked check)'
   expect(request.range.to.valueOf()).toBe(Date.parse(MOCK_TIME_RANGE_TO));
 });
 
-it('shows the insights popup on node hover, with the deep link into the KG app', async () => {
-  setKgInstalled(true);
-  const { nodes, edges } = buildNeighbourhoodFrames();
-  const query = jest.fn().mockReturnValue(of({ data: [nodes, edges], state: LoadingState.Done }));
-  setKgDatasource(query);
+it('opens the insights card on node click, with the deep link into the KG app', async () => {
+  const { user } = await renderGraph();
 
-  const { user } = await renderSection(LINKED_CHECK);
-  await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.graph);
-
-  await user.hover(screen.getByRole('button', { name: 'frontend (Service)' }));
+  await user.click(screen.getByRole('button', { name: 'otel-demo/frontend (Service)' }));
 
   // The service's insights from the frames (insightNames field).
   expect(await screen.findByText('ErrorRatioBreach')).toBeInTheDocument();
   expect(screen.getByText('LatencyAverageBreach')).toBeInTheDocument();
 
-  // The popup carries the entity deep link (clicking a node no longer navigates directly).
+  // The card carries the entity deep link (clicking a node no longer navigates directly).
   // The section header has an "Open in Knowledge Graph" link too, so match on the drawer URL.
   const links = screen.getAllByRole('link', { name: /Open in Knowledge Graph/ });
-  const popupLink = links.find((link) => link.getAttribute('href')?.includes('/entities?'));
-  expect(popupLink).toBeDefined();
-  expect(popupLink).toHaveAttribute('href', expect.stringContaining('ed%5Bname%5D=frontend'));
-  expect(popupLink).toHaveAttribute('href', expect.stringContaining('ed%5Bscope%5D%5Benv%5D=prod'));
+  const cardLink = links.find((link) => link.getAttribute('href')?.includes('ed%5Bname%5D'));
+  expect(cardLink).toBeDefined();
+  expect(cardLink).toHaveAttribute('href', expect.stringContaining('ed%5Bname%5D=frontend'));
+  expect(cardLink).toHaveAttribute('href', expect.stringContaining('ed%5Bscope%5D%5Benv%5D=prod'));
+});
+
+it('keeps the insights card open until it is dismissed', async () => {
+  const { user } = await renderGraph();
+
+  const node = screen.getByRole('button', { name: 'otel-demo/frontend (Service)' });
+  await user.click(node);
+  expect(await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.nodeCard)).toBeInTheDocument();
+
+  // Moving the cursor away no longer closes it — that was the fragile part of the hover popup.
+  await user.unhover(node);
+  expect(screen.getByTestId(CONNECTED_SERVICES_TEST_ID.nodeCard)).toBeInTheDocument();
+
+  await user.keyboard('{Escape}');
+  expect(screen.queryByTestId(CONNECTED_SERVICES_TEST_ID.nodeCard)).not.toBeInTheDocument();
+});
+
+it('opens the insights card from the keyboard', async () => {
+  const { user } = await renderGraph();
+
+  const node = screen.getByRole('button', { name: 'otel-demo/frontend (Service)' });
+  node.focus();
+  await user.keyboard('{Enter}');
+
+  expect(await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.nodeCard)).toBeInTheDocument();
+});
+
+it('links the section header to this check and its services in the KG entity graph', async () => {
+  setKgInstalled(true);
+  await renderSection(LINKED_CHECK);
+
+  const headerLink = screen.getByRole('link', { name: /Open in Knowledge Graph/ });
+  const params = new URLSearchParams(headerLink.getAttribute('href')!.split('?')[1]);
+
+  expect(params.get('filterCriteria[0][entityType]')).toBe('SyntheticCheck');
+  expect(params.get('filterCriteria[0][propertyMatchers][0][value]')).toBe(
+    `${BASIC_HTTP_CHECK.job}__${BASIC_HTTP_CHECK.target}`
+  );
+  expect(params.get('filterCriteria[0][connectToEntityTypes][0]')).toBe('Service');
+  expect(params.get('view')).toBe('graph');
 });
 
 it('highlights an edge on hover and names the connection', async () => {
-  setKgInstalled(true);
-  const { nodes, edges } = buildNeighbourhoodFrames();
-  const query = jest.fn().mockReturnValue(of({ data: [nodes, edges], state: LoadingState.Done }));
-  setKgDatasource(query);
-
-  const { user } = await renderSection(LINKED_CHECK);
-  await screen.findByTestId(CONNECTED_SERVICES_TEST_ID.graph);
+  const { user } = await renderGraph();
 
   const edgeGroups = screen.getAllByTestId(CONNECTED_SERVICES_TEST_ID.edge);
   expect(edgeGroups).toHaveLength(3);

--- a/src/features/knowledgeGraph/ConnectedServices.test.tsx
+++ b/src/features/knowledgeGraph/ConnectedServices.test.tsx
@@ -255,9 +255,9 @@ it('highlights an edge on hover and names the connection', async () => {
   const edgeGroups = screen.getAllByTestId(CONNECTED_SERVICES_TEST_ID.edge);
   expect(edgeGroups).toHaveLength(3);
 
-  // Every edge names its endpoints for the hover tooltip.
+  // Every edge names its endpoints for the hover tooltip, by the same name its nodes carry.
   const edgeTitles = edgeGroups.map((group) => group.querySelector('title')?.textContent);
-  expect(edgeTitles).toContain('frontend → cart');
+  expect(edgeTitles).toContain('otel-demo/frontend → otel-demo/cart');
 
   await user.hover(edgeGroups[0]);
 

--- a/src/features/knowledgeGraph/ConnectedServices.tsx
+++ b/src/features/knowledgeGraph/ConnectedServices.tsx
@@ -18,9 +18,14 @@ import {
   CONNECTED_SERVICES_TITLE,
 } from './ConnectedServices.constants';
 import { useServiceNeighbourhood } from './ConnectedServices.hooks';
-import { getServiceEntityUrl } from './ConnectedServices.utils';
+import { getCheckGraphUrl } from './ConnectedServices.utils';
 import { ConnectedServicesGraph } from './ConnectedServicesGraph';
-import { findLabelValue, KG_NAMESPACE_LABEL, KG_PLUGIN_ID, KG_SERVICE_NAME_LABEL } from './knowledgeGraph';
+import {
+  findLabelValue,
+  getSyntheticCheckEntityName,
+  KG_PLUGIN_ID,
+  KG_SERVICE_NAME_LABEL,
+} from './knowledgeGraph';
 import { useKnowledgeGraphEnabled } from './knowledgeGraph.hooks';
 
 // Reserve room for the loading state so the section doesn't jump when the graph arrives.
@@ -58,7 +63,6 @@ function ConnectedServicesSection({ check }: ConnectedServicesProps) {
   const [isOpen, setIsOpen] = useState(true);
 
   const serviceName = findLabelValue(check.labels ?? [], KG_SERVICE_NAME_LABEL);
-  const namespace = findLabelValue(check.labels ?? [], KG_NAMESPACE_LABEL);
 
   return (
     <section className={styles.container} data-testid={CONNECTED_SERVICES_TEST_ID.section}>
@@ -83,7 +87,7 @@ function ConnectedServicesSection({ check }: ConnectedServicesProps) {
             variant="secondary"
             size="sm"
             icon="external-link-alt"
-            href={getServiceEntityUrl(serviceName, namespace)}
+            href={getCheckGraphUrl(getSyntheticCheckEntityName(check))}
             target="_blank"
           >
             Open in Knowledge Graph

--- a/src/features/knowledgeGraph/ConnectedServices.utils.test.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.utils.test.ts
@@ -80,11 +80,11 @@ describe('buildServiceNeighbourhoodQuery', () => {
     expect(query).toContain(
       'MATCH (sy:SyntheticCheck {name: "vika http check.__http://grafana.com"})<-[:MONITORED_BY]-(s1:Service)'
     );
-    // outbound dependencies
-    expect(query).toContain('OPTIONAL MATCH (s1)-[:CALLS]->(downstream:Service)');
-    // inbound callers
-    expect(query).toContain('OPTIONAL MATCH (upstream:Service)-[:CALLS]->(s1)');
-    expect(query).toContain('RETURN sy, s1, downstream, upstream');
+    // Undirected, so it picks up both the services this one calls and the ones that call it. The
+    // directed inbound form is answered with a 500 by some KG versions.
+    expect(query).toContain('OPTIONAL MATCH (s1)-[:CALLS]-(neighbour:Service)');
+    expect(query).not.toContain('->(downstream:Service)');
+    expect(query).toContain('RETURN sy, s1, neighbour');
   });
 
   it('escapes the entity name it interpolates', () => {

--- a/src/features/knowledgeGraph/ConnectedServices.utils.test.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.utils.test.ts
@@ -4,13 +4,63 @@ import { buildNeighbourhoodFrames } from 'test/fixtures/knowledgeGraph';
 import {
   buildServiceNeighbourhoodQuery,
   escapeCypher,
+  getCheckGraphUrl,
   getEntityDrawerUrl,
+  getNodeDisplayName,
   getRingSegments,
-  getServiceEntityUrl,
   layoutNeighbourhood,
   NeighbourhoodNode,
   parseGraphFrames,
+  wrapLabel,
 } from './ConnectedServices.utils';
+
+function buildNode(overrides: Partial<NeighbourhoodNode> = {}): NeighbourhoodNode {
+  return {
+    id: 'Service:frontend:prod::otel-demo',
+    name: 'frontend',
+    entityType: 'Service',
+    icon: undefined,
+    insightCount: 0,
+    insightNames: [],
+    ringSegments: [{ severity: 'healthy', fraction: 1 }],
+    scope: { env: 'prod', site: '', namespace: 'otel-demo' },
+    ...overrides,
+  };
+}
+
+function paramsOf(url: string): URLSearchParams {
+  return new URLSearchParams(url.split('?')[1]);
+}
+
+/**
+ * Both KG links carry the same graph search — the searched entity, the entity types it connects
+ * out to, and one EQUALS matcher per scope value — so its shape is asserted in one place.
+ */
+function expectGraphSearch(
+  params: URLSearchParams,
+  entityType: string,
+  matchers: Array<[string, string]>,
+  connectToEntityTypes: string[]
+) {
+  expect(params.get('filterCriteria[0][entityType]')).toBe(entityType);
+  expect(params.get('view')).toBe('graph');
+
+  connectToEntityTypes.forEach((connectTo, index) => {
+    expect(params.get(`filterCriteria[0][connectToEntityTypes][${index}]`)).toBe(connectTo);
+  });
+  expect(params.get(`filterCriteria[0][connectToEntityTypes][${connectToEntityTypes.length}]`)).toBeNull();
+
+  matchers.forEach(([name, value], index) => {
+    const prefix = `filterCriteria[0][propertyMatchers][${index}]`;
+    expect(params.get(`${prefix}[name]`)).toBe(name);
+    expect(params.get(`${prefix}[value]`)).toBe(value);
+    expect(params.get(`${prefix}[op]`)).toBe('=');
+    expect(params.get(`${prefix}[type]`)).toBe('String');
+  });
+
+  // Nothing beyond the expected matchers: empty scope values are left out entirely.
+  expect(params.get(`filterCriteria[0][propertyMatchers][${matchers.length}][name]`)).toBeNull();
+}
 
 describe('escapeCypher', () => {
   it('escapes double quotes and backslashes so interpolated values cannot break out of the string', () => {
@@ -44,14 +94,21 @@ describe('buildServiceNeighbourhoodQuery', () => {
   });
 });
 
-describe('getServiceEntityUrl', () => {
-  it('builds a deep link to the Service entity page in the Knowledge Graph app', () => {
-    expect(getServiceEntityUrl('frontend')).toBe('/a/grafana-asserts-app/catalog/Service/frontend');
-  });
+describe('getCheckGraphUrl', () => {
+  it('anchors the KG entity graph on the check, connected to the services it monitors', () => {
+    const url = getCheckGraphUrl('grafana.com homepage__https://grafana.com/');
 
-  it('scopes the link by namespace when provided and encodes both parts', () => {
-    expect(getServiceEntityUrl('front end', 'otel demo')).toBe(
-      '/a/grafana-asserts-app/catalog/Service/front%20end?namespace=otel%20demo'
+    expect(url.startsWith('/a/grafana-asserts-app/entities?')).toBe(true);
+    // A space in the check name encodes as %20, not the form-encoded +.
+    expect(url).toContain('grafana.com%20homepage');
+
+    // Anchoring on the monitored service instead would open that service's own neighbourhood,
+    // which is a wider set than the services this check monitors.
+    expectGraphSearch(
+      paramsOf(url),
+      'SyntheticCheck',
+      [['name', 'grafana.com homepage__https://grafana.com/']],
+      ['Service']
     );
   });
 });
@@ -177,23 +234,15 @@ describe('layoutNeighbourhood', () => {
   });
 
   it('curves edges between nodes in the same row so they arc over the row instead of cutting through it', () => {
-    const buildNode = (id: string, entityType = 'Service'): NeighbourhoodNode => ({
-      id,
-      name: id,
-      entityType,
-      icon: undefined,
-      insightCount: 0,
-      insightNames: [],
-      ringSegments: [{ severity: 'healthy', fraction: 1 }],
-      scope: { env: 'prod', site: '', namespace: '' },
-    });
+    const buildRowNode = (id: string, entityType = 'Service') =>
+      buildNode({ id, name: id, entityType, scope: { env: 'prod', site: '', namespace: '' } });
 
     const layout = layoutNeighbourhood({
       nodes: [
-        buildNode('check', 'SyntheticCheck'),
-        buildNode('service'),
-        buildNode('downstream-a'),
-        buildNode('downstream-b'),
+        buildRowNode('check', 'SyntheticCheck'),
+        buildRowNode('service'),
+        buildRowNode('downstream-a'),
+        buildRowNode('downstream-b'),
       ],
       edges: [
         { id: 'e1', source: 'check', target: 'service' },
@@ -219,16 +268,12 @@ describe('layoutNeighbourhood', () => {
   it('handles a check-only response (service not discovered yet) without edges', () => {
     const layout = layoutNeighbourhood({
       nodes: [
-        {
+        buildNode({
           id: 'SyntheticCheck:a',
           name: 'a',
           entityType: 'SyntheticCheck',
-          icon: undefined,
-          insightCount: 0,
-          insightNames: [],
-          ringSegments: [{ severity: 'healthy', fraction: 1 }],
           scope: { env: 'unknown', site: '', namespace: '' },
-        },
+        }),
       ],
       edges: [],
     });
@@ -239,24 +284,6 @@ describe('layoutNeighbourhood', () => {
 });
 
 describe('getEntityDrawerUrl', () => {
-  function buildNode(overrides: Partial<NeighbourhoodNode> = {}): NeighbourhoodNode {
-    return {
-      id: 'Service:frontend:prod::otel-demo',
-      name: 'frontend',
-      entityType: 'Service',
-      icon: undefined,
-      insightCount: 0,
-      insightNames: [],
-      ringSegments: [{ severity: 'healthy', fraction: 1 }],
-      scope: { env: 'prod', site: '', namespace: 'otel-demo' },
-      ...overrides,
-    };
-  }
-
-  function paramsOf(url: string): URLSearchParams {
-    return new URLSearchParams(url.split('?')[1]);
-  }
-
   it('builds the KG entity-drawer link with type, name and the non-empty scope values', () => {
     const url = getEntityDrawerUrl(buildNode());
     const params = paramsOf(url);
@@ -269,21 +296,36 @@ describe('getEntityDrawerUrl', () => {
     expect(params.get('ed[scope][site]')).toBeNull();
   });
 
-  it('includes a filterCriteria search so the KG graph page loads the entity underneath the drawer', () => {
-    const params = paramsOf(getEntityDrawerUrl(buildNode()));
+  it('searches the graph for the node, scoped by its env and namespace', () => {
+    // A service also connects out to the check monitoring it, so its graph opens with the check.
+    expectGraphSearch(
+      paramsOf(getEntityDrawerUrl(buildNode())),
+      'Service',
+      [
+        ['name', 'frontend'],
+        ['env', 'prod'],
+        ['namespace', 'otel-demo'],
+      ],
+      ['Service', 'SyntheticCheck']
+    );
+  });
 
-    expect(params.get('filterCriteria[0][entityType]')).toBe('Service');
-    expect(params.get('filterCriteria[0][connectToEntityTypes][0]')).toBe('Service');
+  it('connects a check out to services only, matching the section header link', () => {
+    const check = buildNode({
+      name: 'my check__https://grafana.com',
+      entityType: 'SyntheticCheck',
+      scope: { env: 'unknown', site: '', namespace: '' },
+    });
 
-    // name matcher always present; env/namespace matchers mirror the scope
-    expect(params.get('filterCriteria[0][propertyMatchers][0][name]')).toBe('name');
-    expect(params.get('filterCriteria[0][propertyMatchers][0][value]')).toBe('frontend');
-    expect(params.get('filterCriteria[0][propertyMatchers][0][op]')).toBe('=');
-    expect(params.get('filterCriteria[0][propertyMatchers][0][type]')).toBe('String');
-    expect(params.get('filterCriteria[0][propertyMatchers][1][name]')).toBe('env');
-    expect(params.get('filterCriteria[0][propertyMatchers][1][value]')).toBe('prod');
-    expect(params.get('filterCriteria[0][propertyMatchers][2][name]')).toBe('namespace');
-    expect(params.get('filterCriteria[0][propertyMatchers][2][value]')).toBe('otel-demo');
+    expectGraphSearch(
+      paramsOf(getEntityDrawerUrl(check)),
+      'SyntheticCheck',
+      [
+        ['name', 'my check__https://grafana.com'],
+        ['env', 'unknown'],
+      ],
+      ['Service']
+    );
   });
 
   it('omits empty scope values from both the drawer params and the search matchers', () => {
@@ -295,8 +337,48 @@ describe('getEntityDrawerUrl', () => {
     expect(params.get('ed[scope][site]')).toBeNull();
     expect(params.get('ed[scope][namespace]')).toBeNull();
 
-    expect(params.get('filterCriteria[0][propertyMatchers][0][name]')).toBe('name');
-    expect(params.get('filterCriteria[0][propertyMatchers][0][value]')).toBe('frontend');
-    expect(params.get('filterCriteria[0][propertyMatchers][1][name]')).toBeNull();
+    expectGraphSearch(params, 'Service', [['name', 'frontend']], ['Service', 'SyntheticCheck']);
+  });
+});
+
+describe('getNodeDisplayName', () => {
+  it('prefixes a namespaced entity with its namespace, the way the Knowledge Graph does', () => {
+    expect(getNodeDisplayName(buildNode())).toBe('otel-demo/frontend');
+  });
+
+  it('leaves an entity without a namespace as its bare name', () => {
+    expect(getNodeDisplayName(buildNode({ scope: { env: 'prod', site: '', namespace: '' } }))).toBe('frontend');
+  });
+
+  it('never prefixes a check: its composite name is the identity, and it carries no otel namespace', () => {
+    const check = buildNode({
+      name: 'my check__https://grafana.com',
+      entityType: 'SyntheticCheck',
+      scope: { env: 'unknown', site: '', namespace: 'otel-demo' },
+    });
+
+    expect(getNodeDisplayName(check)).toBe('my check__https://grafana.com');
+  });
+});
+
+describe('wrapLabel', () => {
+  it('leaves a label that fits on one line', () => {
+    expect(wrapLabel('frontend', 18, 2)).toEqual(['frontend']);
+  });
+
+  it('breaks after the last separator that fits, so the split lands on a name boundary', () => {
+    expect(wrapLabel('local-lab/local-kg-lab-web', 18, 2)).toEqual(['local-lab/local-', 'kg-lab-web']);
+    expect(wrapLabel('my check__https://grafana.com', 18, 2)).toEqual(['my check__https://', 'grafana.com']);
+  });
+
+  it('hard-breaks a single unbroken token', () => {
+    expect(wrapLabel('abcdefghijklmnopqrstuvwxyz', 10, 2)).toEqual(['abcdefghij', 'klmnopqrs…']);
+  });
+
+  it('ellipsizes whatever does not fit in the allowed lines', () => {
+    expect(wrapLabel('local-lab/local-kg-lab-web-frontend-checkout', 18, 2)).toEqual([
+      'local-lab/local-',
+      'kg-lab-web-fronte…',
+    ]);
   });
 });

--- a/src/features/knowledgeGraph/ConnectedServices.utils.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.utils.ts
@@ -19,21 +19,22 @@ export function escapeCypher(value: string): string {
  *
  * Starting from the SyntheticCheck entity, it walks the MONITORED_BY relationship (Service
  * MONITORED_BY check — the direction the KG's insight propagation expects) to the linked
- * Service, then one hop of CALLS in both directions:
- * - outbound `(s1)-[:CALLS]->(downstream)` — services the monitored service depends on
- * - inbound `(upstream)-[:CALLS]->(s1)` — services that depend on the monitored service
+ * Service, then one hop of CALLS in either direction. Both directions matter for RCA: a failing
+ * check could be caused by a broken downstream dependency, or be the cause of failures in an
+ * upstream caller. Returning both surfaces red-ringed neighbours either way. We deliberately
+ * keep it to a single hop so the graph stays a readable hint rather than the full topology
+ * (which lives in the Knowledge Graph app).
  *
- * Both directions matter for RCA: a failing check could be caused by a broken downstream
- * dependency, or be the cause of failures in an upstream caller. Returning both surfaces
- * red-ringed neighbours either way. We deliberately keep it to a single hop so the graph stays
- * a readable hint rather than the full topology (which lives in the Knowledge Graph app).
+ * The CALLS hop is matched undirected rather than as two directed OPTIONAL MATCHes: some KG
+ * versions answer `OPTIONAL MATCH (s1)<-[:CALLS]-(upstream:Service)` with a 500 (the whole
+ * section then fails), while the undirected form is answered everywhere. Direction is not lost —
+ * it comes from the edges frame's source/target, which parseGraphFrames reads.
  */
 export function buildServiceNeighbourhoodQuery(checkEntityName: string): string {
   return [
     `MATCH (sy:SyntheticCheck {name: "${escapeCypher(checkEntityName)}"})<-[:MONITORED_BY]-(s1:Service)`,
-    `OPTIONAL MATCH (s1)-[:CALLS]->(downstream:Service)`,
-    `OPTIONAL MATCH (upstream:Service)-[:CALLS]->(s1)`,
-    `RETURN sy, s1, downstream, upstream`,
+    `OPTIONAL MATCH (s1)-[:CALLS]-(neighbour:Service)`,
+    `RETURN sy, s1, neighbour`,
   ].join('\n');
 }
 

--- a/src/features/knowledgeGraph/ConnectedServices.utils.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.utils.ts
@@ -439,8 +439,8 @@ export function layoutNeighbourhood(graph: ServiceNeighbourhood): NeighbourhoodL
     positionedEdges.push({
       id: edge.id,
       path: buildElbowPath(source, target),
-      sourceName: source.node.name,
-      targetName: target.node.name,
+      sourceName: getNodeDisplayName(source.node),
+      targetName: getNodeDisplayName(target.node),
     });
   }
 

--- a/src/features/knowledgeGraph/ConnectedServices.utils.ts
+++ b/src/features/knowledgeGraph/ConnectedServices.utils.ts
@@ -37,13 +37,77 @@ export function buildServiceNeighbourhoodQuery(checkEntityName: string): string 
   ].join('\n');
 }
 
+interface GraphSearchTarget {
+  entityType: string;
+  name: string;
+  scope: { env?: string; namespace?: string };
+  /** Entity types to pull in around the searched entity. */
+  connectToEntityTypes: string[];
+}
+
 /**
- * Deep link to the monitored Service's entity page in the Knowledge Graph app, so users can jump
- * from the RCA hint to the full graph. `namespace` is optional; when present it scopes the entity.
+ * The KG entities page derives its graph from `filterCriteria`, so these params are what actually
+ * populate the graph. Shape and semantics mirror the KG's own "Explore connected entities" →
+ * "See in entity graph" action (`ConnectedEntitiesModal`): an EQUALS search on name, plus env and
+ * namespace matchers when the entity is scoped, expanded to the connected entity types. `view`
+ * makes the graph explicit rather than relying on the entities page's default.
  */
-export function getServiceEntityUrl(serviceName: string, namespace?: string): string {
-  const path = `/a/${KG_PLUGIN_ID}/catalog/${KG_SERVICE_ENTITY_TYPE}/${encodeURIComponent(serviceName)}`;
-  return namespace ? `${path}?namespace=${encodeURIComponent(namespace)}` : path;
+function appendGraphSearchParams(params: URLSearchParams, target: GraphSearchTarget): void {
+  params.set('filterCriteria[0][entityType]', target.entityType);
+
+  target.connectToEntityTypes.forEach((entityType, index) => {
+    params.set(`filterCriteria[0][connectToEntityTypes][${index}]`, entityType);
+  });
+
+  const matchers: Array<[name: string, value: string]> = [['name', target.name]];
+  if (target.scope.env) {
+    matchers.push(['env', target.scope.env]);
+  }
+  if (target.scope.namespace) {
+    matchers.push(['namespace', target.scope.namespace]);
+  }
+  matchers.forEach(([name, value], index) => {
+    const prefix = `filterCriteria[0][propertyMatchers][${index}]`;
+    params.set(`${prefix}[name]`, name);
+    params.set(`${prefix}[type]`, 'String');
+    params.set(`${prefix}[op]`, '=');
+    params.set(`${prefix}[value]`, value);
+  });
+
+  params.set('view', 'graph');
+}
+
+/**
+ * `URLSearchParams` serializes a space as `+` (form encoding). That decodes correctly in the KG's
+ * query-string parser, but `%20` is unambiguous everywhere — and check entity names, which are
+ * `job__target`, routinely contain spaces.
+ */
+function toQueryString(params: URLSearchParams): string {
+  return params.toString().replace(/\+/g, '%20');
+}
+
+/**
+ * Deep link to this check's neighbourhood in the Knowledge Graph's entity graph — the same
+ * entities this section renders, in the app that owns them.
+ *
+ * The search is anchored on the check, connected to Services, so the graph opens on exactly the
+ * services this check monitors. Anchoring on the monitored service instead would open that
+ * service's own neighbourhood, which is a different (and wider) set.
+ *
+ * It deliberately doesn't link to the Service's entity page (`/catalog/Service/<name>`): that page
+ * is behind the KG's own feature gating, so on stacks without it the link lands on an empty
+ * "entity not found" page. The entity graph is available everywhere.
+ */
+export function getCheckGraphUrl(checkEntityName: string): string {
+  const params = new URLSearchParams();
+  appendGraphSearchParams(params, {
+    entityType: KG_SYNTHETIC_CHECK_ENTITY_TYPE,
+    name: checkEntityName,
+    scope: {},
+    connectToEntityTypes: [KG_SERVICE_ENTITY_TYPE],
+  });
+
+  return `/a/${KG_PLUGIN_ID}/entities?${toQueryString(params)}`;
 }
 
 /**
@@ -189,9 +253,7 @@ export function parseGraphFrames(frames: DataFrame[]): ServiceNeighbourhood {
  *
  * The `ed` params alone only open the drawer: the KG entities page derives its underlying graph
  * search from `filterCriteria`, not from `ed`, so an ed-only link lands on an empty page with a
- * floating drawer. The `filterCriteria` params mirror what the KG's own "Explore connected
- * entities" → "View Graph" action dispatches (an EQUALS search on name/env/namespace, connected
- * to Services), so the link also populates the graph underneath the drawer.
+ * floating drawer. The graph search params populate the graph underneath the drawer.
  */
 export function getEntityDrawerUrl(node: NeighbourhoodNode): string {
   const params = new URLSearchParams();
@@ -208,25 +270,73 @@ export function getEntityDrawerUrl(node: NeighbourhoodNode): string {
     params.set('ed[scope][namespace]', node.scope.namespace);
   }
 
-  params.set('filterCriteria[0][entityType]', node.entityType);
-  params.set('filterCriteria[0][connectToEntityTypes][0]', KG_SERVICE_ENTITY_TYPE);
+  // A check connects to the services it monitors; a service also connects to the check monitoring
+  // it, so its graph opens with the check alongside its neighbours.
+  const connectToEntityTypes =
+    node.entityType === KG_SYNTHETIC_CHECK_ENTITY_TYPE
+      ? [KG_SERVICE_ENTITY_TYPE]
+      : [KG_SERVICE_ENTITY_TYPE, KG_SYNTHETIC_CHECK_ENTITY_TYPE];
 
-  const matchers: Array<[name: string, value: string]> = [['name', node.name]];
-  if (node.scope.env) {
-    matchers.push(['env', node.scope.env]);
-  }
-  if (node.scope.namespace) {
-    matchers.push(['namespace', node.scope.namespace]);
-  }
-  matchers.forEach(([name, value], index) => {
-    const prefix = `filterCriteria[0][propertyMatchers][${index}]`;
-    params.set(`${prefix}[name]`, name);
-    params.set(`${prefix}[type]`, 'String');
-    params.set(`${prefix}[op]`, '=');
-    params.set(`${prefix}[value]`, value);
+  appendGraphSearchParams(params, {
+    entityType: node.entityType,
+    name: node.name,
+    scope: node.scope,
+    connectToEntityTypes,
   });
 
-  return `/a/${KG_PLUGIN_ID}/entities?${params.toString()}`;
+  return `/a/${KG_PLUGIN_ID}/entities?${toQueryString(params)}`;
+}
+
+/**
+ * Display name for an entity, matching the KG's `getEntityDisplayName`: a namespaced entity reads
+ * as `namespace/name` so services with the same name in different namespaces stay distinguishable.
+ * A check keeps its bare composite name — the KG prefixes from the `otel_namespace` property,
+ * which SyntheticCheck entities don't carry.
+ */
+export function getNodeDisplayName(node: NeighbourhoodNode): string {
+  if (node.entityType === KG_SYNTHETIC_CHECK_ENTITY_TYPE || !node.scope.namespace) {
+    return node.name;
+  }
+  return `${node.scope.namespace}/${node.name}`;
+}
+
+/** Characters a graph label prefers to break after, so wrapped lines split on name boundaries. */
+const LABEL_BREAK_CHARS = new Set([' ', '/', '-', '_', '.', ':']);
+
+/**
+ * Wraps a graph label into at most `maxLines` lines of `maxChars`, breaking after the last
+ * separator that fits (falling back to a hard break for a single unbroken token) and ellipsizing
+ * whatever doesn't fit. Entity names here are long and structured — `namespace/name` for services,
+ * `job__target` for checks — so breaking on their separators keeps both halves readable.
+ */
+export function wrapLabel(text: string, maxChars: number, maxLines: number): string[] {
+  const lines: string[] = [];
+  let rest = text;
+
+  while (rest.length > 0 && lines.length < maxLines) {
+    if (rest.length <= maxChars) {
+      lines.push(rest);
+      return lines;
+    }
+
+    if (lines.length === maxLines - 1) {
+      lines.push(`${rest.slice(0, maxChars - 1)}…`);
+      return lines;
+    }
+
+    let breakAt = maxChars;
+    for (let i = maxChars - 1; i > 0; i--) {
+      if (LABEL_BREAK_CHARS.has(rest[i])) {
+        breakAt = i + 1;
+        break;
+      }
+    }
+
+    lines.push(rest.slice(0, breakAt).trimEnd());
+    rest = rest.slice(breakAt).trimStart();
+  }
+
+  return lines;
 }
 
 // Layout geometry, sized to match the KG's node anatomy (44px nodes, labels beneath).

--- a/src/features/knowledgeGraph/ConnectedServicesGraph.tsx
+++ b/src/features/knowledgeGraph/ConnectedServicesGraph.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, Stack, Text, TextLink, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
+import { Dropdown, Icon, Stack, Text, TextLink, useStyles2, useTheme2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 
 import { CONNECTED_SERVICES_TEST_ID, KG_SEVERITY_COLORS } from './ConnectedServices.constants';
 import {
   getEntityDrawerUrl,
+  getNodeDisplayName,
   layoutNeighbourhood,
   NeighbourhoodNode,
   NODE_RADIUS,
@@ -13,6 +14,7 @@ import {
   PositionedNode,
   RingSegment,
   ServiceNeighbourhood,
+  wrapLabel,
 } from './ConnectedServices.utils';
 import { KG_SERVICE_ENTITY_TYPE, KG_SYNTHETIC_CHECK_ENTITY_TYPE } from './knowledgeGraph';
 import { logo as smLogo } from 'img';
@@ -26,6 +28,8 @@ const ICON_SIZE = 18;
 const BADGE_RADIUS = 9;
 const LABEL_OFFSET = NODE_RADIUS + 16;
 const LABEL_MAX_CHARS = 18;
+const LABEL_MAX_LINES = 2;
+const LABEL_LINE_HEIGHT = 13;
 const ARROW_ID = 'connected-services-arrow';
 const ARROW_HOVER_ID = 'connected-services-arrow-hover';
 /** Invisible stroke width around each edge so thin lines are easy to hover. */
@@ -141,19 +145,23 @@ interface NodeGlyphProps {
 
 function NodeGlyph({ positioned, theme }: NodeGlyphProps) {
   const { node, x, y } = positioned;
-  const label = truncate(node.name);
+  const displayName = getNodeDisplayName(node);
+  const labelLines = wrapLabel(displayName, LABEL_MAX_CHARS, LABEL_MAX_LINES);
 
-  // Interactive tooltip instead of direct navigation: hovering (or focusing — Tooltip makes the
-  // node keyboard-focusable, and clicking focuses it) opens a card with the entity's insights and
-  // the link into the Knowledge Graph. `interactive` keeps it open while moving the cursor into it.
+  // Click to open, rather than hover: the card carries a link, and a hover card that closes as
+  // soon as the cursor strays off the node is hard to reach. Dropdown keeps it open until the
+  // next click outside or Escape. The native <title> covers hover, naming a node whose label the
+  // layout had to truncate.
   return (
-    <Tooltip interactive placement="right" content={<NodeInsightsCard node={node} />}>
+    <Dropdown placement="right" overlay={<NodeInsightsCard node={node} />}>
       <g
         data-testid={CONNECTED_SERVICES_TEST_ID.node}
         role="button"
-        aria-label={`${node.name} (${node.entityType})`}
+        tabIndex={0}
+        aria-label={`${displayName} (${node.entityType})`}
         style={{ cursor: 'pointer', outline: 'none' }}
       >
+        <title>{displayName}</title>
         <circle cx={x} cy={y} r={getDiscRadius(node)} fill={getDiscFill(node, theme)} />
         <Ring x={x} y={y} segments={node.ringSegments} theme={theme} />
         <NodeIcon node={node} x={x} y={y} />
@@ -168,10 +176,14 @@ function NodeGlyph({ positioned, theme }: NodeGlyphProps) {
           // cross an edge.
           style={{ textShadow: `0 0 4px ${theme.colors.background.primary}` }}
         >
-          {label}
+          {labelLines.map((line, index) => (
+            <tspan key={`${index}-${line}`} x={x} dy={index === 0 ? 0 : LABEL_LINE_HEIGHT}>
+              {line}
+            </tspan>
+          ))}
         </text>
       </g>
-    </Tooltip>
+    </Dropdown>
   );
 }
 
@@ -180,40 +192,49 @@ interface NodeInsightsCardProps {
 }
 
 /**
- * Popup card shown on node hover/focus: entity identity, its active insights (the Cypher
+ * Popup card shown when a node is clicked: entity identity, its active insights (the Cypher
  * response carries insight names and the node's overall severity, not per-insight severities),
  * and the deep link into the Knowledge Graph that node clicks used to navigate to directly.
+ * It brings its own surface — Dropdown renders the overlay unstyled.
  */
 function NodeInsightsCard({ node }: NodeInsightsCardProps) {
   const styles = useStyles2(getStyles);
-  const scopeParts = [node.scope.env && node.scope.env !== 'unknown' ? node.scope.env : '', node.scope.namespace]
+  const displayName = getNodeDisplayName(node);
+  // The namespace is already in the display name for the entities that carry one; only repeat it
+  // in the scope line for the ones it isn't (a check keeps its bare composite name).
+  const scopeParts = [
+    node.scope.env && node.scope.env !== 'unknown' ? node.scope.env : '',
+    displayName === node.name ? node.scope.namespace : '',
+  ]
     .filter(Boolean)
     .join(' · ');
 
   return (
-    <Stack direction="column" gap={0.5}>
-      <Text weight="medium">{node.name}</Text>
-      <Text variant="bodySmall" color="secondary">
-        {scopeParts ? `${node.entityType} · ${scopeParts}` : node.entityType}
-      </Text>
-      {node.insightNames.length > 0 ? (
-        <ul className={styles.insightList}>
-          {node.insightNames.map((insightName) => (
-            <li key={insightName}>
-              <span className={styles.insightDot} style={{ background: severityBadgeFill(node.ringSegments[0]) }} />
-              {insightName}
-            </li>
-          ))}
-        </ul>
-      ) : (
+    <div className={styles.card} data-testid={CONNECTED_SERVICES_TEST_ID.nodeCard}>
+      <Stack direction="column" gap={0.5}>
+        <Text weight="medium">{displayName}</Text>
         <Text variant="bodySmall" color="secondary">
-          No active insights
+          {scopeParts ? `${node.entityType} · ${scopeParts}` : node.entityType}
         </Text>
-      )}
-      <TextLink href={getEntityDrawerUrl(node)} variant="bodySmall" icon="external-link-alt" inline>
-        Open in Knowledge Graph
-      </TextLink>
-    </Stack>
+        {node.insightNames.length > 0 ? (
+          <ul className={styles.insightList}>
+            {node.insightNames.map((insightName) => (
+              <li key={insightName}>
+                <span className={styles.insightDot} style={{ background: severityBadgeFill(node.ringSegments[0]) }} />
+                {insightName}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <Text variant="bodySmall" color="secondary">
+            No active insights
+          </Text>
+        )}
+        <TextLink href={getEntityDrawerUrl(node)} variant="bodySmall" icon="external-link-alt" inline>
+          Open in Knowledge Graph
+        </TextLink>
+      </Stack>
+    </div>
   );
 }
 
@@ -349,10 +370,6 @@ function getDiscFill(node: NeighbourhoodNode, theme: GrafanaTheme2): string {
   return theme.visualization.getColorByName('semi-dark-blue');
 }
 
-function truncate(name: string): string {
-  return name.length > LABEL_MAX_CHARS ? `${name.slice(0, LABEL_MAX_CHARS - 1)}…` : name;
-}
-
 const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css({
     display: 'flex',
@@ -361,6 +378,16 @@ const getStyles = (theme: GrafanaTheme2) => ({
     // No surface of its own: the graph sits directly on the section's background so the
     // section reads as one panel. Horizontal padding comes from the section body.
     padding: theme.spacing(1, 0),
+  }),
+  card: css({
+    background: theme.colors.background.elevated ?? theme.colors.background.secondary,
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    boxShadow: theme.shadows.z3,
+    padding: theme.spacing(1, 1.5),
+    maxWidth: 320,
+    // Entity names run long (`namespace/service`, `job__target`) and have no spaces to break on.
+    overflowWrap: 'anywhere',
   }),
   insightList: css({
     listStyle: 'none',


### PR DESCRIPTION
Follow-up to #1831, acting on the feedback we got on the Connected services section.

## Problem

Three things were reported after the section shipped.

The **Open in Knowledge Graph** button in the section header opened a broken page. It linked to the KG's Service entity page (`/catalog/Service/<name>?namespace=…`), which is behind the KG app's own feature gating — on a stack without it, the link lands on an empty "entity not found" page rather than showing anything about the check.

The **node popup was hard to reach**. It opened on hover, so it closed the moment the cursor strayed off the node — and because a node's hover area includes its label, the card is positioned off to one side, which makes that trip easy to lose. The card contains a link, so it needs to be clickable.

**Node labels didn't match the Knowledge Graph.** The KG renders a namespaced entity as `namespace/name`, while this section showed the bare name truncated at 18 characters, so the same service read differently on the two surfaces and long names were cut off mid-word.

## Solution

The header button now opens the KG entity graph with a search anchored on the check itself, connected out to Services, so the graph loads with exactly the services this check monitors — the same neighbourhood the section renders. Anchoring on the monitored service instead (as the first attempt did) opens that service's own neighbourhood, which is a wider and less relevant set. The `filterCriteria` construction added in #1831 is now a single shared helper used by both this link and the node cards, rather than being duplicated.

https://github.com/user-attachments/assets/002a3a69-f24e-4eaa-b1e1-924bc13ae5c9

The node popup is a click-opened card: it stays put until you click elsewhere or press Escape, works from the keyboard, and hovering a node still names it in full through a native SVG title — useful now that labels can wrap or truncate.

https://github.com/user-attachments/assets/89f26dd5-215d-4342-b497-55d75a594697

Labels and card titles read `namespace/name`, matching the KG's own `getEntityDisplayName`

<img width="818" height="346" alt="image" src="https://github.com/user-attachments/assets/91fd9dac-3e5d-45f2-9d86-10518eac9d62" />

Edge titles now go through the same `getNodeDisplayName` as the nodes.

The Connected Services section also stopped rendering entirely on some stacks, showing "The Knowledge Graph datasource didn't respond". The cause was the neighbourhood query: it asked for the services around the monitored one as two separate steps, one for the services it calls and one for the services that call it. Older Knowledge Graph versions fail with a 500 on that second step — it works as a normal `MATCH`, just not as an `OPTIONAL MATCH` — so it's a bug on their side rather than a mistake in what we were asking for. Both steps are now one, `OPTIONAL MATCH (s1)-[:CALLS]-(neighbour:Service)`, which asks for the neighbours without specifying a direction and so returns both groups at once. Every stack answers it, and we don't lose the arrows: the direction of each edge comes from the response, not from how we asked.

## Testing

Integration tests cover the click-to-open card, its dismissal, keyboard access, the namespaced and wrapped labels, and the header link's search params. Unit tests cover both URL builders and the label wrapping. The URL shapes were verified against the KG app's own source (`ConnectedEntitiesModal`, `createEntityDataLink`) and by opening the generated links in ops.

The Cypher change was checked against two live stacks: the failing one, where the current query 500s and the undirected form returns the neighbourhood, and ops, where both forms work and return the same four entities for `grafana.com homepage__https://grafana.com/` — so the fix doesn't regress the stacks that already render.
