### PR TITLE
feat: render invalidLabels from 409 collision response

### DIFF
--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { CONFIG_TEST_ID } from 'test/dataTestIds';
 import { TENANT, TENANT_LABEL_MODE } from 'test/fixtures/tenants';
 import { apiRoute } from 'test/handlers';
 import { render } from 'test/render';
@@ -144,6 +145,95 @@ describe('LabelMigrationTab', () => {
       expect(screen.getByText('probe', { selector: 'code' })).toBeInTheDocument();
       expect(screen.getByText('instance', { selector: 'code' })).toBeInTheDocument();
     });
+    // A colliding-only 409 must not render the invalid-names explanation.
+    expect(screen.queryByText(/would not be valid label names/i)).not.toBeInTheDocument();
+  });
+
+  it('shows invalid label names when API returns 409 with only invalidLabels', async () => {
+    runTestAsSMAdmin();
+    server.use(
+      apiRoute('setLabelMode', {
+        result: () => ({
+          status: 409,
+          json: { msg: 'labels would be invalid without the label_ prefix', invalidLabels: ['9foo', '__bar'] },
+        }),
+      })
+    );
+    await renderTab();
+    const trigger = await screen.findByRole('button', { name: /Enable dual-write/i });
+    await userEvent.click(trigger);
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    const confirmButton = within(screen.getByRole('dialog')).getByRole('button', { name: /^Enable dual-write$/i });
+    await userEvent.click(confirmButton);
+    // The invalid-only 409 must land in the collision alert, not the generic error path.
+    await waitFor(() => expect(screen.getByText(/Label name conflicts/i)).toBeInTheDocument());
+    expect(screen.getByText(/would not be valid label names/i)).toBeInTheDocument();
+    expect(screen.getByText('9foo', { selector: 'code' })).toBeInTheDocument();
+    expect(screen.getByText('__bar', { selector: 'code' })).toBeInTheDocument();
+    expect(screen.queryByText(/Failed to update label migration mode/i)).not.toBeInTheDocument();
+    // No reserved-name collisions were reported, so that explanation stays hidden
+    // and there are no rename rows — but the in-alert retry stays available for
+    // after the labels are fixed in the check editor.
+    expect(screen.queryByText(/conflict with reserved system names/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('rename-input-9foo')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Retry enabling dual-write/i })).toBeEnabled();
+  });
+
+  it('renders colliding and invalid label lists distinctly on a mixed 409', async () => {
+    runTestAsSMAdmin();
+    server.use(
+      apiRoute('setLabelMode', {
+        result: () => ({
+          status: 409,
+          json: {
+            msg: 'labels conflict or would be invalid',
+            collidingLabels: ['probe'],
+            invalidLabels: ['9foo'],
+          },
+        }),
+      })
+    );
+    await renderTab();
+    const trigger = await screen.findByRole('button', { name: /Enable dual-write/i });
+    await userEvent.click(trigger);
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    const confirmButton = within(screen.getByRole('dialog')).getByRole('button', { name: /^Enable dual-write$/i });
+    await userEvent.click(confirmButton);
+    await waitFor(() => expect(screen.getByText(/Label name conflicts/i)).toBeInTheDocument());
+    // Both explanations render; colliding names get rename rows, invalid names
+    // sit in their own list without a rename affordance.
+    expect(screen.getByText(/conflict with reserved system names/i)).toBeInTheDocument();
+    expect(screen.getByText(/would not be valid label names/i)).toBeInTheDocument();
+    const invalidList = screen.getByTestId(CONFIG_TEST_ID.labelMigration.invalidList);
+    expect(within(invalidList).getByText('9foo', { selector: 'code' })).toBeInTheDocument();
+    expect(within(invalidList).queryByText('probe', { selector: 'code' })).not.toBeInTheDocument();
+    expect(screen.getByTestId('rename-input-probe')).toBeInTheDocument();
+    expect(screen.queryByTestId('rename-input-9foo')).not.toBeInTheDocument();
+    // The retry stays gated until the colliding label is renamed.
+    expect(screen.getByRole('button', { name: /Retry enabling dual-write/i })).toBeDisabled();
+  });
+
+  it('routes a 409 with empty label arrays to the generic error path', async () => {
+    runTestAsSMAdmin();
+    server.use(
+      apiRoute('setLabelMode', {
+        result: () => ({
+          status: 409,
+          json: { msg: 'conflicting concurrent update', collidingLabels: [], invalidLabels: [] },
+        }),
+      })
+    );
+    await renderTab();
+    const trigger = await screen.findByRole('button', { name: /Enable dual-write/i });
+    await userEvent.click(trigger);
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    const confirmButton = within(screen.getByRole('dialog')).getByRole('button', { name: /^Enable dual-write$/i });
+    await userEvent.click(confirmButton);
+    // With no label names to act on, the collision alert would be an empty
+    // shell — the generic update error carrying the API's msg is shown instead.
+    await waitFor(() => expect(screen.getByText(/Failed to update label migration mode/i)).toBeInTheDocument());
+    expect(screen.getByText(/conflicting concurrent update/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Label name conflicts/i)).not.toBeInTheDocument();
   });
 
   it('shows an update error without Retry when setLabelMode fails without collisions', async () => {

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Alert, Button, Collapse, Space, Stack, Text } from '@grafana/ui';
+import { CONFIG_TEST_ID } from 'test/dataTestIds';
 
 import { LabelMode } from 'datasource/responses.types';
 import { getUserPermissions } from 'data/permissions';
@@ -16,7 +17,8 @@ import { useCheckInfoLabels } from './useCheckInfoLabels';
 
 interface CollisionError {
   msg: string;
-  collidingLabels: string[];
+  collidingLabels?: string[];
+  invalidLabels?: string[];
 }
 
 function modeLabel(mode: LabelMode): string {
@@ -68,7 +70,10 @@ export function LabelMigrationTab() {
       await setLabelModeMutation.mutateAsync(targetMode);
     } catch (err: unknown) {
       const e = err as { status?: number; data?: CollisionError };
-      if (e?.status === 409 && e?.data?.collidingLabels) {
+      // A 409 can carry reserved-name collisions, invalid-once-unprefixed names,
+      // or both — any non-empty list means "rename these labels first".
+      const labelIssues = (e?.data?.collidingLabels?.length ?? 0) > 0 || (e?.data?.invalidLabels?.length ?? 0) > 0;
+      if (e?.status === 409 && e.data && labelIssues) {
         setCollisionError(e.data);
       } else {
         setUpdateError(getErrorMessage(err, 'Failed to update label migration mode'));
@@ -236,13 +241,37 @@ export function LabelMigrationTab() {
                   title="Label name conflicts — cannot enable dual-write"
                   onRemove={() => setCollisionError(undefined)}
                 >
-                  <Text>
-                    The following labels conflict with reserved system names. Rename them across your checks below, then
-                    retry. Labels set on probes are not covered by the rename and must be edited on the probe itself.
-                  </Text>
-                  <Space v={1} />
+                  {!!collisionError.invalidLabels?.length && (
+                    <>
+                      <Text>
+                        The following labels would not be valid label names once the <code>label_</code> prefix is
+                        removed. Rename them on the checks and probes that carry them before enabling dual-write:
+                      </Text>
+                      <Space v={1} />
+                      <ul data-testid={CONFIG_TEST_ID.labelMigration.invalidList}>
+                        {collisionError.invalidLabels.map((name) => (
+                          <li key={name}>
+                            <code>{name}</code>
+                          </li>
+                        ))}
+                      </ul>
+                      <Space v={1} />
+                    </>
+                  )}
+                  {!!collisionError.collidingLabels?.length && (
+                    <>
+                      <Text>
+                        The following labels conflict with reserved system names. Rename them across your checks below,
+                        then retry. Labels set on probes are not covered by the rename and must be edited on the probe
+                        itself.
+                      </Text>
+                      <Space v={1} />
+                    </>
+                  )}
+                  {/* Rendered even with no colliding labels so the in-alert retry
+                      stays available once invalid labels are fixed externally. */}
                   <CollidingLabelRename
-                    labels={collisionError.collidingLabels}
+                    labels={collisionError.collidingLabels ?? []}
                     systemLabels={state.systemLabels}
                     disabled={!isAdmin}
                     retrying={busy}

--- a/src/test/dataTestIds.ts
+++ b/src/test/dataTestIds.ts
@@ -136,6 +136,9 @@ export const CONFIG_TEST_ID = {
   layout: {
     activeTab: 'config layout active-tab',
   },
+  labelMigration: {
+    invalidList: 'config label-migration invalid-list',
+  },
   secretEditModal: 'config secret-edit-modal',
 } as const;
 


### PR DESCRIPTION
## What this PR does

We return a new `invalidLabels` field in the `409` error response for changing the tenant's labelling mode.

That field captures which labels are blocking due to being invalid for Prometheus compatibility.

There was already an existing `collidingLabels` field capturing labels that clash with our system-reserved names.

Changes:
- `CollisionError` widened: both label array fields are optional.
- The 409 detection previously keyed on `collidingLabels` presence alone; it now fires when **either** array is non-empty, so an invalid-only conflict renders the guidance alert instead of the generic error. A 409 carrying only empty arrays deliberately routes to the generic path (shows the API `msg`) rather than an empty alert.
- Invalid names render as a second section in the existing conflict alert with their own explanation; lists addressed via new `CONFIG_TEST_ID.labelMigration` registry entries.

Without this change the shipped app still detects the new 409 (empty `collidingLabels` is truthy), just with degraded display - merge order with the API PR is not critical.

## Testing

Invalid-only 409 renders the invalid names in the conflict alert; colliding-only regression (invalid section absent); mixed 409 with `within()`-scoped proof each name sits only in its own list; empty-arrays 409 routes to the generic path with the API `msg`. TDD verified failing pre-implementation; two adversarial review rounds; 26/26 tests, typecheck clean, lint 0 errors.

