### PR TITLE
feat: add affordance for checks impacted by label migration

### DIFF
--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/BlockingChecksList.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/BlockingChecksList.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Stack, Text, TextLink } from '@grafana/ui';
+
+import { type Check } from 'types';
+import { AppRoutes } from 'routing/types';
+import { generateRoutePath, getRoute } from 'routing/utils';
+
+function getChecksListHref(label: string) {
+  const params = new URLSearchParams({ search: label });
+  return `${getRoute(AppRoutes.Checks)}?${params.toString()}`;
+}
+
+// BlockingChecksList shows which checks currently carry a given label, so an
+// admin can jump straight to them instead of guessing from the label name
+// alone. A label with zero matches most likely lives on a probe, which this
+// list can't see (probe labels aren't tied to any Check object).
+export function BlockingChecksList({ label, checks }: { label: string; checks: Check[] }) {
+  const blockingChecks = checks.filter((check) => check.labels.some((l) => l.name === label));
+
+  if (blockingChecks.length === 0) {
+    return (
+      <Text color="secondary" variant="bodySmall" data-testid={`blocking-checks-empty-${label}`}>
+        No checks currently carry this label — it may be set on a probe, which must be edited directly.
+      </Text>
+    );
+  }
+
+  return (
+    <Stack direction="row" gap={1} wrap="wrap" alignItems="center" data-testid={`blocking-checks-${label}`}>
+      <Text color="secondary" variant="bodySmall">
+        Blocking checks:
+      </Text>
+      {blockingChecks.map((check, i) => (
+        <React.Fragment key={check.id}>
+          <TextLink variant="bodySmall" href={generateRoutePath(AppRoutes.EditCheck, { id: check.id! })}>
+            {check.job}
+          </TextLink>
+          {i < blockingChecks.length - 1 && <Text color="secondary">,</Text>}
+        </React.Fragment>
+      ))}
+      <TextLink variant="bodySmall" href={getChecksListHref(label)} data-testid={`blocking-checks-view-all-${label}`}>
+        View all {blockingChecks.length} in Checks list
+      </TextLink>
+    </Stack>
+  );
+}

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/BlockingChecksList.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/BlockingChecksList.tsx
@@ -10,11 +10,28 @@ function getChecksListHref(label: string) {
   return `${getRoute(AppRoutes.Checks)}?${params.toString()}`;
 }
 
+interface BlockingChecksListProps {
+  label: string;
+  checks: Check[];
+  checksError?: boolean;
+}
+
 // BlockingChecksList shows which checks currently carry a given label, so an
 // admin can jump straight to them instead of guessing from the label name
 // alone. A label with zero matches most likely lives on a probe, which this
-// list can't see (probe labels aren't tied to any Check object).
-export function BlockingChecksList({ label, checks }: { label: string; checks: Check[] }) {
+// list can't see (probe labels aren't tied to any Check object) — but that
+// reading is only valid if the check list actually loaded. A failed fetch
+// looks identical to "zero matches" from `checks` alone, so `checksError`
+// must be checked first to avoid reporting a false negative as fact.
+export function BlockingChecksList({ label, checks, checksError }: BlockingChecksListProps) {
+  if (checksError) {
+    return (
+      <Text color="secondary" variant="bodySmall" data-testid={`blocking-checks-error-${label}`}>
+        Couldn&apos;t load checks to verify — unable to confirm whether any checks carry this label.
+      </Text>
+    );
+  }
+
   const blockingChecks = checks.filter((check) => check.labels.some((l) => l.name === label));
 
   if (blockingChecks.length === 0) {

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/BlockingChecksList.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/BlockingChecksList.tsx
@@ -62,7 +62,7 @@ export function BlockingChecksList({ label, checks, checksError }: BlockingCheck
         ))}
       </Stack>
       <TextLink variant="bodySmall" href={getChecksListHref(label)} data-testid={`blocking-checks-view-all-${label}`}>
-        View all {blockingChecks.length} in Checks list
+        View all in Checks list
       </TextLink>
     </Stack>
   );

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/BlockingChecksList.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/BlockingChecksList.tsx
@@ -10,6 +10,8 @@ function getChecksListHref(label: string) {
   return `${getRoute(AppRoutes.Checks)}?${params.toString()}`;
 }
 
+const MAX_VISIBLE_CHECKS = 5;
+
 interface BlockingChecksListProps {
   label: string;
   checks: Check[];
@@ -42,19 +44,23 @@ export function BlockingChecksList({ label, checks, checksError }: BlockingCheck
     );
   }
 
+  const visibleChecks = blockingChecks.slice(0, MAX_VISIBLE_CHECKS);
+
   return (
-    <Stack direction="row" gap={1} wrap="wrap" alignItems="center" data-testid={`blocking-checks-${label}`}>
-      <Text color="secondary" variant="bodySmall">
-        Blocking checks:
-      </Text>
-      {blockingChecks.map((check, i) => (
-        <React.Fragment key={check.id}>
-          <TextLink variant="bodySmall" href={generateRoutePath(AppRoutes.EditCheck, { id: check.id! })}>
-            {check.job}
-          </TextLink>
-          {i < blockingChecks.length - 1 && <Text color="secondary">,</Text>}
-        </React.Fragment>
-      ))}
+    <Stack direction="row" justifyContent="space-between" alignItems="center" data-testid={`blocking-checks-${label}`}>
+      <Stack direction="row" gap={1} wrap="wrap" alignItems="center">
+        <Text color="secondary" variant="bodySmall">
+          Blocking checks:
+        </Text>
+        {visibleChecks.map((check, i) => (
+          <React.Fragment key={check.id}>
+            <TextLink variant="bodySmall" href={generateRoutePath(AppRoutes.EditCheck, { id: check.id! })}>
+              {check.job}
+            </TextLink>
+            {i < visibleChecks.length - 1 && <Text color="secondary">,</Text>}
+          </React.Fragment>
+        ))}
+      </Stack>
       <TextLink variant="bodySmall" href={getChecksListHref(label)} data-testid={`blocking-checks-view-all-${label}`}>
         View all {blockingChecks.length} in Checks list
       </TextLink>

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/CollidingLabelRename.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/CollidingLabelRename.tsx
@@ -1,8 +1,11 @@
 import React, { useRef, useState } from 'react';
 import { Button, Field, Input, Space, Stack, Text } from '@grafana/ui';
 
+import { type Check } from 'types';
 import { validateLabelName } from 'validation';
 import { useRenameCheckLabels } from 'data/useRenameCheckLabels';
+
+import { BlockingChecksList } from './BlockingChecksList';
 
 interface RowState {
   value: string;
@@ -15,6 +18,7 @@ interface RowState {
 interface CollidingLabelRenameProps {
   labels: string[];
   systemLabels: string[];
+  checks: Check[];
   disabled: boolean;
   retrying: boolean;
   onRetry: () => void;
@@ -24,7 +28,14 @@ interface CollidingLabelRenameProps {
 // transition retry on every label having been renamed. Renames only cover
 // checks: a label that reports zero updated checks most likely lives on a
 // probe, which must be edited directly.
-export function CollidingLabelRename({ labels, systemLabels, disabled, retrying, onRetry }: CollidingLabelRenameProps) {
+export function CollidingLabelRename({
+  labels,
+  systemLabels,
+  checks,
+  disabled,
+  retrying,
+  onRetry,
+}: CollidingLabelRenameProps) {
   const renameMutation = useRenameCheckLabels();
   const [rows, setRows] = useState<Record<string, RowState>>({});
   // Guards a same-row double click: isPending only disables the button after a
@@ -101,31 +112,34 @@ export function CollidingLabelRename({ labels, systemLabels, disabled, retrying,
               </Text>
             }
           >
-            <Stack direction="row" gap={1} alignItems="center">
-              <Input
-                width={30}
-                placeholder="New label name"
-                disabled={disabled || row.pending || row.renamed}
-                invalid={!!row.error}
-                value={row.value}
-                onChange={(e) => patchRow(label, { value: e.currentTarget.value, error: undefined })}
-                data-testid={`rename-input-${label}`}
-              />
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={() => rename(label)}
-                disabled={disabled || row.pending || row.renamed || renameMutation.isPending}
-              >
-                Rename
-              </Button>
-              {row.renamed && (
-                <Text color="secondary">
-                  {row.updatedCount === 0
-                    ? '✓ no checks carried this label — it may be set on a probe, which must be edited directly'
-                    : `✓ renamed on ${row.updatedCount} check${row.updatedCount === 1 ? '' : 's'}`}
-                </Text>
-              )}
+            <Stack direction="column" gap={1}>
+              <Stack direction="row" gap={1} alignItems="center">
+                <Input
+                  width={30}
+                  placeholder="New label name"
+                  disabled={disabled || row.pending || row.renamed}
+                  invalid={!!row.error}
+                  value={row.value}
+                  onChange={(e) => patchRow(label, { value: e.currentTarget.value, error: undefined })}
+                  data-testid={`rename-input-${label}`}
+                />
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => rename(label)}
+                  disabled={disabled || row.pending || row.renamed || renameMutation.isPending}
+                >
+                  Rename
+                </Button>
+                {row.renamed && (
+                  <Text color="secondary">
+                    {row.updatedCount === 0
+                      ? '✓ no checks carried this label — it may be set on a probe, which must be edited directly'
+                      : `✓ renamed on ${row.updatedCount} check${row.updatedCount === 1 ? '' : 's'}`}
+                  </Text>
+                )}
+              </Stack>
+              {!row.renamed && <BlockingChecksList label={label} checks={checks} />}
             </Stack>
           </Field>
         );

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/CollidingLabelRename.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/CollidingLabelRename.tsx
@@ -19,6 +19,7 @@ interface CollidingLabelRenameProps {
   labels: string[];
   systemLabels: string[];
   checks: Check[];
+  checksError?: boolean;
   disabled: boolean;
   retrying: boolean;
   onRetry: () => void;
@@ -32,6 +33,7 @@ export function CollidingLabelRename({
   labels,
   systemLabels,
   checks,
+  checksError,
   disabled,
   retrying,
   onRetry,
@@ -139,7 +141,7 @@ export function CollidingLabelRename({
                   </Text>
                 )}
               </Stack>
-              {!row.renamed && <BlockingChecksList label={label} checks={checks} />}
+              {!row.renamed && <BlockingChecksList label={label} checks={checks} checksError={checksError} />}
             </Stack>
           </Field>
         );

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/ImpactedChecksWarning.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/ImpactedChecksWarning.tsx
@@ -10,6 +10,7 @@ import { BlockingChecksList } from './BlockingChecksList';
 interface ImpactedChecksWarningProps {
   checks: Check[];
   systemLabels: string[];
+  checksError?: boolean;
 }
 
 // Surfaces which reserved-name collisions already exist before the admin
@@ -18,9 +19,23 @@ interface ImpactedChecksWarningProps {
 // breakdown lives in its own Collapse (not inside the Alert body) so a
 // tenant with many colliding labels doesn't turn the warning into a wall of
 // text — the Alert states the headline, the Collapse holds the detail.
-export function ImpactedChecksWarning({ checks, systemLabels }: ImpactedChecksWarningProps) {
+export function ImpactedChecksWarning({ checks, systemLabels, checksError }: ImpactedChecksWarningProps) {
   const styles = useStyles2(getStyles);
   const [isOpen, setIsOpen] = useState(false);
+
+  // A failed check-list fetch leaves `checks` empty, which looks identical to
+  // a confirmed "no collisions" result below — surface the failure instead of
+  // silently reporting a false negative.
+  if (checksError) {
+    return (
+      <div data-testid="impacted-checks-warning-error">
+        <Alert severity="warning" title="Couldn't verify whether any checks use reserved label names">
+          <Text>The check list failed to load, so this can&apos;t confirm whether this transition will be blocked.</Text>
+        </Alert>
+        <Space v={2} />
+      </div>
+    );
+  }
 
   const impactedLabels = systemLabels.filter((name) => checks.some((check) => check.labels.some((l) => l.name === name)));
 
@@ -44,7 +59,7 @@ export function ImpactedChecksWarning({ checks, systemLabels }: ImpactedChecksWa
         </Text>
       </Alert>
       <Collapse
-        label={`${isOpen ? 'Hide' : 'Show'} ${impactedLabels.length} impacted label${impactedLabels.length === 1 ? '' : 's'}`}
+        label={`Impacted label${impactedLabels.length === 1 ? '' : 's'} (${impactedLabels.length})`}
         isOpen={isOpen}
         onToggle={() => setIsOpen((v) => !v)}
       >

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/ImpactedChecksWarning.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/ImpactedChecksWarning.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Alert, Collapse, Space, Tag, Text, useStyles2 } from '@grafana/ui';
+import { css, cx } from '@emotion/css';
+
+import { type Check } from 'types';
+
+import { BlockingChecksList } from './BlockingChecksList';
+
+interface ImpactedChecksWarningProps {
+  checks: Check[];
+  systemLabels: string[];
+}
+
+// Surfaces which reserved-name collisions already exist before the admin
+// attempts a transition, instead of only after it 409s. Computed entirely
+// client-side from data already on the page (no extra API call). The
+// breakdown lives in its own Collapse (not inside the Alert body) so a
+// tenant with many colliding labels doesn't turn the warning into a wall of
+// text — the Alert states the headline, the Collapse holds the detail.
+export function ImpactedChecksWarning({ checks, systemLabels }: ImpactedChecksWarningProps) {
+  const styles = useStyles2(getStyles);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const impactedLabels = systemLabels.filter((name) => checks.some((check) => check.labels.some((l) => l.name === name)));
+
+  if (impactedLabels.length === 0) {
+    return null;
+  }
+
+  const impactedCheckCount = new Set(
+    checks.filter((check) => check.labels.some((l) => impactedLabels.includes(l.name))).map((check) => check.id)
+  ).size;
+
+  return (
+    <div data-testid="impacted-checks-warning">
+      <Alert
+        severity="warning"
+        title={`${impactedCheckCount} check${impactedCheckCount === 1 ? '' : 's'} use reserved label names`}
+      >
+        <Text>
+          There are {impactedCheckCount} check{impactedCheckCount === 1 ? '' : 's'} that currently use label names
+          reserved by the migration and will block this transition until renamed.
+        </Text>
+      </Alert>
+      <Collapse
+        label={`${isOpen ? 'Hide' : 'Show'} ${impactedLabels.length} impacted label${impactedLabels.length === 1 ? '' : 's'}`}
+        isOpen={isOpen}
+        onToggle={() => setIsOpen((v) => !v)}
+      >
+        {impactedLabels.map((label, i) => (
+          <div key={label} className={cx(styles.row, { [styles.lastRow]: i === impactedLabels.length - 1 })}>
+            <Tag name={label} colorIndex={9} className={styles.labelTag} />
+            <BlockingChecksList label={label} checks={checks} />
+          </div>
+        ))}
+      </Collapse>
+      <Space v={2} />
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  row: css`
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: ${theme.spacing(1.5)};
+    padding: ${theme.spacing(1)} 0;
+    border-bottom: 1px solid ${theme.colors.border.weak};
+  `,
+  lastRow: css`
+    border-bottom: none;
+  `,
+  labelTag: css`
+    font-family: ${theme.typography.fontFamilyMonospace};
+    flex-shrink: 0;
+  `,
+});

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
@@ -66,7 +66,7 @@ describe('LabelMigrationTab', () => {
     const warning = await screen.findByTestId('impacted-checks-warning');
     expect(warning).toHaveTextContent(/1 check/i);
 
-    await userEvent.click(within(warning).getByText(/Show 1 impacted label/i));
+    await userEvent.click(within(warning).getByText(/Impacted label \(1\)/i));
 
     // The offending label name itself is shown, not just the checks carrying it.
     expect(within(warning).getByText('instance')).toBeInTheDocument();
@@ -91,7 +91,7 @@ describe('LabelMigrationTab', () => {
     await renderTab();
 
     const warning = await screen.findByTestId('impacted-checks-warning');
-    await userEvent.click(within(warning).getByText(/Show 1 impacted label/i));
+    await userEvent.click(within(warning).getByText(/Impacted label \(1\)/i));
     expect(within(warning).getByRole('link', { name: 'checkout-ping' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Finalize migration/i })).toBeInTheDocument();
   });
@@ -105,6 +105,34 @@ describe('LabelMigrationTab', () => {
 
     expect(screen.queryByTestId('impacted-checks-warning')).not.toBeInTheDocument();
     expect(screen.getByText(/Label name conflicts/i)).toBeInTheDocument();
+  });
+
+  // A failed checks fetch leaves the checks list empty, which is
+  // indistinguishable from "confirmed zero collisions" unless the failure is
+  // surfaced explicitly — otherwise a real 500/permissions gap silently reads
+  // as an all-clear.
+  it('surfaces a failed check fetch instead of silently reporting no impacted checks', async () => {
+    runTestAsSMAdmin();
+    server.use(apiRoute('listChecks', { result: () => ({ status: 500, json: { msg: 'failed to list checks' } }) }));
+
+    await renderTab();
+
+    const warning = await screen.findByTestId('impacted-checks-warning-error');
+    expect(warning).toHaveTextContent(/couldn't verify/i);
+    // The confident "no collisions" state must not also render.
+    expect(screen.queryByTestId('impacted-checks-warning')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a failed check fetch in the reactive collision alert instead of a false "no checks" hint', async () => {
+    runTestAsSMAdmin();
+    server.use(apiRoute('listChecks', { result: () => ({ status: 500, json: { msg: 'failed to list checks' } }) }));
+
+    await triggerCollision(['instance']);
+
+    expect(await screen.findByTestId('blocking-checks-error-instance')).toHaveTextContent(/couldn't load checks/i);
+    // The unconditional "no checks carry this label" hint is misleading here — a
+    // failed fetch is not evidence the label lives on a probe.
+    expect(screen.queryByTestId('blocking-checks-empty-instance')).not.toBeInTheDocument();
   });
 
   it('shows a confirmation modal with contextual confirmText when Enable dual-write is clicked', async () => {

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.test.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CONFIG_TEST_ID } from 'test/dataTestIds';
+import { BASIC_HTTP_CHECK, BASIC_PING_CHECK, BASIC_TCP_CHECK } from 'test/fixtures/checks';
 import { TENANT, TENANT_LABEL_MODE } from 'test/fixtures/tenants';
 import { apiRoute } from 'test/handlers';
 import { render } from 'test/render';
 import { server } from 'test/server';
 import { runTestAsSMAdmin, runTestAsSMViewer } from 'test/utils';
 
+import { AppRoutes } from 'routing/types';
+import { generateRoutePath, getRoute } from 'routing/utils';
 import { queryInstantMetric } from 'data/utils';
 
 import { LabelMigrationTab } from './LabelMigrationTab';
@@ -44,6 +47,64 @@ describe('LabelMigrationTab', () => {
     runTestAsSMAdmin();
     await renderTab();
     await waitFor(() => expect(screen.getByRole('button', { name: /Enable dual-write/i })).toBeInTheDocument());
+  });
+
+  it('shows no pre-flight warning when no checks use reserved label names', async () => {
+    runTestAsSMAdmin();
+    await renderTab();
+    await screen.findByRole('button', { name: /Enable dual-write/i });
+    expect(screen.queryByTestId('impacted-checks-warning')).not.toBeInTheDocument();
+  });
+
+  it('shows a pre-flight warning with the impacted check count before Enable dual-write is clicked', async () => {
+    runTestAsSMAdmin();
+    const blockingCheck = { ...BASIC_HTTP_CHECK, id: 201, job: 'checkout-http', labels: [{ name: 'instance', value: 'x' }] };
+    server.use(apiRoute('listChecks', { result: () => ({ json: [blockingCheck] }) }));
+
+    await renderTab();
+
+    const warning = await screen.findByTestId('impacted-checks-warning');
+    expect(warning).toHaveTextContent(/1 check/i);
+
+    await userEvent.click(within(warning).getByText(/Show 1 impacted label/i));
+
+    // The offending label name itself is shown, not just the checks carrying it.
+    expect(within(warning).getByText('instance')).toBeInTheDocument();
+    expect(within(warning).getByRole('link', { name: 'checkout-http' })).toHaveAttribute(
+      'href',
+      generateRoutePath(AppRoutes.EditCheck, { id: 201 })
+    );
+    // The action to actually attempt the transition is still available.
+    expect(screen.getByRole('button', { name: /Enable dual-write/i })).toBeInTheDocument();
+  });
+
+  it('shows a pre-flight warning before Finalize migration is clicked', async () => {
+    runTestAsSMAdmin();
+    const blockingCheck = { ...BASIC_PING_CHECK, id: 202, job: 'checkout-ping', labels: [{ name: 'job', value: 'x' }] };
+    server.use(
+      apiRoute('getLabelMode', {
+        result: () => ({ json: { mode: 1, systemLabels: TENANT_LABEL_MODE.systemLabels } }),
+      }),
+      apiRoute('listChecks', { result: () => ({ json: [blockingCheck] }) })
+    );
+
+    await renderTab();
+
+    const warning = await screen.findByTestId('impacted-checks-warning');
+    await userEvent.click(within(warning).getByText(/Show 1 impacted label/i));
+    expect(within(warning).getByRole('link', { name: 'checkout-ping' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Finalize migration/i })).toBeInTheDocument();
+  });
+
+  it('hides the pre-flight warning while the reactive collision alert is shown', async () => {
+    runTestAsSMAdmin();
+    const blockingCheck = { ...BASIC_HTTP_CHECK, id: 203, job: 'checkout-http', labels: [{ name: 'instance', value: 'x' }] };
+    server.use(apiRoute('listChecks', { result: () => ({ json: [blockingCheck] }) }));
+
+    await triggerCollision(['instance']);
+
+    expect(screen.queryByTestId('impacted-checks-warning')).not.toBeInTheDocument();
+    expect(screen.getByText(/Label name conflicts/i)).toBeInTheDocument();
   });
 
   it('shows a confirmation modal with contextual confirmText when Enable dual-write is clicked', async () => {
@@ -709,6 +770,48 @@ describe('LabelMigrationTab', () => {
     // The gate opens even though nothing was fixed: the retry will 409 again
     // and remount the flow — deliberate, since only the API knows the truth.
     expect(screen.getByRole('button', { name: /Retry enabling dual-write/i })).toBeEnabled();
+  });
+
+  it('lists checks that carry a colliding label, linking to each check\'s edit page', async () => {
+    runTestAsSMAdmin();
+    const blockingCheck1 = { ...BASIC_HTTP_CHECK, id: 101, job: 'checkout-http', labels: [{ name: 'probe', value: 'x' }] };
+    const blockingCheck2 = { ...BASIC_PING_CHECK, id: 102, job: 'checkout-ping', labels: [{ name: 'probe', value: 'y' }] };
+    const unrelatedCheck = { ...BASIC_TCP_CHECK, id: 103, job: 'unrelated-tcp', labels: [{ name: 'env', value: 'prod' }] };
+    server.use(apiRoute('listChecks', { result: () => ({ json: [blockingCheck1, blockingCheck2, unrelatedCheck] }) }));
+
+    await triggerCollision(['probe']);
+
+    const blockingList = await screen.findByTestId('blocking-checks-probe');
+    expect(within(blockingList).getByRole('link', { name: 'checkout-http' })).toHaveAttribute(
+      'href',
+      generateRoutePath(AppRoutes.EditCheck, { id: 101 })
+    );
+    expect(within(blockingList).getByRole('link', { name: 'checkout-ping' })).toHaveAttribute(
+      'href',
+      generateRoutePath(AppRoutes.EditCheck, { id: 102 })
+    );
+    expect(within(blockingList).queryByRole('link', { name: 'unrelated-tcp' })).not.toBeInTheDocument();
+  });
+
+  it('links to a Checks list filtered to the colliding label', async () => {
+    runTestAsSMAdmin();
+    const blockingCheck = { ...BASIC_HTTP_CHECK, id: 101, job: 'checkout-http', labels: [{ name: 'probe', value: 'x' }] };
+    server.use(apiRoute('listChecks', { result: () => ({ json: [blockingCheck] }) }));
+
+    await triggerCollision(['probe']);
+
+    const viewAll = await screen.findByTestId('blocking-checks-view-all-probe');
+    expect(viewAll).toHaveAttribute('href', `${getRoute(AppRoutes.Checks)}?search=probe`);
+  });
+
+  it('shows a hint instead of a check list when no check carries the colliding label', async () => {
+    runTestAsSMAdmin();
+    server.use(apiRoute('listChecks', { result: () => ({ json: [] }) }));
+
+    await triggerCollision(['probe']);
+
+    expect(await screen.findByTestId('blocking-checks-empty-probe')).toHaveTextContent(/may be set on a probe/i);
+    expect(screen.queryByTestId('blocking-checks-view-all-probe')).not.toBeInTheDocument();
   });
 
   it('locks a row after a successful rename', async () => {

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
@@ -49,7 +49,7 @@ export function LabelMigrationTab() {
 
   const { data: state, isLoading, error: loadError, refetch, isRefetching } = useLabelMode();
   const setLabelModeMutation = useSetLabelMode();
-  const { data: checks } = useChecks();
+  const { data: checks, isError: checksError } = useChecks();
   const { data: tenant } = useTenant();
   const cooldown = getMigrationCooldown(tenant?.modified, Date.now());
 
@@ -125,7 +125,13 @@ export function LabelMigrationTab() {
                   labels. Enabling dual-write is permanent: you cannot return to prefixed-only labels afterwards.
                 </Text>
                 <Space v={2} />
-                {!collisionError && <ImpactedChecksWarning checks={checks ?? []} systemLabels={state.systemLabels} />}
+                {!collisionError && (
+                  <ImpactedChecksWarning
+                    checks={checks ?? []}
+                    systemLabels={state.systemLabels}
+                    checksError={checksError}
+                  />
+                )}
                 {/* While the conflicts alert is up, its "Retry enabling dual-write"
                     button is the only sanctioned path into dual-write. */}
                 {isAdmin && !collisionError && (
@@ -159,7 +165,13 @@ export function LabelMigrationTab() {
                   metrics and log streams.
                 </Alert>
                 <Space v={2} />
-                {!collisionError && <ImpactedChecksWarning checks={checks ?? []} systemLabels={state.systemLabels} />}
+                {!collisionError && (
+                  <ImpactedChecksWarning
+                    checks={checks ?? []}
+                    systemLabels={state.systemLabels}
+                    checksError={checksError}
+                  />
+                )}
                 {isAdmin && (
                   <Button
                     onClick={() =>
@@ -279,6 +291,7 @@ export function LabelMigrationTab() {
                     labels={collisionError.collidingLabels ?? []}
                     systemLabels={state.systemLabels}
                     checks={checks ?? []}
+                    checksError={checksError}
                     disabled={!isAdmin}
                     retrying={busy}
                     onRetry={() => applyMode(LabelMode.DualWrite)}

--- a/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
+++ b/src/page/ConfigPageLayout/tabs/LabelMigrationTab/LabelMigrationTab.tsx
@@ -4,6 +4,7 @@ import { CONFIG_TEST_ID } from 'test/dataTestIds';
 
 import { LabelMode } from 'datasource/responses.types';
 import { getUserPermissions } from 'data/permissions';
+import { useChecks } from 'data/useChecks';
 import { useLabelMode, useSetLabelMode } from 'data/useLabelMode';
 import { useTenant } from 'data/useTenant';
 import { ConfirmModal } from 'components/ConfirmModal';
@@ -11,6 +12,7 @@ import { ContactAdminAlert } from 'page/ContactAdminAlert';
 
 import { ConfigContent } from '../../ConfigContent';
 import { CollidingLabelRename } from './CollidingLabelRename';
+import { ImpactedChecksWarning } from './ImpactedChecksWarning';
 import { getMigrationCooldown } from './migrationCooldown';
 import { SeriesPreview } from './SeriesPreview';
 import { useCheckInfoLabels } from './useCheckInfoLabels';
@@ -47,6 +49,7 @@ export function LabelMigrationTab() {
 
   const { data: state, isLoading, error: loadError, refetch, isRefetching } = useLabelMode();
   const setLabelModeMutation = useSetLabelMode();
+  const { data: checks } = useChecks();
   const { data: tenant } = useTenant();
   const cooldown = getMigrationCooldown(tenant?.modified, Date.now());
 
@@ -122,6 +125,7 @@ export function LabelMigrationTab() {
                   labels. Enabling dual-write is permanent: you cannot return to prefixed-only labels afterwards.
                 </Text>
                 <Space v={2} />
+                {!collisionError && <ImpactedChecksWarning checks={checks ?? []} systemLabels={state.systemLabels} />}
                 {/* While the conflicts alert is up, its "Retry enabling dual-write"
                     button is the only sanctioned path into dual-write. */}
                 {isAdmin && !collisionError && (
@@ -155,6 +159,7 @@ export function LabelMigrationTab() {
                   metrics and log streams.
                 </Alert>
                 <Space v={2} />
+                {!collisionError && <ImpactedChecksWarning checks={checks ?? []} systemLabels={state.systemLabels} />}
                 {isAdmin && (
                   <Button
                     onClick={() =>
@@ -273,6 +278,7 @@ export function LabelMigrationTab() {
                   <CollidingLabelRename
                     labels={collisionError.collidingLabels ?? []}
                     systemLabels={state.systemLabels}
+                    checks={checks ?? []}
                     disabled={!isAdmin}
                     retrying={busy}
                     onRetry={() => applyMode(LabelMode.DualWrite)}


### PR DESCRIPTION




Previously, it was near impossible to understand the number of checks impacted before starting the label migration or during it. This adds a check _prior_ to starting the migration that lists out the total number of checks impacted along with a collapsable nav section with a list of checks and their associated labels. This allows a user to understand before and during the label migraiton process what checks need to udpating. I've provided a demo of it against a personal stack and showed using gcx to fix the checks prior to starting the migration.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our README

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

5. Name your PR as using conventional commits "<commit_type>: Describe your change", e.g. feat: prevent race condition. The PR name is what gets added to the changelog and determines versioning. For a list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!--
  Please include helpful screenshots and/or videos/gifs to help demonstrate your changes
-->
https://github.com/user-attachments/assets/531e234f-1519-4baa-89f2-ece6a065ad0a