### PR TITLE
Add 70-minute cooldown to finalizing the label migration

### DIFF
--- a/src/data/useLabelMode.ts
+++ b/src/data/useLabelMode.ts
@@ -2,6 +2,7 @@ import { QueryKey } from '@tanstack/query-core';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { LabelMode } from 'datasource/responses.types';
+import { QUERY_KEYS as TENANT_QUERY_KEYS } from 'data/useTenant';
 import { useSMDS } from 'hooks/useSMDS';
 
 export const QUERY_KEYS: Record<'labelMode', QueryKey> = {
@@ -27,6 +28,9 @@ export function useSetLabelMode() {
       // The PUT response carries the new state, so the cache can be updated
       // without a refetch.
       queryClient.setQueryData(QUERY_KEYS.labelMode, data);
+      // A transition bumps tenant.modified server-side (used for the migration
+      // cooldown), so the cached tenant must be refreshed rather than left stale.
+      queryClient.invalidateQueries({ queryKey: TENANT_QUERY_KEYS.tenant });
     },
   });
 }

--- a/src/data/useLabelMode.ts
+++ b/src/data/useLabelMode.ts
@@ -24,13 +24,16 @@ export function useSetLabelMode() {
 
   return useMutation({
     mutationFn: (mode: LabelMode) => smDS.setLabelMode(mode),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       // The PUT response carries the new state, so the cache can be updated
       // without a refetch.
       queryClient.setQueryData(QUERY_KEYS.labelMode, data);
       // A transition bumps tenant.modified server-side (used for the migration
-      // cooldown), so the cached tenant must be refreshed rather than left stale.
-      queryClient.invalidateQueries({ queryKey: TENANT_QUERY_KEYS.tenant });
+      // cooldown), so the cached tenant must be refreshed rather than left
+      // stale. Awaited so the mutation stays pending (busy) until the refetch
+      // lands — otherwise Finalize is briefly clickable before the cooldown
+      // engages.
+      await queryClient.invalidateQueries({ queryKey: TENANT_QUERY_KEYS.tenant });
     },
   });
 }

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { TENANT_LABEL_MODE } from 'test/fixtures/tenants';
+import { TENANT, TENANT_LABEL_MODE } from 'test/fixtures/tenants';
 import { apiRoute } from 'test/handlers';
 import { render } from 'test/render';
 import { server } from 'test/server';
@@ -366,5 +366,109 @@ describe('LabelMigrationTab', () => {
     await renderTab();
     // Reserved labels section is now shown in UNPREFIXED mode for auditing
     await waitFor(() => expect(screen.getByText(/Show reserved label names/i)).toBeInTheDocument());
+  });
+
+  describe('transition cooldown', () => {
+    const NOW = TENANT.modified * 1000 + 6 * 60 * 60 * 1000; // arbitrary fixed "now", well after the fixture's modified time
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    function mockTenantModifiedAgo(msAgo: number) {
+      server.use(
+        apiRoute('getTenant', {
+          result: () => ({ json: { ...TENANT, modified: (NOW - msAgo) / 1000 } }),
+        })
+      );
+    }
+
+    // The button keeps a tooltip prop while cooling down, so @grafana/ui renders
+    // it as aria-disabled (to stay hoverable) rather than natively disabled —
+    // onClick is still nulled out either way, so clicking it is a no-op.
+    async function expectCoolingDown(button: HTMLElement) {
+      await waitFor(() => expect(button).toHaveAttribute('aria-disabled', 'true'));
+      await userEvent.click(button);
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    }
+
+    it('disables Enable dual-write and shows a cooldown message when the tenant changed less than 2 hours ago', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      runTestAsSMAdmin();
+      mockTenantModifiedAgo(30 * 60 * 1000); // 30 minutes ago
+      await renderTab();
+      const button = await screen.findByRole('button', { name: /Enable dual-write/i });
+      await expectCoolingDown(button);
+      // The message appears twice: once as the persistent notice, once as the button's tooltip content.
+      expect(screen.getAllByText('You can change your label mode in 1 hour 30 minutes').length).toBeGreaterThan(0);
+    });
+
+    it('leaves Enable dual-write clickable when the tenant changed more than 2 hours ago', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      runTestAsSMAdmin();
+      mockTenantModifiedAgo(3 * 60 * 60 * 1000); // 3 hours ago
+      await renderTab();
+      const button = await screen.findByRole('button', { name: /Enable dual-write/i });
+      await waitFor(() => expect(button).not.toBeDisabled());
+      expect(screen.queryByText(/You can change your label mode/i)).not.toBeInTheDocument();
+    });
+
+    it('disables Finalize migration in DUAL_WRITE mode during the cooldown', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      runTestAsSMAdmin();
+      mockTenantModifiedAgo(30 * 60 * 1000);
+      server.use(
+        apiRoute('getLabelMode', {
+          result: () => ({ json: { mode: 1, systemLabels: TENANT_LABEL_MODE.systemLabels } }),
+        })
+      );
+      await renderTab();
+      const button = await screen.findByRole('button', { name: /Finalize migration/i });
+      await expectCoolingDown(button);
+      expect(screen.getAllByText(/You can change your label mode in/i).length).toBeGreaterThan(0);
+    });
+
+    it('disables Revert to dual-write in UNPREFIXED mode during the cooldown', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      runTestAsSMAdmin();
+      mockTenantModifiedAgo(30 * 60 * 1000);
+      server.use(
+        apiRoute('getLabelMode', {
+          result: () => ({ json: { mode: 2, systemLabels: TENANT_LABEL_MODE.systemLabels } }),
+        })
+      );
+      await renderTab();
+      const button = await screen.findByRole('button', { name: /Revert to dual-write/i });
+      await expectCoolingDown(button);
+      expect(screen.getAllByText(/You can change your label mode in/i).length).toBeGreaterThan(0);
+    });
+
+    it('disables the next transition button immediately after a successful transition refreshes tenant.modified', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      runTestAsSMAdmin();
+      // Starts outside the cooldown window...
+      mockTenantModifiedAgo(3 * 60 * 60 * 1000);
+      let getTenantCalls = 0;
+      server.use(
+        apiRoute('getTenant', {
+          result: () => {
+            getTenantCalls++;
+            // ...and the transition itself bumps modified to "now", refetched via invalidation.
+            const modified = getTenantCalls === 1 ? (NOW - 3 * 60 * 60 * 1000) / 1000 : NOW / 1000;
+            return { json: { ...TENANT, modified } };
+          },
+        })
+      );
+      await renderTab();
+      const trigger = await screen.findByRole('button', { name: /Enable dual-write/i });
+      await waitFor(() => expect(trigger).not.toBeDisabled());
+      await userEvent.click(trigger);
+      await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+      await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^Enable dual-write$/i }));
+      await waitFor(() => expect(screen.getByText(/Dual-write is active/i)).toBeInTheDocument());
+      const finalizeButton = screen.getByRole('button', { name: /Finalize migration/i });
+      await waitFor(() => expect(finalizeButton).toHaveAttribute('aria-disabled', 'true'));
+      expect(screen.getAllByText('You can change your label mode in 2 hours').length).toBeGreaterThan(0);
+    });
   });
 });

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
@@ -392,31 +392,10 @@ describe('LabelMigrationTab', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     }
 
-    it('disables Enable dual-write and shows a cooldown message when the tenant changed less than 2 hours ago', async () => {
+    it('disables Finalize migration and shows the cooldown message when the tenant changed less than 70 minutes ago', async () => {
       jest.spyOn(Date, 'now').mockReturnValue(NOW);
       runTestAsSMAdmin();
       mockTenantModifiedAgo(30 * 60 * 1000); // 30 minutes ago
-      await renderTab();
-      const button = await screen.findByRole('button', { name: /Enable dual-write/i });
-      await expectCoolingDown(button);
-      // The message appears twice: once as the persistent notice, once as the button's tooltip content.
-      expect(screen.getAllByText('You can change your label mode in 1 hour 30 minutes').length).toBeGreaterThan(0);
-    });
-
-    it('leaves Enable dual-write clickable when the tenant changed more than 2 hours ago', async () => {
-      jest.spyOn(Date, 'now').mockReturnValue(NOW);
-      runTestAsSMAdmin();
-      mockTenantModifiedAgo(3 * 60 * 60 * 1000); // 3 hours ago
-      await renderTab();
-      const button = await screen.findByRole('button', { name: /Enable dual-write/i });
-      await waitFor(() => expect(button).not.toBeDisabled());
-      expect(screen.queryByText(/You can change your label mode/i)).not.toBeInTheDocument();
-    });
-
-    it('disables Finalize migration in DUAL_WRITE mode during the cooldown', async () => {
-      jest.spyOn(Date, 'now').mockReturnValue(NOW);
-      runTestAsSMAdmin();
-      mockTenantModifiedAgo(30 * 60 * 1000);
       server.use(
         apiRoute('getLabelMode', {
           result: () => ({ json: { mode: 1, systemLabels: TENANT_LABEL_MODE.systemLabels } }),
@@ -425,10 +404,36 @@ describe('LabelMigrationTab', () => {
       await renderTab();
       const button = await screen.findByRole('button', { name: /Finalize migration/i });
       await expectCoolingDown(button);
-      expect(screen.getAllByText(/You can change your label mode in/i).length).toBeGreaterThan(0);
+      // The message appears twice: once as the persistent notice, once as the button's tooltip content.
+      expect(screen.getAllByText('You can change your label mode in 40 minutes').length).toBeGreaterThan(0);
     });
 
-    it('disables Revert to dual-write in UNPREFIXED mode during the cooldown', async () => {
+    it('leaves Finalize migration clickable when the tenant changed more than 70 minutes ago', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      runTestAsSMAdmin();
+      mockTenantModifiedAgo(80 * 60 * 1000); // 80 minutes ago
+      server.use(
+        apiRoute('getLabelMode', {
+          result: () => ({ json: { mode: 1, systemLabels: TENANT_LABEL_MODE.systemLabels } }),
+        })
+      );
+      await renderTab();
+      const button = await screen.findByRole('button', { name: /Finalize migration/i });
+      await waitFor(() => expect(button).not.toBeDisabled());
+      expect(screen.queryByText(/You can change your label mode/i)).not.toBeInTheDocument();
+    });
+
+    it('leaves Enable dual-write clickable during the cooldown (only finalizing is gated)', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(NOW);
+      runTestAsSMAdmin();
+      mockTenantModifiedAgo(30 * 60 * 1000);
+      await renderTab();
+      const button = await screen.findByRole('button', { name: /Enable dual-write/i });
+      await waitFor(() => expect(button).not.toBeDisabled());
+      expect(screen.queryByText(/You can change your label mode/i)).not.toBeInTheDocument();
+    });
+
+    it('leaves Revert to dual-write clickable during the cooldown (only finalizing is gated)', async () => {
       jest.spyOn(Date, 'now').mockReturnValue(NOW);
       runTestAsSMAdmin();
       mockTenantModifiedAgo(30 * 60 * 1000);
@@ -439,11 +444,11 @@ describe('LabelMigrationTab', () => {
       );
       await renderTab();
       const button = await screen.findByRole('button', { name: /Revert to dual-write/i });
-      await expectCoolingDown(button);
-      expect(screen.getAllByText(/You can change your label mode in/i).length).toBeGreaterThan(0);
+      await waitFor(() => expect(button).not.toBeDisabled());
+      expect(screen.queryByText(/You can change your label mode/i)).not.toBeInTheDocument();
     });
 
-    it('disables the next transition button immediately after a successful transition refreshes tenant.modified', async () => {
+    it('disables Finalize migration immediately after a successful transition refreshes tenant.modified', async () => {
       jest.spyOn(Date, 'now').mockReturnValue(NOW);
       runTestAsSMAdmin();
       // Starts outside the cooldown window...
@@ -468,7 +473,7 @@ describe('LabelMigrationTab', () => {
       await waitFor(() => expect(screen.getByText(/Dual-write is active/i)).toBeInTheDocument());
       const finalizeButton = screen.getByRole('button', { name: /Finalize migration/i });
       await waitFor(() => expect(finalizeButton).toHaveAttribute('aria-disabled', 'true'));
-      expect(screen.getAllByText('You can change your label mode in 2 hours').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('You can change your label mode in 1 hour 10 minutes').length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
@@ -472,6 +472,12 @@ describe('LabelMigrationTab', () => {
       await userEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /^Enable dual-write$/i }));
       await waitFor(() => expect(screen.getByText(/Dual-write is active/i)).toBeInTheDocument());
       const finalizeButton = screen.getByRole('button', { name: /Finalize migration/i });
+      // The mutation awaits the tenant invalidation, so the instant the
+      // DualWrite UI appears the button must already be inert — first via the
+      // still-pending mutation (busy), then via the cooldown once the refetch
+      // lands. Clicking must never open the confirm dialog in between.
+      await userEvent.click(finalizeButton);
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       await waitFor(() => expect(finalizeButton).toHaveAttribute('aria-disabled', 'true'));
       expect(screen.getAllByText('You can change your label mode in 1 hour 10 minutes').length).toBeGreaterThan(0);
     });

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
@@ -4,10 +4,12 @@ import { Alert, Button, Collapse, Space, Stack, Text } from '@grafana/ui';
 import { LabelMode } from 'datasource/responses.types';
 import { getUserPermissions } from 'data/permissions';
 import { useLabelMode, useSetLabelMode } from 'data/useLabelMode';
+import { useTenant } from 'data/useTenant';
 import { ConfirmModal } from 'components/ConfirmModal';
 import { ContactAdminAlert } from 'page/ContactAdminAlert';
 
 import { ConfigContent } from '../../ConfigContent';
+import { getMigrationCooldown } from './migrationCooldown';
 import { SeriesPreview } from './SeriesPreview';
 import { useCheckInfoLabels } from './useCheckInfoLabels';
 
@@ -42,6 +44,8 @@ export function LabelMigrationTab() {
 
   const { data: state, isLoading, error: loadError, refetch, isRefetching } = useLabelMode();
   const setLabelModeMutation = useSetLabelMode();
+  const { data: tenant } = useTenant();
+  const cooldown = getMigrationCooldown(tenant?.modified, Date.now());
 
   const [updateError, setUpdateError] = useState<string | undefined>(undefined);
   const [collisionError, setCollisionError] = useState<CollisionError | undefined>(undefined);
@@ -125,7 +129,8 @@ export function LabelMigrationTab() {
                         'Enable dual-write'
                       )
                     }
-                    disabled={busy}
+                    disabled={busy || cooldown.isCoolingDown}
+                    tooltip={cooldown.isCoolingDown ? cooldown.message : undefined}
                   >
                     Enable dual-write
                   </Button>
@@ -156,7 +161,8 @@ export function LabelMigrationTab() {
                         'Finalize'
                       )
                     }
-                    disabled={busy}
+                    disabled={busy || cooldown.isCoolingDown}
+                    tooltip={cooldown.isCoolingDown ? cooldown.message : undefined}
                   >
                     Finalize migration
                   </Button>
@@ -190,11 +196,21 @@ export function LabelMigrationTab() {
                         'Revert to dual-write'
                       )
                     }
-                    disabled={busy}
+                    disabled={busy || cooldown.isCoolingDown}
+                    tooltip={cooldown.isCoolingDown ? cooldown.message : undefined}
                   >
                     Revert to dual-write
                   </Button>
                 )}
+              </>
+            )}
+
+            {isAdmin && cooldown.isCoolingDown && (
+              <>
+                <Space v={1} />
+                <Text color="secondary" variant="bodySmall">
+                  {cooldown.message}
+                </Text>
               </>
             )}
 

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
@@ -129,8 +129,7 @@ export function LabelMigrationTab() {
                         'Enable dual-write'
                       )
                     }
-                    disabled={busy || cooldown.isCoolingDown}
-                    tooltip={cooldown.isCoolingDown ? cooldown.message : undefined}
+                    disabled={busy}
                   >
                     Enable dual-write
                   </Button>
@@ -196,8 +195,7 @@ export function LabelMigrationTab() {
                         'Revert to dual-write'
                       )
                     }
-                    disabled={busy || cooldown.isCoolingDown}
-                    tooltip={cooldown.isCoolingDown ? cooldown.message : undefined}
+                    disabled={busy}
                   >
                     Revert to dual-write
                   </Button>
@@ -205,7 +203,7 @@ export function LabelMigrationTab() {
               </>
             )}
 
-            {isAdmin && cooldown.isCoolingDown && (
+            {isAdmin && state.mode === LabelMode.DualWrite && cooldown.isCoolingDown && (
               <>
                 <Space v={1} />
                 <Text color="secondary" variant="bodySmall">

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/migrationCooldown.test.ts
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/migrationCooldown.test.ts
@@ -1,0 +1,34 @@
+import { getMigrationCooldown, MIGRATION_COOLDOWN_MS } from './migrationCooldown';
+
+describe('getMigrationCooldown', () => {
+  const now = 1_800_000_000_000; // fixed reference point, ms
+
+  it('is not cooling down when the tenant modified time is unknown', () => {
+    expect(getMigrationCooldown(undefined, now)).toEqual({ isCoolingDown: false });
+  });
+
+  it('is cooling down when the tenant was modified less than 2 hours ago', () => {
+    const modifiedSeconds = now / 1000 - 30 * 60; // 30 minutes ago
+    expect(getMigrationCooldown(modifiedSeconds, now)).toEqual({
+      isCoolingDown: true,
+      message: 'You can change your label mode in 1 hour 30 minutes',
+    });
+  });
+
+  it('is not cooling down once exactly 2 hours have elapsed', () => {
+    const modifiedSeconds = now / 1000 - MIGRATION_COOLDOWN_MS / 1000;
+    expect(getMigrationCooldown(modifiedSeconds, now)).toEqual({ isCoolingDown: false });
+  });
+
+  it('is not cooling down when the tenant was modified more than 2 hours ago', () => {
+    const modifiedSeconds = now / 1000 - 3 * 60 * 60; // 3 hours ago
+    expect(getMigrationCooldown(modifiedSeconds, now)).toEqual({ isCoolingDown: false });
+  });
+
+  it('is cooling down right after modification, with the full window remaining', () => {
+    expect(getMigrationCooldown(now / 1000, now)).toEqual({
+      isCoolingDown: true,
+      message: 'You can change your label mode in 2 hours',
+    });
+  });
+});

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/migrationCooldown.test.ts
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/migrationCooldown.test.ts
@@ -7,20 +7,20 @@ describe('getMigrationCooldown', () => {
     expect(getMigrationCooldown(undefined, now)).toEqual({ isCoolingDown: false });
   });
 
-  it('is cooling down when the tenant was modified less than 2 hours ago', () => {
+  it('is cooling down when the tenant was modified less than 70 minutes ago', () => {
     const modifiedSeconds = now / 1000 - 30 * 60; // 30 minutes ago
     expect(getMigrationCooldown(modifiedSeconds, now)).toEqual({
       isCoolingDown: true,
-      message: 'You can change your label mode in 1 hour 30 minutes',
+      message: 'You can change your label mode in 40 minutes',
     });
   });
 
-  it('is not cooling down once exactly 2 hours have elapsed', () => {
+  it('is not cooling down once exactly 70 minutes have elapsed', () => {
     const modifiedSeconds = now / 1000 - MIGRATION_COOLDOWN_MS / 1000;
     expect(getMigrationCooldown(modifiedSeconds, now)).toEqual({ isCoolingDown: false });
   });
 
-  it('is not cooling down when the tenant was modified more than 2 hours ago', () => {
+  it('is not cooling down when the tenant was modified more than 70 minutes ago', () => {
     const modifiedSeconds = now / 1000 - 3 * 60 * 60; // 3 hours ago
     expect(getMigrationCooldown(modifiedSeconds, now)).toEqual({ isCoolingDown: false });
   });
@@ -28,7 +28,16 @@ describe('getMigrationCooldown', () => {
   it('is cooling down right after modification, with the full window remaining', () => {
     expect(getMigrationCooldown(now / 1000, now)).toEqual({
       isCoolingDown: true,
-      message: 'You can change your label mode in 2 hours',
+      message: 'You can change your label mode in 1 hour 10 minutes',
+    });
+  });
+
+  it('rounds the remaining time up to whole minutes for fractional timestamps', () => {
+    // 30 minutes and 0.3 seconds ago -> 39 minutes 59.7 seconds remaining -> "40 minutes"
+    const modifiedSeconds = now / 1000 - 30 * 60 - 0.3;
+    expect(getMigrationCooldown(modifiedSeconds, now)).toEqual({
+      isCoolingDown: true,
+      message: 'You can change your label mode in 40 minutes',
     });
   });
 });

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/migrationCooldown.ts
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/migrationCooldown.ts
@@ -1,8 +1,7 @@
 import { formatDuration } from 'utils';
+import { ONE_MINUTE_IN_MS } from 'utils.constants';
 
-export const MIGRATION_COOLDOWN_MS = 70 * 60 * 1000;
-
-const MINUTE_MS = 60 * 1000;
+export const MIGRATION_COOLDOWN_MS = 70 * ONE_MINUTE_IN_MS;
 
 type MigrationCooldown = { isCoolingDown: false } | { isCoolingDown: true; message: string };
 
@@ -21,7 +20,7 @@ export function getMigrationCooldown(tenantModifiedSeconds: number | undefined, 
     return { isCoolingDown: false };
   }
 
-  const wholeMinutesMs = Math.ceil(remainingMs / MINUTE_MS) * MINUTE_MS;
+  const wholeMinutesMs = Math.ceil(remainingMs / ONE_MINUTE_IN_MS) * ONE_MINUTE_IN_MS;
 
   return { isCoolingDown: true, message: `You can change your label mode in ${formatDuration(wholeMinutesMs)}` };
 }

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/migrationCooldown.ts
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/migrationCooldown.ts
@@ -1,0 +1,21 @@
+import { formatDuration } from 'utils';
+
+export const MIGRATION_COOLDOWN_MS = 2 * 60 * 60 * 1000;
+
+type MigrationCooldown = { isCoolingDown: false } | { isCoolingDown: true; message: string };
+
+// tenant.modified is bumped by the label-mode transition itself, so it doubles
+// as "time of last transition" without needing a dedicated timestamp.
+export function getMigrationCooldown(tenantModifiedSeconds: number | undefined, nowMs: number): MigrationCooldown {
+  if (tenantModifiedSeconds === undefined) {
+    return { isCoolingDown: false };
+  }
+
+  const remainingMs = MIGRATION_COOLDOWN_MS - (nowMs - tenantModifiedSeconds * 1000);
+
+  if (remainingMs <= 0) {
+    return { isCoolingDown: false };
+  }
+
+  return { isCoolingDown: true, message: `You can change your label mode in ${formatDuration(remainingMs)}` };
+}

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/migrationCooldown.ts
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/migrationCooldown.ts
@@ -1,11 +1,15 @@
 import { formatDuration } from 'utils';
 
-export const MIGRATION_COOLDOWN_MS = 2 * 60 * 60 * 1000;
+export const MIGRATION_COOLDOWN_MS = 70 * 60 * 1000;
+
+const MINUTE_MS = 60 * 1000;
 
 type MigrationCooldown = { isCoolingDown: false } | { isCoolingDown: true; message: string };
 
 // tenant.modified is bumped by the label-mode transition itself, so it doubles
-// as "time of last transition" without needing a dedicated timestamp.
+// as "time of last transition" without needing a dedicated timestamp. The
+// cooldown only gates finalizing (DUAL_WRITE -> UNPREFIXED); the remaining time
+// is rounded up to whole minutes because the message is static, not a countdown.
 export function getMigrationCooldown(tenantModifiedSeconds: number | undefined, nowMs: number): MigrationCooldown {
   if (tenantModifiedSeconds === undefined) {
     return { isCoolingDown: false };
@@ -17,5 +21,7 @@ export function getMigrationCooldown(tenantModifiedSeconds: number | undefined, 
     return { isCoolingDown: false };
   }
 
-  return { isCoolingDown: true, message: `You can change your label mode in ${formatDuration(remainingMs)}` };
+  const wholeMinutesMs = Math.ceil(remainingMs / MINUTE_MS) * MINUTE_MS;
+
+  return { isCoolingDown: true, message: `You can change your label mode in ${formatDuration(wholeMinutesMs)}` };
 }


### PR DESCRIPTION
## What this PR does

Closes https://github.com/grafana/synthetic-monitoring/issues/665

Users are told that after a label-mode change it may take up to an hour for all checks to settle on the new mode (a check running hourly may not have picked it up yet).

To align the UI with that, the **Finalize migration** button (DUAL_WRITE → UNPREFIXED) is disabled for **70 minutes** after the last tenant update, using `tenant.modified` as the reference for "time of last transition".

- While cooling down, the button shows a tooltip and a persistent secondary-text notice: "You can change your label mode in 40 minutes" (remaining time rounded **up** to whole minutes — the notice is static, not a countdown, and `tenant.modified` is fractional in production).
- `useSetLabelMode` now invalidates the tenant query on success (it has `staleTime: Infinity`), so the cooldown engages immediately after a transition without a page reload.

## Known trade-offs

- Any action that bumps `tenant.modified` (not just label transitions) starts the cooldown.
- No live countdown; the state re-evaluates on the next render (accepted).
- Client-side UX guidance only — the API does not enforce the window.

## Testing

- `migrationCooldown.test.ts`: unknown tenant, inside/outside/boundary of the 70-minute window, full-window message, and whole-minute round-up on fractional timestamps.
- `LabelMigrationTab.test.tsx`: Finalize disabled with message during cooldown (aria-disabled + click is a no-op) and clickable after 80 minutes; Enable dual-write and Revert to dual-write both clickable *during* the cooldown; Finalize disabled immediately after a successful transition (proves the tenant-query invalidation works end to end).
