### PR TITLE
feat: experimental FEO context panel in Timepoint Explorer

### DIFF
--- a/src/scenes/components/TimepointExplorer/FrontendContext.hooks.ts
+++ b/src/scenes/components/TimepointExplorer/FrontendContext.hooks.ts
@@ -1,0 +1,343 @@
+import { useQuery } from '@tanstack/react-query';
+import { DataFrame, FieldType } from '@grafana/data';
+import { parseLokiLogs } from 'features/parseLokiLogs/parseLokiLogs';
+import { queryDS } from 'features/queryDatasources/queryDS';
+import { queryLoki } from 'features/queryDatasources/queryLoki';
+
+import { useLogsDS } from 'hooks/useLogsDS';
+import {
+  AppVersionChange,
+  buildAppVersionHistoryLogQL,
+  buildExceptionRealSessionsLogQL,
+  buildFaroExecutionContextLogQL,
+  buildRealUserExceptionsLogQL,
+  buildRealUserHttpErrorsLogQL,
+  buildRealUserPageLoadsLogQL,
+  buildRealUserVitalP75LogQL,
+  buildSimilarSessionsLogQL,
+  FaroExecutionContext,
+  getAppVersionChange,
+  parseFaroExecutionContext,
+  parseSimilarSessions,
+  SimilarSession,
+  WEB_VITALS,
+  WebVitalName,
+} from 'scenes/components/TimepointExplorer/FrontendContext.utils';
+
+const REF_ID_FARO_EXECUTION_CONTEXT = 'faroExecutionContext';
+
+interface UseFaroExecutionContextProps {
+  executionId: string;
+  from: number;
+  to: number;
+  enabled?: boolean;
+}
+
+export function useFaroExecutionContext({ executionId, from, to, enabled = true }: UseFaroExecutionContextProps) {
+  const logsDS = useLogsDS();
+  const canQuery = Boolean(logsDS && executionId && from && to && from < to && enabled);
+  const expr = canQuery ? buildFaroExecutionContextLogQL(executionId) : '';
+
+  return useQuery<FaroExecutionContext | null>({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- logsDS.uid is a stable identifier
+    queryKey: ['faro-execution-context', logsDS?.uid, expr, from, to],
+    queryFn: async () => {
+      if (!logsDS) {
+        return null;
+      }
+
+      try {
+        const frames = await queryLoki<Record<string, string>, Record<string, string>>({
+          datasource: logsDS,
+          query: expr,
+          start: from,
+          end: to,
+          refId: REF_ID_FARO_EXECUTION_CONTEXT,
+        });
+
+        const parsed = frames[0] ? parseLokiLogs(frames[0]) : [];
+
+        return parseFaroExecutionContext(parsed);
+      } catch {
+        // Fail silently - Faro/FE O11y may not be available in this stack.
+        return null;
+      }
+    },
+    enabled: canQuery,
+    staleTime: 60_000,
+    retry: false,
+    throwOnError: false,
+  });
+}
+
+export interface RealUserPageBaseline {
+  vitals: Partial<Record<WebVitalName, number>>;
+  pageLoads: number | null;
+  exceptions: number | null;
+  httpErrors: number | null;
+}
+
+// How far back we look for the real-user baseline, ending at the execution's
+// time window so the comparison reflects what users saw around the run.
+const BASELINE_RANGE = '1h';
+const BASELINE_RANGE_MS = 60 * 60 * 1000;
+
+interface UseRealUserPageBaselineProps {
+  appId: string;
+  pageId: string;
+  to: number;
+  enabled?: boolean;
+}
+
+export function useRealUserPageBaseline({ appId, pageId, to, enabled = true }: UseRealUserPageBaselineProps) {
+  const logsDS = useLogsDS();
+  const canQuery = Boolean(logsDS && appId && pageId && to && enabled);
+
+  return useQuery<RealUserPageBaseline | null>({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- logsDS.uid is a stable identifier
+    queryKey: ['faro-page-baseline', logsDS?.uid, appId, pageId, to],
+    queryFn: async () => {
+      if (!logsDS) {
+        return null;
+      }
+
+      const queryParams = { appId, pageId, range: BASELINE_RANGE };
+      const instantQuery = {
+        range: false,
+        instant: true,
+        queryType: 'instant',
+        datasource: logsDS,
+        maxDataPoints: 100,
+        intervalMs: 20_000,
+      };
+
+      try {
+        const results = await queryDS({
+          queries: [
+            ...WEB_VITALS.map((vital) => ({
+              ...instantQuery,
+              refId: `wv-${vital}`,
+              expr: buildRealUserVitalP75LogQL({ ...queryParams, vital }),
+            })),
+            { ...instantQuery, refId: 'page-loads', expr: buildRealUserPageLoadsLogQL(queryParams) },
+            { ...instantQuery, refId: 'exceptions', expr: buildRealUserExceptionsLogQL(queryParams) },
+            { ...instantQuery, refId: 'http-errors', expr: buildRealUserHttpErrorsLogQL(queryParams) },
+          ],
+          start: to - BASELINE_RANGE_MS,
+          end: to,
+        });
+
+        const vitals: Partial<Record<WebVitalName, number>> = {};
+
+        WEB_VITALS.forEach((vital) => {
+          const value = getInstantValue(results[`wv-${vital}`]);
+
+          if (value !== null) {
+            vitals[vital] = value;
+          }
+        });
+
+        return {
+          vitals,
+          pageLoads: getInstantValue(results['page-loads']),
+          exceptions: getInstantValue(results['exceptions']),
+          httpErrors: getInstantValue(results['http-errors']),
+        };
+      } catch {
+        // Fail silently - the panel simply won't show a baseline.
+        return null;
+      }
+    },
+    enabled: canQuery,
+    staleTime: 60_000,
+    retry: false,
+    throwOnError: false,
+  });
+}
+
+// Deploys are only useful context if they happened recently — look back far
+// enough to catch a same-day release without scanning days of data.
+const VERSION_LOOKBACK_MS = 6 * 60 * 60 * 1000;
+const VERSION_BUCKET = '10m';
+
+interface UseAppVersionChangeProps {
+  appId: string;
+  runVersion: string;
+  to: number;
+  enabled?: boolean;
+}
+
+export function useAppVersionChange({ appId, runVersion, to, enabled = true }: UseAppVersionChangeProps) {
+  const logsDS = useLogsDS();
+  const canQuery = Boolean(logsDS && appId && runVersion && to && enabled);
+
+  return useQuery<AppVersionChange | null>({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- logsDS.uid is a stable identifier
+    queryKey: ['faro-app-version-change', logsDS?.uid, appId, runVersion, to],
+    queryFn: async () => {
+      if (!logsDS) {
+        return null;
+      }
+
+      try {
+        const results = await queryDS({
+          queries: [
+            {
+              refId: 'versions',
+              expr: buildAppVersionHistoryLogQL({ appId, bucket: VERSION_BUCKET }),
+              range: true,
+              datasource: logsDS,
+              intervalMs: 10 * 60 * 1000,
+              maxDataPoints: 100,
+            },
+          ],
+          start: to - VERSION_LOOKBACK_MS,
+          end: to,
+        });
+
+        const series = (results['versions'] ?? []).map(getVersionActivity).filter(isNotNull);
+
+        return getAppVersionChange(series, runVersion);
+      } catch {
+        // Fail silently - the panel simply won't show version context.
+        return null;
+      }
+    },
+    enabled: canQuery,
+    staleTime: 60_000,
+    retry: false,
+    throwOnError: false,
+  });
+}
+
+function getVersionActivity(frame: DataFrame): { version: string; firstSeen: number; lastSeen: number } | null {
+  const timeField = frame.fields.find((f) => f.type === FieldType.time);
+  const valueField = frame.fields.find((f) => f.type === FieldType.number);
+  const version = valueField?.labels?.app_version;
+
+  if (!timeField || !valueField || !version) {
+    return null;
+  }
+
+  const activeTimes = timeField.values.filter((_, index) => {
+    const value = valueField.values[index];
+    return typeof value === 'number' && value > 0;
+  });
+
+  if (!activeTimes.length) {
+    return null;
+  }
+
+  return { version, firstSeen: Math.min(...activeTimes), lastSeen: Math.max(...activeTimes) };
+}
+
+function isNotNull<T>(value: T | null): value is T {
+  return value !== null;
+}
+
+const MAX_EXCEPTION_MATCHES = 3;
+
+interface UseExceptionRealSessionsProps {
+  appId: string;
+  messages: string[];
+  to: number;
+  enabled?: boolean;
+}
+
+/**
+ * For each of the run's exception messages, how many distinct real-user
+ * sessions threw the same exception in the hour before the run.
+ */
+export function useExceptionRealSessions({ appId, messages, to, enabled = true }: UseExceptionRealSessionsProps) {
+  const logsDS = useLogsDS();
+  const uniqueMessages = [...new Set(messages)].slice(0, MAX_EXCEPTION_MATCHES);
+  const canQuery = Boolean(logsDS && appId && uniqueMessages.length && to && enabled);
+
+  return useQuery<Record<string, number> | null>({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- logsDS.uid is a stable identifier
+    queryKey: ['faro-exception-real-sessions', logsDS?.uid, appId, uniqueMessages.join('|'), to],
+    queryFn: async () => {
+      if (!logsDS) {
+        return null;
+      }
+
+      try {
+        const results = await queryDS({
+          queries: uniqueMessages.map((message, index) => ({
+            refId: `exception-${index}`,
+            expr: buildExceptionRealSessionsLogQL({ appId, message, range: BASELINE_RANGE }),
+            range: false,
+            instant: true,
+            queryType: 'instant',
+            datasource: logsDS,
+            maxDataPoints: 100,
+            intervalMs: 20_000,
+          })),
+          start: to - BASELINE_RANGE_MS,
+          end: to,
+        });
+
+        return Object.fromEntries(
+          uniqueMessages.map((message, index) => [message, getInstantValue(results[`exception-${index}`]) ?? 0])
+        );
+      } catch {
+        // Fail silently - exceptions simply won't show real-user counts.
+        return null;
+      }
+    },
+    enabled: canQuery,
+    staleTime: 60_000,
+    retry: false,
+    throwOnError: false,
+  });
+}
+
+interface UseSimilarRealSessionsProps {
+  appId: string;
+  pageIds: string[];
+  to: number;
+  enabled?: boolean;
+}
+
+export function useSimilarRealSessions({ appId, pageIds, to, enabled = true }: UseSimilarRealSessionsProps) {
+  const logsDS = useLogsDS();
+  const canQuery = Boolean(logsDS && appId && pageIds.length && to && enabled);
+
+  return useQuery<SimilarSession[] | null>({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- logsDS.uid is a stable identifier
+    queryKey: ['faro-similar-sessions', logsDS?.uid, appId, pageIds.join(','), to],
+    queryFn: async () => {
+      if (!logsDS) {
+        return null;
+      }
+
+      try {
+        const frames = await queryLoki<Record<string, string>, Record<string, string>>({
+          datasource: logsDS,
+          query: buildSimilarSessionsLogQL({ appId, pageIds }),
+          start: to - BASELINE_RANGE_MS,
+          end: to,
+          refId: 'faroSimilarSessions',
+        });
+
+        const parsed = frames[0] ? parseLokiLogs(frames[0]) : [];
+
+        return parseSimilarSessions(parsed, pageIds);
+      } catch {
+        // Fail silently - the panel simply won't suggest similar sessions.
+        return null;
+      }
+    },
+    enabled: canQuery,
+    staleTime: 60_000,
+    retry: false,
+    throwOnError: false,
+  });
+}
+
+function getInstantValue(frames?: DataFrame[]): number | null {
+  const field = frames?.[0]?.fields.find((f) => f.type === FieldType.number);
+  const value = field?.values[field.values.length - 1];
+
+  return typeof value === 'number' && !Number.isNaN(value) ? value : null;
+}

--- a/src/scenes/components/TimepointExplorer/FrontendContext.tsx
+++ b/src/scenes/components/TimepointExplorer/FrontendContext.tsx
@@ -94,7 +94,14 @@ const FrontendContextPanel = ({ context, from, to }: { context: FaroExecutionCon
           </Stack>
           <Stack direction="row" gap={1} alignItems="center">
             {context.hasSessionReplay ? (
-              <LinkButton href={sessionHref} icon="play" size="sm" variant="secondary" fill="outline">
+              <LinkButton
+                href={sessionHref}
+                icon="play"
+                size="sm"
+                variant="secondary"
+                fill="outline"
+                target="_blank"
+              >
                 Watch session replay
               </LinkButton>
             ) : (
@@ -204,14 +211,21 @@ const ExceptionsList = ({ context, to }: { context: FaroExecutionContext; to: nu
 const COLLAPSED_REQUEST_COUNT = 5;
 
 const NetworkRequestsList = ({ context }: { context: FaroExecutionContext }) => {
+  const styles = useStyles2(getStyles);
   const tracesDS = useTracesDS();
   const [showAll, setShowAll] = useState(false);
-  // failures first, then chronological — the failing request is what you came for
-  const sorted = [...context.requests].sort(
+  const failedCount = context.requests.filter((request) => request.isError).length;
+
+  // Failures get priority for the collapsed view — the failing request is what
+  // you came for — but rendering below is grouped by page, chronological within.
+  const prioritized = [...context.requests].sort(
     (a, b) => Number(b.isError) - Number(a.isError) || a.timestamp - b.timestamp
   );
-  const failedCount = context.requests.filter((request) => request.isError).length;
-  const visible = showAll ? sorted : sorted.slice(0, COLLAPSED_REQUEST_COUNT);
+  const visibleSet = new Set(showAll ? prioritized : prioritized.slice(0, COLLAPSED_REQUEST_COUNT));
+
+  // Pages in journey order; any request with an unrecognized page lands at the end.
+  const journeyPageIds = context.pages.map((page) => page.pageId);
+  const pageIds = [...new Set([...journeyPageIds, ...context.requests.map((request) => request.pageId)])];
 
   return (
     <Stack direction="column" gap={0.5}>
@@ -219,13 +233,38 @@ const NetworkRequestsList = ({ context }: { context: FaroExecutionContext }) => 
         Network requests during this run ({context.requests.length}
         {failedCount > 0 ? ` · ${failedCount} failed` : ''})
       </Text>
-      {visible.map((request, index) => (
-        <RequestRow key={`${request.timestamp}-${request.url}-${index}`} request={request} tracesDS={tracesDS} />
-      ))}
-      {sorted.length > COLLAPSED_REQUEST_COUNT && (
+      {pageIds.map((pageId) => {
+        const pageRequests = context.requests
+          .filter((request) => request.pageId === pageId && visibleSet.has(request))
+          .sort((a, b) => a.timestamp - b.timestamp);
+
+        if (!pageRequests.length) {
+          return null;
+        }
+
+        return (
+          <Stack key={pageId || 'unknown-page'} direction="column" gap={0.5}>
+            <Text color="secondary" variant="bodySmall" weight="medium">
+              on {pageId || 'unknown page'}
+            </Text>
+            <div className={styles.page}>
+              <Stack direction="column" gap={0.5}>
+                {pageRequests.map((request, index) => (
+                  <RequestRow
+                    key={`${request.timestamp}-${request.url}-${index}`}
+                    request={request}
+                    tracesDS={tracesDS}
+                  />
+                ))}
+              </Stack>
+            </div>
+          </Stack>
+        );
+      })}
+      {context.requests.length > COLLAPSED_REQUEST_COUNT && (
         <PlainButton onClick={() => setShowAll(!showAll)}>
           <Text color="link" variant="bodySmall">
-            {showAll ? 'Show fewer' : `Show all ${sorted.length} requests`}
+            {showAll ? 'Show fewer' : `Show all ${context.requests.length} requests`}
           </Text>
         </PlainButton>
       )}

--- a/src/scenes/components/TimepointExplorer/FrontendContext.tsx
+++ b/src/scenes/components/TimepointExplorer/FrontendContext.tsx
@@ -1,0 +1,458 @@
+import React, { useState } from 'react';
+import { dateTimeFormat, GrafanaTheme2 } from '@grafana/data';
+import { Badge, BadgeColor, Icon, LinkButton, Spinner, Stack, Text, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+
+import { CheckType } from 'types';
+import { getCheckType } from 'utils';
+import { useTracesDS } from 'hooks/useTracesDS';
+import { PlainButton } from 'components/PlainButton';
+import { getExploreTraceUrl } from 'scenes/components/LogsRenderer/TraceLink.utils';
+import {
+  useAppVersionChange,
+  useExceptionRealSessions,
+  useFaroExecutionContext,
+  useRealUserPageBaseline,
+  useSimilarRealSessions,
+} from 'scenes/components/TimepointExplorer/FrontendContext.hooks';
+import {
+  buildFaroPageHref,
+  FaroExecutionContext,
+  FaroPageVisit,
+  formatWebVitalDelta,
+  formatWebVitalValue,
+  getPageComparisonVerdict,
+  rateWebVital,
+  WEB_VITAL_LABELS,
+  WEB_VITALS,
+  WebVitalName,
+  WebVitalRating,
+} from 'scenes/components/TimepointExplorer/FrontendContext.utils';
+import { FARO_APP_PLUGIN_ID } from 'scenes/components/TimepointExplorer/TimepointExplorer.constants';
+import { useTimepointExplorerContext } from 'scenes/components/TimepointExplorer/TimepointExplorer.context';
+import { useStatefulTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.hooks';
+import { StatelessTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
+import { buildFaroSessionHref } from 'scenes/components/TimepointExplorer/TimepointViewerFaroSession.utils';
+
+const RATING_COLOR: Record<WebVitalRating, BadgeColor> = {
+  good: 'green',
+  'needs-improvement': 'orange',
+  poor: 'red',
+};
+
+export const FrontendContext = ({ timepoint }: { timepoint: StatelessTimepoint }) => {
+  const { check, viewerState } = useTimepointExplorerContext();
+  const [, viewerProbeName, viewerExecutionIndex] = viewerState;
+  const isBrowserCheck = getCheckType(check.settings) === CheckType.Browser;
+  const statefulTimepoint = useStatefulTimepoint(timepoint);
+
+  const selectedExecution =
+    viewerProbeName !== undefined && viewerExecutionIndex !== undefined
+      ? statefulTimepoint.probeResults?.[viewerProbeName]?.[viewerExecutionIndex]
+      : undefined;
+  const executionId = selectedExecution?.labels.execution_id;
+  const to = timepoint.adjustedTime + timepoint.timepointDuration + timepoint.config.frequency;
+
+  const { data: context } = useFaroExecutionContext({
+    executionId: executionId ?? '',
+    from: timepoint.adjustedTime,
+    to,
+    enabled: isBrowserCheck && Boolean(executionId),
+  });
+
+  if (!isBrowserCheck || !context) {
+    return null;
+  }
+
+  return <FrontendContextPanel context={context} from={timepoint.adjustedTime} to={to} />;
+};
+
+const FrontendContextPanel = ({ context, from, to }: { context: FaroExecutionContext; from: number; to: number }) => {
+  const styles = useStyles2(getStyles);
+  const sessionHref = buildFaroSessionHref({
+    pluginId: FARO_APP_PLUGIN_ID,
+    appId: context.appId,
+    sessionId: context.sessionId,
+  });
+
+  return (
+    <div className={styles.container}>
+      <Stack direction="column" gap={2}>
+        <Stack direction="row" gap={1} alignItems="center" justifyContent="space-between" wrap="wrap">
+          <Stack direction="row" gap={1} alignItems="center">
+            <Icon name="frontend-observability" />
+            <Text variant="h5">Frontend Observability</Text>
+            {context.appName && <Text color="secondary">{context.appName}</Text>}
+            <Tooltip content="What your check's browser session looked like from inside your application, as recorded by the Faro SDK. Faro measures web vitals at a different point than k6 does, so these values can differ slightly from the k6-reported vitals elsewhere on this page.">
+              <Icon name="info-circle" />
+            </Tooltip>
+          </Stack>
+          <Stack direction="row" gap={1} alignItems="center">
+            {context.hasSessionReplay ? (
+              <LinkButton href={sessionHref} icon="play" size="sm" variant="secondary" fill="outline">
+                Watch session replay
+              </LinkButton>
+            ) : (
+              <Text color="secondary" italic variant="bodySmall">
+                Session replay not available for this run
+              </Text>
+            )}
+          </Stack>
+        </Stack>
+
+        <AppVersionLine context={context} from={from} to={to} />
+
+        {context.exceptions.length > 0 && <ExceptionsList context={context} to={to} />}
+
+        {context.httpErrors.length > 0 && <HttpErrorsList context={context} />}
+
+        <Stack direction="column" gap={1}>
+          <Text weight="medium">Pages visited</Text>
+          {context.pages.map((page) => (
+            <PageVisit key={page.pageId} appId={context.appId} page={page} to={to} />
+          ))}
+        </Stack>
+
+        <SimilarSessions context={context} to={to} />
+      </Stack>
+    </div>
+  );
+};
+
+const AppVersionLine = ({ context, from, to }: { context: FaroExecutionContext; from: number; to: number }) => {
+  const { data: versionChange } = useAppVersionChange({
+    appId: context.appId,
+    runVersion: context.appVersion ?? '',
+    to,
+    enabled: Boolean(context.appVersion),
+  });
+
+  if (!context.appVersion) {
+    return null;
+  }
+
+  const versionLabel = `${context.appVersion}${context.appEnvironment ? ` (${context.appEnvironment})` : ''}`;
+
+  if (!versionChange?.previousVersion || !versionChange.firstSeen) {
+    return (
+      <Text color="secondary" variant="bodySmall">
+        App version: {versionLabel} — no version change detected in the 6 hours before this run
+      </Text>
+    );
+  }
+
+  const minutesBeforeRun = Math.max(0, Math.round((from - versionChange.firstSeen) / 60_000));
+
+  return (
+    <Text color="warning" variant="bodySmall" weight="medium">
+      App version: {versionLabel} — first seen {dateTimeFormat(versionChange.firstSeen, { format: 'HH:mm' })}
+      {minutesBeforeRun > 0 && ` (${formatMinutes(minutesBeforeRun)} before this run)`} · previously{' '}
+      {versionChange.previousVersion}
+    </Text>
+  );
+};
+
+function formatMinutes(minutes: number): string {
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60);
+    const rest = minutes % 60;
+    return rest > 0 ? `${hours} h ${rest} min` : `${hours} h`;
+  }
+
+  return `${minutes} min`;
+}
+
+const ExceptionsList = ({ context, to }: { context: FaroExecutionContext; to: number }) => {
+  const { data: realSessionCounts } = useExceptionRealSessions({
+    appId: context.appId,
+    messages: context.exceptions.map((exception) => exception.message),
+    to,
+  });
+
+  return (
+    <Stack direction="column" gap={0.5}>
+      <Text weight="medium">JS exceptions during this run ({context.exceptions.length})</Text>
+      {context.exceptions.slice(0, 5).map((exception, index) => {
+        const realSessions = realSessionCounts?.[exception.message];
+
+        return (
+          <Text key={index} variant="bodySmall">
+            <Text color="error" variant="bodySmall">
+              {exception.type}: {exception.message} {exception.pageId && <em>on {exception.pageId}</em>}
+            </Text>
+            {realSessions !== undefined && (
+              <Text color={realSessions > 0 ? 'warning' : 'secondary'} variant="bodySmall">
+                {' '}
+                —{' '}
+                {realSessions > 0
+                  ? `also hit ${realSessions} real user ${realSessions === 1 ? 'session' : 'sessions'} in the past hour`
+                  : 'not seen in any real user session in the past hour (likely specific to this run)'}
+              </Text>
+            )}
+          </Text>
+        );
+      })}
+    </Stack>
+  );
+};
+
+const HttpErrorsList = ({ context }: { context: FaroExecutionContext }) => {
+  const tracesDS = useTracesDS();
+
+  return (
+    <Stack direction="column" gap={0.5}>
+      <Text weight="medium">Failed network requests during this run ({context.httpErrors.length})</Text>
+      {context.httpErrors.slice(0, 5).map((error, index) => (
+        <Text key={index} variant="bodySmall">
+          <Text color="error" variant="bodySmall">
+            {error.method} {error.url} → {error.statusCode === 0 ? 'no response' : error.statusCode}
+          </Text>
+          {tracesDS && error.traceId && (
+            <>
+              {' '}
+              ·{' '}
+              <TextLink href={getExploreTraceUrl(tracesDS.uid, error.traceId)} inline={false} variant="bodySmall">
+                view trace
+              </TextLink>
+            </>
+          )}
+        </Text>
+      ))}
+    </Stack>
+  );
+};
+
+const MAX_SIMILAR_SESSIONS = 3;
+
+const SimilarSessions = ({ context, to }: { context: FaroExecutionContext; to: number }) => {
+  const journeyPageIds = context.pages.map((page) => page.pageId);
+  const { data: sessions } = useSimilarRealSessions({
+    appId: context.appId,
+    pageIds: journeyPageIds,
+    to,
+  });
+
+  if (!sessions?.length) {
+    return null;
+  }
+
+  return (
+    <Stack direction="column" gap={0.5}>
+      <Stack direction="row" gap={0.5} alignItems="center">
+        <Text weight="medium">Real user sessions with a similar journey</Text>
+        <Tooltip content="Real user sessions from the hour before this run that loaded the same pages as this check, ranked by how much of the check's journey they cover.">
+          <Icon name="info-circle" size="sm" />
+        </Tooltip>
+      </Stack>
+      {sessions.slice(0, MAX_SIMILAR_SESSIONS).map((session) => (
+        <Stack key={session.sessionId} direction="row" gap={1} alignItems="center">
+          <TextLink
+            href={buildFaroSessionHref({
+              pluginId: FARO_APP_PLUGIN_ID,
+              appId: context.appId,
+              sessionId: session.sessionId,
+            })}
+            inline={false}
+            variant="bodySmall"
+          >
+            {session.sessionId}
+          </TextLink>
+          <Text color="secondary" variant="bodySmall">
+            loaded {session.matchedPages.length} of {journeyPageIds.length} pages (
+            {session.matchedPages.join(', ')}) · last seen {dateTimeFormat(session.lastSeen, { format: 'HH:mm:ss' })}
+          </Text>
+        </Stack>
+      ))}
+    </Stack>
+  );
+};
+
+const PageVisit = ({ appId, page, to }: { appId: string; page: FaroPageVisit; to: number }) => {
+  const styles = useStyles2(getStyles);
+  const [isComparisonOpen, setIsComparisonOpen] = useState(false);
+  const pageHref = buildFaroPageHref({ pluginId: FARO_APP_PLUGIN_ID, appId, pageId: page.pageId });
+  const hasVitals = WEB_VITALS.some((vital) => page.vitals[vital] !== undefined);
+
+  return (
+    <div className={styles.page}>
+      <Stack direction="column" gap={1}>
+        <Stack direction="row" gap={2} alignItems="center" wrap="wrap">
+          <TextLink href={pageHref} inline={false}>
+            {page.pageId}
+          </TextLink>
+          <Stack direction="row" gap={0.5} alignItems="center">
+            {WEB_VITALS.map((vital) => {
+              const value = page.vitals[vital];
+
+              if (value === undefined) {
+                return null;
+              }
+
+              return (
+                <Badge
+                  key={vital}
+                  text={`${WEB_VITAL_LABELS[vital]} ${formatWebVitalValue(vital, value)}`}
+                  color={RATING_COLOR[rateWebVital(vital, value)]}
+                  tooltip="As measured by Frontend Observability during this run"
+                />
+              );
+            })}
+          </Stack>
+          {hasVitals && (
+            <PlainButton onClick={() => setIsComparisonOpen(!isComparisonOpen)}>
+              <Text color="link" variant="bodySmall">
+                <Icon name={isComparisonOpen ? 'angle-up' : 'angle-down'} size="sm" /> Compare with real users
+              </Text>
+            </PlainButton>
+          )}
+        </Stack>
+        {isComparisonOpen && <PageBaseline appId={appId} page={page} to={to} />}
+      </Stack>
+    </div>
+  );
+};
+
+const PageBaseline = ({ appId, page, to }: { appId: string; page: FaroPageVisit; to: number }) => {
+  const styles = useStyles2(getStyles);
+  const { data: baseline, isLoading } = useRealUserPageBaseline({
+    appId,
+    pageId: page.pageId,
+    to,
+  });
+
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  if (!baseline || baseline.pageLoads === null || baseline.pageLoads === 0) {
+    return (
+      <Text color="secondary" italic variant="bodySmall">
+        No real user traffic on {page.pageId} in the hour before this run.
+      </Text>
+    );
+  }
+
+  const verdict = getPageComparisonVerdict(page.vitals, baseline.vitals);
+
+  return (
+    <Stack direction="column" gap={0.5}>
+      {verdict && (
+        <Text color={verdict.tone} variant="bodySmall" weight="medium">
+          {verdict.text}
+        </Text>
+      )}
+      <Text color="secondary" variant="bodySmall">
+        Real users on {page.pageId} in the hour before this run: {baseline.pageLoads} page{' '}
+        {baseline.pageLoads === 1 ? 'load' : 'loads'}
+        {baseline.exceptions !== null && `, ${baseline.exceptions} JS exceptions`}
+        {baseline.httpErrors !== null && `, ${baseline.httpErrors} failed requests`}
+      </Text>
+      <table className={styles.comparisonTable}>
+        <thead>
+          <tr>
+            <th>
+              <Text variant="bodySmall" color="secondary">
+                Web vital
+              </Text>
+            </th>
+            <th>
+              <Text variant="bodySmall" color="secondary">
+                This run
+              </Text>
+            </th>
+            <th>
+              <Text variant="bodySmall" color="secondary">
+                Real users (p75)
+              </Text>
+            </th>
+            <th>
+              <Text variant="bodySmall" color="secondary">
+                Difference
+              </Text>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {WEB_VITALS.map((vital) => {
+            const runValue = page.vitals[vital];
+            const baselineValue = baseline.vitals[vital];
+
+            if (runValue === undefined && baselineValue === undefined) {
+              return null;
+            }
+
+            return (
+              <tr key={vital}>
+                <td>
+                  <Text variant="bodySmall">{WEB_VITAL_LABELS[vital]}</Text>
+                </td>
+                <td>
+                  <ComparisonValue vital={vital} value={runValue} />
+                </td>
+                <td>
+                  <ComparisonValue vital={vital} value={baselineValue} />
+                </td>
+                <td>
+                  {runValue !== undefined && baselineValue !== undefined ? (
+                    <Text
+                      variant="bodySmall"
+                      color={runValue > baselineValue * 1.5 ? 'warning' : 'secondary'}
+                    >
+                      {formatWebVitalDelta(vital, runValue, baselineValue)}
+                    </Text>
+                  ) : (
+                    <Text variant="bodySmall" color="secondary">
+                      -
+                    </Text>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </Stack>
+  );
+};
+
+const ComparisonValue = ({ vital, value }: { vital: WebVitalName; value?: number }) => {
+  if (value === undefined) {
+    return (
+      <Text variant="bodySmall" color="secondary">
+        -
+      </Text>
+    );
+  }
+
+  const rating = rateWebVital(vital, value);
+  const color = rating === 'good' ? 'success' : rating === 'needs-improvement' ? 'warning' : 'error';
+
+  return (
+    <Text variant="bodySmall" color={color}>
+      {formatWebVitalValue(vital, value)}
+    </Text>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css`
+    border: 1px solid ${theme.colors.border.medium};
+    border-radius: ${theme.shape.radius.default};
+    padding: ${theme.spacing(2)};
+  `,
+  page: css`
+    border-left: 2px solid ${theme.colors.border.medium};
+    padding-left: ${theme.spacing(1)};
+  `,
+  comparisonTable: css`
+    border-collapse: collapse;
+    width: max-content;
+
+    th,
+    td {
+      text-align: left;
+      padding: ${theme.spacing(0.25, 4, 0.25, 0)};
+      white-space: nowrap;
+    }
+  `,
+});

--- a/src/scenes/components/TimepointExplorer/FrontendContext.tsx
+++ b/src/scenes/components/TimepointExplorer/FrontendContext.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { dateTimeFormat, GrafanaTheme2 } from '@grafana/data';
 import { Badge, BadgeColor, Icon, LinkButton, Spinner, Stack, Text, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -7,7 +8,9 @@ import { CheckType } from 'types';
 import { getCheckType } from 'utils';
 import { useTracesDS } from 'hooks/useTracesDS';
 import { PlainButton } from 'components/PlainButton';
+import { fetchTraceData } from 'scenes/components/LogsRenderer/LogLine.utils';
 import { getExploreTraceUrl } from 'scenes/components/LogsRenderer/TraceLink.utils';
+import { TracePanel } from 'scenes/components/LogsRenderer/TracePanel';
 import {
   useAppVersionChange,
   useExceptionRealSessions,
@@ -18,10 +21,12 @@ import {
 import {
   buildFaroPageHref,
   FaroExecutionContext,
+  FaroHttpRequest,
   FaroPageVisit,
   formatWebVitalDelta,
   formatWebVitalValue,
   getPageComparisonVerdict,
+  getRequestPath,
   rateWebVital,
   WEB_VITAL_LABELS,
   WEB_VITALS,
@@ -104,7 +109,7 @@ const FrontendContextPanel = ({ context, from, to }: { context: FaroExecutionCon
 
         {context.exceptions.length > 0 && <ExceptionsList context={context} to={to} />}
 
-        {context.httpErrors.length > 0 && <HttpErrorsList context={context} />}
+        {context.requests.length > 0 && <NetworkRequestsList context={context} />}
 
         <Stack direction="column" gap={1}>
           <Text weight="medium">Pages visited</Text>
@@ -196,29 +201,120 @@ const ExceptionsList = ({ context, to }: { context: FaroExecutionContext; to: nu
   );
 };
 
-const HttpErrorsList = ({ context }: { context: FaroExecutionContext }) => {
+const COLLAPSED_REQUEST_COUNT = 5;
+
+const NetworkRequestsList = ({ context }: { context: FaroExecutionContext }) => {
   const tracesDS = useTracesDS();
+  const [showAll, setShowAll] = useState(false);
+  // failures first, then chronological — the failing request is what you came for
+  const sorted = [...context.requests].sort(
+    (a, b) => Number(b.isError) - Number(a.isError) || a.timestamp - b.timestamp
+  );
+  const failedCount = context.requests.filter((request) => request.isError).length;
+  const visible = showAll ? sorted : sorted.slice(0, COLLAPSED_REQUEST_COUNT);
 
   return (
     <Stack direction="column" gap={0.5}>
-      <Text weight="medium">Failed network requests during this run ({context.httpErrors.length})</Text>
-      {context.httpErrors.slice(0, 5).map((error, index) => (
-        <Text key={index} variant="bodySmall">
-          <Text color="error" variant="bodySmall">
-            {error.method} {error.url} → {error.statusCode === 0 ? 'no response' : error.statusCode}
-          </Text>
-          {tracesDS && error.traceId && (
-            <>
-              {' '}
-              ·{' '}
-              <TextLink href={getExploreTraceUrl(tracesDS.uid, error.traceId)} inline={false} variant="bodySmall">
-                view trace
-              </TextLink>
-            </>
-          )}
-        </Text>
+      <Text weight="medium">
+        Network requests during this run ({context.requests.length}
+        {failedCount > 0 ? ` · ${failedCount} failed` : ''})
+      </Text>
+      {visible.map((request, index) => (
+        <RequestRow key={`${request.timestamp}-${request.url}-${index}`} request={request} tracesDS={tracesDS} />
       ))}
+      {sorted.length > COLLAPSED_REQUEST_COUNT && (
+        <PlainButton onClick={() => setShowAll(!showAll)}>
+          <Text color="link" variant="bodySmall">
+            {showAll ? 'Show fewer' : `Show all ${sorted.length} requests`}
+          </Text>
+        </PlainButton>
+      )}
     </Stack>
+  );
+};
+
+const RequestRow = ({
+  request,
+  tracesDS,
+}: {
+  request: FaroHttpRequest;
+  tracesDS: ReturnType<typeof useTracesDS>;
+}) => {
+  const [traceExpanded, setTraceExpanded] = useState(false);
+  const canShowTrace = Boolean(tracesDS && request.traceId);
+
+  return (
+    <Stack direction="column" gap={0.5}>
+      <Text variant="bodySmall">
+        <Text color={request.isError ? 'error' : 'secondary'} variant="bodySmall">
+          {request.method}{' '}
+          <Tooltip content={request.url}>
+            <span>{getRequestPath(request.url)}</span>
+          </Tooltip>{' '}
+          → {request.statusCode === 0 ? 'no response' : request.statusCode}
+          {request.durationMs !== undefined && ` · ${Math.round(request.durationMs)} ms`}
+        </Text>
+        {canShowTrace && (
+          <>
+            {' '}
+            ·{' '}
+            <PlainButton onClick={() => setTraceExpanded(!traceExpanded)}>
+              <Text color="link" variant="bodySmall">
+                {traceExpanded ? 'hide trace' : 'view trace'}
+              </Text>
+            </PlainButton>
+          </>
+        )}
+      </Text>
+      {traceExpanded && tracesDS && request.traceId && (
+        <RequestTrace request={request} tracesDS={tracesDS} onClose={() => setTraceExpanded(false)} />
+      )}
+    </Stack>
+  );
+};
+
+const RequestTrace = ({
+  request,
+  tracesDS,
+  onClose,
+}: {
+  request: FaroHttpRequest;
+  tracesDS: NonNullable<ReturnType<typeof useTracesDS>>;
+  onClose: () => void;
+}) => {
+  const { data: traceData, isLoading } = useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- tracesDS.uid is a stable identifier
+    queryKey: ['faro-request-trace', request.traceId, tracesDS.uid],
+    queryFn: () => fetchTraceData(request.traceId!, tracesDS),
+    enabled: Boolean(request.traceId),
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  if (!traceData || traceData.series.length === 0) {
+    return (
+      <Text color="secondary" italic variant="bodySmall">
+        No trace found for this request — the backend may not have sampled it.{' '}
+        <TextLink href={getExploreTraceUrl(tracesDS.uid, request.traceId!)} inline={false} variant="bodySmall">
+          Try in Explore
+        </TextLink>
+      </Text>
+    );
+  }
+
+  return (
+    <TracePanel
+      traceId={request.traceId!}
+      tracesDS={tracesDS}
+      traceData={traceData}
+      logTimestamp={request.timestamp}
+      arrowOffset={null}
+      onClose={onClose}
+    />
   );
 };
 

--- a/src/scenes/components/TimepointExplorer/FrontendContext.utils.ts
+++ b/src/scenes/components/TimepointExplorer/FrontendContext.utils.ts
@@ -64,11 +64,13 @@ export interface FaroException {
   timestamp: number;
 }
 
-export interface FaroHttpError {
+export interface FaroHttpRequest {
   method: string;
   url: string;
   // 0 means the request got no response at all (network failure, CORS, aborted)
   statusCode: number;
+  isError: boolean;
+  durationMs?: number;
   pageId: string;
   traceId?: string;
   timestamp: number;
@@ -82,7 +84,7 @@ export interface FaroExecutionContext {
   sessionId: string;
   pages: FaroPageVisit[];
   exceptions: FaroException[];
-  httpErrors: FaroHttpError[];
+  requests: FaroHttpRequest[];
   hasSessionReplay: boolean;
 }
 
@@ -120,7 +122,7 @@ export function parseFaroExecutionContext(logs: FaroRecord[]): FaroExecutionCont
 
   const pages = new Map<string, FaroPageVisit>();
   const exceptions: FaroException[] = [];
-  const httpErrors: FaroHttpError[] = [];
+  const requests: FaroHttpRequest[] = [];
   let appName: string | undefined;
   let appVersion: string | undefined;
   let appEnvironment: string | undefined;
@@ -167,12 +169,15 @@ export function parseFaroExecutionContext(logs: FaroRecord[]): FaroExecutionCont
     if (labels.kind === 'event' && HTTP_EVENT_NAMES.includes(labels.event_name ?? '')) {
       // `| logfmt` folds `event_data_http.status_code` into underscores
       const statusCode = Number(labels.event_data_http_status_code);
+      const durationNs = Number(labels.event_data_duration_ns);
 
-      if (!Number.isNaN(statusCode) && isHttpErrorStatus(statusCode)) {
-        httpErrors.push({
+      if (!Number.isNaN(statusCode)) {
+        requests.push({
           method: labels.event_data_http_method ?? 'GET',
           url: labels.event_data_http_url ?? '',
           statusCode,
+          isError: isHttpErrorStatus(statusCode),
+          durationMs: !Number.isNaN(durationNs) ? durationNs / 1_000_000 : undefined,
           pageId,
           traceId: labels.traceID,
           timestamp: record.timestamp,
@@ -189,9 +194,19 @@ export function parseFaroExecutionContext(logs: FaroRecord[]): FaroExecutionCont
     sessionId: session.sessionId,
     pages: [...pages.values()],
     exceptions,
-    httpErrors,
+    requests,
     hasSessionReplay,
   };
+}
+
+/** Compact display form for a request URL: path only, full URL on hover. */
+export function getRequestPath(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return url;
+  }
 }
 
 function escapeLogQLString(value: string): string {

--- a/src/scenes/components/TimepointExplorer/FrontendContext.utils.ts
+++ b/src/scenes/components/TimepointExplorer/FrontendContext.utils.ts
@@ -1,0 +1,466 @@
+import { ParsedLokiRecord } from 'features/parseLokiLogs/parseLokiLogs.types';
+import { getFaroSessionFromLogs } from 'scenes/components/TimepointExplorer/TimepointViewerFaroSession.utils';
+
+export type FaroRecord = ParsedLokiRecord<Record<string, string>, Record<string, string>>;
+
+export const WEB_VITALS = ['ttfb', 'fcp', 'lcp', 'cls', 'inp'] as const;
+export type WebVitalName = (typeof WEB_VITALS)[number];
+
+export const WEB_VITAL_LABELS: Record<WebVitalName, string> = {
+  ttfb: 'TTFB',
+  fcp: 'FCP',
+  lcp: 'LCP',
+  cls: 'CLS',
+  inp: 'INP',
+};
+
+// Thresholds match the ones Frontend Observability displays (web.dev standard).
+// Time-based vitals are in milliseconds, CLS is unitless.
+const WEB_VITAL_THRESHOLDS: Record<WebVitalName, { good: number; poor: number }> = {
+  ttfb: { good: 800, poor: 1800 },
+  fcp: { good: 1800, poor: 3000 },
+  lcp: { good: 2500, poor: 4000 },
+  cls: { good: 0.1, poor: 0.25 },
+  inp: { good: 200, poor: 500 },
+};
+
+export type WebVitalRating = 'good' | 'needs-improvement' | 'poor';
+
+export function rateWebVital(name: WebVitalName, value: number): WebVitalRating {
+  const { good, poor } = WEB_VITAL_THRESHOLDS[name];
+
+  if (value <= good) {
+    return 'good';
+  }
+
+  if (value <= poor) {
+    return 'needs-improvement';
+  }
+
+  return 'poor';
+}
+
+export function formatWebVitalValue(name: WebVitalName, value: number): string {
+  if (name === 'cls') {
+    return value.toFixed(2);
+  }
+
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(2)} s`;
+  }
+
+  return `${Math.round(value)} ms`;
+}
+
+export interface FaroPageVisit {
+  pageId: string;
+  vitals: Partial<Record<WebVitalName, number>>;
+}
+
+export interface FaroException {
+  type: string;
+  message: string;
+  pageId: string;
+  timestamp: number;
+}
+
+export interface FaroHttpError {
+  method: string;
+  url: string;
+  // 0 means the request got no response at all (network failure, CORS, aborted)
+  statusCode: number;
+  pageId: string;
+  traceId?: string;
+  timestamp: number;
+}
+
+export interface FaroExecutionContext {
+  appId: string;
+  appName?: string;
+  appVersion?: string;
+  appEnvironment?: string;
+  sessionId: string;
+  pages: FaroPageVisit[];
+  exceptions: FaroException[];
+  httpErrors: FaroHttpError[];
+  hasSessionReplay: boolean;
+}
+
+/**
+ * Superset of the CTA-button query: also pulls `exception` records so a single
+ * request can power the whole frontend context panel for one execution.
+ */
+export function buildFaroExecutionContextLogQL(executionId: string): string {
+  return `{kind=~"event|measurement|exception"} | logfmt | k6_isK6Browser="true" | k6_testRunId="sm:${executionId}"`;
+}
+
+const HTTP_EVENT_NAMES = ['faro.tracing.fetch', 'faro.tracing.xml-http-request'];
+
+function isHttpErrorStatus(statusCode: number): boolean {
+  return statusCode === 0 || (statusCode >= 400 && statusCode < 600);
+}
+
+/**
+ * Distills the raw Faro records of a single check execution into the pieces we
+ * surface in SM: the page journey, the run's own web vitals (as Faro measured
+ * them — these can legitimately disagree with the k6-reported vitals since the
+ * two tools measure at different points), JS exceptions, and failed HTTP calls.
+ *
+ * Records are scoped to the same session the "View Frontend Session" CTA picks
+ * so both features always tell the same story.
+ */
+export function parseFaroExecutionContext(logs: FaroRecord[]): FaroExecutionContext | null {
+  const session = getFaroSessionFromLogs(logs);
+
+  if (!session) {
+    return null;
+  }
+
+  const records = logs.filter((record) => record.labels?.session_id === session.sessionId);
+
+  const pages = new Map<string, FaroPageVisit>();
+  const exceptions: FaroException[] = [];
+  const httpErrors: FaroHttpError[] = [];
+  let appName: string | undefined;
+  let appVersion: string | undefined;
+  let appEnvironment: string | undefined;
+  let hasSessionReplay = false;
+
+  records.forEach((record) => {
+    const labels = record.labels ?? {};
+    const pageId = labels.page_id ?? '';
+
+    appName = appName ?? labels.app_name;
+    appVersion = appVersion ?? labels.app_version;
+    appEnvironment = appEnvironment ?? labels.app_environment;
+
+    if (pageId && !pages.has(pageId)) {
+      pages.set(pageId, { pageId, vitals: {} });
+    }
+
+    if (labels.kind === 'measurement' && pageId) {
+      const visit = pages.get(pageId)!;
+
+      WEB_VITALS.forEach((vital) => {
+        const value = Number(labels[vital]);
+
+        if (labels[vital] !== undefined && !Number.isNaN(value)) {
+          // records are sorted oldest-first so later reports (e.g. LCP updates) win
+          visit.vitals[vital] = value;
+        }
+      });
+    }
+
+    if (labels.kind === 'exception') {
+      exceptions.push({
+        type: labels.type ?? 'Error',
+        message: labels.value ?? record.body ?? '',
+        pageId,
+        timestamp: record.timestamp,
+      });
+    }
+
+    if (labels.kind === 'event' && labels.event_name?.includes('session_recording')) {
+      hasSessionReplay = true;
+    }
+
+    if (labels.kind === 'event' && HTTP_EVENT_NAMES.includes(labels.event_name ?? '')) {
+      // `| logfmt` folds `event_data_http.status_code` into underscores
+      const statusCode = Number(labels.event_data_http_status_code);
+
+      if (!Number.isNaN(statusCode) && isHttpErrorStatus(statusCode)) {
+        httpErrors.push({
+          method: labels.event_data_http_method ?? 'GET',
+          url: labels.event_data_http_url ?? '',
+          statusCode,
+          pageId,
+          traceId: labels.traceID,
+          timestamp: record.timestamp,
+        });
+      }
+    }
+  });
+
+  return {
+    appId: session.appId,
+    appName,
+    appVersion,
+    appEnvironment,
+    sessionId: session.sessionId,
+    pages: [...pages.values()],
+    exceptions,
+    httpErrors,
+    hasSessionReplay,
+  };
+}
+
+function escapeLogQLString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+interface RealUserQueryParams {
+  appId: string;
+  pageId: string;
+  range: string;
+}
+
+/**
+ * Real-user baseline queries. These mirror the exact LogQL the Frontend
+ * Observability app runs for its per-route panels, including its default
+ * `k6_isK6Browser=~""` filter which restricts results to records where the k6
+ * field is absent — i.e. real users only, no synthetic traffic.
+ */
+export function buildRealUserVitalP75LogQL({ appId, pageId, range, vital }: RealUserQueryParams & { vital: WebVitalName }): string {
+  const page = escapeLogQLString(pageId);
+
+  return `quantile_over_time(0.75, {kind="measurement", app_id="${appId}"} |= " ${vital}=" | logfmt | k6_isK6Browser=~"" | page_id="${page}" | unwrap ${vital} [${range}])`;
+}
+
+export function buildRealUserPageLoadsLogQL({ appId, pageId, range }: RealUserQueryParams): string {
+  const page = escapeLogQLString(pageId);
+
+  return `sum(count_over_time({kind="measurement", app_id="${appId}"} |= " ttfb=" | logfmt | k6_isK6Browser=~"" | page_id="${page}" [${range}]))`;
+}
+
+export function buildRealUserExceptionsLogQL({ appId, pageId, range }: RealUserQueryParams): string {
+  const page = escapeLogQLString(pageId);
+
+  return `sum(count_over_time({kind="exception", app_id="${appId}"} | logfmt | k6_isK6Browser=~"" | page_id="${page}" [${range}]))`;
+}
+
+export function buildRealUserHttpErrorsLogQL({ appId, pageId, range }: RealUserQueryParams): string {
+  const page = escapeLogQLString(pageId);
+
+  return `sum(count_over_time({kind="event", app_id="${appId}"} |~ "event_name=faro.tracing.fetch|event_name=faro.tracing.xml-http-request" |= "event_data_http.status_code=" | logfmt | k6_isK6Browser=~"" | page_id="${page}" | (event_data_http_status_code >= 400 and event_data_http_status_code < 600) or event_data_http_status_code = 0 [${range}]))`;
+}
+
+export function buildFaroPageHref({ pluginId, appId, pageId }: { pluginId: string; appId: string; pageId: string }): string {
+  return `/a/${encodeURIComponent(pluginId)}/apps/${encodeURIComponent(appId)}/route?var-page_performance_page_id=${encodeURIComponent(pageId)}`;
+}
+
+/**
+ * Formats the difference between this run's value and the real-user p75 as a
+ * signed delta, e.g. `+31 ms` (slower than real users) or `-0.04` for CLS.
+ */
+export function formatWebVitalDelta(name: WebVitalName, runValue: number, baselineValue: number): string {
+  const delta = runValue - baselineValue;
+  const sign = delta > 0 ? '+' : '';
+
+  if (name === 'cls') {
+    return `${sign}${delta.toFixed(2)}`;
+  }
+
+  if (Math.abs(delta) >= 1000) {
+    return `${sign}${(delta / 1000).toFixed(2)} s`;
+  }
+
+  return `${sign}${Math.round(delta)} ms`;
+}
+
+export type ComparisonTone = 'success' | 'warning' | 'error' | 'secondary';
+
+export interface PageComparisonVerdict {
+  text: string;
+  tone: ComparisonTone;
+}
+
+// A vital has to be this much bigger than its counterpart before we call the
+// difference out — small deltas between one synthetic run and a p75 are noise.
+const VERDICT_RATIO = 1.5;
+
+/**
+ * Turns the vitals comparison into a one-line, plain-English verdict so users
+ * don't have to interpret the table themselves. The most valuable outcome for
+ * a failed check is "real users are degraded too" (site problem) vs "real
+ * users are fine" (probably the script or the probe's vantage point).
+ */
+export function getPageComparisonVerdict(
+  runVitals: Partial<Record<WebVitalName, number>>,
+  baselineVitals: Partial<Record<WebVitalName, number>>
+): PageComparisonVerdict | null {
+  let worstRunOffender: { vital: WebVitalName; ratio: number } | null = null;
+  let worstUserOffender: { vital: WebVitalName; ratio: number } | null = null;
+  let compared = 0;
+
+  WEB_VITALS.forEach((vital) => {
+    const runValue = runVitals[vital];
+    const baselineValue = baselineVitals[vital];
+
+    if (runValue === undefined || baselineValue === undefined) {
+      return;
+    }
+
+    compared++;
+
+    if (runValue > baselineValue * VERDICT_RATIO && rateWebVital(vital, runValue) !== 'good') {
+      const ratio = baselineValue > 0 ? runValue / baselineValue : Infinity;
+
+      if (!worstRunOffender || ratio > worstRunOffender.ratio) {
+        worstRunOffender = { vital, ratio };
+      }
+    }
+
+    if (baselineValue > runValue * VERDICT_RATIO && rateWebVital(vital, baselineValue) !== 'good') {
+      const ratio = runValue > 0 ? baselineValue / runValue : Infinity;
+
+      if (!worstUserOffender || ratio > worstUserOffender.ratio) {
+        worstUserOffender = { vital, ratio };
+      }
+    }
+  });
+
+  if (compared === 0) {
+    return null;
+  }
+
+  if (worstRunOffender !== null) {
+    const { vital } = worstRunOffender as { vital: WebVitalName; ratio: number };
+    const rating = rateWebVital(vital, runVitals[vital]!);
+
+    return {
+      text: `This run was slower than real users: ${WEB_VITAL_LABELS[vital]} ${formatWebVitalValue(vital, runVitals[vital]!)} vs ${formatWebVitalValue(vital, baselineVitals[vital]!)} p75`,
+      tone: rating === 'poor' ? 'error' : 'warning',
+    };
+  }
+
+  if (worstUserOffender !== null) {
+    const { vital } = worstUserOffender as { vital: WebVitalName; ratio: number };
+
+    return {
+      text: `Real users are having a worse experience than this run: ${WEB_VITAL_LABELS[vital]} p75 ${formatWebVitalValue(vital, baselineVitals[vital]!)} vs ${formatWebVitalValue(vital, runVitals[vital]!)} for this run`,
+      tone: 'warning',
+    };
+  }
+
+  return { text: `In line with what real users experienced`, tone: 'success' };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Finds real-user page loads on any of the pages the synthetic run visited.
+ * Every page load emits a web-vitals measurement carrying `session_id` +
+ * `page_id`, so grouping the result by session tells us which real sessions
+ * walked (part of) the same journey as the check.
+ *
+ * This is a log-stream query (no `[range]` selector — that's only valid on
+ * metric queries); the time window comes from the request's start/end params.
+ */
+export function buildSimilarSessionsLogQL({ appId, pageIds }: { appId: string; pageIds: string[] }): string {
+  const pagePattern = escapeLogQLString(`^(${pageIds.map(escapeRegExp).join('|')})$`);
+
+  return `{kind="measurement", app_id="${appId}"} |= " ttfb=" | logfmt | k6_isK6Browser=~"" | page_id=~"${pagePattern}"`;
+}
+
+export interface SimilarSession {
+  sessionId: string;
+  // pages from the synthetic journey this session also loaded
+  matchedPages: string[];
+  lastSeen: number;
+}
+
+/**
+ * Version activity over time, bucketed so we can spot a deploy: page-load
+ * counts per `app_version`. Includes synthetic traffic on purpose — on
+ * low-traffic apps the checks themselves give the best resolution on when a
+ * new version started serving.
+ */
+export function buildAppVersionHistoryLogQL({ appId, bucket }: { appId: string; bucket: string }): string {
+  return `sum by (app_version) (count_over_time({kind="measurement", app_id="${appId}"} |= " ttfb=" | logfmt | app_version!="" [${bucket}]))`;
+}
+
+export interface AppVersionChange {
+  currentVersion: string;
+  // undefined when no other version was seen before currentVersion in the window
+  previousVersion?: string;
+  // when currentVersion first appeared in the window
+  firstSeen?: number;
+}
+
+interface VersionActivity {
+  version: string;
+  firstSeen: number;
+  lastSeen: number;
+}
+
+/**
+ * Works out whether the version the check ran against replaced another version
+ * recently. `series` is one entry per app_version with the timestamps where it
+ * had page loads. If nothing but the run's version appears in the lookback
+ * window, we report "no change" (the version may well predate the window —
+ * we can only speak to what we looked at).
+ */
+export function getAppVersionChange(series: VersionActivity[], runVersion: string): AppVersionChange {
+  const current = series.find((s) => s.version === runVersion);
+
+  if (!current) {
+    return { currentVersion: runVersion };
+  }
+
+  const candidates = series.filter((s) => s.version !== runVersion && s.firstSeen < current.firstSeen);
+
+  if (candidates.length === 0) {
+    return { currentVersion: runVersion };
+  }
+
+  candidates.sort((a, b) => b.lastSeen - a.lastSeen);
+
+  return {
+    currentVersion: runVersion,
+    previousVersion: candidates[0].version,
+    firstSeen: current.firstSeen,
+  };
+}
+
+/**
+ * Counts distinct real-user sessions that threw the exact same exception
+ * message. Answers "is my script's error a real error users are hitting, or
+ * an artifact of this run?"
+ */
+export function buildExceptionRealSessionsLogQL({
+  appId,
+  message,
+  range,
+}: {
+  appId: string;
+  message: string;
+  range: string;
+}): string {
+  const value = escapeLogQLString(message);
+
+  return `count(sum by (session_id) (count_over_time({kind="exception", app_id="${appId}"} | logfmt | k6_isK6Browser=~"" | value="${value}" [${range}])))`;
+}
+
+export function parseSimilarSessions(logs: FaroRecord[], journeyPageIds: string[]): SimilarSession[] {
+  const journey = new Set(journeyPageIds);
+  const sessions = new Map<string, { pages: Set<string>; lastSeen: number }>();
+
+  logs.forEach((record) => {
+    const labels = record.labels ?? {};
+    const sessionId = labels.session_id;
+    const pageId = labels.page_id;
+
+    if (!sessionId || !pageId || !journey.has(pageId)) {
+      return;
+    }
+
+    const existing = sessions.get(sessionId);
+
+    if (existing) {
+      existing.pages.add(pageId);
+      existing.lastSeen = Math.max(existing.lastSeen, record.timestamp);
+    } else {
+      sessions.set(sessionId, { pages: new Set([pageId]), lastSeen: record.timestamp });
+    }
+  });
+
+  return [...sessions.entries()]
+    .map(([sessionId, { pages, lastSeen }]) => ({
+      sessionId,
+      matchedPages: journeyPageIds.filter((pageId) => pages.has(pageId)),
+      lastSeen,
+    }))
+    .sort((a, b) => b.matchedPages.length - a.matchedPages.length || b.lastSeen - a.lastSeen);
+}

--- a/src/scenes/components/TimepointExplorer/TimepointViewer.tsx
+++ b/src/scenes/components/TimepointExplorer/TimepointViewer.tsx
@@ -11,6 +11,7 @@ import { QueryErrorBoundary } from 'components/QueryErrorBoundary';
 import { useSceneVar } from 'scenes/Common/useSceneVar';
 import { useSceneVarProbes } from 'scenes/Common/useSceneVarProbes';
 import { LOGS_VIEW_OPTIONS, LogsView, LogsViewSelect } from 'scenes/components/LogsRenderer/LogsViewSelect';
+import { FrontendContext } from 'scenes/components/TimepointExplorer/FrontendContext';
 import { useTimepointExplorerContext } from 'scenes/components/TimepointExplorer/TimepointExplorer.context';
 import { useRefetchInterval } from 'scenes/components/TimepointExplorer/TimepointExplorer.hooks';
 import { StatelessTimepoint } from 'scenes/components/TimepointExplorer/TimepointExplorer.types';
@@ -126,6 +127,7 @@ const TimepointViewerContent = ({ logsView, probeNameToView, timepoint }: Timepo
         probeNameToView={probeNameToView}
         timepoint={timepoint}
       />
+      <FrontendContext timepoint={timepoint} />
     </>
   );
 };


### PR DESCRIPTION
## Summary

Adds an experimental "Real user context" panel to the browser check Timepoint Explorer, bridging Faro RUM data (Frontend Observability) alongside a check execution's own results — so a user can answer "if I have FEO set up, is my check's failure/pass representative of what real users are actually seeing?"

**This is explicitly a draft, sent early to collect feedback from FE** before committing to the current design/data model. Please don't read this as review-ready — read it as "does this direction make sense."

For a failed check, the panel checks whether real users are hitting the same failure (shared exception, or a named action's real-user failure rate). For a passed check, it checks representativeness: has the app deployed recently, and does the check's own timing diverge meaningfully from real users' (in either direction — a check that's *unrepresentatively fast* is the more dangerous case, since its pass reads as reassurance that isn't earned).

Everything is read from the same Faro session the existing "View Frontend Session" link already points to, so this and that feature always tell the same story.

## Where to start reviewing

Given the size, two natural entry points:
- `FrontendContext.utils.ts` — the data model and rules engine (pure functions: parsing Faro records into pages/actions/exceptions, the LogQL query builders, the fidelity-verdict and summary-verdict logic). No React in here — probably the higher-value read for judging whether the *logic* makes sense.
- `FrontendContext.tsx` — the panel UI itself, consuming the above.

`FrontendContext.hooks.ts` is the thin React Query layer connecting the two.

## Known gaps (not fixing in this PR)

- **No automated test coverage.** None of the three new files have tests yet. Deliberate for this draft — didn't want to lock in test assertions against a data model and rules engine that's still up for debate. Should be added before this leaves experimental status.
- **No feedback-collection mechanism.** This ships as a plain panel with no way for a user to tell us what they think of it — the app's existing feedback-widget pattern would need to be wired up here too. Flagging as a real gap, but intentionally leaving it for a follow-up rather than doing it in this PR.
- **Nesting page vitals/requests under their owning action** (rather than the current flat page-then-action layout) was raised as a design improvement but is a bigger architecture change, deferred out of this pass.

## Test plan

- [ ] Manual: open a browser check's Timepoint Explorer against an app that has Frontend Observability configured, for both a passing and a failing execution, and confirm the panel's verdict/detail match what FEO's own app shows for the same session.
- [x] `yarn typecheck`, `yarn lint`, `yarn test src/scenes/components/TimepointExplorer` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)