### PR TITLE
Hide label_ prefix hint in custom labels once tenant leaves PREFIXED mode

### DIFF
--- a/src/components/Checkster/components/form/layouts/GenericLabelContent.test.tsx
+++ b/src/components/Checkster/components/form/layouts/GenericLabelContent.test.tsx
@@ -7,6 +7,8 @@ import { server } from 'test/server';
 import { mockFeatureToggles, testUsesCombobox } from 'test/utils';
 
 import { FeatureName } from 'types';
+import { LabelMode } from 'datasource/responses.types';
+import { useLabelMode } from 'data/useLabelMode';
 
 import { formTestRenderer } from '../__test__/formTestRenderer';
 import { GenericLabelContent } from './GenericLabelContent';
@@ -18,6 +20,12 @@ jest.mock('../../ui/SectionContent', () => ({
 jest.mock('../../../hooks/useRelevantErrors', () => ({
   useRelevantErrors: jest.fn(() => []),
 }));
+
+jest.mock('data/useLabelMode', () => ({
+  useLabelMode: jest.fn(),
+}));
+
+const useLabelModeMock = useLabelMode as jest.Mock;
 
 const calNames = TENANT_COST_ATTRIBUTION_LABELS.names;
 
@@ -33,6 +41,36 @@ function renderGenericLabelContent(
 }
 
 describe('GenericLabelContent', () => {
+  beforeEach(() => {
+    useLabelModeMock.mockReturnValue({ data: { mode: LabelMode.Prefixed, systemLabels: [] } });
+  });
+
+  describe('label_ prefix hint', () => {
+    it('shows the label_ prefix hint while the tenant is in PREFIXED mode', () => {
+      useLabelModeMock.mockReturnValue({ data: { mode: LabelMode.Prefixed, systemLabels: [] } });
+      renderGenericLabelContent();
+      expect(screen.getByText('label')).toBeInTheDocument();
+    });
+
+    it('hides the label_ prefix hint once the tenant has moved to DUAL_WRITE', () => {
+      useLabelModeMock.mockReturnValue({ data: { mode: LabelMode.DualWrite, systemLabels: [] } });
+      renderGenericLabelContent();
+      expect(screen.queryByText('label')).not.toBeInTheDocument();
+    });
+
+    it('hides the label_ prefix hint once the tenant has moved to UNPREFIXED', () => {
+      useLabelModeMock.mockReturnValue({ data: { mode: LabelMode.Unprefixed, systemLabels: [] } });
+      renderGenericLabelContent();
+      expect(screen.queryByText('label')).not.toBeInTheDocument();
+    });
+
+    it('shows the hint while the label mode is still loading, matching the legacy always-on behavior', () => {
+      useLabelModeMock.mockReturnValue({ data: undefined });
+      renderGenericLabelContent();
+      expect(screen.getByText('label')).toBeInTheDocument();
+    });
+  });
+
   describe('when CALs feature flag is enabled', () => {
     beforeEach(() => {
       mockFeatureToggles({ [FeatureName.CALs]: true });

--- a/src/components/Checkster/components/form/layouts/GenericLabelContent.tsx
+++ b/src/components/Checkster/components/form/layouts/GenericLabelContent.tsx
@@ -7,6 +7,8 @@ import { useKGReservedLabels } from 'features/knowledgeGraph/KnowledgeGraphServi
 import { CHECKSTER_TEST_ID } from 'test/dataTestIds';
 
 import { CheckFormValues, FeatureName } from 'types';
+import { LabelMode } from 'datasource/responses.types';
+import { useLabelMode } from 'data/useLabelMode';
 import { FeatureFlag } from 'components/FeatureFlag';
 
 import { SectionContent } from '../../ui/SectionContent';
@@ -31,6 +33,9 @@ export function GenericLabelContent({ description, isLoading, calNames = [], lab
   // service_name / namespace belong to the KG service-link section when the KG app is
   // installed: their rows are hidden here and typing them shows a redirect message.
   const kgReservedLabels = useKGReservedLabels();
+  const { data: labelModeState } = useLabelMode();
+  // Unknown (still loading) defaults to showing the hint, matching pre-migration behavior.
+  const isPrefixedMode = labelModeState === undefined || labelModeState.mode === LabelMode.Prefixed;
 
   useEffect(() => {
     const prevCalNames = prevCalNamesRef.current;
@@ -89,19 +94,21 @@ export function GenericLabelContent({ description, isLoading, calNames = [], lab
           limit={labelLimit !== undefined ? labelLimit - calNames.length : undefined}
           reservedNames={kgReservedLabels}
           namePrefix={
-            <Tooltip content="All custom labels have a 'label_' prefix to ensure they don't conflict with system-defined labels.">
-              <span
-                className={css`
-                  padding-right: 2px;
-                  &:after {
-                    position: absolute;
-                    content: '_';
-                  }
-                `}
-              >
-                label
-              </span>
-            </Tooltip>
+            isPrefixedMode ? (
+              <Tooltip content="All custom labels have a 'label_' prefix to ensure they don't conflict with system-defined labels.">
+                <span
+                  className={css`
+                    padding-right: 2px;
+                    &:after {
+                      position: absolute;
+                      content: '_';
+                    }
+                  `}
+                >
+                  label
+                </span>
+              </Tooltip>
+            ) : undefined
           }
         />
         {errors.labels?.root?.message && (


### PR DESCRIPTION
## Summary
- The Custom Labels tab in the check editor always showed a `label_` prefix hint (decorator + tooltip) on every label-name input, regardless of the tenant's label migration state.
- `GenericLabelContent` now reads `useLabelMode()` and only renders the prefix hint while the tenant is in `PREFIXED` mode; it's omitted once the tenant has moved to `DUAL_WRITE` or `UNPREFIXED`.
- While the label mode is still loading, the hint defaults to shown (matches the pre-existing always-on behavior, fails open rather than flickering).

Fixes grafana/synthetic-monitoring#663

## Test plan
- [x] `GenericLabelContent.test.tsx` — new `label_ prefix hint` cases: shown in PREFIXED, hidden in DUAL_WRITE, hidden in UNPREFIXED, shown while loading
- [x] `yarn typecheck`
- [x] `yarn test:ci` (full suite, no regressions)