### PR TITLE
chore: connect the plugin to Crowdin for translation sync

### DIFF
--- a/.github/workflows/i18n-crowdin-create-tasks.yml
+++ b/.github/workflows/i18n-crowdin-create-tasks.yml
@@ -1,0 +1,30 @@
+name: Crowdin automatic task management
+
+on:
+  workflow_dispatch:
+  # Disabled until the existing es-ES translations have been imported into
+  # Crowdin, so translators are not asked to redo work already in the repo.
+  # once a month on the first day of the month at midnight
+  # schedule:
+  #   - cron: '0 0 1 * *'
+
+jobs:
+  create-tasks-in-crowdin:
+    runs-on: ubuntu-x64
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Get vault secrets
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
+        with:
+          # Vault secret paths:
+          # - ci/repo/grafana/synthetic-monitoring-app/grafana-frontend-crowdin-token
+          repo_secrets: |
+            CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
+      - name: Create tasks in Crowdin
+        uses: grafana/grafana-github-actions/crowdin-create-tasks@26e65a1da9ffdf35d3e8cc6dbeffbccf16022d88 # main
+        with:
+          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_project_id: 64

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -1,0 +1,38 @@
+name: Crowdin Download Action
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  download-sources-from-crowdin:
+    if: github.repository == 'grafana/synthetic-monitoring-app'
+    runs-on: ubuntu-x64
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
+        with:
+          github_app: grafana-pr-automation
+      - name: Get vault secrets
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
+        with:
+          # Vault secret paths:
+          # - ci/repo/grafana/synthetic-monitoring-app/grafana-frontend-crowdin-token
+          repo_secrets: |
+            CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
+      - name: Download from Crowdin
+        uses: grafana/grafana-github-actions/crowdin-download@26e65a1da9ffdf35d3e8cc6dbeffbccf16022d88 # main
+        with:
+          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_project_id: 64
+          github_repo_token: ${{ steps.get-github-app-token.outputs.token }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -1,0 +1,34 @@
+name: Crowdin Upload Action
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'src/locales/en-US/grafana-synthetic-monitoring-app.json'
+    branches:
+      - main
+
+jobs:
+  upload-sources-to-crowdin:
+    runs-on: ubuntu-x64
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - name: Get vault secrets
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
+        with:
+          # Vault secret paths:
+          # - ci/repo/grafana/synthetic-monitoring-app/grafana-frontend-crowdin-token
+          repo_secrets: |
+            CROWDIN_TOKEN=grafana-frontend-crowdin-token:access_token
+      - name: Upload to Crowdin
+        uses: grafana/grafana-github-actions/crowdin-upload@26e65a1da9ffdf35d3e8cc6dbeffbccf16022d88 # main
+        with:
+          crowdin_token: ${{ env.CROWDIN_TOKEN }}
+          crowdin_project_id: 64

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,13 @@
+# The following are pulled from env variables
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+
+preserve_hierarchy: true
+files:
+  [
+    {
+      'source': 'src/locales/en-US/grafana-synthetic-monitoring-app.json',
+      'translation': 'src/locales/%locale%/%original_file_name%',
+      'type': 'i18next_json',
+    },
+  ]


### PR DESCRIPTION
Addresses: https://github.com/grafana/synthetic-monitoring-app/issues/1556 (Phase 2)

## Problem

Phase 1 of #1556 made the plugin internationalisable, but nothing connects it to Crowdin, where Grafana's translators actually work. New English strings never reach a translator, and any finished translation has to be copied back into the repo by hand. In practice `es-ES` falls further behind `en-US` with every feature we ship.

## Solution

Connects the repo to Crowdin project 64, following the [internationalisation runbook](https://github.com/grafana/deployment_tools/blob/master/docs/grafana-frontend/plugin-internationalization.md) in `deployment_tools`.

`crowdin.yml` tells Crowdin where the source and translated files live. Three workflows then keep both sides in sync: English strings upload when they change on `main`, finished translations return as a daily pull request, and untranslated strings become tasks for translators.

No product code here, and no user facing change on merge.

## Notes for reviewers

- The ticket lists `i18n-verify` as a fourth workflow to add. It was skipped because `validate-i18n.yml` already runs the same extract and diff check, using our own `setup-env` action.
- These run on `ubuntu-x64`, not `ubuntu-latest`, because `get-vault-secrets` needs a Grafana hosted runner to reach Vault.
- `pr_labels` and `github_board_id` are omitted. This repo has no `i18n` label, and passing one that does not exist fails PR creation.
- The cron in `i18n-crowdin-create-tasks.yml` is commented out on purpose. `src/locales/es-ES/` already holds real translations that must be imported into Crowdin first, or translators will be asked to redo them.

## After merge

1. Run `i18n-crowdin-upload.yml` manually. This PR does not touch the English locale file, so it will not trigger on its own.
2. Import the existing `es-ES` translations into Crowdin.
3. Restore the cron in `i18n-crowdin-create-tasks.yml`.

This does not close #1556. Two Phase 2 criteria are still outstanding: verifying the upload and download workflows actually behave as expected, which is only possible once they are on `main`, and documenting the Crowdin project ID in `CONTRIBUTING`.