### PR TITLE
fix(alerts): respect tenant label mode in alert routing preview

### DIFF
--- a/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
+++ b/src/components/CheckForm/AlertsPerCheck/AlertRoutingPreview.tsx
@@ -8,6 +8,7 @@ import { css } from '@emotion/css';
 import { trackLinkClick } from 'features/tracking/linkEvents';
 
 import { CheckAlertType, CheckFormValues } from 'types';
+import { useLabelMode } from 'data/useLabelMode';
 
 import { AlertLabelsDisplay } from './AlertLabelsDisplay';
 import {
@@ -33,10 +34,18 @@ const AlertRoutingPreviewContent: React.FC<AlertRoutingPreviewProps> = ({ alertT
   const customLabels = getValues().labels;
   const job = getValues().job;
   const instance = getValues().target;
+  const { data: labelModeState } = useLabelMode();
 
   const alertLabels = useMemo(() => {
-    return generateAlertLabels(alertType, { checkType, frequency, customLabels, job, instance });
-  }, [alertType, checkType, frequency, customLabels, job, instance]);
+    return generateAlertLabels(alertType, {
+      checkType,
+      frequency,
+      customLabels,
+      job,
+      instance,
+      labelMode: labelModeState?.mode,
+    });
+  }, [alertType, checkType, frequency, customLabels, job, instance, labelModeState]);
 
   const { isLoading, isError, currentData: routingTreeData } = useMatchInstancesToRouteTrees();
 

--- a/src/components/CheckForm/AlertsPerCheck/alertRoutingUtils.ts
+++ b/src/components/CheckForm/AlertsPerCheck/alertRoutingUtils.ts
@@ -10,6 +10,7 @@ import {
 type RoutingTree = Parameters<typeof matchInstancesToRouteTrees>[0][number];
 
 import { CheckAlertType, CheckType, Label } from 'types';
+import { LabelMode } from 'datasource/responses.types';
 
 export interface PolicyInfo {
   text: string;
@@ -24,7 +25,17 @@ export const generateAlertLabels = (
     customLabels,
     job,
     instance,
-  }: { checkType: CheckType; frequency: number; customLabels: Label[]; job: string; instance: string }
+    labelMode,
+  }: {
+    checkType: CheckType;
+    frequency: number;
+    customLabels: Label[];
+    job: string;
+    instance: string;
+    // Unknown (still loading) is treated as Prefixed, matching pre-migration behavior
+    // and the fallback used elsewhere (see GenericLabelContent).
+    labelMode?: LabelMode;
+  }
 ): Record<string, string> => {
   const labels: Record<string, string> = {
     job: job || '',
@@ -37,9 +48,21 @@ export const generateAlertLabels = (
     alertname: alertType,
   };
 
+  const mode = labelMode ?? LabelMode.Prefixed;
+
   (customLabels || []).forEach((label: Label) => {
     if (label.name && label.value) {
-      labels[`label_${label.name}`] = label.value;
+      // Mirrors the tenant's actual sm_check_info label shape (see SeriesPreview's
+      // exampleUserLabelPairs) so the routing preview reflects what will really be
+      // written, instead of always assuming the legacy prefixed form.
+      if (mode === LabelMode.Unprefixed) {
+        labels[label.name] = label.value;
+      } else if (mode === LabelMode.DualWrite) {
+        labels[label.name] = label.value;
+        labels[`label_${label.name}`] = label.value;
+      } else {
+        labels[`label_${label.name}`] = label.value;
+      }
     }
   });
 


### PR DESCRIPTION
The Alert Routing Summary preview always rendered custom labels with the legacy `label_` prefix, regardless of the tenant's label migration mode.

Customers on DualWrite/Unprefixed mode saw a preview that didn't match what's actually written to `sm_check_info`, causing confusion about which labels their notification policies would match on.

`generateAlertLabels()` now takes the tenant's `LabelMode` (from `useLabelMode()`) and emits labels in the same shape as the real metric series.