### PR TITLE
fix: sync grouped probe checkbox state

### DIFF
--- a/src/components/CheckEditor/CheckProbes/ProbesList.test.tsx
+++ b/src/components/CheckEditor/CheckProbes/ProbesList.test.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { screen } from '@testing-library/react';
+import { DB } from 'test/db';
+import { render } from 'test/render';
+import { probeToMetadataProbe } from 'test/utils';
+
+import { CheckFormValues, ProbeWithMetadata } from 'types';
+
+import { ProbesList } from './ProbesList';
+
+function ProbeSelection() {
+  const form = useForm<CheckFormValues>();
+  const probes: ProbeWithMetadata[] = [
+    probeToMetadataProbe(DB.probe.build({ id: 1, name: 'Calgary' })),
+    probeToMetadataProbe(DB.probe.build({ id: 2, name: 'Montreal' })),
+  ];
+  const [selectedProbes, setSelectedProbes] = useState([probes[0].id!]);
+
+  return (
+    <FormProvider {...form}>
+      <ProbesList
+        title="AMER"
+        probes={probes}
+        selectedProbes={selectedProbes}
+        onSelectionChange={setSelectedProbes}
+      />
+    </FormProvider>
+  );
+}
+
+describe('<ProbesList />', () => {
+  it('shows the region header as checked after the final probe is selected', async () => {
+    const { user } = render(<ProbeSelection />);
+    const header = await screen.findByRole('checkbox', { name: /AMER/ });
+
+    expect(header).toBePartiallyChecked();
+
+    await user.click(await screen.findByRole('checkbox', { name: /Montreal/ }));
+
+    expect(header).toBeChecked();
+    expect(header).not.toBePartiallyChecked();
+  });
+});

--- a/src/components/CheckEditor/CheckProbes/ProbesList.tsx
+++ b/src/components/CheckEditor/CheckProbes/ProbesList.tsx
@@ -92,6 +92,14 @@ export const ProbesList = ({
           onClick={handleToggleAll}
           checked={allProbesSelected}
           indeterminate={someProbesSelected}
+          // Grafana's Checkbox sets the native indeterminate property when it is
+          // enabled, but does not clear it when the prop changes back to false.
+          // Clear it here so the header can transition from partial to checked.
+          ref={(element) => {
+            if (element) {
+              element.indeterminate = someProbesSelected;
+            }
+          }}
           disabled={disabled}
         />
         <Label htmlFor={`header-${title}`} className={styles.headerLabel}>


### PR DESCRIPTION
## Summary
- synchronize grouped probe header checkbox state after the final probe is selected
- add regression coverage for the partial-to-complete selection transition

## Bug

If you check the last box in a list..
<img width="276" height="424" alt="Screenshot 2026-08-27 at 10 37 18" src="https://github.com/user-attachments/assets/0a6dfead-2831-4dad-8fa8-cd52a144ab0f" />
The region checkbox is then unchecked
<img width="274" height="449" alt="Screenshot 2026-08-27 at 10 37 26" src="https://github.com/user-attachments/assets/18d12921-410a-422a-90ab-4efa20b440d1" />


## Test plan
- [x] Targeted ProbesList Jest test
- [x] TypeScript typecheck
- [x] ESLint